### PR TITLE
mla: grafana statefulset dashboard fix

### DIFF
--- a/charts/mla/grafana/files/kkp-kubernetes-statefulsets.json
+++ b/charts/mla/grafana/files/kkp-kubernetes-statefulsets.json
@@ -250,7 +250,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubernetes-nodes-cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubernetes-nodes-cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",

--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -3137,7 +3137,7 @@ data:
               "datasource": {
                 "uid": "$datasource"
               },
-              "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubernetes-nodes-cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
+              "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubernetes-nodes-cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -3137,7 +3137,7 @@ data:
               "datasource": {
                 "uid": "$datasource"
               },
-              "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubernetes-nodes-cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\", container!=\"\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
+              "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubernetes-nodes-cadvisor\", namespace=\"$namespace\", pod=~\"$statefulset.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\",pod=~\"$statefulset.*\"}[3m]))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "",


### PR DESCRIPTION
**What this PR does / why we need it**:
After some updates the structure of `container_network_transmit_bytes_total` metric has changed, no label named `container` exists anymore.

* fixes query in dashboard StatefulSets, panel Network

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
