### PR TITLE
make reconciling for clusters with LoadBalancer expose strategy clearer

### DIFF
--- a/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/pkg/resources/apiserver/tls-serving-certificate.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -35,7 +36,7 @@ type tlsServingCertReconcilerData interface {
 	Cluster() *kubermaticv1.Cluster
 	GetRootCA() (*triple.KeyPair, error)
 	GetTunnelingAgentIP() string
-	GetAPIServerAlternateNames() (*certutil.AltNames, error)
+	GetAPIServerAlternateNames() *certutil.AltNames
 }
 
 // TLSServingCertificateReconciler returns a function to create/update the secret with the apiserver tls certificate used to serve https.
@@ -93,33 +94,17 @@ func TLSServingCertificateReconciler(data tlsServingCertReconcilerData) reconcil
 				altNames.IPs = append(altNames.IPs, net.ParseIP(data.GetTunnelingAgentIP()))
 			}
 
-			additionalAltNames, err := data.GetAPIServerAlternateNames()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get apiserver alternate names: %w", err)
-			}
+			additionalAltNames := data.GetAPIServerAlternateNames()
 
 			// Add the alternate names to the list of DNS names and IPs while ensuring no duplicates.
 			for _, dnsName := range additionalAltNames.DNSNames {
-				found := false
-				for _, existingDNSName := range altNames.DNSNames {
-					if existingDNSName == dnsName {
-						found = true
-						break
-					}
-				}
-				if !found {
+				if !slices.Contains(altNames.DNSNames, dnsName) {
 					altNames.DNSNames = append(altNames.DNSNames, dnsName)
 				}
 			}
+
 			for _, ip := range additionalAltNames.IPs {
-				found := false
-				for _, existingIP := range altNames.IPs {
-					if existingIP.Equal(ip) {
-						found = true
-						break
-					}
-				}
-				if !found {
+				if !slices.ContainsFunc(altNames.IPs, ip.Equal) {
 					altNames.IPs = append(altNames.IPs, ip)
 				}
 			}

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -84,6 +84,7 @@ type TemplateData struct {
 	versions                         kubermatic.Versions
 	caBundle                         CABundle
 	clusterBackupStorageLocation     *kubermaticv1.ClusterBackupStorageLocation
+	apiServerAlternateNames          *certutil.AltNames
 
 	supportsFailureDomainZoneAntiAffinity bool
 
@@ -248,6 +249,11 @@ func (td *TemplateDataBuilder) WithMachineControllerImageRepository(repository s
 
 func (td *TemplateDataBuilder) WithTunnelingAgentIP(tunnelingAgentIP string) *TemplateDataBuilder {
 	td.data.tunnelingAgentIP = tunnelingAgentIP
+	return td
+}
+
+func (td *TemplateDataBuilder) WithAPIServerAlternateNames(altNames *certutil.AltNames) *TemplateDataBuilder {
+	td.data.apiServerAlternateNames = altNames
 	return td
 }
 
@@ -474,51 +480,10 @@ func (d *TemplateData) GetOpenVPNServerPort() (int32, error) {
 	return service.Spec.Ports[0].NodePort, nil
 }
 
-// GetAPIServerAlternateNames returns the alternate names for the apiserver certificate from the corresponding services.
-// This method ensures that if multiple hostnames or IPs have been assigned to the API server service or front-loadbalancer service, then all
-// of them are included in the certificate.
-func (d *TemplateData) GetAPIServerAlternateNames() (*certutil.AltNames, error) {
-	// Get all the loadbalancer Ingresses from the API server service.
-	DNSNames := []string{}
-	IPs := []net.IP{}
-	service := &corev1.Service{}
-	if err := d.client.Get(d.ctx, types.NamespacedName{Namespace: d.cluster.Status.NamespaceName, Name: ApiserverServiceName}, service); err != nil {
-		return nil, fmt.Errorf("failed to get API server service: %w", err)
-	}
-
-	if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
-		for _, ingress := range service.Status.LoadBalancer.Ingress {
-			if ingress.IP != "" {
-				IPs = append(IPs, net.ParseIP(ingress.IP))
-			}
-			if ingress.Hostname != "" {
-				DNSNames = append(DNSNames, ingress.Hostname)
-			}
-		}
-	}
-
-	if d.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
-		service := &corev1.Service{}
-		if err := d.client.Get(d.ctx, types.NamespacedName{Namespace: d.cluster.Status.NamespaceName, Name: FrontLoadBalancerServiceName}, service); err != nil {
-			return nil, fmt.Errorf("failed to get front-loadbalancer service: %w", err)
-		}
-
-		if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
-			for _, ingress := range service.Status.LoadBalancer.Ingress {
-				if ingress.IP != "" {
-					IPs = append(IPs, net.ParseIP(ingress.IP))
-				}
-				if ingress.Hostname != "" {
-					DNSNames = append(DNSNames, ingress.Hostname)
-				}
-			}
-		}
-	}
-
-	return &certutil.AltNames{
-		DNSNames: DNSNames,
-		IPs:      IPs,
-	}, nil
+// GetAPIServerAlternateNames returns the alternate names for the apiserver certificate from the
+// corresponding services in the cluster namespace.
+func (d *TemplateData) GetAPIServerAlternateNames() *certutil.AltNames {
+	return d.apiServerAlternateNames
 }
 
 // GetKonnectivityServerPort returns the nodeport of the external Konnectivity Server service.


### PR DESCRIPTION
**What this PR does / why we need it**:
This clarifies the reconciling code a bit and moves some of the templateData setup logic into the relevant controller code. There was an inherent race condition in `GetAPIServerAlternateNames()`, as it relies on the status of the apiserver LB, which might not exist immediately after that LB Service has just been created. This PR moves the logic into the controller, where a re-reconciliation once the LB is ready is more expected.

**Which issue(s) this PR fixes**:
part of #13563

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
