### PR TITLE
fix: typo issue in kube-state-metric addon

### DIFF
--- a/addons/kube-state-metrics/helm-values
+++ b/addons/kube-state-metrics/helm-values
@@ -3,7 +3,7 @@ podDisruptionBudget:
   # defined a minAvailable=1 PDB, Kubernetes would block that Pod from being
   # evicted, see https://github.com/kubernetes/kubernetes/issues/93476;
   # We still need a PDB to make the Pod evictable by the cluster-autoscaler.
-  maxUnvailable: 1
+  maxUnavailable: 1
 
 kubeRBACProxy:
   enabled: true

--- a/addons/kube-state-metrics/kube-state-metrics.yaml
+++ b/addons/kube-state-metrics/kube-state-metrics.yaml
@@ -69,7 +69,7 @@ metadata:
   name: kube-state-metrics
   namespace: kube-system
 spec:
-  maxUnvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: kube-state-metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
kube-state-addon - when reconciled was throwing warning on cluster events due to spelling mistake in PDB definition. 

Issue identified during KKP 2.26 QA testing.

**Which issue(s) this PR fixes**:
NA

**What type of PR is this?**
/kind bug
/kind chore
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
