### PR TITLE
Add condition to check the ingressClassName value for setting nginx related annotations

### DIFF
--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -100,10 +100,12 @@ func IngressReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Na
 				i.Annotations = make(map[string]string)
 			}
 
-			// NGINX ingress annotations to avoid timeout of websocket connections after 1 minute.
-			// Needed for Web Terminal feature, for example.
-			i.Annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = "3600" // 1 hour
-			i.Annotations["nginx.ingress.kubernetes.io/proxy-send-timeout"] = "3600" // 1 hour
+			if i.Spec.IngressClassName == "nginx" {
+				// NGINX ingress annotations to avoid timeout of websocket connections after 1 minute.
+				// Needed for Web Terminal feature, for example.
+				i.Annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = "3600" // 1 hour
+				i.Annotations["nginx.ingress.kubernetes.io/proxy-send-timeout"] = "3600" // 1 hour
+			}
 
 			// If a Certificate is being issued, configure cert-manager by
 			// setting up the required annotations.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add condition to check the `ingressClassName` field value if set to "nginx" then only set the `nginx.ingress.kubernetes.io/proxy-read-timeout` and  `nginx.ingress.kubernetes.io/proxy-send-timeout` under the `.metadata.annotations` for "kubermatic" and "dex" ingress. 
Currently, these annotations are getting set irrespective of the ingress class that is in use. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
