### PR TITLE
use newer hetzner server types in e2e tests

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	hetznerServerType = "cx31"
+	hetznerServerType = "cx32"
 )
 
 type hetznerScenario struct {
@@ -38,7 +38,7 @@ type hetznerScenario struct {
 }
 
 func (s *hetznerScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](
+	return sets.New(
 		providerconfig.OperatingSystemCentOS,
 		providerconfig.OperatingSystemRockyLinux,
 		providerconfig.OperatingSystemUbuntu,

--- a/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller_test.go
@@ -106,7 +106,7 @@ func TestReconcile(t *testing.T) {
 
 	providerSpec, err := machine.NewBuilder().
 		WithOperatingSystemSpec(operatingsystem.NewUbuntuSpecBuilder(kubermaticv1.HetznerCloudProvider).Build()).
-		WithCloudProviderSpec(provider.NewHetznerConfig().WithServerType("cx21").Build()).
+		WithCloudProviderSpec(provider.NewHetznerConfig().WithServerType("cx22").Build()).
 		BuildProviderSpec()
 	if err != nil {
 		t.Fatalf("Failed to create provider spec: %v", err)

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -216,7 +216,7 @@ func NewHetznerCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, 
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
 		AddSSHPublicKey(SSHPublicKey()).
-		WithCloudProviderSpec(provider.NewHetznerConfig().WithServerType("cx21").Build())
+		WithCloudProviderSpec(provider.NewHetznerConfig().WithServerType("cx22").Build())
 
 	return &TestJig{
 		ProjectJig: projectJig,


### PR DESCRIPTION
**What this PR does / why we need it**:
The cx_1 types are deprecated (https://docs.hetzner.com/cloud/servers/deprecated-plans/), so I changed the server type to their logical equivalent (same vCPU/memory) as per https://docs.hetzner.com/cloud/servers/overview/.

The deprecated server types have very litte capacity and often take very long to boot up, making our tests fail.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
