### PR TITLE
Use GOFLAGS=-trimpath for all binaries, enable gocache usage in CI

### DIFF
--- a/cmd/conformance-tester/Makefile
+++ b/cmd/conformance-tester/Makefile
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 export CGO_ENABLED=0
+export GOFLAGS ?= -trimpath
 
 DOCKER_REPO ?= "quay.io/kubermatic"
+LDFLAGS ?= -w -extldflags '-static'
+GOTOOLFLAGS ?= -ldflags '$(LDFLAGS)' -v
 
 .PHONY: build
 build:
-	go build -v -o ./_build/conformance-tester .
+	go build $(GOTOOLFLAGS) -o ./_build/conformance-tester .
 
 .PHONY: docker
 docker: build

--- a/cmd/etcd-launcher/Makefile
+++ b/cmd/etcd-launcher/Makefile
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 export CGO_ENABLED=0
+export GOFLAGS ?= -trimpath
 
 DOCKER_REPO ?= "quay.io/kubermatic"
+LDFLAGS ?= -w -extldflags '-static'
+GOTOOLFLAGS ?= -ldflags '$(LDFLAGS)' -v
 
 .PHONY: build
 build:
-	go build -v -o ./_build/etcd-launcher .
+	go build $(GOTOOLFLAGS) -o ./_build/etcd-launcher .
 
 .PHONY: docker
 docker: build

--- a/cmd/kubeletdnat-controller/Makefile
+++ b/cmd/kubeletdnat-controller/Makefile
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 export CGO_ENABLED=0
+export GOFLAGS ?= -trimpath
 
 DOCKER_REPO ?= "quay.io/kubermatic"
+LDFLAGS ?= -w -extldflags '-static'
+GOTOOLFLAGS ?= -ldflags '$(LDFLAGS)' -v
 
 .PHONY: build
 build:
-	go build -v -o ./_build/kubeletdnat-controller .
+	go build $(GOTOOLFLAGS) -v -o ./_build/kubeletdnat-controller .
 
 .PHONY: docker
 docker: build

--- a/cmd/network-interface-manager/Makefile
+++ b/cmd/network-interface-manager/Makefile
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 export CGO_ENABLED=0
+export GOFLAGS ?= -trimpath
 
 DOCKER_REPO ?= "quay.io/kubermatic"
+LDFLAGS ?= -w -extldflags '-static'
+GOTOOLFLAGS ?= -ldflags '$(LDFLAGS)' -v
 
 .PHONY: build
 build:
-	go build -v -o ./_build/network-interface-manager .
+	go build $(GOTOOLFLAGS) -o ./_build/network-interface-manager .
 
 .PHONY: docker
 docker: build

--- a/cmd/nodeport-proxy/Makefile
+++ b/cmd/nodeport-proxy/Makefile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 export CGO_ENABLED=0
+export GOFLAGS ?= -trimpath
 
 DOCKER_REPO ?= "quay.io/kubermatic"
 

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CGO_ENABLED=0
+export GOFLAGS ?= -trimpath
+
 KUBERMATIC_EDITION ?= ce
 DOCKER_REPO ?= "quay.io/kubermatic"
 LDFLAGS ?= -w -extldflags '-static'
 GOTOOLFLAGS ?= -ldflags '$(LDFLAGS)' -v
-
-export CGO_ENABLED=0
 
 .PHONY: build
 build:


### PR DESCRIPTION
**What this PR does / why we need it**:
We had gocaches for amd64 and arm64 for a long time, but never made use of the arm64 cache because we never quite figured out why Go would refuse to use it. So we just ignored it and lived with it.

However over time more and more multiarch images were added in KKP and now we already need a good 90 minutes to build all of them. This is then causing other issues with jobs that time out waiting for the images to be available.

I think I finally figured out the issue: It wasn't the build tags (`-tags`), it wasn't the `-ldflags`, it was `GOFLAGS=-trimpath`. The moment this is consistently set, Go immediately accepts our caches and life is good(tm). `-mod=vendor` is not relevant either.

So this PR ensures we set `GOFLAGS` everywhere and also harmonizes the other build related flags a bit.

During image building, the appropriate cache is now copied into the working copy and is available for building inside the docker containers. Moving the caches back and forth helps to avoid having to copy ~4GB of useless data into the docker context (and once again with the `COPY . .` directive).

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
