### PR TITLE
[release/v2.24] Fix vSphere CCM/CSI Images (#13720)

### DIFF
--- a/addons/csi/vsphere/csi-migration-webhook.yaml
+++ b/addons/csi/vsphere/csi-migration-webhook.yaml
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: csi-migration-webhook
       containers:
         - name: vsphere-webhook
-          image: '{{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.1" }}'
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.0.1" }}
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -318,7 +318,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.0.2" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -379,7 +379,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.0.2" }}
           args:
             - "--leader-election"
             - "--leader-election-lease-duration=120s"
@@ -521,7 +521,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.2" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.0.2" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -66,8 +66,7 @@ func vsphereDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 				return nil, err
 			}
 
-			version := VSphereCCMVersion(data.Cluster().Status.Versions.ControlPlane)
-			container := getVSphereCCMContainer(version, data)
+			container := getVSphereCCMContainer(data)
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = ptr.To(false)
 			dep.Spec.Template.Spec.Volumes = getVolumes(data.IsKonnectivityEnabled(), true)
@@ -80,8 +79,12 @@ func vsphereDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 	}
 }
 
-func getVSphereCCMContainer(version string, data *resources.TemplateData) corev1.Container {
-	controllerManagerImage := registry.Must(data.RewriteImage(resources.RegistryGCR + "/cloud-provider-vsphere/cpi/release/manager:v" + version))
+func getVSphereCCMContainer(data *resources.TemplateData) corev1.Container {
+	clusterVersion := data.Cluster().Status.Versions.ControlPlane
+	version := VSphereCCMVersion(clusterVersion)
+	repository := ccmRepository(clusterVersion)
+
+	controllerManagerImage := registry.Must(data.RewriteImage(repository + ":v" + version))
 	c := corev1.Container{
 		Name:  ccmContainerName,
 		Image: controllerManagerImage,
@@ -112,6 +115,17 @@ func getVSphereCCMContainer(version string, data *resources.TemplateData) corev1
 	}
 
 	return c
+}
+
+var registryCutoff = semver.NewSemverOrDie("1.28.0")
+
+func ccmRepository(version semver.Semver) string {
+	// See https://github.com/kubermatic/kubermatic/issues/13719 for why we have mirrored pre-1.28 images.
+	if version.LessThan(registryCutoff) {
+		return resources.RegistryQuay + "/kubermatic/mirror/cloud-provider-vsphere/ccm"
+	}
+
+	return resources.RegistryK8S + "/cloud-pv-vsphere/cloud-provider-vsphere"
 }
 
 func VSphereCCMVersion(version semver.Semver) string {

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.2
+        image: quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.26.2
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.27.0
+        image: quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.27.0
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.28.0
+        image: registry.k8s.io/cloud-pv-vsphere/cloud-provider-vsphere:v1.28.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13720.

/hold until the original PR is merged.

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix vSphere CCM images (pre 1.28 clusters will now use a Kubermatic-managed mirror on quay.io for the images).
```

**Documentation**:
```documentation
NONE
```
