### PR TITLE
Add cloud-credentials secret for Baremetal provider

### DIFF
--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -18,6 +18,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -446,7 +447,7 @@ func createOrUpdateBaremetalSecret(ctx context.Context, seedClient ctrlruntimecl
 
 	// Ensure Tinkerbell provisioner is configured, as it is mandatory.
 	if spec.Tinkerbell == nil {
-		return false, fmt.Errorf("tinkerbell provisioner configuration is required but missing")
+		return false, errors.New("tinkerbell provisioner configuration is required but missing")
 	}
 
 	// Check if migration is necessary; return early if not.


### PR DESCRIPTION
**What this PR does / why we need it**:
When we create a baremetal cluster, the OSM fails because it expects to have cloud-credentials secret object. 
This PR will fix this issue by creating this secret! 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
