### PR TITLE
[release/v2.26]  Update the kubevirt csi-driver image to upstream (#13818)

### DIFF
--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	csiVersion = "cc71b72b8d5a205685985244c61707c5e40c9d5f"
+	csiVersion = "35836e0c8b68d9916d29a838ea60cdd3fc6199cf"
 )
 
 // DeploymentsReconcilers returns the CSI controller Deployments for KubeVirt.


### PR DESCRIPTION
**What this PR does / why we need it**:
(cherry picked from commit 45bc71ce5fa988afcb9b1d12e8e43bffe275dec2)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
upgrade kubevirt csi driver to commit 35836e0c8b68d9916d29a838ea60cdd3fc6199cf
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
