### PR TITLE
[release/v2.25] drop replica label from alerts

### DIFF
--- a/charts/monitoring/prometheus/config/prometheus.yaml
+++ b/charts/monitoring/prometheus/config/prometheus.yaml
@@ -35,6 +35,10 @@ rule_files:
 
 {{- if or .Values.prometheus.alertmanagers.files .Values.prometheus.alertmanagers.configs }}
 alerting:
+{{- if .Values.prometheus.alerting.alert_relabel_configs }}
+  alert_relabel_configs:
+{{- toYaml .Values.prometheus.alerting.alert_relabel_configs | nindent 4 }}
+{{- end }}
   alertmanagers:
   {{- range .Values.prometheus.alertmanagers.files }}
   {{- range $filename, $content := $.Files.Glob . }}

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -83,6 +83,11 @@ prometheus:
 
   # Similarly to the scraping config, you can configure the
   # target alertmanagers here.
+  alerting:
+    alert_relabel_configs:
+    - action: labeldrop
+      regex: replica
+    
   alertmanagers:
     files:
     - config/alertmanagers/*.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop the replica label in the alerts so that the same alerts doesn't show up for each prometheus replica. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubermatic/kubermatic/issues/11191

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:
Manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/13569

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Deduplicate alerts in alertmanager.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
