### PR TITLE
Fix reconcilition error for apiserver-external service for non ClusterIP service type.

### DIFF
--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -87,7 +87,10 @@ func ServiceReconciler(exposeStrategy kubermaticv1.ExposeStrategy, externalURL s
 			se.Spec.Ports[0].Port = 443
 			if exposeStrategy == kubermaticv1.ExposeStrategyTunneling {
 				se.Spec.Ports[0].TargetPort = intstr.FromInt(resources.APIServerSecurePort)
-				se.Spec.Ports[0].NodePort = 0 // allows switching from other expose strategies
+				// skip setting nodeport as zero if the service type is LoadBalancer
+				if se.Spec.Type != corev1.ServiceTypeLoadBalancer {
+					se.Spec.Ports[0].NodePort = 0 // allows switching from other expose strategies
+				}
 			} else {
 				// We assign the target port the same value as the NodePort port.
 				// The reason is that we need  both access the apiserver using

--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -87,8 +87,7 @@ func ServiceReconciler(exposeStrategy kubermaticv1.ExposeStrategy, externalURL s
 			se.Spec.Ports[0].Port = 443
 			if exposeStrategy == kubermaticv1.ExposeStrategyTunneling {
 				se.Spec.Ports[0].TargetPort = intstr.FromInt(resources.APIServerSecurePort)
-				// skip setting nodeport as zero if the service type is LoadBalancer
-				if se.Spec.Type != corev1.ServiceTypeLoadBalancer {
+				if se.Spec.Type == corev1.ServiceTypeClusterIP {
 					se.Spec.Ports[0].NodePort = 0 // allows switching from other expose strategies
 				}
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
When we set `apiServerServiceType: LoadBalancer` the `apiserver-external` service is of type `LoadBalancer` as expected, setting the nodeport for it to zero is not possible which causes continuous reconcile error for the service, this used to work earlier as the service type was always `ClusterIP` on using expose strategy as Tunneling, but now we have the option to specify other types as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/13584

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
**Documentation**:
```documentation
NONE
```
