### PR TITLE
Support KubeVirt VolumeBindingMode for Tenant Cluster 

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -76,6 +76,11 @@ spec:
                         : true If missing or false, annotation will be: storageclass.kubernetes.io/is-default-class
                         : false'
                       type: boolean
+                    volumeBindingMode:
+                      description: VolumeBindingMode indicates how PersistentVolumeClaims
+                        should be provisioned and bound. When unset, VolumeBindingImmediate
+                        is used.
+                      type: string
                   required:
                   - infraStorageClassName
                   type: object

--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -375,6 +375,7 @@ spec:
 {{- range  .Cluster.KubeVirtInfraStorageClasses }}
    - infraStorageClassName: {{ .Name }}
      isDefaultClass: {{ .IsDefaultClass }}
+     volumeBindingMode: {{ .VolumeBindingMode }}
      bus: scsi
 {{- end }}
 {{end}}

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -206,6 +206,9 @@ spec:
               # storageclass.kubernetes.io/is-default-class : false
               isDefaultClass: true
               name: rook-ceph-block
+              # VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+              # VolumeBindingImmediate is used.
+              volumeBindingMode: null
           # NamespacedMode represents the configuration for enabling the single namespace mode for all user-clusters in the KubeVirt datacenter.
           namespacedMode: null
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -209,6 +209,9 @@ spec:
               # storageclass.kubernetes.io/is-default-class : false
               isDefaultClass: true
               name: rook-ceph-block
+              # VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+              # VolumeBindingImmediate is used.
+              volumeBindingMode: null
           # NamespacedMode represents the configuration for enabling the single namespace mode for all user-clusters in the KubeVirt datacenter.
           namespacedMode: null
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	storagev1 "k8s.io/api/storage/v1"
 	"strings"
 
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -845,6 +846,9 @@ type KubeVirtInfraStorageClass struct {
 	// If missing or false, annotation will be:
 	// storageclass.kubernetes.io/is-default-class : false
 	IsDefaultClass *bool `json:"isDefaultClass,omitempty"`
+	// VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+	// VolumeBindingImmediate is used.
+	VolumeBindingMode *storagev1.VolumeBindingMode `json:"volumeBindingMode,omitempty"`
 }
 
 // CustomNetworkPolicy contains a name and the Spec of a NetworkPolicy.

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	storagev1 "k8s.io/api/storage/v1"
 	"strings"
 
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -25,6 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -26,6 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/machine-controller/pkg/providerconfig/types"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -4228,6 +4229,11 @@ func (in *KubeVirtInfraStorageClass) DeepCopyInto(out *KubeVirtInfraStorageClass
 	if in.IsDefaultClass != nil {
 		in, out := &in.IsDefaultClass, &out.IsDefaultClass
 		*out = new(bool)
+		**out = **in
+	}
+	if in.VolumeBindingMode != nil {
+		in, out := &in.VolumeBindingMode, &out.VolumeBindingMode
+		*out = new(storagev1.VolumeBindingMode)
 		**out = **in
 	}
 }

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -989,6 +989,11 @@ spec:
                                 type: boolean
                               name:
                                 type: string
+                              volumeBindingMode:
+                                description: |-
+                                  VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+                                  VolumeBindingImmediate is used.
+                                type: string
                             required:
                               - name
                             type: object

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -983,6 +983,11 @@ spec:
                                 type: boolean
                               name:
                                 type: string
+                              volumeBindingMode:
+                                description: |-
+                                  VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+                                  VolumeBindingImmediate is used.
+                                type: string
                             required:
                               - name
                             type: object

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -980,6 +980,11 @@ spec:
                                       type: boolean
                                     name:
                                       type: string
+                                    volumeBindingMode:
+                                      description: |-
+                                        VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+                                        VolumeBindingImmediate is used.
+                                      type: string
                                   required:
                                     - name
                                   type: object


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeVirt CSI driver doesn't set the VolumeBindingMode based on the Tenant CRD. This PR supports the passing of the VolumeBindingMode from the datacenter to the cluster and eventually will land in the tenant cluster storage classes. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KubeVirt VolumeBindingMode in the tenant storage class 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```
