### PR TITLE
Skip datastore validation if datastorecluster is specified for vsphere

### DIFF
--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -181,26 +181,26 @@ func (v *VSphere) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Cloud
 	}
 	defer session.Logout(ctx)
 
-	effectiveDatastore := v.dc.DefaultDatastore
-	if ds := spec.VSphere.Datastore; ds != "" {
-		effectiveDatastore = ds
-	}
+	if dc := spec.VSphere.DatastoreCluster; dc != "" {
+		if _, err := session.Finder.DatastoreCluster(ctx, spec.VSphere.DatastoreCluster); err != nil {
+			return fmt.Errorf("failed to get datastore cluster provided by cluster spec %q: %w", dc, err)
+		}
+	} else {
+		effectiveDatastore := v.dc.DefaultDatastore
+		if ds := spec.VSphere.Datastore; ds != "" {
+			effectiveDatastore = ds
+		}
 
-	if effectiveDatastore != "" {
-		if _, err := session.Finder.Datastore(ctx, effectiveDatastore); err != nil {
-			return fmt.Errorf("failed to get effective datastore %q: %w", effectiveDatastore, err)
+		if effectiveDatastore != "" {
+			if _, err := session.Finder.Datastore(ctx, effectiveDatastore); err != nil {
+				return fmt.Errorf("failed to get effective datastore %q: %w", effectiveDatastore, err)
+			}
 		}
 	}
 
 	if rp := spec.VSphere.ResourcePool; rp != "" {
 		if _, err := session.Finder.ResourcePool(ctx, rp); err != nil {
 			return fmt.Errorf("failed to get resource pool %s: %w", rp, err)
-		}
-	}
-
-	if dc := spec.VSphere.DatastoreCluster; dc != "" {
-		if _, err := session.Finder.DatastoreCluster(ctx, spec.VSphere.DatastoreCluster); err != nil {
-			return fmt.Errorf("failed to get datastore cluster provided by cluster spec %q: %w", dc, err)
 		}
 	}
 

--- a/pkg/provider/cloud/vsphere/provider_test.go
+++ b/pkg/provider/cloud/vsphere/provider_test.go
@@ -272,6 +272,17 @@ func TestProviderValidateCloudSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "Inaccessible default datastore at datacenter level and datastore cluster at cluster level",
+			dc: &kubermaticv1.DatacenterSpecVSphere{
+				DefaultDatastore: "i-am-inaccessible",
+			},
+			spec: kubermaticv1.CloudSpec{
+				VSphere: &kubermaticv1.VSphereCloudSpec{
+					DatastoreCluster: "DC0_POD0",
+				},
+			},
+		},
+		{
 			name: "Default datastore at datacenter level overridden at cluster level by non existing Datastore",
 			dc: &kubermaticv1.DatacenterSpecVSphere{
 				DefaultDatastore: "LocalDS_0",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently datastore validation is done for vsphere cloudspec even if datastorecluster is specified, this causes an error if the user has access only to the datastore cluster and not to the default datastore in the dc.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default datastore validation is skipped if datastore cluster is specified for user clusters on vsphere.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
