### PR TITLE
Migration from machine-controller userdata to OSM

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -45,6 +45,7 @@ import (
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
+	operatingsystemmanagermigrator "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/operating-system-manager-migrator"
 	operatingsystemprofilesynchronizer "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer"
 	presetcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/preset-controller"
 	projectcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/project"
@@ -83,6 +84,7 @@ var AllControllers = map[string]controllerCreator{
 	ipam.ControllerName:                                     createIPAMController,
 	clusterstuckcontroller.ControllerName:                   createClusterStuckController,
 	operatingsystemprofilesynchronizer.ControllerName:       createOperatingSystemProfileController,
+	operatingsystemmanagermigrator.ControllerName:           createOperatingSystemManagerMigratorController,
 	defaultapplicationcontroller.ControllerName:             createDefaultApplicationController,
 	clustercredentialscontroller.ControllerName:             createClusterCredentialsController,
 	applicationsecretclustercontroller.ControllerName:       createApplicationSecretClusterController,
@@ -458,6 +460,17 @@ func createOperatingSystemProfileController(ctrlCtx *controllerContext) error {
 	)
 }
 
+func createOperatingSystemManagerMigratorController(ctrlCtx *controllerContext) error {
+	return operatingsystemmanagermigrator.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.clientProvider,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.workerCount,
+		ctrlCtx.versions,
+	)
+}
+
 func createDefaultApplicationController(ctrlCtx *controllerContext) error {
 	return defaultapplicationcontroller.Add(
 		ctrlCtx.ctx,
@@ -470,6 +483,7 @@ func createDefaultApplicationController(ctrlCtx *controllerContext) error {
 		ctrlCtx.versions,
 	)
 }
+
 func createClusterCredentialsController(ctrlCtx *controllerContext) error {
 	return clustercredentialscontroller.Add(
 		ctrlCtx.mgr,

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -439,6 +439,7 @@ const (
 	ClusterConditionApplicationInstallationControllerReconcilingSuccess          ClusterConditionType = "ApplicationInstallationControllerReconciledSuccessfully"
 	ClusterConditionDefaultApplicationInstallationControllerReconcilingSuccess   ClusterConditionType = "DefaultApplicationInstallationControllerReconciledSuccessfully"
 	ClusterConditionDefaultApplicationInstallationsControllerCreatedSuccessfully ClusterConditionType = "DefaultApplicationsCreatedSuccessfully"
+	ClusterConditionOperatingSystemManagerMigratorControllerReconcilingSuccess   ClusterConditionType = "OperatingSystemManagerMigratorControllerReconciledSuccessfully"
 	ClusterConditionKubeLBControllerReconcilingSuccess                           ClusterConditionType = "KubeLBControllerReconciledSuccessfully"
 	ClusterConditionCNIControllerReconcilingSuccess                              ClusterConditionType = "CNIControllerReconciledSuccessfully"
 	ClusterConditionMLAControllerReconcilingSuccess                              ClusterConditionType = "MLAControllerReconciledSuccessfully"

--- a/pkg/controller/seed-controller-manager/operating-system-manager-migrator/controller.go
+++ b/pkg/controller/seed-controller-manager/operating-system-manager-migrator/controller.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemmanagermigrator
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
+	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+	osmresources "k8c.io/operating-system-manager/pkg/controllers/osc/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	ControllerName = "kkp-operating-system-manager-migrator"
+)
+
+// UserClusterClientProvider provides functionality to get a user cluster client.
+type UserClusterClientProvider interface {
+	GetClient(ctx context.Context, c *kubermaticv1.Cluster, options ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error)
+}
+
+type Reconciler struct {
+	ctrlruntimeclient.Client
+	log *zap.SugaredLogger
+
+	workerNameLabelSelector       labels.Selector
+	workerName                    string
+	recorder                      record.EventRecorder
+	userClusterConnectionProvider UserClusterClientProvider
+	versions                      kubermatic.Versions
+}
+
+func Add(
+	mgr manager.Manager,
+	userClusterConnectionProvider UserClusterClientProvider,
+	log *zap.SugaredLogger,
+	workerName string,
+	numWorkers int,
+	versions kubermatic.Versions,
+) error {
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &Reconciler{
+		log:                           log.Named(ControllerName),
+		workerNameLabelSelector:       workerSelector,
+		workerName:                    workerName,
+		recorder:                      mgr.GetEventRecorderFor(ControllerName),
+		userClusterConnectionProvider: userClusterConnectionProvider,
+		Client:                        mgr.GetClient(),
+		versions:                      versions,
+	}
+
+	_, err = builder.ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(&kubermaticv1.Cluster{}, builder.WithPredicates(workerlabel.Predicate(workerName), withEventFilter())).
+		Build(reconciler)
+
+	return err
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	if cluster.DeletionTimestamp != nil {
+		// Cluster is queued for deletion; no action required
+		r.log.Debugw("Cluster is queued for deletion; no action required", "cluster", cluster.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// Add a wrapping here so we can emit an event on error
+	result, err := kubermaticv1helper.ClusterReconcileWrapper(
+		ctx,
+		r.Client,
+		r.workerName,
+		cluster,
+		r.versions,
+		kubermaticv1.ClusterConditionOperatingSystemManagerMigratorControllerReconcilingSuccess,
+		func() (*reconcile.Result, error) {
+			return r.reconcile(ctx, cluster)
+		},
+	)
+
+	if result == nil || err != nil {
+		result = &reconcile.Result{}
+	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return *result, err
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
+	// To migrate the cluster, we simply have to iterate through all the machine deployments and set the annotation `k8c.io/operating-system-profile`
+	// to the name of the operating system profile.
+	userClusterClient, err := r.userClusterConnectionProvider.GetClient(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get usercluster client: %w", err)
+	}
+
+	mdList := &clusterv1alpha1.MachineDeploymentList{}
+	if err := userClusterClient.List(ctx, mdList); err != nil {
+		return nil, fmt.Errorf("failed to list existing MachineDeployments: %w", err)
+	}
+
+	for _, md := range mdList.Items {
+		if md.DeletionTimestamp != nil {
+			// MachineDeployment is queued for deletion; no action required
+			r.log.Debugw("MachineDeployment is queued for deletion; no action required", "machineDeployment", md.Name)
+			continue
+		}
+
+		if md.Annotations == nil {
+			md.Annotations = make(map[string]string)
+		}
+
+		if _, ok := md.Annotations[osmresources.MachineDeploymentOSPAnnotation]; !ok {
+			config, err := providerconfig.GetConfig(md.Spec.Template.Spec.ProviderSpec)
+			if err != nil {
+				return nil, err
+			}
+			md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = fmt.Sprintf("osp-%s", config.OperatingSystem)
+		}
+
+		if err := userClusterClient.Update(ctx, &md); err != nil {
+			return nil, fmt.Errorf("failed to update MachineDeployment: %w", err)
+		}
+	}
+
+	// If we have reached this point, we have successfully migrated the cluster. Update the cluster and set EnableOperatingSystemManager to nil.
+	//nolint:staticcheck
+	cluster.Spec.EnableOperatingSystemManager = nil
+	if err := r.Update(ctx, cluster); err != nil {
+		return nil, fmt.Errorf("failed to update cluster: %w", err)
+	}
+
+	// The predicate will prevent us from reconciling this cluster again.
+	r.recorder.Event(cluster, corev1.EventTypeNormal, "ClusterMigrated", "Cluster has been migrated from the legacy machine-controller userdata to operating-system-manager")
+	return nil, nil
+}
+
+func withEventFilter() predicate.Funcs {
+	return kubermaticpred.Factory(func(o ctrlruntimeclient.Object) bool {
+		cluster, ok := o.(*kubermaticv1.Cluster)
+		if !ok {
+			return false
+		}
+		// Only reconcile clusters that have OSM explicitly set to false.
+		//nolint:staticcheck
+		return cluster.Spec.EnableOperatingSystemManager != nil && !*cluster.Spec.EnableOperatingSystemManager
+	})
+}

--- a/pkg/controller/seed-controller-manager/operating-system-manager-migrator/doc.go
+++ b/pkg/controller/seed-controller-manager/operating-system-manager-migrator/doc.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package operatingsystemmanagermigrator contains the operating-system-manager-migrator controller.
+
+The operating-system-manager-migrator controller is responsible for migrating user clusters that are using the legacy machine-controller
+user-data to to operating-system-manager.
+
+TODO: This package is being introduced in KKP 2.26 and should be removed in KKP 2.27.
+*/
+
+package operatingsystemmanagermigrator


### PR DESCRIPTION
**What this PR does / why we need it**:
For migration, all we need is the following:
1. For all clusters that have OSM **explicitly** disabled.
2. Iterate through all the machine deployments and set `k8c.io/operating-system-profile` annotation

![Screenshot 2024-09-03 at 12 04 00](https://github.com/user-attachments/assets/8f9efaad-9e88-4627-a5f1-863cf08c72de)

As per requirements, we wanted to place this migration logic outside of the kubermatic-installer since not all of our customers use the installer. Hence, I resorted to a minimal controller that can perform this migration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13402

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
I've mentioned in the release notes regarding the drift between machines that existed pre-migration and the ones created after the migration. It will only be a "recommendation" to the users that they should rotate the old machines. We don't want to push/force them to do that since those are working nodes and no functionality should be broken due to this migration. After migration, whenever a new machine is created, it will use OSM.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* KKP will perform automated migrations for clusters that are using machine-controller user data to OSM
* [ACTION REQUIRED] Migration from machine-controller user data to OSM is automated. Users can scale up/down their machines, and there won't be any hindrance. However, existing machines/nodes using MC user data will not be rotated. This is by design to avoid unnecessary node rotations, but this can also lead to a drift between the cloud-config for new and old machines. It is recommended, not mandatory, to either rotate the machines one by one or rotate the machine deployment as a whole following https://docs.kubermatic.com/kubermatic/v2.26/cheat-sheets/rollout-machinedeployment/
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
