### PR TITLE
Do not override configured OpenStack floating IP pool with default external network

### DIFF
--- a/pkg/provider/cloud/openstack/internal/testing/fixtures.go
+++ b/pkg/provider/cloud/openstack/internal/testing/fixtures.go
@@ -55,6 +55,11 @@ var ExternalNetwork = Network{
 	NetworkExternalExt: external.NetworkExternalExt{External: true},
 }
 
+var ExternalNetworkFoo = Network{
+	Network:            networks.Network{Name: "foo", ID: "59618382-5aba-49c5-b415-aabb79708098"},
+	NetworkExternalExt: external.NetworkExternalExt{External: true},
+}
+
 var InternalNetwork = Network{
 	Network: networks.Network{Name: "kubernetes-cluster-xyz", ID: NetworkID},
 }

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -228,11 +228,6 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		cluster, err = fetchExtNetwork(ctx, netClient, cluster, update)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	// Reconciling the Network
@@ -313,40 +308,37 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 }
 
 func reconcileExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	extNetwork, err := getDefaultExternalNetwork(netClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get external network: %w", err)
+	var (
+		err        error
+		extNetwork *NetworkWithExternalExt
+	)
+
+	if cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
+		// Fetch the default external network if no floating IP pool was provided.
+		extNetwork, err = getDefaultExternalNetwork(netClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get external network for floating IP pool: %w", err)
+		}
+	} else {
+		// Fetch the configured external network by name if a floating IP pool is provided.
+		extNetwork, err = getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.FloatingIPPool, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get external network for floating IP pool by name: %w", err)
+		}
 	}
+
+	// We're just searching for the floating ip pool here & don't create anything. Thus no need to create a finalizer.
 	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+		// This should be a noop if the floating IP pool was already correctly provided.
 		cluster.Spec.Cloud.Openstack.FloatingIPPool = extNetwork.Name
 
 		if cluster.Annotations == nil {
 			cluster.Annotations = make(map[string]string)
 		}
 		cluster.Annotations[FloatingIPPoolIDAnnotation] = extNetwork.ID
-		// We're just searching for the floating ip pool here & don't create anything. Thus no need to create a finalizer
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update cluster floating IP pool: %w", err)
-	}
-
-	return cluster, err
-}
-
-func fetchExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	extNetwork, err := getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.FloatingIPPool, true)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get external network by name: %w", err)
-	}
-	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
-		if cluster.Annotations == nil {
-			cluster.Annotations = make(map[string]string)
-		}
-		cluster.Annotations[FloatingIPPoolIDAnnotation] = extNetwork.ID
-		// We're just searching for the floating ip pool here & don't create anything. Thus no need to create a finalizer
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to update cluster floating IP pool ID annotation: %w", err)
 	}
 
 	return cluster, err

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -223,11 +223,11 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 	}
 
 	// Reconciling the external Network (the floating IP pool used for machines and LBs)
-	if force || cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
-		cluster, err = reconcileExtNetwork(ctx, netClient, cluster, update)
-		if err != nil {
-			return nil, err
-		}
+	// We don't need the usual if conditional here because the reconcile function doesn't
+	// create anything.
+	cluster, err = reconcileExtNetwork(ctx, netClient, cluster, update)
+	if err != nil {
+		return nil, err
 	}
 
 	// Reconciling the Network


### PR DESCRIPTION
**What this PR does / why we need it**:
#12975 unfortunately introduced a regression that I should have caught: On subsequent reconcile loops (since the OpenStack cloud provider is a reconciling one now), `force` is set to `true`. This means that the code introduced in #12975 overrode the configured floating IP pool with the default external network when the cluster gets reconciled a second time, as reported in https://github.com/kubermatic/kubermatic/pull/12975#issuecomment-2440990997.

That was obviously not the intention of the changes, so this PR addresses it by making the `reconcileExtNetwork` function aware of whether the field is already set or not and unifying the code paths. This is much closer to how the other fields are reconciled as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: A regression in 2.26.0 started overriding the `floatingIPPool` fields of OpenStack Clusters with the default external network. If you are using a floating IP pool that is not the default external network, you might have to update `Cluster` objects manually after upgrading KKP to set the correct floating IP pool again
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
