### PR TITLE
Bump KubeVirt csi-driver-operator to Latest Commit

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -336,7 +336,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: {{ Image "quay.io/kubermatic/kubevirt-csi-driver-operator:v0.3.0" }}
+          image: {{ Image "quay.io/kubermatic/kubevirt-csi-driver-operator:368063807b26fead1a57b6c2198f077ff0659afb" }}
           imagePullPolicy: Always
           command:
             - /manager


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeVirt csi-driver-operator is running with a very old version that has quite some limitations. One of those limitations is, it doesn't sync up the storage class volumeBindingMode. This PR, updates the image version to a certain commit that has the previously mentioned feature supported. Currently, there is no real release process in place however, we need to consider either using the upstream operator or simply have a release process in place. 

P.S: also the upstream operator doesn't have a release process in place AFAIK. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bump the kubevirt  csi-driver-operator to the latest commit 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```
