### PR TITLE
fix resetting Application values to an empty value

### DIFF
--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -378,7 +378,9 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 			// ApplicationInstallation spec. If an existing ApplicationInstallation gets reconciled,
 			// both values (from pre-reconciliation) and valuesBlock (from this very reconciler func)
 			// would otherwise be set and fail validation at the webhook.
-			app.Spec.Values = runtime.RawExtension{}
+			app.Spec.Values = runtime.RawExtension{
+				Raw: []byte("{}"),
+			}
 
 			return app, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to #13736. Setting just an empty RawExtension will work the first time to switch from values to valuesBlock, but afterwards it confuses the reconciling framework, which sees a `values: {}` coming from the apiserver and tries to set `values: <rawRuntimeExtensionThingy>`, which is not an actual change to the object and so is never reflected in the cache and so the reconciler waits forever for this change.


**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix reconciling loop when resetting Application values to an empty value
```

**Documentation**:
```documentation
NONE
```
