### PR TITLE
Bump AWS cloud-controller-manager

### DIFF
--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -140,6 +140,6 @@ func AWSCCMVersion(version semver.Semver) string {
 	case v131:
 		fallthrough
 	default:
-		return "v1.31.0"
+		return "v1.31.1"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: secretAccessKey
               name: cloud-credentials
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.31.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.31.1
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
For unknown reasons, the 1.31 AWS e2e tests have recently stopped working because the AWS cloud-ctrl-mgr fails to boot up:

> F1101 07:27:18.888652       1 main.go:104] Cloud provider could not be initialized: could not init cloud provider "aws": error creating AWS metadata client: "unable to get instance identity document: EC2MetadataRequestError: failed to get EC2 instance identity document\ncaused by: EC2MetadataError: failed to make EC2Metadata request\n\n\tstatus code: 401, request id: "

From what I tested, this only happens in CI. KKP 2.26.0 on the latest snapshot environment is not affected, for example.

If I pause an e2e test and change the AWS CCM image to 1.30.3, it works. If i change it to 1.31.1, it also begins to work. The 1.31.1 version basically only fixes a single issue: https://github.com/kubernetes/cloud-provider-aws/issues/1027, where the CCM failed to boot with

> F0924 09:21:48.998037       1 main.go:104] Cloud provider could not be initialized: could not init cloud provider "aws": error creating AWS metadata client: "unable to get instance identity document: EC2MetadataRequestError: failed to get EC2 instance identity document\ncaused by: RequestCanceled: EC2 IMDS access disabled via AWS_EC2_METADATA_DISABLED env var"

That's not the error we experience and KKP also doesn't set this env var, so I'm not sure how 1.31.1 is related to our CI issue, but it does fix it and so why not simply use it.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update AWS cloud-controller-manager to 1.31.1
```

**Documentation**:
```documentation
NONE
```
