### PR TITLE
Allow setting the value for ingressClassName in IAP

### DIFF
--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -35,7 +35,7 @@ metadata:
 {{ toYaml .ingress.annotations | indent 4 }}
 {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .ingress.class | default 'nginx' }}
   tls:
   {{- if .ingress.tlsSecretName }}
   - secretName: {{ .ingress.tlsSecretName }}

--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -35,7 +35,7 @@ metadata:
 {{ toYaml .ingress.annotations | indent 4 }}
 {{- end }}
 spec:
-  ingressClassName: {{ .ingress.class | default 'nginx' }}
+  ingressClassName: {{ .ingress.class | default "nginx" }}
   tls:
   {{- if .ingress.tlsSecretName }}
   - secretName: {{ .ingress.tlsSecretName }}

--- a/charts/iap/test/values.custom-tls-secret.yaml
+++ b/charts/iap/test/values.custom-tls-secret.yaml
@@ -35,3 +35,5 @@ iap:
         host: "grafana.kubermatic.tld"
         tlsSecretName: "custom-tls"
         annotations: {}
+        ## Optional: Default set to "nginx"
+        class: "nginx"

--- a/charts/iap/test/values.example.yaml
+++ b/charts/iap/test/values.example.yaml
@@ -37,6 +37,8 @@ iap:
         tlsSecretName: ""
         host: "alertmanager.kubermatic.tld"
         annotations: {}
+        ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+        class: "nginx"
     #
     grafana:
       name: grafana
@@ -58,6 +60,8 @@ iap:
       ingress:
         host: "grafana.kubermatic.tld"
         annotations: {}
+        ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+        class: "nginx"
 
   certIssuer:
     name: letsencrypt-prod

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -58,6 +58,8 @@ iap:
     #     tlsSecretName: ""
     #     host: "alertmanager.kubermatic.tld"
     #     annotations: {}
+    #     ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+    #     class: "nginx"
     #
     # grafana:
     #   name: grafana
@@ -79,6 +81,8 @@ iap:
     #   ingress:
     #     host: "grafana.kubermatic.tld"
     #     annotations: {}
+    #     ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+    #     class: "nginx"
     #
     # prometheus:
     #   name: prometheus
@@ -98,6 +102,9 @@ iap:
     #     host: "prometheus.kubermatic.tld"
     #     annotations:
     #       ingress.kubernetes.io/upstream-hash-by: "ip_hash" ## needed for prometheus federations
+    #     ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+    #     class: "nginx"
+
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates;
   # set this to an empty value to disable creating Certificate resources; in this case you need


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to allow setting the value for ingressClassName in IAP when the ingress controller is different such as cilium i.e. not default one nginx-ingress-controller provided by KKP 
Since in KKP, we can skip the specific helm chart installation using `--skip-charts` option with the `kubermatic-installer` and configure different ingress controller of choice. Extending support for IAP chart to use the ingress class of choice set/configured by the end user, instead of defaulting it to "nginx".

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow `ingressClassName` configuration in IAP
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
