### PR TITLE
provide default Helm values for nvidia GPU operator to prevent name length issues

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
@@ -34,6 +34,9 @@ spec:
             chartVersion: v23.9.1
             url: https://helm.ngc.nvidia.com/nvidia
       version: v23.9.1
+  defaultValues:
+    node-feature-discovery:
+      fullnameOverride: gpu-operator-node-feature-discovery
   documentationURL: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html
   sourceURL: https://github.com/NVIDIA/gpu-operator/
   logo: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Installing the nvidia GPU operator app with default settings results in

> handling installation of application installation: failed to create resource: Service "nvidia-gpu-operator-nvidia-gpu-operator-node-feature-discovery-master" is invalid: metadata.name: Invalid value: "nvidia-gpu-operator-nvidia-gpu-operator-node-feature-discovery-master": must be no more than 63 characters

By providing an override for the subchart's name we can avoid this issue.

Fixes #13592

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
nvidia-gpu-operator Application now configures a name override to be installable in the default `nvidia-gpu-operator` namespace.
```

```documentation
NONE
```
