### PR TITLE
Initial applications should be deployed in the specified namespace instead of kube-system

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -33,6 +33,9 @@ type ObjectMeta struct {
 	// Name represents human readable name for the resource
 	Name string `json:"name"`
 
+	// Namespace represents the namespace for the resource.
+	Namespace string `json:"namespace,omitempty"`
+
 	// Annotations that can be added to the resource
 	Annotations map[string]string `json:"annotations,omitempty"`
 

--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -333,6 +333,8 @@ func (r *Reconciler) generateApplicationInstallation(application appskubermaticv
 		Spec: appskubermaticv1.ApplicationInstallationSpec{
 			Namespace: appskubermaticv1.AppNamespaceSpec{
 				Name: application.Name,
+				// This ensures that the namespace is created in the user cluster, if it doesn't already exist.
+				Create: true,
 			},
 			ApplicationRef: appskubermaticv1.ApplicationRef{
 				Name:    application.Name,

--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -272,7 +272,7 @@ func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, applicat
 	application.UID = existingApplication.UID
 
 	if err := userClusterClient.Update(ctx, &application); err != nil {
-		return fmt.Errorf("failed to update application installation: %w", err)
+		return fmt.Errorf("failed to update application installation %q: %w", application.Name, err)
 	}
 	return nil
 }

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -172,7 +172,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 
 	var errs []error
 	for _, app := range applications {
-		if err := r.createInitialApplicationInstallations(ctx, userClusterClient, app, cluster); err != nil {
+		if err := r.createInitialApplicationInstallation(ctx, userClusterClient, app, cluster); err != nil {
 			errs = append(errs, err)
 			r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ApplicationInstallationFailed", "Failed to create ApplicationInstallation %s", app.Name)
 		}
@@ -189,7 +189,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	return nil, nil
 }
 
-func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, client ctrlruntimeclient.Client, application apiv1.Application, cluster *kubermaticv1.Cluster) error {
+func (r *Reconciler) createInitialApplicationInstallation(ctx context.Context, client ctrlruntimeclient.Client, application apiv1.Application, cluster *kubermaticv1.Cluster) error {
 	namespace := application.Namespace
 	if namespace == "" {
 		namespace = application.Spec.Namespace.Name

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -195,15 +195,13 @@ func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, 
 		namespace = application.Spec.Namespace.Name
 	}
 
-	// Before creating an application, make sure that the namespace exists.
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
 	}
-
-	// First check if the namespace exists
-	err := client.Get(ctx, types.NamespacedName{Name: namespace}, ns)
+	// Before creating an application, make sure that the namespace exists.
+	err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(ns), ns)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If the namespace does not exist, create it

--- a/pkg/webhook/application/applicationinstallation/validation/validation.go
+++ b/pkg/webhook/application/applicationinstallation/validation/validation.go
@@ -89,7 +89,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 	}
 
 	if len(allErrs) > 0 {
-		return webhook.Denied(fmt.Sprintf("ApplicationInstallation validation request %s denied: %v", req.UID, allErrs))
+		return webhook.Denied(fmt.Sprintf("ApplicationInstallation validation request %s denied for ApplicationInstallation %s/%s with error: %v", req.UID, ad.Namespace, ad.Name, allErrs))
 	}
 
 	return webhook.Allowed(fmt.Sprintf("ApplicationInstallation validation request %s allowed", req.UID))


### PR DESCRIPTION
## Why we need this PR

The implementation for handling initial applications was added, by yours truly, in https://github.com/kubermatic/kubermatic/pull/9655. Back in the time, it was decided that ALL the application installations will exist in `kube-system` namespace while the `application.spec.namespace.name` would determine the namespace in which the resources against that application will be deployed. To put it simple `helm install blah --namespace ${namespace}`, the namespace is determined by spec and the namespace for ApplicationInstallation CR would have been `kube-system`. This was supposed to be the case for all the applications that were installed using dashboard, initial ones that are propagated using annotations and the ones created after cluster creation as well.

However, somewhere down the line, we made a drift from this logic/decision and decided that when new applications are added to existing clusters using the dashboard, we'll place the ApplicationInstallations in the dedicated namespace deduced from `application.spec.namespace.name`. I don't have an opinion regarding if this is wrong/right, don't want to comment on that. 

But this brings an unnecessary drift between the initial applications and the applications added after cluster creation. This also is problematic for default/enforced applications since the default applications are handled by `initial-application-controller` which forces them to be created in the `kube-system` namespace. While enforced applications, following the golden path take the namespace of ApplicationInstallation from the spec itself. 

So, if you have a default application, let's say for Flux, and you later on decide to enforce it. You'll end up with two instances of that application, the defaulted one in `kube-system` namespace and the enforced one in `flux` namespace. Both will try to manage the same `helm installation` since the namespace in spec would be the same for both.

## What this PR changes
 
This PR aims to remove this drift and place the applications in the correct namespaces instead of `kube-system`. I will add an `action required`, but this doesn't break or affect ANY existing clusters since `initial-applications-controller` only processes new clusters with the `kubermatic.io/initial-application-installations-request` annotation.

Apart from the main changes, https://github.com/kubermatic/kubermatic/pull/13746/commits/2fddbf653c5133cb3ee52f5471ceee1f9f980872 improves the logging a bit to make the errors more deterministic. https://github.com/kubermatic/kubermatic/pull/13746/commits/c927572ae823f3754b534ef9ecbc6dff197602c6 should potentially take care of the following error found during application testing:

```sh
{"level":"error","time":"2024-09-19T12:12:27.868Z","caller":"controller/controller.go:263","msg":"Reconciler error","controller":"kkp-default-application-controller","controllerGroup":"kubermatic.k8c.io","controllerKind":"Cluster","Cluster":{"name":"q9chxtrqtz"},"namespace":"","name":"q9chxtrqtz","reconcileID":"da4c92e6-6699-4e19-bc67-75e4f0e677c9","error":"failed to update application installation: admission webhook \"applicationinstallations.apps.kubermatic.k8c.io\" denied the request: ApplicationInstallation validation request e0d25f0e-6f2e-468b-887e-8140cab08494 denied: [spec.namespace.create: Invalid value: false: field is immutable]"}
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
I've also created https://github.com/kubermatic/dashboard/issues/6858 to make it less ambiguous on the UI. A dedicated field should make it easy for our users to decide where to put the ApplicationInstallation.

There is _no action required_ against this change, but I'm not sure how else I can make it "stand out" or be more visible in the release notes. I haven't followed the final drafted release notes/changelogs much.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* [ACTION REQUIRED] Initial applications are created in the namespace specified in the application specification instead of `kube-system` namespace. This doesn't affect any existing clusters and only applies to newly created clusters. Users are not affected and no action is required from their side.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
