### PR TITLE
[release/v2.25] skip DNS check in the KKP installer when using the local command (#13620)

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -198,7 +198,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 		case "kubermatic-seed":
 			kubermaticStack = kubermaticseed.NewStack()
 		case "kubermatic-master", "":
-			kubermaticStack = kubermaticmaster.NewStack()
+			kubermaticStack = kubermaticmaster.NewStack(true)
 		default:
 			return fmt.Errorf("unknown stack %q specified", stackName)
 		}

--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -324,7 +324,7 @@ func installKubermatic(logger *logrus.Logger, dir string, kubeClient ctrlruntime
 	ensureResource(kubeClient, logger, &kindIngressControllerService)
 	ensureResource(kubeClient, logger, &kindNodeportProxyService)
 
-	ms := kubermaticmaster.MasterStack{}
+	ms := kubermaticmaster.NewStack(false)
 	k, uk, err := loadKubermaticConfiguration(kubermaticPath)
 	if err != nil {
 		logger.Panicf("Failed to load %v after autoconfiguration: %v", kubermaticPath, err)

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -69,10 +69,15 @@ const (
 	NodePortProxyService = "nodeport-proxy"
 )
 
-type MasterStack struct{}
+type MasterStack struct {
+	// showDNSHelp is used by the local command to skip a useless DNS probe.
+	showDNSHelp bool
+}
 
-func NewStack() stack.Stack {
-	return &MasterStack{}
+func NewStack(enableDNSCheck bool) stack.Stack {
+	return &MasterStack{
+		showDNSHelp: enableDNSCheck,
+	}
 }
 
 var _ stack.Stack = &MasterStack{}
@@ -114,7 +119,9 @@ func (s *MasterStack) Deploy(ctx context.Context, opt stack.DeployOptions) error
 		return fmt.Errorf("failed to deploy default Application catalog: %w", err)
 	}
 
-	showDNSSettings(ctx, opt.Logger, opt.KubeClient, opt)
+	if s.showDNSHelp {
+		showDNSSettings(ctx, opt.Logger, opt.KubeClient, opt)
+	}
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is manual backport of #13620

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
`local` command in KKP installer does not check / wait for DNS anymore.
```

**Documentation**:
```documentation
NONE
```
