### PR TITLE
fix KKP version check for CRD upgrades when using commit-based images

### DIFF
--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -200,8 +200,9 @@ var versionRegex = regexp.MustCompile(`^(.+)-([0-9]+)-g[0-9a-f]+$`)
 // special, and so would say "v2.21.0-10-gfd517a" < "v2.21.0-7-gfd517a".
 // Semverlib correctly handles the version suffix, so alpha.4 is smaller than
 // alpha.12.
-// This function knows about the KKP versioning scheme and zerofills the
-// number of commits to allow a stable sorting order.
+// This function knows about the KKP versioning scheme and turns the commit
+// number into a zeta suffix, effectively turning "v2.21.0-7-gabcdef" into
+// "v2.21.0-zeta.7".
 func comparableVersionSuffix(version string) string {
 	match := versionRegex.FindStringSubmatch(version)
 	if match == nil {
@@ -217,8 +218,8 @@ func comparableVersionSuffix(version string) string {
 
 		if parsed.Prerelease() == "" {
 			// Inject zeta as hopefully the highest we ever go in prereleases,
-			// so that "v1.0.0-zeta" > "v1.0.0-beta"
-			return fmt.Sprintf("%s-zeta-0", version)
+			// so that "v1.0.0-zeta.0" > "v1.0.0-beta"
+			return fmt.Sprintf("%s-zeta.0", version)
 		}
 
 		return version
@@ -227,11 +228,11 @@ func comparableVersionSuffix(version string) string {
 	base := match[1]
 	commits := match[2]
 
-	// a version like "v1.2.3-00007" is not valid, so we must treat
+	// a version like "v1.2.3-7" is not valid, so we must treat
 	// versions without a second segment special
 	if !strings.Contains(base, "-") {
-		return fmt.Sprintf("%s-zeta-%09s", base, commits)
+		return fmt.Sprintf("%s-zeta.%s", base, commits)
 	}
 
-	return fmt.Sprintf("%s-%09s", base, commits)
+	return fmt.Sprintf("%s.%s", base, commits)
 }

--- a/pkg/controller/operator/common/resources_test.go
+++ b/pkg/controller/operator/common/resources_test.go
@@ -17,10 +17,24 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	semverlib "github.com/Masterminds/semver/v3"
+	"github.com/google/go-cmp/cmp"
+
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestComparableVersionSuffix(t *testing.T) {
@@ -40,6 +54,7 @@ func TestComparableVersionSuffix(t *testing.T) {
 		{"v1.0.1", "v1.0.0-9-gabcdef"},
 		{"v1.0.1-beta.1-9-gabcdef", "v1.0.0-beta.1"},
 		{"v1.0.1-beta.1-10-gabcdef", "v1.0.0-beta.1-9-gabcdef"},
+		{"v1.0.0-beta.2", "v1.0.0-beta.1-7-gabcdef"},
 	}
 
 	for _, testcase := range testcases {
@@ -56,6 +71,167 @@ func TestComparableVersionSuffix(t *testing.T) {
 
 			if !greater.GreaterThan(smaller) {
 				t.Fatalf("Comparing %q > %q after patching (%q > %q) should have yielded true.", testcase.greater, testcase.smaller, greater.String(), smaller.String())
+			}
+		})
+	}
+}
+
+func TestReconcilingCRDs(t *testing.T) {
+	const crdName = "objects.kubermatic.k8c.io"
+
+	theUpdate := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crdName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Scope: apiextensionsv1.ClusterScoped,
+		},
+	}
+
+	testcases := []struct {
+		name     string
+		versions kubermaticversion.Versions
+		existing *apiextensionsv1.CustomResourceDefinition
+		expected *apiextensionsv1.CustomResourceDefinition
+	}{
+		{
+			name:     "CRD doesn't exist yet, should be created",
+			versions: kubermaticversion.Versions{Kubermatic: "irrelevant-too", KubermaticCommit: "does-not-matter-in-this-case"},
+			existing: nil,
+			expected: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "does-not-matter-in-this-case",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.ClusterScoped,
+				},
+			},
+		},
+		{
+			name:     "upgrade existing v1 CRD to v2",
+			versions: kubermaticversion.Versions{Kubermatic: "v2.0.0", KubermaticCommit: "v2.0.0"},
+			existing: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "v1.9.0",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.NamespaceScoped,
+				},
+			},
+			expected: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "v2.0.0",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.ClusterScoped,
+				},
+			},
+		},
+		{
+			name:     "do not downgrade a v3 CRD to v2",
+			versions: kubermaticversion.Versions{Kubermatic: "v2.0.0", KubermaticCommit: "v2.0.0"},
+			existing: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "v3.1.0",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.NamespaceScoped,
+				},
+			},
+			expected: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "v3.1.0",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.NamespaceScoped,
+				},
+			},
+		},
+		{
+			name:     "upgrade from non-tagged version to a newer tagged version",
+			versions: kubermaticversion.Versions{Kubermatic: "v2.26.0-beta.2", KubermaticCommit: "v2.26.0-beta.2"},
+			existing: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "v2.26.0-beta.1-13-g108b0b653",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.NamespaceScoped,
+				},
+			},
+			expected: &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crdName,
+					Annotations: map[string]string{
+						resources.VersionLabel: "v2.26.0-beta.2",
+					},
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Scope: apiextensionsv1.ClusterScoped,
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	logger := log.NewDefault().Sugar()
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			clientBuilder := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme)
+			if tc.existing != nil {
+				clientBuilder.WithObjects(tc.existing)
+			}
+
+			client := clientBuilder.Build()
+
+			factories := []reconciling.NamedCustomResourceDefinitionReconcilerFactory{
+				CRDReconciler(theUpdate, logger, tc.versions),
+			}
+
+			// reconcile the CRD
+			err := reconciling.ReconcileCustomResourceDefinitions(ctx, factories, "", client)
+			if err != nil {
+				t.Fatalf("Failed to reconcile CRD: %v", err)
+			}
+
+			// get the new state in-cluster
+			newState := &apiextensionsv1.CustomResourceDefinition{}
+			if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(theUpdate), newState); err != nil {
+				t.Fatalf("Failed to get new CRD state from cluster: %v", err)
+			}
+
+			// assert that the desired changes (if any) were made
+			if !cmp.Equal(newState.Annotations, tc.expected.Annotations) {
+				t.Errorf("Expected annotations = %v, but got %v.", tc.expected.Annotations, newState.Annotations)
+			}
+
+			// makes comparisons easier in this testcase
+			newState.Spec.Conversion = nil
+
+			if !cmp.Equal(newState.Spec, tc.expected.Spec) {
+				t.Errorf("Expected spec = %+v, but got %+v.", tc.expected.Spec, newState.Spec)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a cornercase in the version comparison logic that we have to allow commit-based KKP versions (used on dev and QA). This is not something that would ever affect users who use regular, tagged KKP releases.

I have added the cornercase to the tests, fixed the helper function and then added some additional tests for the CRD reconciler.

The bug existed because the old helper function would have turned `v2.26.0-beta.1-13-g108b0b653` into `v2.26.0-beta.1-000000013`. The semver spec however only considers dots to be separators in the prerelease part of a version, so when comparing `v2.26.0-beta.1-000000013` to `v2.26.0-beta.2`, semverlib would compare `1-000000013` to `2` and that yields unexpected results for us.

The new helper function appends the commit count as the virtual `zeta` release stage in the form `zeta.13` instead of `000000013`. Because this is so weird, the helper function must never ever leave the package and be available for anything but as an internal helper for comparing two KKP semvers. That's also the reason there is no test for the explicit return values of the helper func, as those are not really interesting. The only thing that counts is that we can compare correctly, not how we sneak the commit count into the version.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix KKP version check for CRD upgrades when using commit-based images
```

**Documentation**:
```documentation
NONE
```
