### PR TITLE
Equinix Metal: use modern env names for downstream components like KubeOne or MC

### DIFF
--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -54,8 +54,8 @@ elif [[ $provider == "aws" ]]; then
     -aws-kkp-datacenter=aws-eu-west-1a"
 elif [[ $provider == "packet" ]]; then
   maxDuration=90
-  EXTRA_ARGS="-packet-api-key=${PACKET_API_KEY}
-    -packet-project-id=${PACKET_PROJECT_ID}
+  EXTRA_ARGS="-packet-api-key=${METAL_AUTH_TOKEN:-$PACKET_API_KEY}
+    -packet-project-id=${METAL_PROJECT_ID:-$PACKET_PROJECT_ID}
     -packet-kkp-datacenter=packet-am"
 elif [[ $provider == "gcp" ]]; then
   EXTRA_ARGS="-gcp-service-account=$(safebase64 "$GOOGLE_SERVICE_ACCOUNT")

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -131,8 +131,8 @@ openstack)
   ;;
 
 packet)
-  extraArgs="-packet-api-key=$PACKET_API_KEY
-    -packet-project-id=$PACKET_PROJECT_ID
+  extraArgs="-packet-api-key=${METAL_AUTH_TOKEN:-$PACKET_API_KEY}
+    -packet-project-id=${METAL_PROJECT_ID:-$PACKET_PROJECT_ID}
     -packet-kkp-datacenter=packet-am"
   ;;
 

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -990,7 +990,7 @@ type CloudSpec struct {
 	Azure *AzureCloudSpec `json:"azure,omitempty"`
 	// Openstack defines the configuration data of an OpenStack cloud.
 	Openstack *OpenstackCloudSpec `json:"openstack,omitempty"`
-	// Packet defines the configuration data of a Packet cloud.
+	// Packet defines the configuration data of a Packet / Equinix Metal cloud.
 	Packet *PacketCloudSpec `json:"packet,omitempty"`
 	// Hetzner defines the configuration data of the Hetzner cloud.
 	Hetzner *HetznerCloudSpec `json:"hetzner,omitempty"`

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -1361,7 +1361,7 @@ func setEnvForProvider(providerName string, envVar []corev1.EnvVar, credentialSe
 		envVar = append(
 			envVar,
 			corev1.EnvVar{
-				Name:      "PACKET_API_KEY",
+				Name:      "METAL_AUTH_TOKEN",
 				ValueFrom: envVarSource,
 			},
 		)
@@ -1369,7 +1369,7 @@ func setEnvForProvider(providerName string, envVar []corev1.EnvVar, credentialSe
 		envVar = append(
 			envVar,
 			corev1.EnvVar{
-				Name:      "PACKET_PROJECT_ID",
+				Name:      "METAL_PROJECT_ID",
 				ValueFrom: envVarSource,
 			},
 		)

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1265,7 +1265,7 @@ spec:
                         - subnetID
                       type: object
                     packet:
-                      description: Packet defines the configuration data of a Packet cloud.
+                      description: Packet defines the configuration data of a Packet / Equinix Metal cloud.
                       properties:
                         apiKey:
                           type: string

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1259,7 +1259,7 @@ spec:
                         - subnetID
                       type: object
                     packet:
-                      description: Packet defines the configuration data of a Packet cloud.
+                      description: Packet defines the configuration data of a Packet / Equinix Metal cloud.
                       properties:
                         apiKey:
                           type: string

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -86,9 +86,9 @@ const (
 	// Alibaba credential env.
 	envAlibabaAccessKeyID     = "ALIBABA_ACCESS_KEY_ID"
 	envAlibabaAccessKeySecret = "ALIBABA_ACCESS_KEY_SECRET"
-	// Packet credential env.
-	envPacketToken     = "PACKET_API_KEY"
-	envPacketProjectID = "PACKET_PROJECT_ID"
+	// Equinix Metal credential env.
+	envMetalToken     = "METAL_AUTH_TOKEN"
+	envMetalProjectID = "METAL_PROJECT_ID"
 	// KubeVirt credential env.
 	envKubeVirtKubeconfig = "KUBEVIRT_KUBECONFIG"
 )
@@ -172,7 +172,7 @@ func getGCPResourceRequirements(ctx context.Context, userClient ctrlruntimeclien
 
 	serviceAccount, err := configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ServiceAccount, envGoogleServiceAccount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the value of \"serviceAccount\" field, error = %w", err)
+		return nil, fmt.Errorf("failed to get the value of \"serviceAccount\" field: %w", err)
 	}
 
 	machineType, err := configVarResolver.GetConfigVarStringValue(rawConfig.MachineType)
@@ -631,12 +631,12 @@ func getPacketResourceRequirements(ctx context.Context, client ctrlruntimeclient
 		return nil, fmt.Errorf("failed to get packet raw config: %w", err)
 	}
 
-	token, err := configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Token, envPacketToken)
+	token, err := configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Token, envMetalToken)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get the value of packet \"apiKey\": %w", err)
+		return nil, fmt.Errorf("failed to get the value of packet \"token\": %w", err)
 	}
 
-	projectID, err := configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ProjectID, envPacketProjectID)
+	projectID, err := configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ProjectID, envMetalProjectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the value of packet \"projectID\": %w", err)
 	}

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -834,8 +834,8 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		}
 	}
 	if cluster.Spec.Cloud.Packet != nil {
-		vars = append(vars, corev1.EnvVar{Name: "PACKET_API_KEY", ValueFrom: refTo(PacketAPIKey)})
-		vars = append(vars, corev1.EnvVar{Name: "PACKET_PROJECT_ID", ValueFrom: refTo(PacketProjectID)})
+		vars = append(vars, corev1.EnvVar{Name: "METAL_AUTH_TOKEN", ValueFrom: refTo(PacketAPIKey)})
+		vars = append(vars, corev1.EnvVar{Name: "METAL_PROJECT_ID", ValueFrom: refTo(PacketProjectID)})
 	}
 	if cluster.Spec.Cloud.GCP != nil {
 		vars = append(vars, corev1.EnvVar{Name: "GOOGLE_SERVICE_ACCOUNT", ValueFrom: refTo(GCPServiceAccount)})


### PR DESCRIPTION
**What this PR does / why we need it**:
I randomly noticed that both KubeOne and MC have long deprecated the PACKET_ env vars (see https://github.com/kubermatic/kubeone/blob/v1.7.2/pkg/credentials/credentials.go#L75 and https://github.com/kubermatic/machine-controller/blob/main/pkg/cloudprovider/provider/equinixmetal/provider.go#L100-L102).

This PR is an attempt to gently move us towards a Packet-less world: KKP at least is not setting deprecated environment variables anymore, but other than that, KKP's codebase still uses "packet" in (too many) places. I'm not sure if we want this "drift", like:

```go
vars = append(vars, corev1.EnvVar{Name: "METAL_AUTH_TOKEN", ValueFrom: refTo(PacketAPIKey)})
```

(apiKey vs. AuthToken). I guess we could change 95% of the occurences of "Packet" in our codebase, except for the few field names in our CRDs, but that would be a larger change.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Set `METAL_` environment variables instead of `PACKET_` for machine-controller and KubeOne.
```

**Documentation**:
```documentation
NONE
```
