### PR TITLE
Fix Azure CSI addon

### DIFF
--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -13,8 +13,144 @@
 # limitations under the License.
 
 presubmits:
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.27
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.27"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: PROVIDER
+              value: "azure"
+            - name: DEFAULT_TIMEOUT_MINUTES
+              value: "20"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.28
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.28"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: PROVIDER
+              value: "azure"
+            - name: DEFAULT_TIMEOUT_MINUTES
+              value: "20"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
+  - name: pre-kubermatic-e2e-azure-ubuntu-1.29
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-azure: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.29"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: PROVIDER
+              value: "azure"
+            - name: DEFAULT_TIMEOUT_MINUTES
+              value: "20"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
   - name: pre-kubermatic-e2e-azure-ubuntu-1.30
     decorate: true
+    run_if_changed: "(addons/csi/azure.*|addons/azure.*|pkg/provider/cloud/azure|pkg/resources/cloudconfig/azure)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-azure: "true"

--- a/addons/csi/azure-disk/Makefile
+++ b/addons/csi/azure-disk/Makefile
@@ -33,6 +33,7 @@ build:
 	kubectl kustomize . > $(OUTPUT_FILE).tmp
 	../../templatify.sh $(OUTPUT_FILE).tmp --dynamic "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:version"
 	cat _header.txt $(OUTPUT_FILE).tmp _footer.txt > $(OUTPUT_FILE)
+	git apply --no-unsafe-paths --no-recount customizations.patch
 	rm $(OUTPUT_FILE).tmp
 
 .PHONY: setup-helm

--- a/addons/csi/azure-disk/customizations.patch
+++ b/addons/csi/azure-disk/customizations.patch
@@ -1,0 +1,23 @@
+--- a/addons/csi/azure-disk/driver.yaml
++++ b/addons/csi/azure-disk/driver.yaml
+@@ -531,7 +532,9 @@ spec:
+             - --vmss-cache-ttl-seconds=-1
+             - --enable-traffic-manager=false
+             - --traffic-manager-port=7788
++            {{- if semverCompare .Cluster.Version ">= 1.29" }}
+             - --enable-otel-tracing=false
++            {{- end }}
+             - --check-disk-lun-collision=true
+           env:
+             - name: AZURE_CREDENTIAL_FILE
+@@ -774,8 +775,10 @@ spec:
+             - --allow-empty-cloud-config=true
+             - --support-zone=true
+             - --get-node-info-from-labels=false
++            {{- if semverCompare .Cluster.Version ">= 1.29" }}
+             - --get-nodeid-from-imds=false
+             - --enable-otel-tracing=false
++            {{- end }}
+           env:
+             - name: AZURE_CREDENTIAL_FILE
+               value: /etc/kubernetes/azure.json

--- a/addons/csi/azure-disk/customizations.patch
+++ b/addons/csi/azure-disk/customizations.patch
@@ -1,15 +1,18 @@
 --- a/addons/csi/azure-disk/driver.yaml
 +++ b/addons/csi/azure-disk/driver.yaml
-@@ -531,7 +532,9 @@ spec:
+@@ -531,8 +532,12 @@ spec:
              - --vmss-cache-ttl-seconds=-1
              - --enable-traffic-manager=false
              - --traffic-manager-port=7788
 +            {{- if semverCompare .Cluster.Version ">= 1.29" }}
              - --enable-otel-tracing=false
 +            {{- end }}
++            {{- if semverCompare .Cluster.Version ">= 1.30" }}
              - --check-disk-lun-collision=true
++            {{- end }}
            env:
              - name: AZURE_CREDENTIAL_FILE
+               value: /etc/kubernetes/azure.json
 @@ -774,8 +775,10 @@ spec:
              - --allow-empty-cloud-config=true
              - --support-zone=true

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -535,7 +535,9 @@ spec:
             {{- if semverCompare .Cluster.Version ">= 1.29" }}
             - --enable-otel-tracing=false
             {{- end }}
+            {{- if semverCompare .Cluster.Version ">= 1.30" }}
             - --check-disk-lun-collision=true
+            {{- end }}
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: /etc/kubernetes/azure.json

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -148,6 +148,7 @@ rules:
       - list
       - watch
       - create
+      - patch
       - delete
   - apiGroups:
       - ""
@@ -531,7 +532,9 @@ spec:
             - --vmss-cache-ttl-seconds=-1
             - --enable-traffic-manager=false
             - --traffic-manager-port=7788
+            {{- if semverCompare .Cluster.Version ">= 1.29" }}
             - --enable-otel-tracing=false
+            {{- end }}
             - --check-disk-lun-collision=true
           env:
             - name: AZURE_CREDENTIAL_FILE
@@ -774,8 +777,10 @@ spec:
             - --allow-empty-cloud-config=true
             - --support-zone=true
             - --get-node-info-from-labels=false
+            {{- if semverCompare .Cluster.Version ">= 1.29" }}
             - --get-nodeid-from-imds=false
             - --enable-otel-tracing=false
+            {{- end }}
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: /etc/kubernetes/azure.json

--- a/addons/csi/azure-file/Makefile
+++ b/addons/csi/azure-file/Makefile
@@ -33,6 +33,7 @@ build:
 	kubectl kustomize . > $(OUTPUT_FILE).tmp
 	../../templatify.sh $(OUTPUT_FILE).tmp --dynamic "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:version"
 	cat _header.txt $(OUTPUT_FILE).tmp _footer.txt > $(OUTPUT_FILE)
+	git apply --no-unsafe-paths --no-recount customizations.patch
 	rm $(OUTPUT_FILE).tmp
 
 .PHONY: setup-helm

--- a/addons/csi/azure-file/customizations.patch
+++ b/addons/csi/azure-file/customizations.patch
@@ -1,0 +1,12 @@
+--- a/addons/csi/azure-file/driver.yaml
++++ b/addons/csi/azure-file/driver.yaml
+@@ -802,7 +802,9 @@ spec:
+             - --custom-user-agent=
+             - --user-agent-suffix=OSS-helm
+             - --allow-empty-cloud-config=true
++            {{- if semverCompare .Cluster.Version ">= 1.28" }}
+             - --enable-volume-mount-group=true
++            {{- end }}
+             - --enable-get-volume-stats=true
+             - --mount-permissions=511
+             - --allow-inline-volume-key-access-with-identity=false

--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -802,7 +802,9 @@ spec:
             - --custom-user-agent=
             - --user-agent-suffix=OSS-helm
             - --allow-empty-cloud-config=true
+            {{- if semverCompare .Cluster.Version ">= 1.28" }}
             - --enable-volume-mount-group=true
+            {{- end }}
             - --enable-get-volume-stats=true
             - --mount-permissions=511
             - --allow-inline-volume-key-access-with-identity=false

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/Masterminds/semver/v3"
+	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/Masterminds/sprig/v3"
 
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -60,7 +60,7 @@ func addonFunctions(overwriteRegistry string) template.FuncMap {
 // will silently return false to aid in using it in Go templates.
 func semverCompare(version any, constraint any) bool {
 	if sver, ok := version.(string); ok {
-		parsed, err := semver.NewVersion(sver)
+		parsed, err := semverlib.NewVersion(sver)
 		if err != nil {
 			return false
 		}
@@ -69,7 +69,7 @@ func semverCompare(version any, constraint any) bool {
 	}
 
 	if scon, ok := constraint.(string); ok {
-		parsed, err := semver.NewConstraint(scon)
+		parsed, err := semverlib.NewConstraint(scon)
 		if err != nil {
 			return false
 		}
@@ -77,12 +77,12 @@ func semverCompare(version any, constraint any) bool {
 		return semverCompare(version, parsed)
 	}
 
-	ver, ok := version.(*semver.Version)
+	ver, ok := version.(*semverlib.Version)
 	if !ok {
 		return false
 	}
 
-	con, ok := constraint.(*semver.Constraints)
+	con, ok := constraint.(*semverlib.Constraints)
 	if !ok {
 		return false
 	}

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/Masterminds/sprig/v3"
 
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -48,7 +49,45 @@ func addonFunctions(overwriteRegistry string) template.FuncMap {
 	funcs["Registry"] = registry.GetOverwriteFunc(overwriteRegistry)
 	funcs["Image"] = registry.GetImageRewriterFunc(overwriteRegistry)
 	funcs["join"] = strings.Join
+	funcs["semverCompare"] = semverCompare
+
 	return funcs
+}
+
+// semverCompare checks if a given version matches the given constraint.
+// Both version and constraint can be either strings or already parsed semver
+// objects. If parsing fails or an incompatible type is given, the function
+// will silently return false to aid in using it in Go templates.
+func semverCompare(version any, constraint any) bool {
+	if sver, ok := version.(string); ok {
+		parsed, err := semver.NewVersion(sver)
+		if err != nil {
+			return false
+		}
+
+		return semverCompare(parsed, constraint)
+	}
+
+	if scon, ok := constraint.(string); ok {
+		parsed, err := semver.NewConstraint(scon)
+		if err != nil {
+			return false
+		}
+
+		return semverCompare(version, parsed)
+	}
+
+	ver, ok := version.(*semver.Version)
+	if !ok {
+		return false
+	}
+
+	con, ok := constraint.(*semver.Constraints)
+	if !ok {
+		return false
+	}
+
+	return con.Check(ver)
 }
 
 func listAddonFilesRecursively(root string) ([]string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In #13593 I noticed that I broke the Azure CSI addon in #13514, but in that PR I did not notice because we only had Prowjobs to Azure on Kube 1.30.

This PR adds one Azure test per Kube version (in the future we could, similar to KubeOne, generate them) and then adds the necessary changes to make the Azure CSI addon work again. Sadly the current Helm chart always outputs a flag that doesn't existing in pre-1.29 versions and the best way to make it go away is, like in #13599, to reach for a patch file and `git apply`. :-/

I also added a convenience function to make version constraints easier to write in the templates.

If you wonder why suddenly the `patch` permission was added: Upstream has _changed_ the 1.30.1 Helm chart in https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/2439.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
No release note because the broken Azure CSI addon was never released.
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
