### PR TITLE
feat: add seed cluster podCIDR to front-load-balancer allowlist

### DIFF
--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -885,3 +885,17 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 
 	return vars, nil
 }
+
+// GetPodCIDR returns the PodCIDR configured for the nodes in the cluster.
+func (d *TemplateData) GetPodCIDR() (string, error) {
+	nodeList := &corev1.NodeList{}
+	err := d.client.List(d.ctx, nodeList)
+	if err != nil {
+		return "", fmt.Errorf("could not get node list: %w", err)
+	}
+
+	if len(nodeList.Items) > 0 {
+		return nodeList.Items[0].Spec.PodCIDR, nil
+	}
+	return "", nil
+}

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -444,6 +444,14 @@ func FrontLoadBalancerServiceReconciler(data *resources.TemplateData) reconcilin
 			// Check if allowed IP ranges are configured and set the LoadBalancer source ranges
 			if data.Cluster().Spec.APIServerAllowedIPRanges != nil {
 				sourceIPList.Insert(data.Cluster().Spec.APIServerAllowedIPRanges.CIDRBlocks...)
+				podCIDR, err := data.GetPodCIDR()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get seed cluster pod CIDR: %w", err)
+				}
+
+				if podCIDR != "" && !sourceIPList.Has(podCIDR) {
+					sourceIPList.Insert(podCIDR)
+				}
 			}
 
 			s.Spec.LoadBalancerSourceRanges = sets.List(sourceIPList)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/13541

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Automatically add seed cluster podCIDR when APIServerAllowedIPRanges are set.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1729
```
