### PR TITLE
fix config format confusion in IAP Helm chart

### DIFF
--- a/charts/iap/templates/configmaps.yaml
+++ b/charts/iap/templates/configmaps.yaml
@@ -19,7 +19,7 @@ kind: ConfigMap
 metadata:
   name: iap-{{ .name }}-configmap
 data:
-  config.yaml: |
+  config.toml: |
 {{- with .config }}
 {{ toToml . | indent 4 }}
 {{ end }}

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -57,7 +57,7 @@ spec:
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --skip-provider-button=true
-        - --config=/config/config.yaml
+        - --config=/config/config.toml
         envFrom:
         - secretRef:
             name: iap-{{ .name }}-secret
@@ -102,8 +102,8 @@ spec:
         configMap:
           name: iap-{{ .name }}-configmap
           items:
-          - key: config.yaml
-            path: config.yaml
+          - key: config.toml
+            path: config.toml
       {{- if $.Values.iap.customProviderCA }}
       - name: ca
         secret:

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -29,7 +29,7 @@ kind: ConfigMap
 metadata:
   name: iap-grafana-configmap
 data:
-  config.yaml: |
+  config.toml: |
     email_domains = ["*"]
     pass_user_headers = true
     scope = "groups openid email"
@@ -75,7 +75,7 @@ spec:
         app: iap
         target: grafana
       annotations:
-        checksum/config: 936eab509d15a40f2b18a0897a108817cb8245ddafa2d0aede0f4dc907a2f84f
+        checksum/config: 3eb19f22de67d07022b88471775d905239c8243cc606e074e23ed5ef0cf460e3
         checksum/secrets: a61bd91da5fb2369cbc0ba73e52178417ac106a21ef3621f1f212c7a49665749
     spec:
       containers:
@@ -93,7 +93,7 @@ spec:
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --skip-provider-button=true
-        - --config=/config/config.yaml
+        - --config=/config/config.toml
         envFrom:
         - secretRef:
             name: iap-grafana-secret
@@ -139,8 +139,8 @@ spec:
         configMap:
           name: iap-grafana-configmap
           items:
-          - key: config.yaml
-            path: config.yaml
+          - key: config.toml
+            path: config.toml
       nodeSelector:
         {}
       affinity:

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -53,7 +53,7 @@ kind: ConfigMap
 metadata:
   name: iap-alertmanager-configmap
 data:
-  config.yaml: |
+  config.toml: |
     email_domains = ["*"]
     github_org = "mygithuborg"
     github_team = "mygroup"
@@ -66,7 +66,7 @@ kind: ConfigMap
 metadata:
   name: iap-grafana-configmap
 data:
-  config.yaml: |
+  config.toml: |
     email_domains = ["*"]
     pass_user_headers = true
     scope = "groups openid email"
@@ -132,7 +132,7 @@ spec:
         app: iap
         target: alertmanager
       annotations:
-        checksum/config: 9d42d5e5e3115f9e165027dbe538999f504cb248ea530ca85e7edb082741e69d
+        checksum/config: 17ed91a5ca15d5e382000192ade7030736b5f2037cc9fbe9020535cef3dbf750
         checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
     spec:
       containers:
@@ -150,7 +150,7 @@ spec:
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --skip-provider-button=true
-        - --config=/config/config.yaml
+        - --config=/config/config.toml
         envFrom:
         - secretRef:
             name: iap-alertmanager-secret
@@ -196,8 +196,8 @@ spec:
         configMap:
           name: iap-alertmanager-configmap
           items:
-          - key: config.yaml
-            path: config.yaml
+          - key: config.toml
+            path: config.toml
       nodeSelector:
         {}
       affinity:
@@ -233,7 +233,7 @@ spec:
         app: iap
         target: grafana
       annotations:
-        checksum/config: 9d42d5e5e3115f9e165027dbe538999f504cb248ea530ca85e7edb082741e69d
+        checksum/config: 17ed91a5ca15d5e382000192ade7030736b5f2037cc9fbe9020535cef3dbf750
         checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
     spec:
       containers:
@@ -251,7 +251,7 @@ spec:
         - --silence-ping-logging=true
         - --reverse-proxy=true
         - --skip-provider-button=true
-        - --config=/config/config.yaml
+        - --config=/config/config.toml
         envFrom:
         - secretRef:
             name: iap-grafana-secret
@@ -297,8 +297,8 @@ spec:
         configMap:
           name: iap-grafana-configmap
           items:
-          - key: config.yaml
-            path: config.yaml
+          - key: config.toml
+            path: config.toml
       nodeSelector:
         {}
       affinity:

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -23,7 +23,6 @@ iap:
   #   - name: quay-io-pull-secret
   imagePullSecrets: []
 
-
   # secret which holds the CA certificates that should be used when connecting to the provider
   # custom_provider_ca_secret: provider-ca-secret
 
@@ -41,13 +40,14 @@ iap:
     #   client_id: alertmanager
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+    #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview
     #     scope: "groups openid email"
     #     email_domains:
     #       - '*'
     #     ## example configuration allowing access only to the mygroup from mygithuborg organization
-    #     github_org: mygithuborg
-    #     github_team: mygroup
+    #     githubConfig:
+    #       org: mygithuborg
+    #       team: "mygroup,mygroup2"
     #     ## do not route health endpoint through the proxy
     #     skip_auth_regex:
     #       - '/-/healthy'
@@ -66,7 +66,7 @@ iap:
     #   client_id: grafana
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+    #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview
     #     scope: "groups openid email"
     #     email_domains:
     #       - '*'
@@ -89,7 +89,7 @@ iap:
     #   client_id: prometheus
     #   client_secret: xxx
     #   encryption_key: xxx
-    #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+    #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview
     #     scope: "groups openid email"
     #     email_domains:
     #       - '*'


### PR DESCRIPTION
**What this PR does / why we need it**:
Since #5777, 4 years ago, we accidentally created a TOML file but named it `.yaml`. For most configurations, this is not ap problem as gocfg seems to transparently just try YAML first and then TOML. However when more complex configuration is used, the oauth2-proxy will CrashLoop with something like

```
[2024/09/27 12:37:04] [main.go:41] ERROR: failed to load config: error unmarshalling config: 1 error(s) decoding:

* '' has invalid keys: resources, scopes
```

This PR completes the YAML->TOML change and uses .toml consistently everywhere.

Also, `github_team` and `github_org` are supposedly legacy options and so I updated it to the new provider options (https://github.com/oauth2-proxy/oauth2-proxy/blob/master/pkg/apis/options/providers.go#L171-L184).

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix TOML/YAML configuration mixup in the IAP Helm chart.
```

**Documentation**:
```documentation
NONE
```
