### PR TITLE
Bump cloud-controller-managers

### DIFF
--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -18,19 +18,19 @@
 {{ if eq .Cluster.CloudProviderName "azure" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.27" }}
-{{ $version = "v1.27.20" }}
+{{ $version = "v1.27.21" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.28" }}
-{{ $version = "v1.28.12" }}
+{{ $version = "v1.28.13" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.29" }}
-{{ $version = "v1.29.9" }}
+{{ $version = "v1.29.11" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.30" }}
-{{ $version = "v1.30.4" }}
+{{ $version = "v1.30.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.31" }}
-{{ $version = "v1.31.0" }}
+{{ $version = "v1.31.1" }}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 apiVersion: v1

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -115,17 +115,17 @@ func AzureCCMVersion(version semver.Semver) (string, error) {
 
 	switch version.MajorMinor() {
 	case v127:
-		return "1.27.20", nil
+		return "1.27.21", nil
 	case v128:
-		return "1.28.11", nil
+		return "1.28.13", nil
 	case v129:
-		return "1.29.9", nil
+		return "1.29.11", nil
 	case v130:
-		fallthrough
+		return "1.30.7", nil
 	case v131:
 		fallthrough
 	default:
-		return "1.30.5", nil
+		return "1.31.1", nil
 	}
 }
 

--- a/pkg/resources/cloudcontroller/digitalocean.go
+++ b/pkg/resources/cloudcontroller/digitalocean.go
@@ -127,17 +127,17 @@ func DigitaloceanCCMVersion(version semver.Semver) string {
 
 	switch version.MajorMinor() {
 	case v127: // 30 May 2023 – 27 July 2024
-		fallthrough
+		return "v0.1.54"
 	case v128: // 18 September 2023 – 27 November 2024
 		fallthrough
 	case v129: // 17 January 2024 – 27 March 2025
 		fallthrough
 	case v130: // 21 May 2024 – 27 July 2025
 		fallthrough
-	case v131: // (not supported yet)
+	case v131: // 13 September 2024 – 27 November 2025
 		fallthrough
 	default:
 		// This should always be the latest version.
-		return "v0.1.54"
+		return "v0.1.56"
 	}
 }

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -116,13 +116,13 @@ func OpenStackCCMTag(version semver.Semver) (string, error) {
 	case v127:
 		return "v1.27.3", nil
 	case v128:
-		return "v1.28.2", nil
+		return "v1.28.3", nil
 	case v129:
-		return "v1.29.0", nil
+		return "v1.29.1", nil
 	case v130:
-		fallthrough
+		return "v1.30.1", nil
 	case v131:
-		return "v1.30.0", nil
+		return "v1.31.1", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.11
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.13
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.29.9
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.29.11
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.30.5
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.30.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.30.5
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.31.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.54
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.54
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.54
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.54
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.2
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.3
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.29.0
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.29.1
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.0
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.1
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.0
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.31.1
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps all CCMs for all cloud providers.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update cloud-controller-managers to their latest releases. Azure and OpenStack now use the 1.31.x CCMs for 1.31 clusters.
```

**Documentation**:
```documentation
NONE
```
