### PR TITLE
refactor CustomOSP sync controller to immediately provision new user clusters

### DIFF
--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/initial_reconciler.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/initial_reconciler.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemprofilesynchronizer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// clusterInitReconciler is used to watch for new clusters and to install the
+// initial set of OSPs into them. This is more involved than simply filtering
+// for CREATE events only, since we need to wait for the control plane to
+// actually become ready. So this reconciler will just listen for CREATE events
+// *and* then requeue a cluster if it's not actually ready yet. Once the initial
+// setup is done, the cluster is no longer requeued.
+// We use a dedicated reconciler instead of a condition on the cluster object
+// because this is simply a performance optimization to avoid having to install
+// OSPs into all clustes whenever a cluster changes.
+type clusterInitReconciler struct {
+	seedClient                    ctrlruntimeclient.Client
+	log                           *zap.SugaredLogger
+	namespace                     string
+	recorder                      record.EventRecorder
+	userClusterConnectionProvider UserClusterClientProvider
+}
+
+func addClusterInitReconciler(
+	seedMgr manager.Manager,
+	userClusterConnectionProvider UserClusterClientProvider,
+	log *zap.SugaredLogger,
+	workerName string,
+	namespace string,
+	numWorkers int,
+) error {
+	controllerName := controllerName("initial-controller")
+
+	reconciler := &clusterInitReconciler{
+		seedClient:                    seedMgr.GetClient(),
+		recorder:                      seedMgr.GetEventRecorderFor(controllerName),
+		log:                           log.Named(controllerName),
+		userClusterConnectionProvider: userClusterConnectionProvider,
+		namespace:                     namespace,
+	}
+
+	_, err := builder.ControllerManagedBy(seedMgr).
+		Named(controllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(
+			&kubermaticv1.Cluster{},
+			builder.WithPredicates(workerlabel.Predicate(workerName), clusterFilter()),
+		).
+		Build(reconciler)
+
+	return err
+}
+
+func clusterFilter() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			cluster, ok := e.Object.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			return cluster.DeletionTimestamp == nil && cluster.Status.NamespaceName != ""
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func (r *clusterInitReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request.Name)
+	log.Debug("Reconciling")
+
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	if cluster.DeletionTimestamp != nil || cluster.Spec.Pause {
+		return reconcile.Result{}, nil
+	}
+
+	// do not even try the initial setup before the control plane is healthy
+	if !cluster.Status.ExtendedHealth.ControlPlaneHealthy() {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	err := r.reconcile(ctx, cluster)
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	// If the reconciling failed, we return an error here, which will make controller-runtime
+	// requeue the request.
+	return reconcile.Result{}, err
+}
+
+func (r *clusterInitReconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	ospList := &unstructured.UnstructuredList{}
+	ospList.SetAPIVersion(operatingSystemManagerAPIVersion)
+	ospList.SetKind(fmt.Sprintf("%sList", customOperatingSystemProfileKind))
+
+	if err := r.seedClient.List(ctx, ospList, &ctrlruntimeclient.ListOptions{Namespace: r.namespace}); err != nil {
+		return fmt.Errorf("failed to list CustomOperatingSystemProfiles: %w", err)
+	}
+
+	userClusterClient, err := r.userClusterConnectionProvider.GetClient(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get user cluster client: %w", err)
+	}
+
+	factories := []reconciling.NamedOperatingSystemProfileReconcilerFactory{}
+	for _, unstructuredOSP := range ospList.Items {
+		// If OSP is marked for deletion then remove it from the user cluster.
+		if unstructuredOSP.GetDeletionTimestamp() != nil {
+			toDelete := &osmv1alpha1.OperatingSystemProfile{}
+			toDelete.Name = unstructuredOSP.GetName()
+			toDelete.Namespace = unstructuredOSP.GetNamespace()
+
+			if err := userClusterClient.Delete(ctx, toDelete); ctrlruntimeclient.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("failed to delete OSP: %w", err)
+			}
+		} else {
+			osp, err := customOSPToOSP(&unstructuredOSP)
+			if err != nil {
+				return err
+			}
+
+			factories = append(factories, ospReconciler(osp))
+		}
+	}
+
+	if err := reconciling.ReconcileOperatingSystemProfiles(ctx, factories, ospNamespace, userClusterClient); err != nil {
+		return fmt.Errorf("failed to reconcile OSPs: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/sync_reconciler.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/sync_reconciler.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemprofilesynchronizer
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticpred "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// cleanupFinalizer indicates that the OperatingSystemProfile needs to be removed from all the user-cluster namespaces.
+	cleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-operating-system-profiles"
+	ospNamespace     = metav1.NamespaceSystem
+)
+
+// syncReconciler watches custom OSPs and syncs them into all existing user clusters
+// whenever a custom OSP changes.
+type syncReconciler struct {
+	log                           *zap.SugaredLogger
+	workerName                    string
+	recorder                      record.EventRecorder
+	namespace                     string
+	seedClient                    ctrlruntimeclient.Client
+	userClusterConnectionProvider UserClusterClientProvider
+}
+
+func addSyncReconciler(
+	mgr manager.Manager,
+	userClusterConnectionProvider UserClusterClientProvider,
+	log *zap.SugaredLogger,
+	workerName string,
+	namespace string,
+	numWorkers int,
+) error {
+	controllerName := controllerName("synchronizer")
+
+	reconciler := &syncReconciler{
+		log:                           log.Named(controllerName),
+		workerName:                    workerName,
+		recorder:                      mgr.GetEventRecorderFor(controllerName),
+		namespace:                     namespace,
+		userClusterConnectionProvider: userClusterConnectionProvider,
+		seedClient:                    mgr.GetClient(),
+	}
+
+	customOSP := &unstructured.Unstructured{}
+	customOSP.SetAPIVersion(operatingSystemManagerAPIVersion)
+	customOSP.SetKind(customOperatingSystemProfileKind)
+
+	_, err := builder.ControllerManagedBy(mgr).
+		Named(controllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(customOSP, builder.WithPredicates(kubermaticpred.ByNamespace(namespace))).
+		Build(reconciler)
+
+	return err
+}
+
+func (r *syncReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("operatingsystemprofile", request.NamespacedName.String())
+	log.Debug("Reconciling")
+
+	cosp := &unstructured.Unstructured{}
+	cosp.SetAPIVersion(operatingSystemManagerAPIVersion)
+	cosp.SetKind(customOperatingSystemProfileKind)
+
+	if err := r.seedClient.Get(ctx, request.NamespacedName, cosp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	err := r.reconcile(ctx, log, cosp)
+	if err != nil {
+		r.recorder.Event(cosp, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *syncReconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cosp *unstructured.Unstructured) error {
+	if cosp.GetDeletionTimestamp() != nil {
+		return r.handleDeletion(ctx, log, cosp)
+	}
+
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.seedClient, cosp, cleanupFinalizer); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
+	}
+
+	return r.syncAllUserClusters(ctx, cosp)
+}
+
+func (r *syncReconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, cosp *unstructured.Unstructured) error {
+	log.Debug("Deletion timestamp found for OperatingSystemProfile")
+
+	if !kuberneteshelper.HasFinalizer(cosp, cleanupFinalizer) {
+		return nil
+	}
+
+	err := r.syncAllUserClusters(ctx, cosp)
+	if err != nil {
+		return err
+	}
+
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.seedClient, cosp, cleanupFinalizer)
+}
+
+func (r *syncReconciler) syncAllUserClusters(ctx context.Context, cosp *unstructured.Unstructured) error {
+	osp, err := customOSPToOSP(cosp)
+	if err != nil {
+		return err
+	}
+
+	clusters := &kubermaticv1.ClusterList{}
+	if err := r.seedClient.List(ctx, clusters); err != nil {
+		return fmt.Errorf("failed to list clusters: %w", err)
+	}
+
+	var errors []error
+	for _, cluster := range clusters.Items {
+		// Ensure that this is a reconcilable cluster
+		if r.syncableCluster(&cluster) {
+			err := r.syncOperatingSystemProfile(ctx, osp, &cluster)
+			if err != nil {
+				errors = append(errors, err)
+			}
+		}
+	}
+
+	return kerrors.NewAggregate(errors)
+}
+
+func (r *syncReconciler) syncableCluster(cluster *kubermaticv1.Cluster) bool {
+	return true &&
+		!cluster.Spec.Pause &&
+		cluster.Labels[kubermaticv1.WorkerNameLabelKey] == r.workerName &&
+		cluster.DeletionTimestamp == nil &&
+		cluster.Status.ExtendedHealth.ControlPlaneHealthy()
+}
+
+func (r *syncReconciler) syncOperatingSystemProfile(ctx context.Context, osp *osmv1alpha1.OperatingSystemProfile, cluster *kubermaticv1.Cluster) error {
+	userClusterClient, err := r.userClusterConnectionProvider.GetClient(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get user cluster client: %w", err)
+	}
+
+	// If OSP is marked for deletion then remove it from the user cluster.
+	if osp.DeletionTimestamp != nil {
+		toDelete := &osmv1alpha1.OperatingSystemProfile{}
+		toDelete.Name = osp.Name
+		toDelete.Namespace = osp.Namespace
+
+		return ctrlruntimeclient.IgnoreNotFound(userClusterClient.Delete(ctx, toDelete))
+	}
+
+	creators := []reconciling.NamedOperatingSystemProfileReconcilerFactory{
+		ospReconciler(osp),
+	}
+
+	if err := reconciling.ReconcileOperatingSystemProfiles(ctx, creators, ospNamespace, userClusterClient); err != nil {
+		return fmt.Errorf("failed to reconcile OSP: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The original idea behind the OSP syncer controller was two-fold:

1. Everytime a COSP changes on the seed, sync it into all user clusters, turning it from a COSP into an OSP in the process.
2. When a new cluster is provisioned, sync all COSPs into that new cluster.

The controller tried to prevent excessive work and only intends to do step (2) ideally once per cluster. For this, an eventFilter was used that only let CREATE events through, _but_ the Cluster additionally also had to be up and running already (i.e. have a namespace at the very least). This is basically always impossible and so step (2) cannot happen as intended.

It will instead happen later, when the underlying caches re-sync and issue a CREATE event for every single object in them, effectively forcing the controller to fully resync all clusters eventually.

This PR fixes that behaviour and ensures that new clusters are initialized earlier.

---

Normally one could introduce a new Condition on the ClusterStatus, which would keep track of this one-time setup, but since the condition is purely a performance optimization, I did not consider a condition to be the right approach here.

My initial idea was to make use of controller-runtime's new generic reconciler and reconcile a `struct request {cluster, cosp}` instead of the well-known `reconcile.Request`. In that scenario I could have simply re-queued all requests for clusters not yet running. That would have worked fine, but causes trouble when cleaning up: Which of the many requests would be the one that is allowed to remove the finalizer?

To ensure proper cleanup, the controller _has_ to primarily act on (i.e. own) COSPs. To requeue clusters that are not yet ready, the controller _has_ to own Clusters. It cannot own both either, as shown above.

So I made the next logical conclusion and split the controller into 2 reconcilers. One for the intial setup, one for the continuous COSP watching. To further reduce errors, the reconcilers now wait for the cluster's extended health to be green instead of just waiting for the namespace to be set.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
CustomOperatingSystemProfiles are now applied more consistently and earlier when creating new user clusters.
```

**Documentation**:
```documentation
NONE
```
