### PR TITLE
Fix doc generation for DNSPolicy

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -796,8 +796,10 @@ type DatacenterSpecFake struct {
 type DatacenterSpecKubevirt struct {
 	// NamespacedMode represents the configuration for enabling the single namespace mode for all user-clusters in the KubeVirt datacenter.
 	NamespacedMode *NamespacedMode `json:"namespacedMode,omitempty"`
+
 	// +kubebuilder:validation:Enum=ClusterFirstWithHostNet;ClusterFirst;Default;None
 	// +kubebuilder:default=ClusterFirst
+
 	// DNSPolicy represents the dns policy for the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
 	// 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
 	// policy selected with DNSPolicy.


### PR DESCRIPTION
**What this PR does / why we need it**:
After some [recent changes](https://github.com/kubermatic/kubermatic/pull/13614), the Kubebuilder markers are also being added to the swagger specification generated for KKP API. This PR fixes that issue by simply adding a new line between the docs and Kubebuilder markers for the field `DNSPolicy`

![Screenshot 2024-08-27 at 10 40 52](https://github.com/user-attachments/assets/62e22950-86e7-47c4-90ef-b13c270fc41e)

Reference: https://github.com/kubermatic/dashboard/pull/6774/files#diff-81315e14766d552cc73a67b93898283cbc85f823a373033ba3068dd33d5125bbR30114-R30120

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cc @cnvergence 