### PR TITLE
[release/v2.23] Fix vSphere CCM/CSI Images (#13720)

### DIFF
--- a/addons/csi/vsphere/csi-migration-webhook.yaml
+++ b/addons/csi/vsphere/csi-migration-webhook.yaml
@@ -80,7 +80,7 @@ spec:
       serviceAccountName: csi-migration-webhook
       containers:
         - name: vsphere-webhook
-          image: '{{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.1" }}'
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.0.1" }}
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -310,7 +310,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.1" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.0.1" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -371,7 +371,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v3.0.1" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/syncer:v3.0.1" }}
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -503,7 +503,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v3.0.1" }}
+          image: {{ Image "quay.io/kubermatic/mirror/cloud-provider-vsphere/csi/release/driver:v3.0.1" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.24.5
+        image: quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.24.5
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.25.2
+        image: quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.25.2
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.1
+        image: quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.26.1
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.1
+        image: quay.io/kubermatic/mirror/cloud-provider-vsphere/ccm:v1.26.1
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13720.

/hold until the original PR is merged.

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix vSphere CCM/CSI images (clusters will now use a Kubermatic-managed mirror on quay.io for the images).
```

**Documentation**:
```documentation
NONE
```
