### PR TITLE
Add Kubernetes v1.31.1, v1.30.5, v1.29.9, v1.28.14

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -454,31 +454,31 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.30.3
+    default: v1.30.5
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.30
+        default: v1.31
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.31
           - v1.30
           - v1.29
           - v1.28
-          - v1.27
       eks:
         # Default is the default version to offer users.
-        default: v1.30
+        default: v1.31
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.31
           - v1.30
           - v1.29
           - v1.28
-          - v1.27
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
@@ -555,16 +555,14 @@ spec:
       - v1.28.6
       - v1.28.7
       - v1.28.9
-      - v1.28.11
-      - v1.28.12
+      - v1.28.14
       - v1.29.0
       - v1.29.1
       - v1.29.2
       - v1.29.4
-      - v1.29.6
-      - v1.29.7
-      - v1.30.3
-      - v1.31.0
+      - v1.29.9
+      - v1.30.5
+      - v1.31.1
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -454,31 +454,31 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.30.3
+    default: v1.30.5
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.30
+        default: v1.31
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.31
           - v1.30
           - v1.29
           - v1.28
-          - v1.27
       eks:
         # Default is the default version to offer users.
-        default: v1.30
+        default: v1.31
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.31
           - v1.30
           - v1.29
           - v1.28
-          - v1.27
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
@@ -555,16 +555,14 @@ spec:
       - v1.28.6
       - v1.28.7
       - v1.28.9
-      - v1.28.11
-      - v1.28.12
+      - v1.28.14
       - v1.29.0
       - v1.29.1
       - v1.29.2
       - v1.29.4
-      - v1.29.6
-      - v1.29.7
-      - v1.30.3
-      - v1.31.0
+      - v1.29.9
+      - v1.30.5
+      - v1.31.1
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.30.3"),
+		Default: semver.NewSemverOrDie("v1.30.5"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -231,19 +231,17 @@ var (
 			newSemver("v1.28.6"),
 			newSemver("v1.28.7"),
 			newSemver("v1.28.9"),
-			newSemver("v1.28.11"),
-			newSemver("v1.28.12"),
+			newSemver("v1.28.14"),
 			// Kubernetes 1.29
 			newSemver("v1.29.0"),
 			newSemver("v1.29.1"),
 			newSemver("v1.29.2"),
 			newSemver("v1.29.4"),
-			newSemver("v1.29.6"),
-			newSemver("v1.29.7"),
+			newSemver("v1.29.9"),
 			// Kubernetes 1.30
-			newSemver("v1.30.3"),
+			newSemver("v1.30.5"),
 			// Kubernetes 1.31
-			newSemver("v1.31.0"),
+			newSemver("v1.31.1"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.27 =======

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -347,12 +347,12 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.30"),
+		Default: semver.NewSemverOrDie("v1.31"),
 		Versions: []semver.Semver{
+			newSemver("v1.31"),
 			newSemver("v1.30"),
 			newSemver("v1.29"),
 			newSemver("v1.28"),
-			newSemver("v1.27"),
 		},
 	}
 

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -359,12 +359,12 @@ var (
 	aksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
-		Default: semver.NewSemverOrDie("v1.30"),
+		Default: semver.NewSemverOrDie("v1.31"),
 		Versions: []semver.Semver{
+			newSemver("v1.31"),
 			newSemver("v1.30"),
 			newSemver("v1.29"),
 			newSemver("v1.28"),
-			newSemver("v1.27"),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps our supported Kubernetes releases to the latest patch releases. I removed 1.31.0 because it was never in a released KKP release and this way we can just keep the number of choices down for the enduser. This could lead to some hiccups on dev/QA, but those should not be problematic.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Add support for Kubernetes v1.31.1, v1.30.5, v1.29.9, v1.28.14
* Add 1.31, remove 1.27 from the list of supported Kubernetes releases on AKS and EKS
```

**Documentation**:
```documentation
NONE
```
