### PR TITLE
make SIG Apps the code owner of the default app catalog

### DIFF
--- a/pkg/ee/default-application-catalog/OWNERS
+++ b/pkg/ee/default-application-catalog/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-app-management
+
+reviewers:
+  - sig-app-management
+
+labels:
+  - sig/app-management
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes to the default apps should always be overseen by the SIG that maintains them.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
