### PR TITLE
remove leftover default cilium addon

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -323,12 +323,6 @@ spec:
         - apiVersion: kubermatic.k8c.io/v1
           kind: Addon
           metadata:
-            name: cilium
-            labels:
-              addons.kubermatic.io/ensure: true
-        - apiVersion: kubermatic.k8c.io/v1
-          kind: Addon
-          metadata:
             name: csi
             labels:
               addons.kubermatic.io/ensure: true

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -323,12 +323,6 @@ spec:
         - apiVersion: kubermatic.k8c.io/v1
           kind: Addon
           metadata:
-            name: cilium
-            labels:
-              addons.kubermatic.io/ensure: true
-        - apiVersion: kubermatic.k8c.io/v1
-          kind: Addon
-          metadata:
             name: csi
             labels:
               addons.kubermatic.io/ensure: true

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -810,12 +810,6 @@ items:
 - apiVersion: kubermatic.k8c.io/v1
   kind: Addon
   metadata:
-    name: cilium
-    labels:
-      addons.kubermatic.io/ensure: true
-- apiVersion: kubermatic.k8c.io/v1
-  kind: Addon
-  metadata:
     name: csi
     labels:
       addons.kubermatic.io/ensure: true


### PR DESCRIPTION
**What this PR does / why we need it**:
There is no such addon anymore and we forgot to remove it in #13229.

**Which issue(s) this PR fixes**:
Fixes #13760

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
