### PR TITLE
use Ubuntu for Digitalocean e2e tests

### DIFF
--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -13,7 +13,139 @@
 # limitations under the License.
 
 presubmits:
-  - name: pre-kubermatic-e2e-do-centos-1.30
+  - name: pre-kubermatic-e2e-do-ubuntu-1.27
+    decorate: true
+    always_run: false
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.27"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
+  - name: pre-kubermatic-e2e-do-ubuntu-1.28
+    decorate: true
+    always_run: false
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.28"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
+  - name: pre-kubermatic-e2e-do-ubuntu-1.29
+    decorate: true
+    always_run: false
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-digitalocean: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.29"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: PROVIDER
+              value: "digitalocean"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
+  - name: pre-kubermatic-e2e-do-ubuntu-1.30
     decorate: true
     always_run: false
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -37,7 +169,7 @@ presubmits:
             - name: RELEASES_TO_TEST
               value: "1.30"
             - name: DISTRIBUTIONS
-              value: centos
+              value: ubuntu
             - name: PROVIDER
               value: "digitalocean"
             - name: SERVICE_ACCOUNT_KEY


### PR DESCRIPTION
**What this PR does / why we need it**:
CentOS is dead and not supported by Digitalocean anymore:

> {"level":"error","time":"2024-08-29T12:41:43.776Z","logger":"machine-controller","caller":"machine/controller.go:388","msg":"Reconciling failed","machine":"kube-system/e2e-pvzzv-559fc7777f-h9dgk","error":"failed to create machine at cloudprovider, due to POST https://api.digitalocean.com/v2/droplets: 422 (request \"2f9e692c-109e-49ef-b445-edc1255a0d06\") You specified an invalid image for Droplet creation."}

Like #13636, this PR also introduces tests for each supported Kube version, in anticipation that we'll soon do this for all cloud providers anyway.

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
