### PR TITLE
Update to Go 1.23

### DIFF
--- a/.golangci.apis.yml
+++ b/.golangci.apis.yml
@@ -15,7 +15,7 @@
 run:
   timeout: 3m
   modules-download-mode: readonly
-  skip-files:
+  exclude-files:
     - zz_generated.*.go
 
 linters:

--- a/.golangci.apis.yml
+++ b/.golangci.apis.yml
@@ -15,8 +15,6 @@
 run:
   timeout: 3m
   modules-download-mode: readonly
-  exclude-files:
-    - zz_generated.*.go
 
 linters:
   enable:
@@ -29,3 +27,7 @@ linters-settings:
       rules:
         json: goCamel
         yaml: goCamel
+
+issues:
+  exclude-files:
+    - zz_generated.*.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - intrange
     - misspell
     - noctx
     - nolintlint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - errname
     - errorlint
     - exportloopref
+    - fatcontext
     - goconst
     - gocritic
     - gocyclo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,17 +28,13 @@ run:
     - ipam
     - kubevirt
     - logout
-  skip-files:
-    - zz_generated.*.go
-    # This package was forked from upstream (in #9826)
-    # and we want to keep it as close to upstream as possible.
-    - pkg/provider/cloud/eks/authenticator
 
 linters:
   enable:
     - asciicheck
     - bidichk
     - bodyclose
+    - copyloopvar
     - depguard
     - durationcheck
     - errcheck
@@ -72,6 +68,13 @@ linters:
 # NOTE: Do not use commas in the exclude patterns, or else the regex will be
 # split and you will be sad: https://github.com/golangci/golangci-lint/issues/665
 issues:
+  exclude-files:
+    - zz_generated.*.go
+  exclude-dirs:
+    # This package was forked from upstream (in #9826)
+    # and we want to keep it as close to upstream as possible.
+    - pkg/provider/cloud/eks/authenticator
+
   # defaults to 3, which often needlessly hides issues and forces
   # to re-run the linter across the entire repo many times
   max-same-issues: 50

--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -578,7 +578,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -616,7 +616,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: "ee"
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -118,7 +118,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -206,7 +206,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -244,7 +244,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -152,9 +152,9 @@ presubmits:
 
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.30-datastore-cluster
     decorate: true
-    # This job is disabled currently because we have a datastore cluster 
+    # This job is disabled currently because we have a datastore cluster
     # but it will not work as it is connected to vSAN and vSAN is messed up.
-    # run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)" 
+    # run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vsphere: "true"
@@ -169,7 +169,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -203,7 +203,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -227,7 +227,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/release-utility-images.sh"
           env:

--- a/cmd/conformance-tester/pkg/scenarios/generator.go
+++ b/cmd/conformance-tester/pkg/scenarios/generator.go
@@ -200,7 +200,7 @@ func shuffle(vals []Scenario) []Scenario {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	ret := make([]Scenario, len(vals))
 	n := len(vals)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		randIndex := r.Intn(len(vals))
 		ret[i] = vals[randIndex]
 		vals = append(vals[:randIndex], vals[randIndex+1:]...)

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -356,7 +356,7 @@ func (e *Cluster) IsClusterHealthy(ctx context.Context, log *zap.SugaredLogger) 
 
 func initialMemberList(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, n int, namespace string, useTLSPeer bool) []string {
 	members := []string{}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		var pod corev1.Pod
 
 		if err := client.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("etcd-%d", i), Namespace: namespace}, &pod); err != nil {
@@ -388,7 +388,7 @@ func initialMemberList(ctx context.Context, log *zap.SugaredLogger, client ctrlr
 
 func peerHostsList(n int, namespace string) []string {
 	hosts := []string{}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		hosts = append(hosts, fmt.Sprintf("etcd-%d.etcd.%s.svc.cluster.local", i, namespace))
 	}
 	return hosts
@@ -397,7 +397,7 @@ func peerHostsList(n int, namespace string) []string {
 func clientEndpoints(n int, namespace string) []string {
 	endpoints := []string{}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		endpoints = append(endpoints, fmt.Sprintf("https://etcd-%d.etcd.%s.svc.cluster.local:2379", i, namespace))
 	}
 
@@ -515,7 +515,7 @@ func (e *Cluster) getUnwantedMembers(ctx context.Context, log *zap.SugaredLogger
 		}
 
 		// check all found peer URLs for being valid
-		for i := 0; i < len(member.PeerURLs); i++ {
+		for i := range len(member.PeerURLs) {
 			peerURL, err := url.Parse(member.PeerURLs[i])
 			if err != nil {
 				return []*etcdserverpb.Member{}, err
@@ -557,7 +557,7 @@ func (e *Cluster) isLeader(ctx context.Context, log *zap.SugaredLogger) (bool, e
 	}
 	defer closeClient(localClient, log)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		resp, err := localClient.Status(ctx, e.endpoint())
 		if err != nil || resp.Leader == 0 {
 			time.Sleep(2 * time.Second)

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.5 AS builder
+FROM docker.io/golang:1.23.0 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.5 AS builder
+FROM docker.io/golang:1.23.0 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.22.5 AS builder
+FROM docker.io/golang:1.23.0 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -456,7 +456,7 @@ func validateReflect(value reflect.Value, path []string) error {
 
 	switch typ.Kind() {
 	case reflect.Struct:
-		for i := 0; i < typ.NumField(); i++ {
+		for i := range typ.NumField() {
 			fieldName := typ.Field(i).Name
 
 			p = append(p, fieldName)
@@ -498,7 +498,7 @@ func validateReflect(value reflect.Value, path []string) error {
 			return fmt.Errorf("%s is invalid: slices of complex types must contain at least one item", strings.Join(path, "."))
 		}
 
-		for i := 0; i < value.Len(); i++ {
+		for i := range value.Len() {
 			p = append(p, fmt.Sprintf("[%d]", i))
 
 			if err := validateReflect(value.Index(i), p); err != nil {

--- a/codegen/godoc/main.go
+++ b/codegen/godoc/main.go
@@ -76,7 +76,7 @@ func generateDocumentation(docs []string, v reflect.Value) []string {
 
 		docs = append(docs, doc)
 
-		for n := 0; n < v.NumField(); n++ {
+		for n := range v.NumField() {
 			docs = generateDocumentation(docs, v.Field(n))
 		}
 	}

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+FROM quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
 LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/hack/images/integration-tests/Dockerfile"
 LABEL org.opencontainers.image.vendor="Kubermatic"
 LABEL org.opencontainers.image.authors="support@kubermatic.com"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-11 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-0 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.22.5 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=golang:1.23.0 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.22.5 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=golang:1.23.0 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/update-kubermatic-ca-bundle.sh
+++ b/hack/update-kubermatic-ca-bundle.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.22.5 containerize ./hack/update-kubermatic-ca-bundle.sh
+CONTAINERIZE_IMAGE=golang:1.23.0 containerize ./hack/update-kubermatic-ca-bundle.sh
 
 echodate "Updating CA bundle..."
 curl -Lo charts/kubermatic-operator/static/ca-bundle.pem https://curl.se/ca/cacert.pem

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-11 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-0 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-11 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-0 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/api/v1/time.go
+++ b/pkg/api/v1/time.go
@@ -40,8 +40,8 @@ func NewTime(t time.Time) Time {
 
 // Date returns the Time corresponding to the supplied parameters
 // by wrapping time.Date.
-func Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) Time {
-	return Time{time.Date(year, month, day, hour, min, sec, nsec, loc)}
+func Date(year int, month time.Month, day, hour, minute, sec, nsec int, loc *time.Location) Time {
+	return Time{time.Date(year, month, day, hour, minute, sec, nsec, loc)}
 }
 
 // Now returns the current local time.

--- a/pkg/apis/kubermatic/v1/datacenter_test.go
+++ b/pkg/apis/kubermatic/v1/datacenter_test.go
@@ -160,7 +160,6 @@ func TestSetSeedDefaults(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tc.seed.SetDefaults()

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -509,7 +509,7 @@ func TestEnsureProjectClusterRBACRoleBindingForResources(t *testing.T) {
 			fakeMasterClient := kubermaticface.NewClientBuilder().WithObjects(objs...).Build()
 
 			seedClientMap := make(map[string]ctrlruntimeclient.Client)
-			for i := 0; i < test.seedClusters; i++ {
+			for i := range test.seedClusters {
 				objs := []ctrlruntimeclient.Object{}
 				for _, existingClusterRoleBinding := range test.existingClusterRoleBindingsForSeeds {
 					objs = append(objs, existingClusterRoleBinding)
@@ -788,7 +788,7 @@ func TestEnsureProjectCleanup(t *testing.T) {
 			fakeMasterClusterClient := kubermaticface.NewClientBuilder().WithObjects(allObjs...).Build()
 
 			seedClusterClientMap := make(map[string]ctrlruntimeclient.Client)
-			for i := 0; i < test.seedClusters; i++ {
+			for i := range test.seedClusters {
 				objs := []ctrlruntimeclient.Object{}
 				for _, existingClusterRoleBinding := range test.existingClusterRoleBindingsForSeeds {
 					objs = append(objs, existingClusterRoleBinding)
@@ -1090,7 +1090,7 @@ func TestEnsureProjectClusterRBACRoleForResources(t *testing.T) {
 			fakeMasterClient := kubermaticface.NewClientBuilder().WithObjects(objs...).Build()
 
 			seedClients := make(map[string]ctrlruntimeclient.Client)
-			for i := 0; i < test.seedClusters; i++ {
+			for i := range test.seedClusters {
 				seedClients[strconv.Itoa(i)] = kubermaticface.NewClientBuilder().Build()
 			}
 
@@ -1419,7 +1419,7 @@ func TestEnsureProjectRBACRoleForResources(t *testing.T) {
 			fakeMasterClient := kubermaticface.NewClientBuilder().WithObjects(objs...).Build()
 
 			seedClientMap := make(map[string]ctrlruntimeclient.Client)
-			for i := 0; i < test.seedClusters; i++ {
+			for i := range test.seedClusters {
 				seedClientMap[strconv.Itoa(i)] = kubermaticface.NewClientBuilder().Build()
 			}
 
@@ -1847,7 +1847,7 @@ func TestEnsureProjectRBACRoleBindingForResources(t *testing.T) {
 			fakeMasterClient := kubermaticface.NewClientBuilder().WithObjects(objs...).Build()
 
 			seedClusterClientMap := make(map[string]ctrlruntimeclient.Client)
-			for i := 0; i < test.seedClusters; i++ {
+			for i := range test.seedClusters {
 				objs := []ctrlruntimeclient.Object{}
 				for _, existingRoleBinding := range test.existingRoleBindingsForSeeds {
 					objs = append(objs, existingRoleBinding)
@@ -2129,7 +2129,7 @@ func TestEnsureProjectCleanUpForRoleBindings(t *testing.T) {
 			// manually set lister as we don't want to start informers in the tests
 
 			seedClusterClientMap := make(map[string]ctrlruntimeclient.Client)
-			for i := 0; i < test.seedClusters; i++ {
+			for i := range test.seedClusters {
 				objs := []ctrlruntimeclient.Object{}
 				for _, existingRoleBinding := range test.existingRoleBindingsForSeeds {
 					objs = append(objs, existingRoleBinding)

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -293,12 +293,12 @@ func APIPDBReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Nam
 			// To prevent the PDB from blocking node rotations, we accept
 			// 0 minAvailable if the replica count is only 1.
 			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
-			min := intstr.FromInt(1)
+			minReplicas := intstr.FromInt(1)
 			if cfg.Spec.API.Replicas != nil && *cfg.Spec.API.Replicas < 2 {
-				min = intstr.FromInt(0)
+				minReplicas = intstr.FromInt(0)
 			}
 
-			pdb.Spec.MinAvailable = &min
+			pdb.Spec.MinAvailable = &minReplicas
 			pdb.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: apiPodLabels(),
 			}

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -110,12 +110,12 @@ func MasterControllerManagerPDBReconciler(cfg *kubermaticv1.KubermaticConfigurat
 			// To prevent the PDB from blocking node rotations, we accept
 			// 0 minAvailable if the replica count is only 1.
 			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
-			min := intstr.FromInt(1)
+			minReplicas := intstr.FromInt(1)
 			if cfg.Spec.MasterController.Replicas != nil && *cfg.Spec.MasterController.Replicas < 2 {
-				min = intstr.FromInt(0)
+				minReplicas = intstr.FromInt(0)
 			}
 
-			pdb.Spec.MinAvailable = &min
+			pdb.Spec.MinAvailable = &minReplicas
 			pdb.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: masterControllerManagerPodLabels(),
 			}

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -120,12 +120,12 @@ func UIPDBReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Name
 			// To prevent the PDB from blocking node rotations, we accept
 			// 0 minAvailable if the replica count is only 1.
 			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
-			min := intstr.FromInt(1)
+			minReplicas := intstr.FromInt(1)
 			if cfg.Spec.UI.Replicas != nil && *cfg.Spec.UI.Replicas < 2 {
-				min = intstr.FromInt(0)
+				minReplicas = intstr.FromInt(0)
 			}
 
-			pdb.Spec.MinAvailable = &min
+			pdb.Spec.MinAvailable = &minReplicas
 			pdb.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: uiPodLabels(),
 			}

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -252,12 +252,12 @@ func SeedControllerManagerPDBReconciler(cfg *kubermaticv1.KubermaticConfiguratio
 			// To prevent the PDB from blocking node rotations, we accept
 			// 0 minAvailable if the replica count is only 1.
 			// NB: The cfg is defaulted, so Replicas==nil cannot happen.
-			min := intstr.FromInt(1)
+			minReplicas := intstr.FromInt(1)
 			if cfg.Spec.SeedController.Replicas != nil && *cfg.Spec.SeedController.Replicas < 2 {
-				min = intstr.FromInt(0)
+				minReplicas = intstr.FromInt(0)
 			}
 
-			pdb.Spec.MinAvailable = &min
+			pdb.Spec.MinAvailable = &minReplicas
 			pdb.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: seedControllerManagerPodLabels(),
 			}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -150,9 +150,9 @@ func (r *reconciler) createClusters(ctx context.Context, instance *kubermaticv1.
 			return fmt.Errorf("failed to get template %s: %w", instance.Spec.ClusterTemplateID, err)
 		}
 
-		for i := 0; i < int(instance.Spec.Replicas); i++ {
+		for i := range instance.Spec.Replicas {
 			if err := r.createCluster(ctx, log, template, instance); err != nil {
-				created := int64(i)
+				created := i
 				totalReplicas := instance.Spec.Replicas
 
 				if patchErr := r.patchInstance(ctx, instance, func(i *kubermaticv1.ClusterTemplateInstance) {

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -188,7 +188,7 @@ func genClusterRootCaSecret() *corev1.Secret {
 
 func genBackupStatusList(n int, gen func(i int) kubermaticv1.BackupStatus) []kubermaticv1.BackupStatus {
 	var result []kubermaticv1.BackupStatus
-	for i := 0; i < n; i++ {
+	for i := range n {
 		result = append(result, gen(i))
 	}
 	return result
@@ -196,7 +196,7 @@ func genBackupStatusList(n int, gen func(i int) kubermaticv1.BackupStatus) []kub
 
 func genJobList(n int, gen func(i int) batchv1.Job) []batchv1.Job {
 	var result []batchv1.Job
-	for i := 0; i < n; i++ {
+	for i := range n {
 		result = append(result, gen(i))
 	}
 	return result

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -378,7 +378,6 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			cluster := genTestCluster()
@@ -587,7 +586,6 @@ func TestStartPendingBackupJobs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -933,7 +931,6 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -1223,7 +1220,6 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -1546,7 +1542,6 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/pkg/controller/seed-controller-manager/ipam/range_allocation.go
+++ b/pkg/controller/seed-controller-manager/ipam/range_allocation.go
@@ -101,7 +101,7 @@ func findFirstFreeRangesOfPool(poolName, poolCIDR string, allocationRange int, d
 	if len(rangeFreeIPs) > 0 {
 		rangeFreeIPsIterator := 0
 		firstAddressRangeIP := rangeFreeIPs[rangeFreeIPsIterator]
-		for j := 0; j < allocationRange; j++ {
+		for j := range allocationRange {
 			ipToAllocate := rangeFreeIPs[rangeFreeIPsIterator]
 
 			dcIPAMPoolUsageMap.Insert(ipToAllocate)

--- a/pkg/controller/user-cluster-controller-manager/node-labeler/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/controller_test.go
@@ -217,7 +217,7 @@ func TestMatchOSLabels(t *testing.T) {
 	for n, test := range tests {
 		// go map iterations are randomized, so we just hammer out the entropy
 		// by running the same test a gazillion times
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			result := findDistributionLabel(test.osImage)
 
 			if result != test.expected {

--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -345,7 +345,7 @@ func GetMDStatusMessage(np *container.NodePool) string {
 	}
 	statusMessage = np.StatusMessage
 	if statusMessage == "" {
-		if np.Conditions != nil && len(np.Conditions) > 1 {
+		if len(np.Conditions) > 1 {
 			statusMessage = np.Conditions[1].Message
 		}
 	}
@@ -392,7 +392,7 @@ func GetStatusMessage(gkeCluster *container.Cluster) string {
 	}
 	statusMessage = gkeCluster.StatusMessage
 	if statusMessage == "" {
-		if gkeCluster.Conditions != nil && len(gkeCluster.Conditions) > 1 {
+		if len(gkeCluster.Conditions) > 1 {
 			statusMessage = gkeCluster.Conditions[1].Message
 		}
 	}

--- a/pkg/provider/cloud/vmwareclouddirector/helper.go
+++ b/pkg/provider/cloud/vmwareclouddirector/helper.go
@@ -48,7 +48,7 @@ func deleteVApp(vdc *govcd.Vdc, vapp *govcd.VApp) error {
 func getOrgVDCNetworks(vdc *govcd.Vdc, spec kubermaticv1.VMwareCloudDirectorCloudSpec) ([]*govcd.OrgVDCNetwork, error) {
 	var networks []string
 
-	if spec.OVDCNetworks != nil && len(spec.OVDCNetworks) > 0 {
+	if len(spec.OVDCNetworks) > 0 {
 		networks = spec.OVDCNetworks
 	} else {
 		networks = []string{spec.OVDCNetwork}

--- a/pkg/provider/cloud/vsphere/provider_test.go
+++ b/pkg/provider/cloud/vsphere/provider_test.go
@@ -122,7 +122,6 @@ func TestGetCredentialsForCluster(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			defer func() {

--- a/pkg/resources/etcd/etcdservices.go
+++ b/pkg/resources/etcd/etcdservices.go
@@ -73,7 +73,7 @@ func ServiceReconciler(data serviceReconcilerData) reconciling.NamedServiceRecon
 // GetClientEndpoints returns the slice with the etcd endpoints for client communication.
 func GetClientEndpoints(namespace string) []string {
 	var endpoints []string
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		// Pod DNS name
 		serviceDNSName := resources.GetAbsoluteServiceDNSName(resources.EtcdServiceName, namespace)
 		absolutePodDNSName := fmt.Sprintf("https://etcd-%d.%s:2379", i, serviceDNSName)

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -224,7 +224,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 			} else {
 				endpoints := []string{}
 
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					endpoints = append(endpoints, fmt.Sprintf(memberListPattern, i, i, resources.EtcdServiceName, data.Cluster().Status.NamespaceName))
 				}
 

--- a/pkg/resources/etcd/tls-serving-certificate.go
+++ b/pkg/resources/etcd/tls-serving-certificate.go
@@ -56,7 +56,7 @@ func TLSCertificateReconciler(data tlsCertificateReconcilerData) reconciling.Nam
 			if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
 				etcdClusterSize = kubermaticv1.MaxEtcdClusterSize
 			}
-			for i := 0; i < etcdClusterSize; i++ {
+			for i := range etcdClusterSize {
 				// Member name
 				podName := fmt.Sprintf("etcd-%d", i)
 				altNames.DNSNames = append(altNames.DNSNames, podName)

--- a/pkg/resources/vpa.go
+++ b/pkg/resources/vpa.go
@@ -76,7 +76,6 @@ func getVPAReconcilerForPodTemplate(name string, pod corev1.PodSpec, controllerR
 func getVerticalPodAutoscalersForResource(ctx context.Context, client ctrlruntimeclient.Client, names []string, namespace string, obj ctrlruntimeclient.Object, enabled bool) ([]reconciling.NamedVerticalPodAutoscalerReconcilerFactory, error) {
 	var creators []reconciling.NamedVerticalPodAutoscalerReconcilerFactory
 	for _, name := range names {
-		name := name
 		key := types.NamespacedName{Namespace: namespace, Name: name}
 
 		err := client.Get(ctx, key, obj)

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -120,10 +120,10 @@ func testUserCluster(t *testing.T, ctx context.Context, log *zap.SugaredLogger, 
 		if err != nil {
 			t.Logf("Failed to get events from usercluster: %+v", err)
 		}
-		t.Logf("Events for debugging logged below.")
+		t.Log("Events for debugging logged below.")
 		for _, event := range events.Items {
 			e, _ := json.Marshal(event)
-			t.Logf(string(e))
+			t.Log(string(e))
 		}
 	}()
 

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -265,7 +265,7 @@ func testUserCluster(ctx context.Context, t *testing.T, log *zap.SugaredLogger, 
 			return fmt.Errorf("failed to get flow client: %w", err), nil
 		}
 
-		for c := 0; c < nFlows; c++ {
+		for range nFlows {
 			_, err := flowsClient.Recv()
 			if err != nil {
 				return fmt.Errorf("failed to get flow: %w", err), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps all scripts and jobs to Go 1.23 and adds some new-ish linters :)

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.23.0
```

**Documentation**:
```documentation
NONE
```
