### PR TITLE
Add kubevirt provider network

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1399,6 +1399,10 @@ type KubevirtCloudSpec struct {
 	StorageClasses []KubeVirtInfraStorageClass `json:"storageClasses,omitempty"`
 	// ImageCloningEnabled flag enable/disable cloning for a cluster.
 	ImageCloningEnabled bool `json:"imageCloningEnabled,omitempty"`
+	// VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt.
+	VPCName string `json:"vpcName,omitempty"`
+	// SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
+	SubnetName string `json:"subnetName,omitempty"`
 }
 
 type PreAllocatedDataVolume struct {

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -407,6 +407,12 @@ type Kubevirt struct {
 
 	// Kubeconfig is the cluster's kubeconfig file, encoded with base64.
 	Kubeconfig string `json:"kubeconfig"`
+
+	// VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt
+	VPCName string `json:"vpcName,omitempty"`
+
+	// SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
+	SubnetName string `json:"subnetName,omitempty"`
 }
 
 func (s Kubevirt) IsValid() bool {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -993,6 +993,12 @@ spec:
                               - name
                             type: object
                           type: array
+                        subnetName:
+                          description: SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
+                          type: string
+                        vpcName:
+                          description: VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt.
+                          type: string
                       type: object
                     nutanix:
                       description: Nutanix defines the configuration data of the Nutanix.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -987,6 +987,12 @@ spec:
                               - name
                             type: object
                           type: array
+                        subnetName:
+                          description: SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
+                          type: string
+                        vpcName:
+                          description: VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt.
+                          type: string
                       type: object
                     nutanix:
                       description: Nutanix defines the configuration data of the Nutanix.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -463,6 +463,12 @@ spec:
                     kubeconfig:
                       description: Kubeconfig is the cluster's kubeconfig file, encoded with base64.
                       type: string
+                    subnetName:
+                      description: SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
+                      type: string
+                    vpcName:
+                      description: VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt
+                      type: string
                   required:
                     - kubeconfig
                   type: object


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding new cloud spec for KubeVirt to manage VMs networks when KubeOVN is used as a cni for the KubeVirt infra cluster, 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding support for KubeVirt provider network.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
