### PR TITLE
Fix vSphere CCM/CSI Images

### DIFF
--- a/addons/csi/vsphere/csi-migration-webhook.yaml
+++ b/addons/csi/vsphere/csi-migration-webhook.yaml
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: csi-migration-webhook
       containers:
         - name: vsphere-webhook
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.1.2" }}
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -310,7 +310,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.1.2" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -375,7 +375,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.1.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.1.2" }}
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=30s"
@@ -521,7 +521,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.1.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.1.2" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -101,7 +101,7 @@ spec:
       country: DE
       spec:
         vsphere:
-          cluster: vcenter.dc.k8c.io
+          cluster: vSAN Cluster
           datacenter: Hamburg
           datastore: Datastore0-truenas
           endpoint: https://10.10.0.100
@@ -112,7 +112,7 @@ spec:
             centos: kkp-centos-7
             flatcar: kkp-flatcar-3033.2.2
             rhel: kkp-rhel-8.6
-            ubuntu: kkp-ubuntu-22.04
+            ubuntu: kubeone-ubuntu-22.04
             rockylinux: kkp-rockylinux-8
     azure-westeurope:
       location: "Azure West europe"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.28.0
+        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.28.1
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.29.0
+        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.29.0
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.30.1
+        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.30.1
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.30.1
+        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.31.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces the registry used for vSphere CCM images with the new official upstream one. There is, not visible in the generated code, also code to handle 1.27 (so it's still upgradable by KKP) and for 1.27 we unfortunately have to resort to mirroring the old images. The same will apply to CSI which is worked on by someone else at the moment.

Since there are no official non-staged images available for CSI, plus because it's easier to always use quay.io regardless of the cluster version, this PR also moves the recent CSI images to quay (meaning that I anticipate that these images will be fixed eventually by upstream, but I want to avoid the if-else logic inside the templates, as it just makes backporting more annoying).

part of #13719

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix vSphere CCM/CSI images (pre 1.28 clusters will now use a Kubermatic-managed mirror on quay.io for the images).
```

**Documentation**:
```documentation
NONE
```
