### PR TITLE
Add seed default before reconciling user cluster resources

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -29,6 +29,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -80,6 +81,11 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 	config, err := r.configGetter(ctx)
 	if err != nil {
 		return nil, err
+	}
+	// get default seed values.
+	seed, err = defaulting.DefaultSeed(seed, config, r.log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply default values to Seed: %w", err)
 	}
 	data, err := r.getClusterTemplateData(ctx, cluster, seed, config)
 	if err != nil {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -258,7 +258,12 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 			}, nil
 		},
 		configGetter: func(_ context.Context) (*kubermaticv1.KubermaticConfiguration, error) {
-			return &kubermaticv1.KubermaticConfiguration{}, nil
+			kubermaticConfig := &kubermaticv1.KubermaticConfiguration{}
+			kubermaticConfig, err := defaulting.DefaultConfiguration(kubermaticConfig, kubermaticlog.Logger)
+			if err != nil {
+				return nil, err
+			}
+			return kubermaticConfig, nil
 		},
 		caBundle:                caBundle,
 		userClusterConnProvider: new(testUserClusterConnectionProvider),


### PR DESCRIPTION
**What this PR does / why we need it**:
Seed controller panics when it tries to create `nodeport-proxy-envoy` deployment in the user cluser namespace when applicable, the panic is caused due to image repository being empty, we are setting the default image for it in the seed but seed defaulting is not done before we reconcile the user cluster resources.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix seed controller panic while creating `nodeport-proxy-envoy` deployment for user clusters.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
