### PR TITLE
bump integration-tests image to Kube 1.31

### DIFF
--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -17,14 +17,10 @@ LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/
 LABEL org.opencontainers.image.vendor="Kubermatic"
 LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
-# envtest binaries are not available for all k8s patch releases, so beware when updating
 ENV KUBE_VERSION=1.31.0
 
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \
-    mkdir -p /usr/local/kubebuilder/ && \
-    curl --fail -sL "https://go.kubebuilder.io/test-tools/${KUBE_VERSION}/$os/$arch" | tar -xz --strip-components=1 -C /usr/local/kubebuilder/ && \
-    curl --fail https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/$os/${arch}/kube-apiserver -L -o /tmp/kube-apiserver && \
-    chmod +x /tmp/kube-apiserver && \
-    mv /tmp/kube-apiserver /usr/local/kubebuilder/bin/kube-apiserver && \
+    mkdir -p /usr/local/kubebuilder/bin/ && \
+    curl --fail -sL "https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v${KUBE_VERSION}/envtest-v${KUBE_VERSION}-$os-$arch.tar.gz" | tar -xz --strip-components=2 -C /usr/local/kubebuilder/bin/ && \
     echo 'export PATH=$PATH:/usr/local/kubebuilder/bin' >> ~/.bashrc

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+FROM quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
 LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/hack/images/integration-tests/Dockerfile"
 LABEL org.opencontainers.image.vendor="Kubermatic"
 LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating
-ENV KUBE_VERSION=1.30.0
+ENV KUBE_VERSION=1.31.0
 
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \

--- a/hack/images/integration-tests/settings.sh
+++ b/hack/images/integration-tests/settings.sh
@@ -1,1 +1,1 @@
-TAG=k8s-1.30.0-rev1
+TAG=k8s-1.31.0-rev0


### PR DESCRIPTION
**What this PR does / why we need it**:
This is technically required for the Kube 1.31 support in KKP, but since we need the image to be available before we can use it, this is a standalone PR.

As per https://github.com/kubernetes-sigs/kubebuilder/discussions/4082, the old location (go.kubebuilder.io) is not supported and updated anymore and instead community infrastructure is to be used. The new binaries (the issue isn't clear whether only 1.31 or every release starting with 1.31) are now available on GitHub releases.

Since I now have more confidence in  the availability of envtest binaries, I have removed the ooold (Dec 2019, https://github.com/kubermatic/infra/pull/799) hack where we take a kubebuilder download as a "base" and then simply replace the kube-apiserver. Since kubebuilder was released in-step with Kubernetes (though laggy), we hadn't used this mechanism anyway.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
