### PR TITLE
Use registry.k8s.io for etcd images

### DIFF
--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -54,15 +54,15 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
-			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+			if strings.HasPrefix(container.Image, legacyRegistryK8SGCR) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
 				)
 			}
 			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
-				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
-				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", legacyRegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", legacyRegistryUSGCR)) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
@@ -71,15 +71,15 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 		}
 
 		for _, initContainer := range pod.Spec.InitContainers {
-			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+			if strings.HasPrefix(initContainer.Image, legacyRegistryK8SGCR) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
 				)
 			}
 			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
-				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
-				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", legacyRegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", legacyRegistryUSGCR)) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),

--- a/cmd/conformance-tester/pkg/tests/usercluster_controller.go
+++ b/cmd/conformance-tester/pkg/tests/usercluster_controller.go
@@ -134,6 +134,11 @@ func TestUserClusterSeccompProfiles(ctx context.Context, log *zap.SugaredLogger,
 	return errors.New(strings.Join(errorMsgs, "\n"))
 }
 
+const (
+	// legacyRegistryK8SGCR defines the kubernetes specific docker registry at google.
+	legacyRegistryK8SGCR = "k8s.gcr.io"
+)
+
 func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client) error {
 	if !opts.Tests.Has(ctypes.UserClusterSeccompTests) {
 		log.Info("User cluster Seccomp tests disabled, skipping.")
@@ -151,7 +156,7 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
-			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+			if strings.HasPrefix(container.Image, legacyRegistryK8SGCR) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
@@ -168,7 +173,7 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 		}
 
 		for _, initContainer := range pod.Spec.InitContainers {
-			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+			if strings.HasPrefix(initContainer.Image, legacyRegistryK8SGCR) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),

--- a/cmd/conformance-tester/pkg/tests/usercluster_controller.go
+++ b/cmd/conformance-tester/pkg/tests/usercluster_controller.go
@@ -137,6 +137,10 @@ func TestUserClusterSeccompProfiles(ctx context.Context, log *zap.SugaredLogger,
 const (
 	// legacyRegistryK8SGCR defines the kubernetes specific docker registry at google.
 	legacyRegistryK8SGCR = "k8s.gcr.io"
+	// legacyRegistryEUGCR defines the docker registry at google EU.
+	legacyRegistryEUGCR = "eu.gcr.io"
+	// legacyRegistryUSGCR defines the docker registry at google US.
+	legacyRegistryUSGCR = "us.gcr.io"
 )
 
 func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client) error {
@@ -163,8 +167,8 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 				)
 			}
 			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
-				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
-				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", legacyRegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", legacyRegistryUSGCR)) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
@@ -180,8 +184,8 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 				)
 			}
 			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
-				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
-				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", legacyRegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", legacyRegistryUSGCR)) {
 				errorMsgs = append(
 					errorMsgs,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -61,7 +61,7 @@ const (
 	// DeleteAllBackupsFinalizer indicates that the backups still need to be deleted in the backend.
 	DeleteAllBackupsFinalizer = "kubermatic.k8c.io/delete-all-backups"
 	// DefaultBackupContainerImage holds the default Image used for creating the etcd backups.
-	DefaultBackupContainerImage = "gcr.io/etcd-development/etcd"
+	DefaultBackupContainerImage = "registry.k8s.io/etcd"
 
 	// requeueAfter time after starting a job
 	// should be the time after which a started job will usually have completed.

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -55,7 +55,7 @@ func anexiaDeploymentReconciler(data *resources.TemplateData) reconciling.NamedD
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: registry.Must(data.RewriteImage(resources.RegistryAnexia + "/anexia/anx-cloud-controller-manager:" + anexiaCCMVersion)),
+					Image: registry.Must(data.RewriteImage("anx-cr.io/anexia/anx-cloud-controller-manager:" + anexiaCCMVersion)),
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -78,7 +78,7 @@ func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDe
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        registry.Must(data.RewriteImage(resources.RegistryMCR + "/oss/kubernetes/azure-cloud-controller-manager:v" + version)),
+					Image:        registry.Must(data.RewriteImage("mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v" + version)),
 					Command:      []string{"cloud-controller-manager"},
 					Args:         getAzureFlags(data),
 					Env:          getEnvVars(),

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -236,7 +236,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 				{
 					Name: resources.EtcdStatefulSetName,
 
-					Image:           registry.Must(data.RewriteImage(resources.RegistryGCR + "/etcd-development/etcd:" + imageTag)),
+					Image:           registry.Must(data.RewriteImage(resources.RegistryK8S + "/etcd:" + imageTag + "-0")),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         getEtcdCommand(data.Cluster(), enableDataCorruptionChecks, launcherEnabled),
 					Env:             etcdEnv,
@@ -413,7 +413,10 @@ func GetBasePodLabels(cluster *kubermaticv1.Cluster) map[string]string {
 	return resources.BaseAppLabels(resources.EtcdStatefulSetName, additionalLabels)
 }
 
-// ImageTag returns the correct etcd image tag for a given Cluster
+// ImageTag returns the correct etcd image tag for a given Cluster. Note that this tag does not
+// contain the "-0" suffix that the registry.k8s.io images have appended to them. This is because
+// semver comparisons then fail further up in the code and it's simpler to treat the "-0" suffix
+// as not part of the etcd tag itself.
 // TODO: Other functions use this function, switch them to getLauncherImage.
 func ImageTag(c *kubermaticv1.Cluster) string {
 	// most other control plane parts refer to the controller-manager's version, which
@@ -428,7 +431,7 @@ func ImageTag(c *kubermaticv1.Cluster) string {
 	// 	return "v3.4.3"
 	// }
 
-	return "v3.5.9"
+	return "3.5.9"
 }
 
 func computeReplicas(data etcdStatefulSetReconcilerData, set *appsv1.StatefulSet) int32 {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -423,8 +423,6 @@ const (
 	// EtcdClusterSize defines the size of the etcd to use.
 	EtcdClusterSize = 3
 
-	// RegistryK8SGCR defines the kubernetes specific docker registry at google.
-	RegistryK8SGCR = "k8s.gcr.io"
 	// RegistryK8S defines the (new) official registry hosted by the Kubernetes project.
 	RegistryK8S = "registry.k8s.io"
 	// RegistryEUGCR defines the docker registry at google EU.

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -425,20 +425,12 @@ const (
 
 	// RegistryK8S defines the (new) official registry hosted by the Kubernetes project.
 	RegistryK8S = "registry.k8s.io"
-	// RegistryEUGCR defines the docker registry at google EU.
-	RegistryEUGCR = "eu.gcr.io"
-	// RegistryUSGCR defines the docker registry at google US.
-	RegistryUSGCR = "us.gcr.io"
 	// RegistryGCR defines the kubernetes docker registry at google.
 	RegistryGCR = "gcr.io"
 	// RegistryDocker defines the default docker.io registry.
 	RegistryDocker = "docker.io"
 	// RegistryQuay defines the image registry from coreos/redhat - quay.
 	RegistryQuay = "quay.io"
-	// RegistryMCR defines the image registry at Microsoft.
-	RegistryMCR = "mcr.microsoft.com"
-	// RegistryAnexia defines the anexia specific docker registry.
-	RegistryAnexia = "anx-cr.io"
 
 	// TopologyKeyHostname defines the topology key for the node hostname.
 	TopologyKeyHostname = "kubernetes.io/hostname"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.30.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.30.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.31.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.31.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.30.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.30.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.31.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.31.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.31.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.31.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-edge-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-edge-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-edge-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-edge-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.31.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.31.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.31.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.31.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.31.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.31.0-etcd-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.31.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.31.0-etcd.yaml
@@ -107,7 +107,7 @@ spec:
           value: https://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2379
         - name: INITIAL_CLUSTER
           value: etcd-0=http://etcd-0.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-1=http://etcd-1.etcd.cluster-de-test-01.svc.cluster.local:2380,etcd-2=http://etcd-2.etcd.cluster-de-test-01.svc.cluster.local:2380
-        image: gcr.io/etcd-development/etcd:v3.5.9
+        image: registry.k8s.io/etcd:3.5.9-0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
GCR is going away and Kubernetes has started to mirror the images into their community registry. As per #13723, we want to reduce our dependency on GCR and this PR is one step for that.

I also removed the constants for Anexia and Microsoft's registries, as they were used once in the entire codebase and I do know why. It made searching for images harder and provided no benefit.

The other GCR constants (the main one is still in use by vSphere, see #13720) I also moved and made private as they are only relevant for tests anyway.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
etcd container images are now loaded from registry.k8s.io instead of gcr.io/etcd-development.
```

**Documentation**:
```documentation
NONE
```
