### PR TITLE
Tweak configuration of the kube-state-metrics v2.13.0 addon

### DIFF
--- a/addons/kube-state-metrics/helm-values
+++ b/addons/kube-state-metrics/helm-values
@@ -15,7 +15,7 @@ kubeRBACProxy:
       cpu: 20m
       memory: 20Mi
 
-# with kubeRBACProxy enabled above, default scraping won't work, showring errors
+# with kubeRBACProxy enabled above, default scraping won't work, showing errors
 prometheusScrape: false
 
 networkPolicy:
@@ -36,9 +36,9 @@ networkPolicy:
   egress:
     - to:
         - ipBlock:
-            cidr: '{{ .Cluster.Address.IP }}/32'
+            cidr: "{{ .Cluster.Address.IP }}/32"
       ports:
-        - port: '{{ .Cluster.Address.Port }}'
+        - port: "{{ .Cluster.Address.Port }}"
 
 resources:
   limits:

--- a/addons/kube-state-metrics/helm-values
+++ b/addons/kube-state-metrics/helm-values
@@ -15,6 +15,9 @@ kubeRBACProxy:
       cpu: 20m
       memory: 20Mi
 
+# with kubeRBACProxy enabled above, default scraping won't work, showring errors
+prometheusScrape: false
+
 networkPolicy:
   enabled: true
 

--- a/addons/kube-state-metrics/kube-state-metrics.yaml
+++ b/addons/kube-state-metrics/kube-state-metrics.yaml
@@ -362,8 +362,7 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/scrape: "true"
+  annotations: null
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: kube-state-metrics

--- a/addons/kube-state-metrics/mla-rolebinding.yaml
+++ b/addons/kube-state-metrics/mla-rolebinding.yaml
@@ -1,0 +1,37 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Cluster.MLA.MonitoringEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy-authorized-client
+rules:
+- apiGroups: [""]
+  resources: ["services/kube-state-metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy-authorized-client
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy-authorized-client
+subjects:
+- kind: ServiceAccount
+  name: mla-monitoring-agent
+  namespace: mla-system
+{{ end }}

--- a/addons/kube-state-metrics/mla-rolebinding.yaml
+++ b/addons/kube-state-metrics/mla-rolebinding.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
#13599 introduced new helm chart to generate kube-state-metrics addon, this PR:
* adds correct RBAC for mla-monitoring-agent
* removes old scraping annotation (broken with introduction of kube-rbac-proxy)

Without this there are 3 targets for kube-state-metrics, all down (one due to rbac proxy responding with a 403, 2 down because the usual endpoints don't work anymore)

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
