### PR TITLE
fix automatic version updates

### DIFF
--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -1150,6 +1150,48 @@ func TestValidateVersion(t *testing.T) {
 			}}, nil, nil),
 		},
 		{
+			name:  "version with automatic update via Automatic not supported",
+			valid: false,
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.2"),
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.2"),
+					},
+					{
+						Version: semverlib.MustParse("1.2.3"),
+					},
+				},
+				[]*version.Update{{
+					From:      "1.2.2",
+					To:        "1.2.3",
+					Automatic: true,
+				}}, nil),
+		},
+		{
+			name:  "version with automatic update via AutomaticNodeUpdate not supported",
+			valid: false,
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.2"),
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.2"),
+					},
+					{
+						Version: semverlib.MustParse("1.2.3"),
+					},
+				},
+				[]*version.Update{{
+					From:                "1.2.2",
+					To:                  "1.2.3",
+					AutomaticNodeUpdate: true,
+				}}, nil),
+		},
+		{
 			name:           "version update supported",
 			valid:          true,
 			currentVersion: semver.NewSemverOrDie("1.2.3"),

--- a/pkg/version/manager.go
+++ b/pkg/version/manager.go
@@ -208,7 +208,7 @@ func (m *Manager) automaticUpdate(fromVersionRaw string, isForNode bool) (*Versi
 		if isForNode {
 			return u.AutomaticNodeUpdate
 		}
-		return u.Automatic
+		return u.Automatic || u.AutomaticNodeUpdate
 	}
 
 	var toVersions []string

--- a/pkg/version/manager_test.go
+++ b/pkg/version/manager_test.go
@@ -22,6 +22,7 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 
+	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 )
 
@@ -82,6 +83,217 @@ func TestAutomaticNodeUpdate(t *testing.T) {
 
 			if !version.Version.Equal(tc.expectedVersion.Version) {
 				t.Errorf("expected version %q, got version %q", tc.expectedVersion.Version.String(), version.Version.String())
+			}
+		})
+	}
+}
+
+func TestAutomaticControlPlaneUpdate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		fromVersion     string
+		updates         []*Update
+		versions        []*Version
+		expectErr       bool
+		expectedVersion *Version
+	}{
+		{
+			name:        "automatic version update via Automatic supported",
+			fromVersion: "1.5.0",
+			updates: []*Update{{
+				From:      "1.5.0",
+				To:        "1.6.0",
+				Automatic: true,
+			}},
+			versions: []*Version{{
+				Version: semverlib.MustParse("1.6.0"),
+			}},
+			expectErr:       false,
+			expectedVersion: &Version{Version: semverlib.MustParse("1.6.0")},
+		},
+		{
+			name:        "automatic version update via AutomaticNodeUpdate supported",
+			fromVersion: "1.5.0",
+			updates: []*Update{{
+				From:                "1.5.0",
+				To:                  "1.6.0",
+				AutomaticNodeUpdate: true,
+			}},
+			versions: []*Version{{
+				Version: semverlib.MustParse("1.6.0"),
+			}},
+			expectErr:       false,
+			expectedVersion: &Version{Version: semverlib.MustParse("1.6.0")},
+		},
+		{
+			name:        "automatic version update from wildcard version supported",
+			fromVersion: "1.5.0",
+			updates: []*Update{{
+				From:      "1.5.*",
+				To:        "1.5.1",
+				Automatic: true,
+			}},
+			versions: []*Version{{
+				Version: semverlib.MustParse("1.5.1"),
+			}},
+			expectErr:       false,
+			expectedVersion: &Version{Version: semverlib.MustParse("1.5.1")},
+		},
+		{
+			name:        "automatic version update to wildcard version not supported",
+			fromVersion: "1.5.0",
+			updates: []*Update{{
+				From:      "1.5.0",
+				To:        "1.5.*",
+				Automatic: true,
+			}},
+			versions: []*Version{{
+				Version: semverlib.MustParse("1.5.2"),
+			}},
+			expectErr: true,
+		},
+		{
+			name:        "automatic version update to non-existing version not supported",
+			fromVersion: "1.5.0",
+			updates: []*Update{{
+				From:      "1.5.0",
+				To:        "1.5.1",
+				Automatic: true,
+			}},
+			versions: []*Version{{
+				Version: semverlib.MustParse("1.5.2"),
+			}},
+			expectErr: true,
+		},
+		{
+			name:        "automatic version update with multiple target versions not supported",
+			fromVersion: "1.5.0",
+			updates: []*Update{
+				{
+					From:      "1.5.0",
+					To:        "1.5.1",
+					Automatic: true,
+				},
+				{
+					From:      "1.5.0",
+					To:        "1.5.2",
+					Automatic: true,
+				},
+			},
+			versions: []*Version{
+				{
+					Version: semverlib.MustParse("1.5.1"),
+				},
+				{
+					Version: semverlib.MustParse("1.5.2"),
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{
+				updates:  tc.updates,
+				versions: tc.versions,
+			}
+
+			version, err := m.AutomaticControlplaneUpdate(tc.fromVersion)
+
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("expect err %v, got err %q", tc.expectErr, err)
+				return
+			}
+
+			if !reflect.DeepEqual(tc.expectedVersion, version) {
+				t.Errorf("expected version %v, got version %v", tc.expectedVersion, version)
+			}
+		})
+	}
+}
+
+func TestGetVersions(t *testing.T) {
+	testCases := []struct {
+		name             string
+		updates          []*Update
+		versions         []*Version
+		expectedVersions []*Version
+	}{
+		{
+			name: "versions without automatic update included",
+			updates: []*Update{{
+				From: "1.5.0",
+				To:   "1.6.0",
+			}},
+			versions: []*Version{
+				{
+					Version: semverlib.MustParse("1.5.0"),
+				},
+				{
+					Version: semverlib.MustParse("1.6.0"),
+				},
+			},
+			expectedVersions: []*Version{
+				{
+					Version: semverlib.MustParse("1.5.0"),
+				},
+				{
+					Version: semverlib.MustParse("1.6.0"),
+				},
+			},
+		},
+		{
+			name: "version with automatic update via Automatic excluded",
+			updates: []*Update{{
+				From:      "1.5.0",
+				To:        "1.6.0",
+				Automatic: true,
+			}},
+			versions: []*Version{
+				{
+					Version: semverlib.MustParse("1.5.0"),
+				},
+				{
+					Version: semverlib.MustParse("1.6.0"),
+				},
+			},
+			expectedVersions: []*Version{{
+				Version: semverlib.MustParse("1.6.0"),
+			}},
+		},
+		{
+			name: "version with automatic update via AutomaticNodeUpdate excluded",
+			updates: []*Update{{
+				From:                "1.5.0",
+				To:                  "1.6.0",
+				AutomaticNodeUpdate: true,
+			}},
+			versions: []*Version{
+				{
+					Version: semverlib.MustParse("1.5.0"),
+				},
+				{
+					Version: semverlib.MustParse("1.6.0"),
+				},
+			},
+			expectedVersions: []*Version{{
+				Version: semverlib.MustParse("1.6.0"),
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{
+				updates:  tc.updates,
+				versions: tc.versions,
+			}
+
+			versions, _ := m.GetVersions()
+
+			if !reflect.DeepEqual(tc.expectedVersions, versions) {
+				t.Errorf("versions differ:\n%v", diff.ObjectDiff(tc.expectedVersions, versions))
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

As stated in [our documentation](https://docs.kubermatic.com/kubermatic/v2.25/tutorials-howtos/administration/version-and-upgrade-configuration/), updates configured in the `KubermaticConfiguration` with `automaticNodeUpdate` set to true should also result in an update of the control plane, because worker nodes must not have a newer version than the control plane. However, configuring an update with only `automaticNodeUpdate: true` (without explicitly setting `automatic: true`) resulted in no update at all.

This PR fixes this issue and ensures that updates with `automaticNodeUpdate: true` will result in an update of the control plane and worker nodes.

**Which issue(s) this PR fixes**:

Partially #13669

The [validation of the automatic update rules](https://github.com/kubermatic/kubermatic/blob/v2.25.8/pkg/validation/kubermaticconfiguration.go#L123) in the `KubermaticConfiguration` needs also some attention.

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

Perhaps it makes sense to keep the current behavior: updates are treated as automatic if and only if `automatic: true` is set. Worker nodes are updated automatically only if `automaticNodeUpdate: true` is set _additionally_. It just feels odd that an update rule with `automatic: false` set explicitly and `automaticNodeUpdate: true` will still result in an update of user clusters.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Only applicable if custom update rules in `KubermaticConfiguration.spec.versions.updates` were defined:

* Custom update rules with `automaticNodeUpdate: true` and `automatic` either absent or explicitly set to "false" will be treated as automatic update rule.
* All existing user clusters with a version matching the "from" version constraint of such a rule will be automatically updated to the configured target version.
* New user clusters can not be created with a version matching the "from" version constraint of such a rule.
```

**Documentation**:

```documentation
https://docs.kubermatic.com/kubermatic/v2.25/tutorials-howtos/administration/version-and-upgrade-configuration/
```
