### PR TITLE
Update Canal addon to v3.27.4 and v3.28.1

### DIFF
--- a/addons/canal/canal_v3.27.yaml
+++ b/addons/canal/canal_v3.27.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Source: https://github.com/projectcalico/calico/blob/v3.27.3/manifests/canal.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.27.4/manifests/canal.yaml
 # Modifications:
 #   - templated cni_network_config ipam for dual-stack
 #   - templated net-conf.json Network & CALICO_IPV4POOL_CIDR + CALICO_IPV6POOL_CIDR
@@ -4825,7 +4825,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Image "quay.io/calico/cni:v3.27.3" }}'
+          image: '{{ Image "quay.io/calico/cni:v3.27.4" }}'
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4874,7 +4874,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: '{{ Image "quay.io/calico/node:v3.27.3" }}'
+          image: '{{ Image "quay.io/calico/node:v3.27.4" }}'
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4900,7 +4900,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Image "quay.io/calico/node:v3.27.3" }}'
+          image: '{{ Image "quay.io/calico/node:v3.27.4" }}'
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -5067,9 +5067,11 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+            type: DirectoryOrCreate
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
+            type: DirectoryOrCreate
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock
@@ -5094,6 +5096,7 @@ spec:
         - name: cni-bin-dir
           hostPath:
             path: /opt/cni/bin
+            type: DirectoryOrCreate
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
@@ -5148,7 +5151,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Image "quay.io/calico/kube-controllers:v3.27.3" }}'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.27.4" }}'
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/addons/canal/canal_v3.28.yaml
+++ b/addons/canal/canal_v3.28.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Source: https://github.com/projectcalico/calico/blob/v3.28.0/manifests/canal.yaml
+# Source: https://github.com/projectcalico/calico/blob/v3.28.1/manifests/canal.yaml
 # Modifications:
 #   - templated cni_network_config ipam for dual-stack
 #   - templated net-conf.json Network & CALICO_IPV4POOL_CIDR + CALICO_IPV6POOL_CIDR
@@ -4844,7 +4844,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Image "quay.io/calico/cni:v3.28.0" }}'
+          image: '{{ Image "quay.io/calico/cni:v3.28.1" }}'
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -4893,7 +4893,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: '{{ Image "quay.io/calico/node:v3.28.0" }}'
+          image: '{{ Image "quay.io/calico/node:v3.28.1" }}'
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -4919,7 +4919,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Image "quay.io/calico/node:v3.28.0" }}'
+          image: '{{ Image "quay.io/calico/node:v3.28.1" }}'
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -5086,9 +5086,11 @@ spec:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
+            type: DirectoryOrCreate
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
+            type: DirectoryOrCreate
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock
@@ -5113,6 +5115,7 @@ spec:
         - name: cni-bin-dir
           hostPath:
             path: /opt/cni/bin
+            type: DirectoryOrCreate
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
@@ -5167,7 +5170,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Image "quay.io/calico/kube-controllers:v3.28.0" }}'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.28.1" }}'
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an upstream bug in Canal 3.27.3 and 3.28.0 that causes CPU spikes, see https://github.com/projectcalico/calico/issues/8856 for details. This PR updates our Canal addon to the latest available versions from the Calico side. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Canal 3.27 to 3.27.4 and Canal 3.28 to 3.28.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
