### PR TITLE
mark CentOS as no longer supported on digitalocean

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/digitalocean.go
+++ b/cmd/conformance-tester/pkg/scenarios/digitalocean.go
@@ -38,8 +38,7 @@ type digitaloceanScenario struct {
 }
 
 func (s *digitaloceanScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](
-		providerconfig.OperatingSystemCentOS,
+	return sets.New(
 		providerconfig.OperatingSystemRockyLinux,
 		providerconfig.OperatingSystemUbuntu,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
We already do not have a CentOS-based e2e job anymore, so this will make sure that manually running the conformance-tester will not attempt to start scenarios that cannot work.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
