### PR TITLE
migrate to newer sample app image in e2e tests

### DIFF
--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -175,7 +175,7 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 			return fmt.Errorf("failed to read response body from Hello-Kubernetes Pod (%s): %w", hostURL, err), nil
 		}
 
-		needle := "Hello Kubernetes!"
+		needle := "Hello, world!"
 		if strings.Contains(string(contents), needle) {
 			return nil, nil
 		}

--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -105,7 +105,7 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 			Containers: []corev1.Container{
 				{
 					Name:  "hello-kubernetes",
-					Image: "gcr.io/google-samples/node-hello:1.0",
+					Image: "us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0",
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/cmd/conformance-tester/pkg/tests/metrics.go
+++ b/cmd/conformance-tester/pkg/tests/metrics.go
@@ -159,7 +159,7 @@ func TestUserClusterPodAndNodeMetrics(ctx context.Context, log *zap.SugaredLogge
 			Containers: []corev1.Container{
 				{
 					Name:  "hello-kubernetes",
-					Image: "gcr.io/google-samples/node-hello:1.0",
+					Image: "us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0",
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",


### PR DESCRIPTION
**What this PR does / why we need it**:
gcr.io is going away and this PR takes care of moving the sample app to its new location, as per https://github.com/kubernetes/website/pull/46553

part of #13723

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
