### PR TITLE
always clone maps when ensuring labels

### DIFF
--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -19,6 +19,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"sort"
 	"strconv"
@@ -384,7 +385,7 @@ func EnsureUniqueOwnerReference(o metav1.Object, ref metav1.OwnerReference) {
 }
 
 func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
-	labels := o.GetLabels()
+	labels := maps.Clone(o.GetLabels())
 
 	if labels == nil {
 		labels = make(map[string]string)
@@ -396,7 +397,7 @@ func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
 }
 
 func EnsureAnnotations(o metav1.Object, toEnsure map[string]string) {
-	annotations := o.GetAnnotations()
+	annotations := maps.Clone(o.GetAnnotations())
 
 	if annotations == nil {
 		annotations = make(map[string]string)

--- a/pkg/resources/reconciling/modifier/related_revisions.go
+++ b/pkg/resources/reconciling/modifier/related_revisions.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -79,18 +80,7 @@ func addRevisionLabelsToPodSpec(ctx context.Context, client ctrlruntimeclient.Cl
 		return err
 	}
 
-	// Clone the original labels in case the identical map is also referenced elsewhere in the
-	// PodTemplate (most notably the MatchLabels in the Selector).
-
-	labels := map[string]string{}
-	for k, v := range ps.GetLabels() {
-		labels[k] = v
-	}
-	for k, v := range revisionLabels {
-		labels[k] = v
-	}
-
-	ps.SetLabels(labels)
+	kubernetes.EnsureLabels(ps, revisionLabels)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
For the revisionLabel modifier we already had a unit test since #13703 to ensure no accidental map modifications. For the versionLabel modifier we did not have such a test and this affected the nodeport-proxy-updater Deployment, which suddenly had its version in the MatchLabels -- no good.

In this PR I am changing my mind :grin: and have decided that it might be a good idea after all to always clone the labels/annotations. Calling `kubernetes.EnsureLabels()` never indicates that the caller wants to modify *other* maps. At least I think so. I am open to other thoughts, as my PR would "break" objects now by splitting maps, which might also be an unintended side effect? However for me personally at least, relying on map identity is not my style and nothing I would rely on.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
