### PR TITLE
Refactor packngo User-Agent configuration

### DIFF
--- a/pkg/provider/cloud/packet/provider.go
+++ b/pkg/provider/cloud/packet/provider.go
@@ -119,10 +119,16 @@ func GetCredentialsForCluster(cloudSpec kubermaticv1.CloudSpec, secretKeySelecto
 }
 
 func ValidateCredentials(apiKey, projectID string) error {
-	client := packngo.NewClientWithAuth("kubermatic", apiKey, nil)
+	client := getClient(apiKey)
 	client.UserAgent = fmt.Sprintf("kubermatic %s", client.UserAgent)
 	_, _, err := client.Projects.Get(projectID, nil)
 	return err
+}
+
+func getClient(apiKey string) *packngo.Client {
+	client := packngo.NewClientWithAuth("kubermatic", apiKey, nil)
+	client.UserAgent = fmt.Sprintf("kubermatic %s", client.UserAgent)
+	return client
 }
 
 // Used to decode response object.
@@ -139,7 +145,7 @@ func DescribeSize(apiKey, projectID, instanceType string) (*provider.NodeCapacit
 		return nil, fmt.Errorf("missing required parameter: projectID")
 	}
 
-	packetclient := packngo.NewClientWithAuth("kubermatic", apiKey, nil)
+	packetclient := getClient(apiKey)
 	req, err := packetclient.NewRequest(http.MethodGet, "/projects/"+projectID+"/plans", nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubermatic/kubermatic/pull/13629 adds the UserAgent configuration in the client used in `ValidateCredentials` function. However, that function is not used anywhere so it's no-op. This PR adds a dedicated `getClient` function so that we can initialize the client from a single point.

We also wanted to add KKP versions to the Agent. Although in my opinion it wouldn't really help much or add any value. We only use the `packngo` client for a single feature/API call that is to list the sizes for quota calculations.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
