### PR TITLE
fix Dockerfile syntax warning

### DIFF
--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.5 as builder
+FROM docker.io/golang:1.22.5 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.5 as builder
+FROM docker.io/golang:1.22.5 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.5 as builder
+FROM docker.io/golang:1.22.5 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing

![2024-08-12_11-42](https://github.com/user-attachments/assets/fe6e54f3-a1d4-477c-9d60-e478a5a322fd)

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
