### PR TITLE
Revert "feat: append front-load-balancer allowlist source ranges with cluster pod and service CIDR (#13579)

### DIFF
--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -888,17 +888,3 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 
 	return vars, nil
 }
-
-// GetPodCIDR returns the PodCIDR configured for the nodes in the cluster.
-func (d *TemplateData) GetPodCIDR() (string, error) {
-	nodeList := &corev1.NodeList{}
-	err := d.client.List(d.ctx, nodeList)
-	if err != nil {
-		return "", fmt.Errorf("could not get node list: %w", err)
-	}
-
-	if len(nodeList.Items) > 0 {
-		return nodeList.Items[0].Spec.PodCIDR, nil
-	}
-	return "", nil
-}

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -444,14 +444,6 @@ func FrontLoadBalancerServiceReconciler(data *resources.TemplateData) reconcilin
 			// Check if allowed IP ranges are configured and set the LoadBalancer source ranges
 			if data.Cluster().Spec.APIServerAllowedIPRanges != nil {
 				sourceIPList.Insert(data.Cluster().Spec.APIServerAllowedIPRanges.CIDRBlocks...)
-				podCIDR, err := data.GetPodCIDR()
-				if err != nil {
-					return nil, fmt.Errorf("failed to get seed cluster pod CIDR: %w", err)
-				}
-
-				if podCIDR != "" && !sourceIPList.Has(podCIDR) {
-					sourceIPList.Insert(podCIDR)
-				}
 			}
 
 			s.Spec.LoadBalancerSourceRanges = sets.List(sourceIPList)


### PR DESCRIPTION
**What this PR does / why we need it**:
#13772 noticed that the feature seems broken and the original author suggested to just remove it outright and trying to fix it again later. There was no definite decision being reached, so I am making one here: We are reverting the change.


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
(revert #13579, please remove release-note from generated changelog.)
```

**Documentation**:
```documentation
NONE
```
