### PR TITLE
Fix KubeVirt CSI Tenant CR Indentation and KubeVirt CCM Cloud-Config

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -396,9 +396,7 @@ spec:
   storageClasses:
 {{- range  .Cluster.KubeVirtInfraStorageClasses }}
    - infraStorageClassName: {{ .Name }}
-{{- if .IsDefaultClass }}
      isDefaultClass: {{ .IsDefaultClass }}
-{{- end }}
 {{- if .VolumeBindingMode  }}
      volumeBindingMode: {{ .VolumeBindingMode }}
 {{- end }}
@@ -406,13 +404,13 @@ spec:
 {{- if .Regions }}
      regions:
 {{- range .Regions }}
-- {{ . }}
+     - {{ . }}
 {{- end }}
 {{- end }}
 {{- if .Zones }}
      zones:
 {{- range .Zones }}
-- {{ . }}
+     - {{ . }}
 {{- end }}
 {{- end }}
 {{- if .Labels }}

--- a/pkg/resources/cloudconfig/kubevirt/cloudconfig.go
+++ b/pkg/resources/cloudconfig/kubevirt/cloudconfig.go
@@ -28,11 +28,11 @@ type CloudConfig struct {
 	// Namespace used in KubeVirt cloud-controller-manager as infra cluster namespace.
 	Namespace string `yaml:"namespace"`
 	// InstancesV2 used in KubeVirt cloud-controller-manager as metadata information about the infra cluster nodes
-	InstancesV2 InstancesV2 `yaml:"instancesV2,omitempty"`
+	InstancesV2 InstancesV2 `yaml:"instancesV2"`
 }
 
 type InstancesV2 struct {
-	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled,omitempty"`
+	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled"`
 }
 
 func ForCluster(cluster *kubermaticv1.Cluster, dc *kubermaticv1.Datacenter) CloudConfig {


### PR DESCRIPTION
**What this PR does / why we need it**:
As the title says fixing the addon template indentation for the Kubevirt CSI driver and making the ccmZoneAndRegionEnabled required
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
