### PR TITLE
react to any changes to a Cluster object from the usercluster-ctrl-mgr

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1643,26 +1643,6 @@ func (cluster *Cluster) GetSecretName() string {
 	return ""
 }
 
-func (cluster *Cluster) GetUserClusterMLAResourceRequirements() map[string]*corev1.ResourceRequirements {
-	if cluster.Spec.MLA == nil {
-		return nil
-	}
-	return map[string]*corev1.ResourceRequirements{
-		"monitoring": cluster.Spec.MLA.MonitoringResources,
-		"logging":    cluster.Spec.MLA.LoggingResources,
-	}
-}
-
-func (cluster *Cluster) GetUserClusterOPAResourceRequirements() map[string]*corev1.ResourceRequirements {
-	if cluster.Spec.OPAIntegration == nil {
-		return nil
-	}
-	return map[string]*corev1.ResourceRequirements{
-		"controller": cluster.Spec.OPAIntegration.ControllerResources,
-		"audit":      cluster.Spec.OPAIntegration.AuditResources,
-	}
-}
-
 // IsEncryptionConfigurationEnabled returns whether encryption-at-rest is configured on this cluster.
 func (cluster *Cluster) IsEncryptionEnabled() bool {
 	return cluster.Spec.Features[ClusterFeatureEncryptionAtRest] && cluster.Spec.EncryptionConfiguration != nil && cluster.Spec.EncryptionConfiguration.Enabled

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -150,9 +150,9 @@ func Add(
 
 		return []reconcile.Request{
 			{NamespacedName: types.NamespacedName{
-				// There is no "parent object" like e.e. a cluster that can be used to reconcile, we just have a random set of resources
-				// we reconcile one after another. To ensure we always have only one reconcile running at a time, we
-				// use a static string as identifier
+				// There is no "parent object" like for example a cluster that can be used to reconcile,
+				// we just have a random set of resources we reconcile one after another.
+				// To ensure we always have only one reconcile running at a time, we use a static string as identifier.
 				Name:      "identifier",
 				Namespace: "",
 			}}}


### PR DESCRIPTION
**What this PR does / why we need it**:
When testing #13756 I noticed that my changes in the Cluster object were not applied immediately, but only with a large delay. It turns out we explicitly ignore every change to the Cluster object, except for MLA/OPA resources, and ignore the Cluster object entirely if MLA/OPA are disabled.

I think this is wrong and the usercluster-ctrl-mgr should react to any spec changes in the Cluster object. Evidently more than just resources have an influence over the in-cluster resources.

In a future PR we might even want to scope this down again to only watch the _relevant_ Cluster object, not all of them. But for that the usercluster-ctrl-mgr's startup logic should change to identify the relevant cluster once and then just remember the name during runtime.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Changes to a Cluster object were not always applied immediately to usercluster resources.
```

**Documentation**:
```documentation
NONE
```
