### PR TITLE
Add removal notice for values and defaultValues in ApplicationInstallation and ApplicationDefinition

### DIFF
--- a/docs/zz_generated.applicationInstallation.ce.yaml
+++ b/docs/zz_generated.applicationInstallation.ce.yaml
@@ -26,7 +26,7 @@ spec:
     # Should be a valid lowercase RFC1123 domain name
     name: my-namespace
   # Values specify values overrides that are passed to helm templating. Comments are not preserved.
-  # Deprecated: Use ValuesBlock instead.
+  # Deprecated: Use ValuesBlock instead. This field was deprecated in KKP 2.25 and will be removed in KKP 2.27+.
   values:
     commonLabels:
       owner: somebody

--- a/docs/zz_generated.applicationInstallation.ee.yaml
+++ b/docs/zz_generated.applicationInstallation.ee.yaml
@@ -26,7 +26,7 @@ spec:
     # Should be a valid lowercase RFC1123 domain name
     name: my-namespace
   # Values specify values overrides that are passed to helm templating. Comments are not preserved.
-  # Deprecated: Use ValuesBlock instead.
+  # Deprecated: Use ValuesBlock instead. This field was deprecated in KKP 2.25 and will be removed in KKP 2.27+.
   values:
     commonLabels:
       owner: somebody

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -213,7 +213,7 @@ type ApplicationDefinitionSpec struct {
 	Method TemplateMethod `json:"method"`
 
 	// DefaultValues specify default values for the UI which are passed to helm templating when creating an application. Comments are not preserved.
-	// Deprecated: use DefaultValuesBlock instead
+	// Deprecated: Use DefaultValuesBlock instead. This field was deprecated in KKP 2.25 and will be removed in KKP 2.27+.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	DefaultValues *runtime.RawExtension `json:"defaultValues,omitempty"`
 

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -71,7 +71,7 @@ type ApplicationInstallationSpec struct {
 
 	// Values specify values overrides that are passed to helm templating. Comments are not preserved.
 	// +kubebuilder:pruning:PreserveUnknownFields
-	// Deprecated: Use ValuesBlock instead.
+	// Deprecated: Use ValuesBlock instead. This field was deprecated in KKP 2.25 and will be removed in KKP 2.27+.
 	Values runtime.RawExtension `json:"values,omitempty"`
 	// As kubebuilder does not support interface{} as a type, deferring json decoding, seems to be our best option (see https://github.com/kubernetes-sigs/controller-tools/issues/294#issuecomment-518379253)
 

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -82,7 +82,7 @@ spec:
                 defaultValues:
                   description: |-
                     DefaultValues specify default values for the UI which are passed to helm templating when creating an application. Comments are not preserved.
-                    Deprecated: use DefaultValuesBlock instead
+                    Deprecated: Use DefaultValuesBlock instead. This field was deprecated in KKP 2.25 and will be removed in KKP 2.27+.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 defaultValuesBlock:

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -133,7 +133,7 @@ spec:
                 values:
                   description: |-
                     Values specify values overrides that are passed to helm templating. Comments are not preserved.
-                    Deprecated: Use ValuesBlock instead.
+                    Deprecated: Use ValuesBlock instead. This field was deprecated in KKP 2.25 and will be removed in KKP 2.27+.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 valuesBlock:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add removal notice for `values` and `defaultValues` in ApplicationInstallation and ApplicationDefinition. Just to make sure that we don't have an "oops forgot to inform customers about the removal" moment in the near future. :D

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
The release notes here should be NONE since they have been already deprecated since 2.25 IMO.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The field `values` in ApplicationInstallation and `defaultValues` in ApplicationDefinition were deprecated in KKP 2.25 and will be removed in KKP 2.27+.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cc @xrstf 
/milestone KKP 2.26
