### PR TITLE
Add initial-cni annotation to hidden annotations for UI

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -137,7 +137,7 @@ type SettingSpec struct {
 
 // AnnotationSettings is the settings for the annotations.
 type AnnotationSettings struct {
-	// +kubebuilder:default:={"kubectl.kubernetes.io/last-applied-configuration", "kubermatic.io/initial-application-installations-request", "kubermatic.io/initial-machinedeployment-request"}
+	// +kubebuilder:default:={"kubectl.kubernetes.io/last-applied-configuration", "kubermatic.io/initial-application-installations-request", "kubermatic.io/initial-machinedeployment-request", "kubermatic.io/initial-cni-values-request"}
 
 	// HiddenAnnotations are the annotations that are hidden from the user in the UI.
 	// +optional

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -59,6 +59,7 @@ spec:
                         - kubectl.kubernetes.io/last-applied-configuration
                         - kubermatic.io/initial-application-installations-request
                         - kubermatic.io/initial-machinedeployment-request
+                        - kubermatic.io/initial-cni-values-request
                       description: HiddenAnnotations are the annotations that are hidden from the user in the UI.
                       items:
                         type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

Through https://github.com/kubermatic/dashboard/issues/6859, we figured out that `kubermatic.io/initial-cni-values-request` should also be included in the list of default hidden annotations.

Right now, the defaulting is divided between API and the CRD itself but API is the main component that is enforcing our defaults for hidden and protected annotations. Through https://github.com/kubermatic/kubermatic/issues/13671, we'd like to change this, it is yet to be planned/refined/finalized but it requires significant effort and is out of scope for 2.26. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`kubermatic.io/initial-cni-values-request` is now included in the default hidden annotations list for the dashboard
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
