### PR TITLE
Annotations for Cluster Templates

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -58,6 +58,7 @@ type ClusterTemplate struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	ClusterLabels          map[string]string `json:"clusterLabels,omitempty"`
+	ClusterAnnotations     map[string]string `json:"clusterAnnotations,omitempty"`
 	InheritedClusterLabels map[string]string `json:"inheritedClusterLabels,omitempty"`
 	Credential             string            `json:"credential"`
 

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -1543,6 +1543,13 @@ func (in *ClusterTemplate) DeepCopyInto(out *ClusterTemplate) {
 			(*out)[key] = val
 		}
 	}
+	if in.ClusterAnnotations != nil {
+		in, out := &in.ClusterAnnotations, &out.ClusterAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.InheritedClusterLabels != nil {
 		in, out := &in.InheritedClusterLabels, &out.InheritedClusterLabels
 		*out = make(map[string]string, len(*in))

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -246,7 +246,7 @@ func genNewCluster(template *kubermaticv1.ClusterTemplate, instance *kubermaticv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Labels:      template.ClusterLabels,
-			Annotations: template.Annotations,
+			Annotations: template.ClusterAnnotations,
 		},
 	}
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -40,6 +40,10 @@ spec:
                 may reject unrecognized values.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
+            clusterAnnotations:
+              additionalProperties:
+                type: string
+              type: object
             clusterLabels:
               additionalProperties:
                 type: string

--- a/pkg/test/generator/objects.go
+++ b/pkg/test/generator/objects.go
@@ -629,6 +629,7 @@ func GenClusterTemplate(name, id, projectID, scope, userEmail string) *kubermati
 			Annotations: map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail},
 		},
 		ClusterLabels:          nil,
+		ClusterAnnotations:     nil,
 		InheritedClusterLabels: nil,
 		Credential:             "",
 		Spec: kubermaticv1.ClusterSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce `ClusterAnnotations` in ClusterTemplate to specify annotations for the generated clusters. Since the cluster template has a dedicated field `ClusterLabels` for labels, we follow the same path to avoid ambiguity and introduce `ClusterAnnotations` for annotations.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/11569

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce `ClusterAnnotations` in ClusterTemplate to specify annotations for the generated clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cc @mohamed-rafraf 