### PR TITLE
Remove default backends from Ingresses

### DIFF
--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -44,11 +44,6 @@ spec:
   {{- end }}
     hosts:
     - {{ .ingress.host | trim }}
-  defaultBackend:
-    service:
-      name: {{ .name }}-iap
-      port:
-        number: {{ $.Values.iap.port }}
   rules:
   - host: {{ .ingress.host | trim }}
     http:

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -171,11 +171,6 @@ spec:
   - secretName: custom-tls
     hosts:
     - grafana.kubermatic.tld
-  defaultBackend:
-    service:
-      name: grafana-iap
-      port:
-        number: 3000
   rules:
   - host: grafana.kubermatic.tld
     http:

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -330,11 +330,6 @@ spec:
   - secretName: alertmanager-tls
     hosts:
     - alertmanager.kubermatic.tld
-  defaultBackend:
-    service:
-      name: alertmanager-iap
-      port:
-        number: 3000
   rules:
   - host: alertmanager.kubermatic.tld
     http:
@@ -363,11 +358,6 @@ spec:
   - secretName: grafana-tls
     hosts:
     - grafana.kubermatic.tld
-  defaultBackend:
-    service:
-      name: grafana-iap
-      port:
-        number: 3000
   rules:
   - host: grafana.kubermatic.tld
     http:

--- a/charts/oauth/templates/ingress.yaml
+++ b/charts/oauth/templates/ingress.yaml
@@ -36,11 +36,6 @@ spec:
     hosts:
     - {{ .Values.dex.ingress.host }}
 {{- end }}
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: {{ .Values.dex.ingress.host }}
     http:

--- a/charts/oauth/test/default.yaml.out
+++ b/charts/oauth/test/default.yaml.out
@@ -347,11 +347,6 @@ spec:
   - secretName: dex-tls
     hosts:
     - 
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: 
     http:

--- a/charts/oauth/test/image-pull-secret.yaml.out
+++ b/charts/oauth/test/image-pull-secret.yaml.out
@@ -349,11 +349,6 @@ spec:
   - secretName: dex-tls
     hosts:
     - 
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: 
     http:

--- a/charts/oauth/test/ingress-annotations.yaml.out
+++ b/charts/oauth/test/ingress-annotations.yaml.out
@@ -349,11 +349,6 @@ spec:
   - secretName: dex-tls
     hosts:
     - kkp.example.com
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: kkp.example.com
     http:

--- a/charts/oauth/test/theme-with-overwrites.yaml.out
+++ b/charts/oauth/test/theme-with-overwrites.yaml.out
@@ -348,11 +348,6 @@ spec:
   - secretName: dex-tls
     hosts:
     - 
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: 
     http:

--- a/charts/oauth/test/values.example.ce.yaml.out
+++ b/charts/oauth/test/values.example.ce.yaml.out
@@ -371,11 +371,6 @@ spec:
   - secretName: dex-tls
     hosts:
     - kkp.example.com
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: kkp.example.com
     http:

--- a/charts/oauth/test/values.example.ee.yaml.out
+++ b/charts/oauth/test/values.example.ee.yaml.out
@@ -371,11 +371,6 @@ spec:
   - secretName: dex-tls
     hosts:
     - kkp.example.com
-  defaultBackend:
-    service:
-      name: dex
-      port:
-        number: 5556
   rules:
   - host: kkp.example.com
     http:

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -130,15 +130,6 @@ func IngressReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Na
 				}
 			}
 
-			i.Spec.DefaultBackend = &networkingv1.IngressBackend{
-				Service: &networkingv1.IngressServiceBackend{
-					Name: uiServiceName,
-					Port: networkingv1.ServiceBackendPort{
-						Number: 80,
-					},
-				},
-			}
-
 			pathType := networkingv1.PathTypePrefix
 
 			i.Spec.Rules = []networkingv1.IngressRule{
@@ -162,7 +153,14 @@ func IngressReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Na
 								{
 									Path:     "/",
 									PathType: &pathType,
-									Backend:  *i.Spec.DefaultBackend,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: uiServiceName,
+											Port: networkingv1.ServiceBackendPort{
+												Number: 80,
+											},
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Redundant defaultBackends can lead to confusing results depending on the ingress controller being used. To prevent this, this PR removes the redundant backends. See the attached ticket for more background.

**Which issue(s) this PR fixes**:
Fixes #13649

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Ingresses (for KKP, Dex & IAP) do not define a `defaultBackend` anymore to improve compatibility with ingress controllers.
```

**Documentation**:
```documentation
NONE
```
