### PR TITLE
Add kv-infra-namespace flag to usercluster-controller

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -435,11 +435,13 @@ func main() {
 		if err != nil {
 			log.Fatalw("Failed to get KubeVirt infra kubeconfig", zap.Error(err))
 		}
+		// VM and VMIs are created in a namespace having the same name as the cluster namespace name.
 		kvCacheOpts := cache.Options{
 			DefaultNamespaces: map[string]cache.Config{
 				runOp.namespace: {},
 			},
 		}
+		// If kv-infra-namespace flag is set, that means Kubevirt is running in the namespaced mode, so all workloads will be deployed in the specified namespace.
 		if runOp.kubeVirtInfraNamespace != "" {
 			kvCacheOpts = cache.Options{
 				DefaultNamespaces: map[string]cache.Config{
@@ -450,8 +452,7 @@ func main() {
 		kubevirtInfraMgr, err := manager.New(kubevirtInfraConfig, manager.Options{
 			LeaderElection: false,
 			Metrics:        metricsserver.Options{BindAddress: "0"},
-			// VM and VMIs are created in a namespace having the same name as the cluster namespace name.
-			Cache: kvCacheOpts,
+			Cache:          kvCacheOpts,
 		})
 		if err != nil {
 			log.Fatalw("Failed to construct kubevirt infra mgr", zap.Error(err))

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -436,23 +436,19 @@ func main() {
 			log.Fatalw("Failed to get KubeVirt infra kubeconfig", zap.Error(err))
 		}
 		// VM and VMIs are created in a namespace having the same name as the cluster namespace name.
-		kvCacheOpts := cache.Options{
-			DefaultNamespaces: map[string]cache.Config{
-				runOp.namespace: {},
-			},
-		}
+		kvInfraNamespace := runOp.namespace
 		// If kv-infra-namespace flag is set, that means Kubevirt is running in the namespaced mode, so all workloads will be deployed in the specified namespace.
 		if runOp.kubeVirtInfraNamespace != "" {
-			kvCacheOpts = cache.Options{
-				DefaultNamespaces: map[string]cache.Config{
-					runOp.kubeVirtInfraNamespace: {},
-				},
-			}
+			kvInfraNamespace = runOp.kubeVirtInfraNamespace
 		}
 		kubevirtInfraMgr, err := manager.New(kubevirtInfraConfig, manager.Options{
 			LeaderElection: false,
 			Metrics:        metricsserver.Options{BindAddress: "0"},
-			Cache:          kvCacheOpts,
+			Cache: cache.Options{
+				DefaultNamespaces: map[string]cache.Config{
+					kvInfraNamespace: {},
+				},
+			},
 		})
 		if err != nil {
 			log.Fatalw("Failed to construct kubevirt infra mgr", zap.Error(err))

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -223,6 +223,9 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 			if data.Cluster().Spec.Cloud.Kubevirt != nil {
 				args = append(args, "-kv-vmi-eviction-controller")
 				args = append(args, "-kv-infra-kubeconfig", "/etc/kubernetes/kubevirt/infra-kubeconfig")
+				if data.DC().Spec.Kubevirt != nil && data.DC().Spec.Kubevirt.NamespacedMode != nil && data.DC().Spec.Kubevirt.NamespacedMode.Enabled {
+					args = append(args, "-kv-infra-namespace", data.DC().Spec.Kubevirt.NamespacedMode.Namespace)
+				}
 			}
 
 			if data.UserClusterMLAEnabled() && data.Cluster().Spec.MLA != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubevirt vmi eviction controller expects the workload to be deployed in the same namespace as passed in arguments to usercluster-controller deployment.
This PR will add the support for namespace mode, so the controller can watch resources in the selected namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kv-infra-namespace flag to usercluster-controller
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
