### PR TITLE
bump machine-controller to include AWS IMDS/Cilium fix

### DIFF
--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -54,7 +54,7 @@ var (
 
 const (
 	Name = "machine-controller"
-	Tag  = "1f263db7e53fd6b1487f094bf7935a1f3d9516e5"
+	Tag  = "5349a3cb7f1da6efcd295d0a342c634314732ef0"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller.yaml
@@ -83,7 +83,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller.yaml
@@ -68,7 +68,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller.yaml
@@ -104,7 +104,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller-webhook.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller.yaml
@@ -91,7 +91,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:1f263db7e53fd6b1487f094bf7935a1f3d9516e5
+        image: quay.io/kubermatic/machine-controller:5349a3cb7f1da6efcd295d0a342c634314732ef0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings us https://github.com/kubermatic/machine-controller/pull/1833, which should unblock our AWS e2e tests.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix AWS nodes connectivity issue to the Metadata Service when using Cilium as the CNI (this impacted most visibly the EBS CSI driver not functioning correctly)
```

**Documentation**:
```documentation
NONE
```
