### PR TITLE
Update flatcar update operator

### DIFF
--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -310,7 +310,7 @@ products:
       - helmChart: { directory: charts/oauth }
 
   - name: Flatcar Linux Update Operator
-    source: https://github.com/kinvolk/flatcar-linux-update-operator
+    source: https://github.com/flatcar/flatcar-linux-update-operator
     occurrences:
       - goConstant:
           package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar/resources

--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -308,3 +308,10 @@ products:
     source: https://github.com/dexidp/dex
     occurrences:
       - helmChart: { directory: charts/oauth }
+
+  - name: Flatcar Linux Update Operator
+    source: https://github.com/kinvolk/flatcar-linux-update-operator
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar/resources
+          constant: operatorVersion

--- a/pkg/controller/user-cluster-controller-manager/flatcar/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/controller.go
@@ -108,7 +108,7 @@ func (r *Reconciler) cleanupUpdateOperatorResources(ctx context.Context) error {
 }
 
 // reconcileUpdateOperatorResources deploys the FlatcarUpdateOperator
-// https://github.com/kinvolk/flatcar-linux-update-operator
+// https://github.com/flatcar/flatcar-linux-update-operator
 func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error {
 	saReconcilers := []reconciling.NamedServiceAccountReconcilerFactory{
 		resources.OperatorServiceAccountReconciler(),

--- a/pkg/controller/user-cluster-controller-manager/flatcar/doc.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/doc.go
@@ -16,6 +16,6 @@ limitations under the License.
 
 /*
 Package flatcar linux contains the flatcar linux controller that is responsible for deploying the
-[Flatcar Linux Update Operator](https://github.com/kinvolk/flatcar-linux-update-operator) operator and DaemonSet
+[Flatcar Linux Update Operator](https://github.com/flatcar/flatcar-linux-update-operator) operator and DaemonSet
 */
 package flatcar

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/clusterrole.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/clusterrole.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	OperatorClusterRoleName = "flatcar-linux-update-operator"
-	AgentClusterRoleName    = "flatcar-linux-update-agent"
+	operatorClusterRoleName = "flatcar-linux-update-operator"
+	agentClusterRoleName    = "flatcar-linux-update-agent"
 )
 
 func OperatorClusterRoleReconciler() reconciling.NamedClusterRoleReconcilerFactory {
 	return func() (string, reconciling.ClusterRoleReconciler) {
-		return OperatorClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+		return operatorClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
@@ -39,49 +39,6 @@ func OperatorClusterRoleReconciler() reconciling.NamedClusterRoleReconcilerFacto
 						"list",
 						"watch",
 						"update",
-					},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"configmaps"},
-					Verbs: []string{
-						"create",
-						"get",
-						"update",
-						"list",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"events"},
-					Verbs: []string{
-						"create",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs: []string{
-						"get",
-						"list",
-						"delete",
-					},
-				},
-				{
-					APIGroups: []string{"apps"},
-					Resources: []string{"daemonsets"},
-					Verbs: []string{
-						"get",
-					},
-				},
-				{
-					APIGroups:     []string{"policy"},
-					ResourceNames: []string{"flatcar-linux-update-operator"},
-					Resources:     []string{"podsecuritypolicies"},
-					Verbs: []string{
-						"use",
 					},
 				},
 			}
@@ -92,7 +49,7 @@ func OperatorClusterRoleReconciler() reconciling.NamedClusterRoleReconcilerFacto
 
 func AgentClusterRoleReconciler() reconciling.NamedClusterRoleReconcilerFactory {
 	return func() (string, reconciling.ClusterRoleReconciler) {
-		return AgentClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+		return agentClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
@@ -106,25 +63,6 @@ func AgentClusterRoleReconciler() reconciling.NamedClusterRoleReconcilerFactory 
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"configmaps"},
-					Verbs: []string{
-						"create",
-						"get",
-						"update",
-						"list",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"events"},
-					Verbs: []string{
-						"create",
-						"watch",
-					},
-				},
-				{
-					APIGroups: []string{""},
 					Resources: []string{"pods"},
 					Verbs: []string{
 						"get",
@@ -133,18 +71,17 @@ func AgentClusterRoleReconciler() reconciling.NamedClusterRoleReconcilerFactory 
 					},
 				},
 				{
+					APIGroups: []string{""},
+					Resources: []string{"pods/eviction"},
+					Verbs: []string{
+						"create",
+					},
+				},
+				{
 					APIGroups: []string{"apps"},
 					Resources: []string{"daemonsets"},
 					Verbs: []string{
 						"get",
-					},
-				},
-				{
-					APIGroups:     []string{"policy"},
-					ResourceNames: []string{"flatcar-linux-update-agentß"},
-					Resources:     []string{"podsecuritypolicies"},
-					Verbs: []string{
-						"use",
 					},
 				},
 			}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/delete.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/delete.go
@@ -28,50 +28,65 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func EnsureAllDeleted(ctx context.Context, client ctrlruntimeclient.Client) error {
+func EnsureAllDeleted(ctx context.Context, client ctrlruntimeclient.Client, operatorNamespace string) error {
 	objects := []ctrlruntimeclient.Object{
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      AgentDaemonSetName,
-				Namespace: metav1.NamespaceSystem,
+				Namespace: operatorNamespace,
 			},
 		},
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      OperatorDeploymentName,
-				Namespace: metav1.NamespaceSystem,
+				Namespace: operatorNamespace,
 			},
 		},
-		&rbacv1.ClusterRoleBinding{
+		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: OperatorClusterRoleBindingName,
+				Name: operatorRoleName,
 			},
 		},
-		&rbacv1.ClusterRoleBinding{
+		&rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: AgentClusterRoleBindingName,
+				Name: operatorRoleBindingName,
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: agentRoleBindingName,
 			},
 		},
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: OperatorClusterRoleName,
+				Name: operatorClusterRoleName,
 			},
 		},
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: AgentClusterRoleName,
+				Name: agentClusterRoleName,
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: operatorClusterRoleBindingName,
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: agentClusterRoleBindingName,
 			},
 		},
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      OperatorServiceAccountName,
-				Namespace: metav1.NamespaceSystem,
+				Name:      operatorServiceAccountName,
+				Namespace: operatorNamespace,
 			},
 		},
 		&corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      AgentServiceAccountName,
-				Namespace: metav1.NamespaceSystem,
+				Name:      agentServiceAccountName,
+				Namespace: operatorNamespace,
 			},
 		},
 	}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/role.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/role.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"k8c.io/reconciler/pkg/reconciling"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+const (
+	operatorRoleName = "flatcar-linux-update-operator"
+)
+
+func OperatorRoleReconciler() reconciling.NamedRoleReconcilerFactory {
+	return func() (string, reconciling.RoleReconciler) {
+		return operatorRoleName, func(cr *rbacv1.Role) (*rbacv1.Role, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs: []string{
+						"create",
+					},
+				},
+				{
+					APIGroups:     []string{""},
+					Resources:     []string{"configmaps"},
+					ResourceNames: []string{"flatcar-linux-update-operator-lock"},
+					Verbs: []string{
+						"get",
+						"update",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs: []string{
+						"create",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs: []string{
+						"create",
+					},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					ResourceNames: []string{"flatcar-linux-update-operator-lock"},
+					Verbs: []string{
+						"get",
+						"update",
+					},
+				},
+			}
+			return cr, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/rolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/rolebinding.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,17 +23,17 @@ import (
 )
 
 const (
-	operatorClusterRoleBindingName = "flatcar-linux-update-operator"
-	agentClusterRoleBindingName    = "flatcar-linux-update-agent"
+	operatorRoleBindingName = "flatcar-linux-update-operator"
+	agentRoleBindingName    = "flatcar-linux-update-agent"
 )
 
-func OperatorClusterRoleBindingReconciler(operatorNamespace string) reconciling.NamedClusterRoleBindingReconcilerFactory {
-	return func() (string, reconciling.ClusterRoleBindingReconciler) {
-		return operatorClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+func OperatorRoleBindingReconciler(operatorNamespace string) reconciling.NamedRoleBindingReconcilerFactory {
+	return func() (string, reconciling.RoleBindingReconciler) {
+		return operatorRoleBindingName, func(crb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			crb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     operatorClusterRoleName,
+				Kind:     "Role",
+				Name:     operatorRoleName,
 			}
 			crb.Subjects = []rbacv1.Subject{
 				{
@@ -47,13 +47,18 @@ func OperatorClusterRoleBindingReconciler(operatorNamespace string) reconciling.
 	}
 }
 
-func AgentClusterRoleBindingReconciler(operatorNamespace string) reconciling.NamedClusterRoleBindingReconcilerFactory {
-	return func() (string, reconciling.ClusterRoleBindingReconciler) {
-		return agentClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+// This RoleBinding is defined upstream, but points to a non-existing Role.
+// cf. https://github.com/flatcar/flatcar-linux-update-operator/pull/163
+// It seems harmless so we stay in-sync with upstream rather than deciding
+// ourselves that the RoleBinding is unnecessary.
+
+func AgentRoleBindingReconciler(operatorNamespace string) reconciling.NamedRoleBindingReconcilerFactory {
+	return func() (string, reconciling.RoleBindingReconciler) {
+		return agentRoleBindingName, func(crb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			crb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     agentClusterRoleName,
+				Kind:     "Role",
+				Name:     "flatcar-linux-update-agent",
 			}
 			crb.Subjects = []rbacv1.Subject{
 				{

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/serviceaccount.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/serviceaccount.go
@@ -23,13 +23,13 @@ import (
 )
 
 const (
-	OperatorServiceAccountName = "flatcar-linux-update-operator-sa"
-	AgentServiceAccountName    = "flatcar-linux-update-agent"
+	operatorServiceAccountName = "flatcar-linux-update-operator-sa"
+	agentServiceAccountName    = "flatcar-linux-update-agent"
 )
 
 func OperatorServiceAccountReconciler() reconciling.NamedServiceAccountReconcilerFactory {
 	return func() (string, reconciling.ServiceAccountReconciler) {
-		return OperatorServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+		return operatorServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 			return sa, nil
 		}
 	}
@@ -37,7 +37,7 @@ func OperatorServiceAccountReconciler() reconciling.NamedServiceAccountReconcile
 
 func AgentServiceAccountReconciler() reconciling.NamedServiceAccountReconcilerFactory {
 	return func() (string, reconciling.ServiceAccountReconciler) {
-		return AgentServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+		return agentServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 			return sa, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	nodelabelerapi "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
-	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -30,6 +29,7 @@ import (
 
 const (
 	AgentDaemonSetName = "flatcar-linux-update-agent"
+	operatorVersion    = "v0.7.3"
 )
 
 var (
@@ -64,7 +64,7 @@ func AgentDaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "update-agent",
-					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kinvolk/flatcar-linux-update-operator:v0.7.3")),
+					Image:   operatorImage(imageRewriter),
 					Command: []string{"/bin/update-agent"},
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: &userCore,

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -29,7 +29,6 @@ import (
 
 const (
 	AgentDaemonSetName = "flatcar-linux-update-agent"
-	operatorVersion    = "v0.7.3"
 )
 
 var (

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -30,6 +29,7 @@ import (
 
 const (
 	OperatorDeploymentName = "flatcar-linux-update-operator"
+	operatorVersion        = "v0.9.0"
 )
 
 var (
@@ -98,5 +98,5 @@ func OperatorDeploymentReconciler(imageRewriter registry.ImageRewriter, updateWi
 }
 
 func operatorImage(imageRewriter registry.ImageRewriter) string {
-	return registry.Must(imageRewriter(resources.RegistryQuay + "/kinvolk/flatcar-linux-update-operator:" + operatorVersion))
+	return registry.Must(imageRewriter("ghcr.io/flatcar/flatcar-linux-update-operator:" + operatorVersion))
 }

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -51,11 +51,13 @@ func OperatorDeploymentReconciler(imageRewriter registry.ImageRewriter, updateWi
 				},
 			}
 
+			// We broke compatibility with upstream in #5875 and instead of performing a migration,
+			// we simply keep the changed labels.
 			labels := map[string]string{"app.kubernetes.io/name": OperatorDeploymentName}
 
 			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			dep.Spec.Template.ObjectMeta.Labels = labels
-			dep.Spec.Template.Spec.ServiceAccountName = OperatorServiceAccountName
+			dep.Spec.Template.Spec.ServiceAccountName = operatorServiceAccountName
 
 			env := []corev1.EnvVar{
 				{

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -86,7 +86,7 @@ func OperatorDeploymentReconciler(imageRewriter registry.ImageRewriter, updateWi
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "update-operator",
-					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kinvolk/flatcar-linux-update-operator:v0.7.3")),
+					Image:   operatorImage(imageRewriter),
 					Command: []string{"/bin/update-operator"},
 					Env:     env,
 				},
@@ -95,4 +95,8 @@ func OperatorDeploymentReconciler(imageRewriter registry.ImageRewriter, updateWi
 			return dep, nil
 		}
 	}
+}
+
+func operatorImage(imageRewriter registry.ImageRewriter) string {
+	return registry.Must(imageRewriter(resources.RegistryQuay + "/kinvolk/flatcar-linux-update-operator:" + operatorVersion))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Last time we updated the operator we were still in lockdown... So I updated it now and brought it back in-sync with the upstream manifests. However there are a few things of note:

* the controller now sets the namespace of everything, i.e. fewer `metav1.NamespaceSystem` are sprinkled throughout the package
* RBAC has upstream been split into ClusterRoles and Roles, however there is no Role for the Agent. I didn't just accidentally forget it :grin: However I chose to keep the RoleBinding intact, even though it's meaningless. Just so we stay as close to upstream as possible.
* I changed the effective UID for the Agent from 500 (supposedly Flatcar's admin user) to root (0), because upstream also uses root and our original PR did not document why we deviated from that. If someone knows and is sure that 500 is better, please improve upstream :)
* The upstream manifests contain tolerations for the master/control-plane nodes, which are not relevant in a KKP usercluster and so have been condensed down.

I checked the logs of the 0.9.0 version in a GCP cluster and the operator and agent were running quite happily.

**Which issue(s) this PR fixes**:
Fixes #13662

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update flatcar-linux-update-operator to 0.9.0
```

**Documentation**:
```documentation
NONE
```
