### PR TITLE
Fix machine deployment creation in baremetal provider

### DIFF
--- a/pkg/machine/helpers.go
+++ b/pkg/machine/helpers.go
@@ -24,6 +24,7 @@ import (
 	anexia "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	aws "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/types"
 	azure "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/types"
+	baremetal "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/baremetal/types"
 	digitalocean "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean/types"
 	equinixmetal "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/equinixmetal/types"
 	gce "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce/types"
@@ -192,6 +193,8 @@ func ProviderTypeFromSpec(cloudProviderSpec interface{}) (kubermaticv1.ProviderT
 		return kubermaticv1.VMwareCloudDirectorCloudProvider, nil
 	case vsphere.RawConfig:
 		return kubermaticv1.VSphereCloudProvider, nil
+	case baremetal.RawConfig:
+		return kubermaticv1.BaremetalCloudProvider, nil
 	default:
 		return "", fmt.Errorf("cannot handle unknown cloud provider %T", cloudProviderSpec)
 	}
@@ -225,6 +228,8 @@ func DecodeCloudProviderSpec(cloudProvider kubermaticv1.ProviderType, pconfig pr
 		return vmwareclouddirector.GetConfig(pconfig)
 	case kubermaticv1.VSphereCloudProvider:
 		return vsphere.GetConfig(pconfig)
+	case kubermaticv1.BaremetalCloudProvider:
+		return baremetal.GetConfig(pconfig)
 	default:
 		return nil, fmt.Errorf("cannot handle unknown cloud provider %q", cloudProvider)
 	}
@@ -288,6 +293,8 @@ func CompleteCloudProviderSpec(cloudProviderSpec interface{}, cloudProvider kube
 		return provider.CompleteVMwareCloudDirectorProviderSpec(assert[vmwareclouddirector.RawConfig](cloudProviderSpec), cluster, datacenter.Spec.VMwareCloudDirector, os)
 	case kubermaticv1.VSphereCloudProvider:
 		return provider.CompleteVSphereProviderSpec(assert[vsphere.RawConfig](cloudProviderSpec), cluster, datacenter.Spec.VSphere, os)
+	case kubermaticv1.BaremetalCloudProvider:
+		return provider.CompleteBaremetalProviderSpec(assert[baremetal.RawConfig](cloudProviderSpec), cluster, datacenter.Spec.Baremetal)
 	default:
 		return nil, fmt.Errorf("cannot handle unknown cloud provider %q", cloudProvider)
 	}

--- a/pkg/machine/provider/baremetal.go
+++ b/pkg/machine/provider/baremetal.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+
+	baremetal "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/baremetal/types"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+)
+
+type baremetalConfig struct {
+	baremetal.RawConfig
+}
+
+func NewBaremetalConfig() *baremetalConfig {
+	return &baremetalConfig{}
+}
+
+func CompleteBaremetalProviderSpec(config *baremetal.RawConfig, cluster *kubermaticv1.Cluster, datacenter *kubermaticv1.DatacenterSpecBaremetal) (*baremetal.RawConfig, error) {
+	if cluster != nil && cluster.Spec.Cloud.Baremetal == nil {
+		return nil, fmt.Errorf("cannot use cluster to create Baremetal cloud spec as cluster uses %q", cluster.Spec.Cloud.ProviderName)
+	}
+
+	if cluster.Spec.Cloud.Baremetal.Tinkerbell != nil {
+		config.Driver.Value = "tinkerbell"
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fix the machine deployment creation in baremetal provider, when we are trying to create a baremetal cluster we'are receiving an error that the machine deployment cannot be created in this provider (unknown)
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/king bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
