### PR TITLE
fix dev deploy script not creating the iap namespace

### DIFF
--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -74,10 +74,14 @@ function deploy {
     echodate "Deployment has been manually disabled on this cluster. Skipping this chart."
   else
     echodate "Upgrading $name..."
-
-    # Do not set --force, as this will cause problems when upgrading a Helm release.
-    # See Helm issue #7956 and the upstream k8s bug #91459, which was fixed in 1.22+.
-    retry 5 helm --namespace "$namespace" upgrade --install --atomic --timeout "$timeout" --values "$VALUES_FILE" "$name" "$path"
+    retry 5 helm upgrade \
+      --namespace "$namespace" \
+      --create-namespace \
+      --install \
+      --atomic \
+      --timeout "$timeout" \
+      --values "$VALUES_FILE" \
+      "$name" "$path"
   fi
 
   unset TEST_NAME


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the original issue by providing `--create-namespace` and removes a comment.

The comment originated in #7574. However since we disabled it, we have never actually encountered issues without the `--force` flag and so I think we do not actually need it anyway. Plus it would be a good indicator of accidental breaking changes if a Helm upgrade were to fail, so not having `--force` is actually IMHO a slight advantage.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
