### PR TITLE
Allow migrate existing clusters from IPv4-only to IPv4-IPv6

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -230,6 +230,18 @@ func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConf
 		}
 	}
 
+	// If the cluster is configured for DualStack but has only one CIDRBlock
+	// for Pods or Services, we automatically add the default v6 ones.
+	if specClusterNetwork.IPFamily == kubermaticv1.IPFamilyDualStack && (len(specClusterNetwork.Pods.CIDRBlocks) == 1 || len(specClusterNetwork.Services.CIDRBlocks) == 1) {
+		if len(specClusterNetwork.Pods.CIDRBlocks) == 1 {
+			specClusterNetwork.Pods.CIDRBlocks = append(specClusterNetwork.Pods.CIDRBlocks, resources.DefaultClusterPodsCIDRIPv6)
+		}
+
+		if len(specClusterNetwork.Services.CIDRBlocks) == 1 {
+			specClusterNetwork.Services.CIDRBlocks = append(specClusterNetwork.Services.CIDRBlocks, resources.DefaultClusterServicesCIDRIPv6)
+		}
+	}
+
 	if specClusterNetwork.NodeCIDRMaskSizeIPv4 == nil && specClusterNetwork.Pods.HasIPv4CIDR() {
 		specClusterNetwork.NodeCIDRMaskSizeIPv4 = ptr.To[int32](resources.DefaultNodeCIDRMaskSizeIPv4)
 	}

--- a/pkg/defaulting/cluster_test.go
+++ b/pkg/defaulting/cluster_test.go
@@ -223,6 +223,47 @@ func TestDefaultClusterNetwork(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "migrating to dual stack, default IPv6 CIDRs added",
+			spec: &kubermaticv1.ClusterSpec{
+				ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+					IPFamily: "IPv4+IPv6",
+					Pods: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"173.26.0.0/16"},
+					},
+					Services: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"11.241.17.0/20"},
+					},
+					ProxyMode: "proxy-test",
+					IPVS: &kubermaticv1.IPVSConfiguration{
+						StrictArp: ptr.To(false),
+					},
+					NodeCIDRMaskSizeIPv4:     ptr.To[int32](32),
+					NodeCIDRMaskSizeIPv6:     ptr.To[int32](48),
+					NodeLocalDNSCacheEnabled: ptr.To(false),
+					DNSDomain:                "cluster.local.test",
+				},
+			},
+			expectedChangedSpec: &kubermaticv1.ClusterSpec{
+				ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+					IPFamily: "IPv4+IPv6",
+					Pods: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"173.26.0.0/16", "fd01::/48"},
+					},
+					Services: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"11.241.17.0/20", "fd02::/120"},
+					},
+					ProxyMode: "proxy-test",
+					IPVS: &kubermaticv1.IPVSConfiguration{
+						StrictArp: ptr.To(false),
+					},
+					NodeCIDRMaskSizeIPv4:     ptr.To[int32](32),
+					NodeCIDRMaskSizeIPv6:     ptr.To[int32](48),
+					NodeLocalDNSCacheEnabled: ptr.To(false),
+					DNSDomain:                "cluster.local.test",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -1216,10 +1216,29 @@ func ValidateNodePortRange(nodePortRange string, fldPath *field.Path) *field.Err
 	return nil
 }
 
+// validateOnlyOneEntryAdded checks if two lists (old and new) are identical
+// besides the new one having a single entry added at the end.
+func validateOnlyOneEntryAdded(list, oldList []string) bool {
+	if len(oldList)+1 != len(list) {
+		return false
+	}
+
+	for i, e := range oldList {
+		if list[i] != e {
+			return false
+		}
+	}
+
+	return true
+}
+
 func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.ClusterNetworkingConfig, labels map[string]string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if oldC.IPFamily != "" {
+	// we allow changing from IPv4-only to DualStack - no changing back, though
+	migratingToDualStack := oldC.IPFamily == kubermaticv1.IPFamilyIPv4 && c.IPFamily == kubermaticv1.IPFamilyDualStack
+
+	if oldC.IPFamily != "" && !migratingToDualStack {
 		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
 			c.IPFamily,
 			oldC.IPFamily,
@@ -1228,19 +1247,23 @@ func validateClusterNetworkingConfigUpdateImmutability(c, oldC *kubermaticv1.Clu
 	}
 
 	if len(oldC.Pods.CIDRBlocks) != 0 {
-		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
-			c.Pods.CIDRBlocks,
-			oldC.Pods.CIDRBlocks,
-			fldPath.Child("pods", "cidrBlocks"),
-		)...)
+		if !migratingToDualStack || !validateOnlyOneEntryAdded(c.Pods.CIDRBlocks, oldC.Pods.CIDRBlocks) {
+			allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
+				c.Pods.CIDRBlocks,
+				oldC.Pods.CIDRBlocks,
+				fldPath.Child("pods", "cidrBlocks"),
+			)...)
+		}
 	}
 
 	if len(oldC.Services.CIDRBlocks) != 0 {
-		allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
-			c.Services.CIDRBlocks,
-			oldC.Services.CIDRBlocks,
-			fldPath.Child("services", "cidrBlocks"),
-		)...)
+		if !migratingToDualStack || !validateOnlyOneEntryAdded(c.Services.CIDRBlocks, oldC.Services.CIDRBlocks) {
+			allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(
+				c.Services.CIDRBlocks,
+				oldC.Services.CIDRBlocks,
+				fldPath.Child("services", "cidrBlocks"),
+			)...)
+		}
 	}
 
 	if oldC.ProxyMode != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

Clusters can be created either with just IPv4 networking or with DualStack (IPv4+IPv6) networking, but so far that could not be changed after a cluster was created. This PR changes the Cluster validation and defaulting to allow going from IPv4-only to DualStack (but not back).

**Which issue(s) this PR fixes**:

Related to #10860 

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

My tests so far looked like everything is migrated just fine and it's really only the validation preventing this so far. I did my tests on 2.23.18 though, but since the commits I made for that applied cleanly on `main`, I hope nothing changed too much here.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Existing clusters can now be migrated from IPv4-only to DualStack networking
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
