### PR TITLE
Bump Konnectivity network proxy versions to match Kubernetes version

### DIFF
--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -136,12 +136,16 @@ func NetworkProxyVersion(clusterVersion semver.Semver) string {
 
 	switch clusterVersion.MajorMinor() {
 	case "1.27":
-		return "v0.1.5"
+		return "v0.1.10"
 	case "1.28":
-		return "v0.28.2"
+		return "v0.28.6"
 	case "1.29":
+		return "v0.29.3"
+	case "1.30":
+		return "v0.30.3"
+	case "1.31":
 		fallthrough
 	default:
-		return "v0.29.0"
+		return "v0.31.0"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.2
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.28.6
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.30.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --keepalive-time=1m
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.29.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumping versions of Konnectivity, fixing some CVEs and allowing the use of channel size configuration, added in 1.31 version https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/624, that will possibly help us to mitigate and further investigate the issue https://github.com/kubermatic/kubermatic/issues/13321

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Konnectivity version tags to match corresponding Kubernetes cluster versions.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
