### PR TITLE
Avoid Changing User Cluster External IP  

### DIFF
--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -323,5 +323,13 @@ func (m *ModifiersBuilder) getExternalIP(hostname string) (string, error) {
 	if len(ips) > 1 {
 		m.log.Debugw("Lookup returned multiple IP addresses. Picking the first one after sorting", "hostname", hostname, "foundAddresses", ips, "pickedAddress", ips[0])
 	}
+
+	// If the current cluster external address is found among the resolved IPs, the same IP will be returned, as there's no
+	// need to change the user cluster external endpoint. Otherwise, the cluster control plane components may enter an
+	// infinite reconciliation loop
+	if ipList.Has(m.cluster.Status.Address.IP) {
+		return m.cluster.Status.Address.IP, nil
+	}
+
 	return ips[0], nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases, the cluster external DNS would resolved to multiple IPs where those IPs are returned based on a round-robin approach other than health checks(e.g: with each dns resolve request a new IP will be returned). This would lead to the cluster control plane components entering to an infinite reconciliation loop due to getting different IP with each dns resolve. This PR makes sure that, if the current ip address that's being assigned to the cluster is returned among the resolved ips, we simply avoid changing that IP.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
