### PR TITLE
[release/v2.25] add 2.25.11 changelog

### DIFF
--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -11,6 +11,15 @@
 - [v2.25.8](#v2258)
 - [v2.25.9](#v2259)
 - [v2.25.10](#v22510)
+- [v2.25.11](#v22511)
+
+## v2.25.11
+
+**GitHub release: [v2.25.11](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.11)**
+
+### Bugfixes
+
+- Fix reconciling loop when resetting Application values to an empty value ([#13741](https://github.com/kubermatic/kubermatic/pull/13741))
 
 ## v2.25.10
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the new changelog for today's second (sigh) release.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
