### PR TITLE
[release/v2.24] Fix missing image rewrites (#13435)

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -122,7 +122,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
 		return fmt.Errorf("failed to create external cluster controller: %w", err)
 	}
-	if err := kubeone.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
+	if err := kubeone.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, ctrlCtx.overwriteRegistry); err != nil {
 		return fmt.Errorf("failed to create kubeone controller: %w", err)
 	}
 	if err := kcstatuscontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.versions); err != nil {

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -81,6 +81,7 @@ type controllerContext struct {
 	labelSelectorFunc       func(*metav1.ListOptions)
 	namespace               string
 	versions                kubermatic.Versions
+	overwriteRegistry       string
 
 	configGetter provider.KubermaticConfigurationGetter
 }
@@ -101,6 +102,7 @@ func main() {
 	flag.StringVar(&runOpts.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources.")
 	flag.BoolVar(&runOpts.enableLeaderElection, "enable-leader-election", true, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&ctrlCtx.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.StringVar(&runOpts.leaderElectionNamespace, "leader-election-namespace", "", "Leader election namespace. In-cluster discovery will be attempted in such case.")
 	flag.Var(&runOpts.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&runOpts.configFile, "kubermatic-configuration-file", "", "(for development only) path to a KubermaticConfiguration YAML file")

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	reconcilerlog "k8c.io/reconciler/pkg/log"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -102,20 +103,27 @@ const (
 	KubeOneMigrateConfigMap = "kubeone-migrate"
 )
 
+type templateData interface {
+	RewriteImage(image string) (string, error)
+}
+
 type reconciler struct {
 	ctrlruntimeclient.Client
 	log               *zap.SugaredLogger
 	secretKeySelector provider.SecretKeySelectorValueFunc
+	overwriteRegistry string
 }
 
 func Add(
 	ctx context.Context,
 	mgr manager.Manager,
-	log *zap.SugaredLogger) error {
+	log *zap.SugaredLogger,
+	overwriteRegistry string) error {
 	reconciler := &reconciler{
 		Client:            mgr.GetClient(),
 		log:               log.Named(ControllerName),
 		secretKeySelector: provider.SecretKeySelectorValueFuncFactory(ctx, mgr.GetClient()),
+		overwriteRegistry: overwriteRegistry,
 	}
 	c, err := controller.New(ControllerName, mgr, controller.Options{Reconciler: reconciler})
 	if err != nil {
@@ -234,7 +242,11 @@ func (r *reconciler) reconcile(ctx context.Context, externalClusterName string, 
 		return nil
 	}
 
-	kubeOneSecrests, err := r.ensureKubeOneSecrets(ctx, log, externalCluster)
+	data := resources.NewTemplateDataBuilder().
+		WithOverwriteRegistry(r.overwriteRegistry).
+		Build()
+
+	kubeOneSecrests, err := r.ensureKubeOneSecrets(ctx, log, data, externalCluster)
 	if err != nil {
 		return err
 	}
@@ -255,15 +267,15 @@ func (r *reconciler) reconcile(ctx context.Context, externalClusterName string, 
 		}
 	}
 
-	if err := r.importAction(ctx, log, externalCluster); err != nil {
+	if err := r.importAction(ctx, log, data, externalCluster); err != nil {
 		return err
 	}
 
-	if err = r.upgradeAction(ctx, log, externalCluster); err != nil {
+	if err = r.upgradeAction(ctx, log, data, externalCluster); err != nil {
 		return err
 	}
 
-	if err = r.migrateAction(ctx, log, externalCluster); err != nil {
+	if err = r.migrateAction(ctx, log, data, externalCluster); err != nil {
 		return err
 	}
 
@@ -280,7 +292,12 @@ func (r *reconciler) syncSecrets(ctx context.Context, externalCluster *kubermati
 	return nil
 }
 
-func (r *reconciler) ensureKubeOneSecrets(ctx context.Context, log *zap.SugaredLogger, externalCluster *kubermaticv1.ExternalCluster) ([]corev1.Secret, error) {
+func (r *reconciler) ensureKubeOneSecrets(
+	ctx context.Context,
+	log *zap.SugaredLogger,
+	data templateData,
+	externalCluster *kubermaticv1.ExternalCluster,
+) ([]corev1.Secret, error) {
 	kubeOneSecrets := []corev1.Secret{}
 
 	credRef := externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference
@@ -367,7 +384,7 @@ func (r *reconciler) ensureKubeOneSecrets(ctx context.Context, log *zap.SugaredL
 			if apierrors.IsNotFound(err) {
 				// trying to refetch cluster kubeconfig to recreate kubeconfig secret in case kubeconfig secret was deleted for some reason.
 				log.Info("trying to refetch cluster kubeconfig to recreate kubeconfig secret in case kubeconfig secret was deleted for some reason.")
-				err := r.initiateImportCluster(ctx, log, externalCluster)
+				err := r.initiateImportCluster(ctx, log, data, externalCluster)
 				if err != nil {
 					log.Errorw("failed to import kubeone cluster", zap.Error(err))
 					return nil, err
@@ -437,9 +454,11 @@ func (r *reconciler) deleteSecrets(ctx context.Context, secrets []corev1.Secret)
 func (r *reconciler) importAction(
 	ctx context.Context,
 	log *zap.SugaredLogger,
-	externalCluster *kubermaticv1.ExternalCluster) error {
+	data templateData,
+	externalCluster *kubermaticv1.ExternalCluster,
+) error {
 	if externalCluster.Spec.KubeconfigReference == nil {
-		err := r.initiateImportCluster(ctx, log, externalCluster)
+		err := r.initiateImportCluster(ctx, log, data, externalCluster)
 		if err != nil {
 			log.Errorw("failed to import kubeone cluster", zap.Error(err))
 			return err
@@ -465,9 +484,12 @@ func (r *reconciler) importAction(
 	return nil
 }
 
-func (r *reconciler) initiateImportCluster(ctx context.Context,
+func (r *reconciler) initiateImportCluster(
+	ctx context.Context,
 	log *zap.SugaredLogger,
-	externalCluster *kubermaticv1.ExternalCluster) error {
+	data templateData,
+	externalCluster *kubermaticv1.ExternalCluster,
+) error {
 	log.Info("Importing kubeone cluster...")
 
 	kubeoneNamespace := externalCluster.GetKubeOneNamespaceName()
@@ -480,7 +502,7 @@ func (r *reconciler) initiateImportCluster(ctx context.Context,
 	}
 
 	log.Info("Generating kubeone job to fetch kubeconfig...")
-	job, err := r.generateKubeOneActionJob(ctx, log, externalCluster, ImportAction)
+	job, err := r.generateKubeOneActionJob(ctx, log, data, externalCluster, ImportAction)
 	if err != nil {
 		return fmt.Errorf("could not generate kubeone job: %w", err)
 	}
@@ -592,9 +614,12 @@ func (r *reconciler) initiateImportCluster(ctx context.Context,
 	return ctrlruntimeclient.IgnoreNotFound(err)
 }
 
-func (r *reconciler) upgradeAction(ctx context.Context,
+func (r *reconciler) upgradeAction(
+	ctx context.Context,
 	log *zap.SugaredLogger,
-	externalCluster *kubermaticv1.ExternalCluster) error {
+	data templateData,
+	externalCluster *kubermaticv1.ExternalCluster,
+) error {
 	manifestRef := externalCluster.Spec.CloudSpec.KubeOne.ManifestReference
 	kubeOneNamespaceName := externalCluster.GetKubeOneNamespaceName()
 
@@ -695,7 +720,7 @@ func (r *reconciler) upgradeAction(ctx context.Context,
 		return err
 	}
 
-	err = r.initiateClusterUpgrade(ctx, log, *currentVersion, desiredVersion, externalCluster)
+	err = r.initiateClusterUpgrade(ctx, log, data, *currentVersion, desiredVersion, externalCluster)
 	if err != nil {
 		log.Errorw("failed to upgrade kubeone cluster", zap.Error(err))
 		return err
@@ -704,13 +729,17 @@ func (r *reconciler) upgradeAction(ctx context.Context,
 	return nil
 }
 
-func (r *reconciler) initiateClusterUpgrade(ctx context.Context,
+func (r *reconciler) initiateClusterUpgrade(
+	ctx context.Context,
 	log *zap.SugaredLogger,
-	currentVersion, desiredVersion semver.Semver,
-	cluster *kubermaticv1.ExternalCluster) error {
+	data templateData,
+	currentVersion semver.Semver,
+	desiredVersion semver.Semver,
+	cluster *kubermaticv1.ExternalCluster,
+) error {
 	log.Info("Upgrading kubeone cluster...")
 
-	job, err := r.generateKubeOneActionJob(ctx, log, cluster, UpgradeControlPlaneAction)
+	job, err := r.generateKubeOneActionJob(ctx, log, data, cluster, UpgradeControlPlaneAction)
 	if err != nil {
 		return err
 	}
@@ -762,9 +791,12 @@ func objectLogger(obj ctrlruntimeclient.Object) *zap.SugaredLogger {
 	return logger.With("name", obj.GetName())
 }
 
-func (r *reconciler) migrateAction(ctx context.Context,
+func (r *reconciler) migrateAction(
+	ctx context.Context,
 	log *zap.SugaredLogger,
-	externalCluster *kubermaticv1.ExternalCluster) error {
+	data templateData,
+	externalCluster *kubermaticv1.ExternalCluster,
+) error {
 	manifestRef := externalCluster.Spec.CloudSpec.KubeOne.ManifestReference
 
 	clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r.Client)
@@ -842,7 +874,7 @@ func (r *reconciler) migrateAction(ctx context.Context,
 		return err
 	}
 
-	err = r.initiateClusterMigration(ctx, log, currentContainerRuntime, desiredContainerRuntime, externalCluster)
+	err = r.initiateClusterMigration(ctx, log, data, currentContainerRuntime, desiredContainerRuntime, externalCluster)
 	if err != nil {
 		log.Errorw("failed to migrate kubeone cluster", zap.Error(err))
 		return err
@@ -851,10 +883,14 @@ func (r *reconciler) migrateAction(ctx context.Context,
 	return nil
 }
 
-func (r *reconciler) initiateClusterMigration(ctx context.Context,
+func (r *reconciler) initiateClusterMigration(
+	ctx context.Context,
 	log *zap.SugaredLogger,
-	currentContainerRuntime, desiredContainerRuntime string,
-	cluster *kubermaticv1.ExternalCluster) error {
+	data templateData,
+	currentContainerRuntime string,
+	desiredContainerRuntime string,
+	cluster *kubermaticv1.ExternalCluster,
+) error {
 	log.Info("Migrating kubeone cluster...")
 	if err := r.updateClusterStatus(ctx, cluster, kubermaticv1.ExternalClusterCondition{
 		Phase:   kubermaticv1.KubeOnePhaseReconcilingMigrate,
@@ -863,7 +899,7 @@ func (r *reconciler) initiateClusterMigration(ctx context.Context,
 		return err
 	}
 
-	job, err := r.generateKubeOneActionJob(ctx, log, cluster, MigrateContainerRuntimeAction)
+	job, err := r.generateKubeOneActionJob(ctx, log, data, cluster, MigrateContainerRuntimeAction)
 	if err != nil {
 		return fmt.Errorf("could not generate kubeone pod %s/%s to migrate container runtime: %w", job.Name, job.Namespace, err)
 	}
@@ -906,7 +942,7 @@ func (r *reconciler) initiateClusterMigration(ctx context.Context,
 	return nil
 }
 
-func (r *reconciler) generateKubeOneActionJob(ctx context.Context, log *zap.SugaredLogger, externalCluster *kubermaticv1.ExternalCluster, action string) (*batchv1.Job, error) {
+func (r *reconciler) generateKubeOneActionJob(ctx context.Context, log *zap.SugaredLogger, data templateData, externalCluster *kubermaticv1.ExternalCluster, action string) (*batchv1.Job, error) {
 	var kubeoneJobName, kubeoneCMName string
 	var sshSecret, manifestSecret *corev1.Secret
 	var err error
@@ -1037,7 +1073,7 @@ func (r *reconciler) generateKubeOneActionJob(ctx context.Context, log *zap.Suga
 					InitContainers: []corev1.Container{
 						{
 							Name:    "copy-ro-manifest",
-							Image:   "busybox",
+							Image:   registry.Must(data.RewriteImage("registry.k8s.io/busybox:1.27.2")),
 							Command: []string{"/bin/sh"},
 							Args: []string{
 								"-c",
@@ -1049,7 +1085,7 @@ func (r *reconciler) generateKubeOneActionJob(ctx context.Context, log *zap.Suga
 					Containers: []corev1.Container{
 						{
 							Name:    "kubeone",
-							Image:   fmt.Sprintf("%s:%s", resources.KubeOneImage, resources.KubeOneImageTag),
+							Image:   registry.Must(data.RewriteImage(fmt.Sprintf("%s:%s", resources.KubeOneImage, resources.KubeOneImageTag))),
 							Command: []string{"/bin/sh"},
 							Args: []string{
 								"-c",

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -61,6 +61,7 @@ func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticCon
 				fmt.Sprintf("-namespace=%s", cfg.Namespace),
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.MasterController.PProfEndpoint),
 				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
+				fmt.Sprintf("-overwrite-registry=%s", cfg.Spec.UserCluster.OverwriteRegistry),
 			}
 
 			if cfg.Spec.MasterController.DebugLog {

--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,7 +103,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-driver",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/kubermatic/kubevirt-csi-driver:" + csiVersion,
+					Image:           registry.Must(data.RewriteImage("quay.io/kubermatic/kubevirt-csi-driver:" + csiVersion)),
 					Args: []string{
 						"--endpoint=$(CSI_ENDPOINT)",
 						fmt.Sprintf("--infra-cluster-namespace=%s", data.Cluster().Status.NamespaceName),
@@ -180,7 +181,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-provisioner",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/openshift/origin-csi-external-provisioner:4.13.0",
+					Image:           registry.Must(data.RewriteImage("quay.io/openshift/origin-csi-external-provisioner:4.13.0")),
 					Args: []string{
 						"--csi-address=$(ADDRESS)",
 						"--default-fstype=ext4",
@@ -213,7 +214,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-attacher",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/openshift/origin-csi-external-attacher:4.13.0",
+					Image:           registry.Must(data.RewriteImage("quay.io/openshift/origin-csi-external-attacher:4.13.0")),
 					Args: []string{
 						"--csi-address=$(ADDRESS)",
 						"--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig",
@@ -245,7 +246,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-liveness-probe",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/openshift/origin-csi-livenessprobe:4.13.0",
+					Image:           registry.Must(data.RewriteImage("quay.io/openshift/origin-csi-livenessprobe:4.13.0")),
 					Args: []string{
 						"--csi-address=/csi/csi.sock",
 						"--probe-timeout=3s",


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13435.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix missing registry overwrites for cluster-backup (Velero) images, kubevirt CSI images and KubeOne jobs
```

**Documentation**:
```documentation
NONE
```
