### PR TITLE
Update oauth2-proxy to 7.7.0

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: 9.9.9-dev
-appVersion: v7.6.0
+appVersion: v7.7.0
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.7.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.7.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -238,7 +238,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.7.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.6.0
+    tag: v7.7.0
     pullPolicy: IfNotPresent
 
   # list of image pull secret references, e.g.


### PR DESCRIPTION
**What this PR does / why we need it**:
v7.7.0 addresses a number of CVEs: https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.0

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update oauth2-proxy to 7.7.0.
```

**Documentation**:
```documentation
NONE
```
