### PR TITLE
fix: check for cilium system application in default application controller

### DIFF
--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -29,7 +29,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
-	"k8c.io/kubermatic/v2/pkg/cni"
 	"k8c.io/kubermatic/v2/pkg/controller/util"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -164,17 +163,13 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		return nil, fmt.Errorf("failed to get user cluster client: %w", err)
 	}
 
-	if cluster.Spec.CNIPlugin != nil && cni.IsManagedByAppInfra(cluster.Spec.CNIPlugin.Type, cluster.Spec.CNIPlugin.Version) {
-		ciliumApp, err := util.GetCNIApplicationInstallation(ctx, userClusterClient, cluster.Spec.CNIPlugin.Type)
-		if err != nil {
-			r.log.Debug("Requeue as it could not get Cilium system ApplicationInstallation")
-			return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
-		// check if application is deployed and status is updated with app version.
-		if ciliumApp != nil && ciliumApp.Status.ApplicationVersion == nil {
-			r.log.Debug("Requeue as Cilium system application is not ready yet")
-			return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
+	cniReady, err := util.IsCNIApplicationReady(ctx, userClusterClient, cluster)
+	if err != nil {
+		return &reconcile.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("failed to check if CNI application is ready: %w", err)
+	}
+	if !cniReady {
+		r.log.Debug("CNI application is not ready yet")
+		return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Ensure that cluster is in a state when creating ApplicationInstallation is permissible

--- a/pkg/controller/util/util.go
+++ b/pkg/controller/util/util.go
@@ -231,7 +231,7 @@ func getCNIApplicationInstallation(ctx context.Context, userClusterClient ctrlru
 	return nil, fmt.Errorf("unsupported CNI type: %s", cniType)
 }
 
-// IsCNIApplicationReady checks if the CNI application is deployed and ready
+// IsCNIApplicationReady checks if the CNI application is deployed and ready.
 func IsCNIApplicationReady(ctx context.Context, userClusterClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) (bool, error) {
 	if cluster.Spec.CNIPlugin == nil || !cni.IsManagedByAppInfra(cluster.Spec.CNIPlugin.Type, cluster.Spec.CNIPlugin.Version) {
 		return true, nil // No CNI plugin or not managed by app infra, consider it ready


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently we have added default applications and we have found out that this [issue](https://github.com/kubermatic/kubermatic/issues/12820) has emerged once again,[check comment](https://github.com/kubermatic/kubermatic/issues/12820#issuecomment-2481423649)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12820

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixing the issue with blocked cluster provisioning, when selecting default applications that conflicted with Cilium system application and user-cluster-controller-manager was stuck.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
