### PR TITLE
Sync changelogs for Nov 2024 Patch releases

### DIFF
--- a/docs/changelogs/CHANGELOG-2.24.md
+++ b/docs/changelogs/CHANGELOG-2.24.md
@@ -14,6 +14,22 @@
 - [v2.24.11](#v22411)
 - [v2.24.12](#v22412)
 - [v2.24.13](#v22413)
+- [v2.24.14](#v22414)
+
+## v2.24.14
+
+**GitHub release: [2.24.14](https://github.com/kubermatic/kubermatic/releases/tag/2.24.14)**
+
+### Bugfixes
+
+- Fix seed controller panic while creating `nodeport-proxy-envoy` deployment for user clusters ([#13835](https://github.com/kubermatic/kubermatic/pull/13835))
+- Fix TOML/YAML configuration mixup in the IAP Helm chart ([#13786](https://github.com/kubermatic/kubermatic/pull/13786))
+- Select correct template value when editing MD of VCD provider ([#6927](https://github.com/kubermatic/dashboard/pull/6927))
+
+### Updates
+
+- Security: Update Cilium to 1.13.14 / 1.14.16 because the previous versions are affected by multiple CVEs ([#13849](https://github.com/kubermatic/kubermatic/pull/13849))
+
 
 ## v2.24.13
 

--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -10,6 +10,45 @@
 - [v2.25.7](#v2257)
 - [v2.25.8](#v2258)
 - [v2.25.9](#v2259)
+- [v2.25.10](#v22510)
+- [v2.25.11](#v22511)
+- [v2.25.12](#v22512)
+
+## v2.25.12
+
+**GitHub release: [2.25.12](https://github.com/kubermatic/kubermatic/releases/tag/2.25.12)**
+
+### Bugfixes
+
+- Update oauth2-proxy to 7.7.0 ([#13794](https://github.com/kubermatic/kubermatic/pull/13794))
+    - Fix TOML/YAML configuration mixup in the IAP Helm chart.
+- Fix seed controller panic while creating `nodeport-proxy-envoy` deployment for user clusters ([#13835](https://github.com/kubermatic/kubermatic/pull/13835))
+- [EE]: Fix Cluster Backups failing because of empty label selectors ([#6971](https://github.com/kubermatic/dashboard/pull/6971))
+- Fix CNI plugin defaulting for Edge cloud provider ([#6879](https://github.com/kubermatic/dashboard/pull/6879))
+- Fix default CNI application values in cluster wizard ([#6887](https://github.com/kubermatic/dashboard/pull/6887))
+- Select correct template value when editing MD of VCD provider ([#6927](https://github.com/kubermatic/dashboard/pull/6927))
+
+### Updates
+
+- Security: Update Cilium to 1.14.16 because the previous versions are affected by CVE-2024-47825 ([#13848](https://github.com/kubermatic/kubermatic/pull/13848))
+- Update to Go 1.22.8 ([#13790](https://github.com/kubermatic/kubermatic/pull/13790))
+
+## v2.25.11
+
+**GitHub release: [v2.25.11](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.11)**
+
+### Bugfixes
+
+- Fix reconciling loop when resetting Application values to an empty value ([#13741](https://github.com/kubermatic/kubermatic/pull/13741))
+
+## v2.25.10
+
+**GitHub release: [v2.25.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.10)**
+
+### Bugfixes
+
+- Fix failure to migrate Cilium `ApplicationInstallations` to new `valuesBlock` field (this has been an undocumented change in KKP 2.25.9) ([#13736](https://github.com/kubermatic/kubermatic/pull/13736))
+
 
 ## v2.25.9
 

--- a/docs/changelogs/CHANGELOG-2.26.md
+++ b/docs/changelogs/CHANGELOG-2.26.md
@@ -14,6 +14,8 @@
 ### New Features
 
 - Bump KubeVirt CSI Driver Operator to support zone-aware topologies ([#13833](https://github.com/kubermatic/kubermatic/pull/13833))
+- Support `ZoneAndRegionEnable` field in the CCM cloud config ([#13876](https://github.com/kubermatic/kubermatic/pull/13876))
+- Setup KubeVirt network controller in the seed-controller-manager. ([#13858](https://github.com/kubermatic/kubermatic/pull/13858))
 - Support for Kube-OVN subnet and VPCs for KubeVirt ([#6941](https://github.com/kubermatic/dashboard/pull/6941))
 
 ### Bugfixes

--- a/docs/changelogs/CHANGELOG-2.26.md
+++ b/docs/changelogs/CHANGELOG-2.26.md
@@ -1,6 +1,40 @@
 # Kubermatic 2.26
 
 - [v2.26.0](#v2260)
+- [v2.26.1](#v2261)
+
+## v2.26.1
+
+**GitHub release: [2.26.1](https://github.com/kubermatic/kubermatic/releases/tag/2.26.1)**
+
+### ACTION REQUIRED
+
+- A regression in 2.26.0 started overriding the `floatingIPPool` fields of OpenStack Clusters with the default external network. If you are using a floating IP pool that is not the default external network, you might have to update `Cluster` objects manually after upgrading KKP to set the correct floating IP pool again ([#13834](https://github.com/kubermatic/kubermatic/pull/13834))
+
+### New Features
+
+- Bump KubeVirt CSI Driver Operator to support zone-aware topologies ([#13833](https://github.com/kubermatic/kubermatic/pull/13833))
+- Support for Kube-OVN subnet and VPCs for KubeVirt ([#6941](https://github.com/kubermatic/dashboard/pull/6941))
+
+### Bugfixes
+
+- Fix cluster credentials not being synced into cluster namespaces whenever a Secret is updated in the KKP namespace ([#13819](https://github.com/kubermatic/kubermatic/pull/13819))
+- Fix seed controller panic while creating `nodeport-proxy-envoy` deployment for user clusters ([#13835](https://github.com/kubermatic/kubermatic/pull/13835))
+- Refactor Cluster Backups ([#13807](https://github.com/kubermatic/kubermatic/pull/13807))
+    - The controllers for this feature now run in the master-controller-manager and usercluster-controller-manager instead of the seed-controller-manager
+    - Fix ClusterBackupStorageLocations not being synchronized from the master to seed clusters.
+- [EE] Fix Cluster Backups failing because of empty label selectors ([#6971](https://github.com/kubermatic/dashboard/pull/6971))
+- KubeVirt: use infra namespace from datacenter configuration, if specified ([#6964](https://github.com/kubermatic/dashboard/pull/6964))
+
+### Updates
+
+- Security: Update Cilium to 1.14.16 / 1.15.10 because the previous versions are affected by CVE-2024-47825 ([#13832](https://github.com/kubermatic/kubermatic/pull/13832))
+- Update AWS cloud-controller-manager to 1.31.1 ([#13838](https://github.com/kubermatic/kubermatic/pull/13838))
+- Support KubeVirt VolumeBindingMode in the tenant storage class ([#13821](https://github.com/kubermatic/kubermatic/pull/13821))
+
+### Miscellaneous
+
+- CustomOperatingSystemProfiles are now applied more consistently and earlier when creating new user clusters ([#13831](https://github.com/kubermatic/kubermatic/pull/13831))
 
 
 ## v2.26.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to sync changelogs for Nov 2024 patch releases 2.26.1, 2.25.12 and 2.24.14.
/hold until patch releases are out.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
