### PR TITLE
fix initial sync for CustomOperatingSystemProfiles

### DIFF
--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/initial_reconciler.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/initial_reconciler.go
@@ -93,11 +93,7 @@ func addClusterInitReconciler(
 func clusterFilter() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			cluster, ok := e.Object.(*kubermaticv1.Cluster)
-			if !ok {
-				return false
-			}
-			return cluster.DeletionTimestamp == nil && cluster.Status.NamespaceName != ""
+			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return false


### PR DESCRIPTION
**What this PR does / why we need it**:
In #13831 the idea was that the initial sync controller enqueues new clusters as they are created and then keeps requeing them until they are healthy, after which the Custom OSPs will be synced for the first time. However I forgot to remove the old part of the event filter, which has negated that aspect of #13831.

I tested this on our latest snapshot environment and as expected, shortly after the control plane became healthy, the custom OSPs were added to my usercluster.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix initial sync for CustomOperatingSystemProfiles when creating new user clusters (follow-up to #13831).
```

**Documentation**:
```documentation
NONE
```
