### PR TITLE
Cluster Backup E2E tests

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -272,3 +272,39 @@ presubmits:
               cpu: 2
             limits:
               memory: 6Gi
+
+  - name: pre-kubermatic-cluster-backup-e2e
+    run_if_changed: "pkg/ee/cluster-backup/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws-e2e-kkp: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-e2e-ssh: "true"
+      preset-goproxy: "true"
+      preset-kind-volume-mounts: "true"
+      preset-kubeconfig-ci: "true"
+      preset-vault: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+          command:
+            - "./hack/ci/run-cluster-backup-e2e-tests.sh"
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi

--- a/hack/ci/run-cluster-backup-e2e-tests.sh
+++ b/hack/ci/run-cluster-backup-e2e-tests.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+TEST_NAME="Pre-warm Go build cache"
+echodate "Attempting to pre-warm Go build cache"
+
+beforeGocache=$(nowms)
+make download-gocache
+pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
+retry 5 vault_ci_login
+
+backupCredentials="$(vault kv get --format=json dev/e2e-kkp-cluster-backup)"
+export BACKUP_ACCESS_KEY_ID="$(echo "$backupCredentials" | jq -r '.data.data.accessKeyID')"
+export BACKUP_SECRET_ACCESS_KEY="$(echo "$backupCredentials" | jq -r '.data.data.secretAccessKey')"
+export BACKUP_BUCKET="$(echo "$backupCredentials" | jq -r '.data.data.bucket')"
+export BACKUP_REGION="$(echo "$backupCredentials" | jq -r '.data.data.region')"
+
+if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
+  echodate "Getting default SSH pubkey for machines from Vault"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
+else
+  E2E_SSH_PUBKEY_CONTENT="${E2E_SSH_PUBKEY}"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  echo "${E2E_SSH_PUBKEY_CONTENT}" > "${E2E_SSH_PUBKEY}"
+fi
+
+echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
+
+export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
+
+source hack/ci/setup-kind-cluster.sh
+
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+
+source hack/ci/setup-kubermatic-cluster-backup-in-kind.sh
+
+echodate "Running cluster-backup tests..."
+
+go_test cluster_backup_e2e -timeout 120m -tags e2e -v ./pkg/test/e2e/cluster-backup \
+  -kubeconfig "$KUBECONFIG" \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
+
+echodate "Tests completed successfully!"

--- a/hack/ci/setup-kubermatic-cluster-backup-in-kind.sh
+++ b/hack/ci/setup-kubermatic-cluster-backup-in-kind.sh
@@ -1,0 +1,159 @@
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source hack/lib.sh
+
+if [ -z "${KIND_CLUSTER_NAME:-}" ]; then
+  echodate "KIND_CLUSTER_NAME must be set by calling setup-kind-cluster.sh first."
+  exit 1
+fi
+
+# The Kubermatic version to build.
+export KUBERMATIC_VERSION="${KUBERMATIC_VERSION:-$(git rev-parse HEAD)}"
+
+REPOSUFFIX=""
+if [ "$KUBERMATIC_EDITION" != "ce" ]; then
+  REPOSUFFIX="-$KUBERMATIC_EDITION"
+fi
+
+# This is just used as a const
+export SEED_NAME=kubermatic
+
+# Set docker config
+echo "$IMAGE_PULL_SECRET_DATA" | base64 -d > /config.json
+
+# Build binaries and load the Docker images into the kind cluster
+echodate "Building binaries for $KUBERMATIC_VERSION"
+TEST_NAME="Build Kubermatic binaries"
+
+beforeGoBuild=$(nowms)
+time retry 1 make build
+pushElapsed kubermatic_go_build_duration_milliseconds $beforeGoBuild
+
+beforeDockerBuild=$(nowms)
+
+(
+  echodate "Building Kubermatic Docker image"
+  TEST_NAME="Build Kubermatic Docker image"
+  IMAGE_NAME="quay.io/kubermatic/kubermatic$REPOSUFFIX:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "$IMAGE_NAME" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building addons image"
+  TEST_NAME="Build addons Docker image"
+  cd addons
+  IMAGE_NAME="quay.io/kubermatic/addons:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building nodeport-proxy image"
+  TEST_NAME="Build nodeport-proxy Docker image"
+  cd cmd/nodeport-proxy
+  make build
+  IMAGE_NAME="quay.io/kubermatic/nodeport-proxy:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building kubeletdnat-controller image"
+  TEST_NAME="Build kubeletdnat-controller Docker image"
+  cd cmd/kubeletdnat-controller
+  make build
+  IMAGE_NAME="quay.io/kubermatic/kubeletdnat-controller:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building etcd-launcher image"
+  TEST_NAME="Build etcd-launcher Docker image"
+  IMAGE_NAME="quay.io/kubermatic/etcd-launcher:${KUBERMATIC_VERSION}"
+  time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+(
+  echodate "Building network-interface-manager image"
+  TEST_NAME="Build network-interface-manager Docker image"
+  cd cmd/network-interface-manager
+  make build
+  IMAGE_NAME="quay.io/kubermatic/network-interface-manager:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
+
+pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
+echodate "Successfully built and loaded all images"
+
+# prepare to run kubermatic-installer
+KUBERMATIC_CONFIG="$(mktemp)"
+IMAGE_PULL_SECRET_INLINE="$(echo "$IMAGE_PULL_SECRET_DATA" | base64 --decode | jq --compact-output --monochrome-output '.')"
+KUBERMATIC_DOMAIN="${KUBERMATIC_DOMAIN:-ci.kubermatic.io}"
+
+cp hack/ci/testdata/kubermatic_cluster_backup.yaml $KUBERMATIC_CONFIG
+
+sed -i "s;__SERVICE_ACCOUNT_KEY__;$SERVICE_ACCOUNT_KEY;g" $KUBERMATIC_CONFIG
+sed -i "s;__IMAGE_PULL_SECRET__;$IMAGE_PULL_SECRET_INLINE;g" $KUBERMATIC_CONFIG
+sed -i "s;__KUBERMATIC_DOMAIN__;$KUBERMATIC_DOMAIN;g" $KUBERMATIC_CONFIG
+
+HELM_VALUES_FILE="$(mktemp)"
+cat << EOF > $HELM_VALUES_FILE
+kubermaticOperator:
+  image:
+    repository: "quay.io/kubermatic/kubermatic$REPOSUFFIX"
+    tag: "$KUBERMATIC_VERSION"
+EOF
+
+# prepare CRDs
+copy_crds_to_chart
+set_crds_version_annotation
+
+# install dependencies and Kubermatic Operator into cluster
+TEST_NAME="Install KKP into kind"
+
+echodate "Installing Master..."
+./_build/kubermatic-installer deploy \
+  --disable-telemetry \
+  --storageclass copy-default \
+  --config "$KUBERMATIC_CONFIG" \
+  --helm-values "$HELM_VALUES_FILE"
+
+# TODO: The installer should wait for everything to finish reconciling.
+echodate "Waiting for Kubermatic Operator to deploy Master components..."
+# sleep a bit to prevent us from checking the Deployments too early, before
+# the operator had time to reconcile
+sleep 5
+retry 10 check_all_deployments_ready kubermatic
+
+TEST_NAME="Setup KKP Seed"
+echodate "Installing Seed..."
+SEED_MANIFEST="$(mktemp)"
+SEED_KUBECONFIG="$(cat $KUBECONFIG | sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./' | base64 -w0)"
+
+cp hack/ci/testdata/seed.yaml $SEED_MANIFEST
+
+sed -i "s/__SEED_NAME__/$SEED_NAME/g" $SEED_MANIFEST
+sed -i "s/__KUBECONFIG__/$SEED_KUBECONFIG/g" $SEED_MANIFEST
+
+retry 8 kubectl apply --filename $SEED_MANIFEST
+retry 8 check_seed_ready kubermatic "$SEED_NAME"
+echodate "Finished installing Seed"
+
+sleep 5
+echodate "Waiting for Deployments to roll out..."
+retry 9 check_all_deployments_ready kubermatic
+
+appendTrap cleanup_kubermatic_clusters_in_kind EXIT
+
+echodate "Finished installing Kubermatic."

--- a/hack/ci/testdata/kubermatic_cluster_backup.yaml
+++ b/hack/ci/testdata/kubermatic_cluster_backup.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kubermatic.k8c.io/v1
+kind: KubermaticConfiguration
+metadata:
+  name: e2e
+  namespace: kubermatic
+spec:
+  ingress:
+    # Even though no ingress will be created (due to the HeadlessInstallation
+    # feature gate), we still need the base domain to construct the URLs to
+    # the usercluster kube-apiserver. This traffic however is never routed
+    # through nginx.
+    domain: '__KUBERMATIC_DOMAIN__'
+  imagePullSecret: '__IMAGE_PULL_SECRET__'
+  userCluster:
+    apiserverReplicas: 1
+  featureGates:
+    HeadlessInstallation: true
+    EtcdLauncher: true

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -49,7 +49,7 @@ if ! [ -x "$(command -v $velero)" ]; then
   echodate "Done!"
 fi
 
-crd_dir="pkg/ee/cluster-backup/resources/user-cluster/static"
+crd_dir="pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static"
 cd "$crd_dir"
 
 version=$($velero version --client-only | grep Version | cut -d' ' -f2)

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -235,7 +235,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		return nil, err
 	}
 
-	var cbsl *kubermaticv1.ClusterBackupStorageLocation
+	cbsl := &kubermaticv1.ClusterBackupStorageLocation{}
 	if cluster.Spec.IsClusterBackupEnabled() {
 		key := types.NamespacedName{
 			Namespace: resources.KubermaticNamespace,
@@ -247,6 +247,8 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 			// seed-level reconciling for this cluster.
 			cbsl = nil
 		}
+	} else {
+		cbsl = nil
 	}
 
 	konnectivityEnabled := cluster.Spec.ClusterNetwork.KonnectivityEnabled != nil && *cluster.Spec.ClusterNetwork.KonnectivityEnabled //nolint:staticcheck

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/backuprepositories.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/backuprepositories.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: backuprepositories.velero.io
@@ -29,10 +29,19 @@ spec:
         openAPIV3Schema:
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -40,7 +49,9 @@ spec:
               description: BackupRepositorySpec is the specification for a BackupRepository.
               properties:
                 backupStorageLocation:
-                  description: BackupStorageLocation is the name of the BackupStorageLocation that should contain this repository.
+                  description: |-
+                    BackupStorageLocation is the name of the BackupStorageLocation
+                    that should contain this repository.
                   type: string
                 maintenanceFrequency:
                   description: MaintenanceFrequency is how often maintenance should be run.
@@ -53,10 +64,14 @@ spec:
                     - ""
                   type: string
                 resticIdentifier:
-                  description: ResticIdentifier is the full restic-compatible string for identifying this repository.
+                  description: |-
+                    ResticIdentifier is the full restic-compatible string for identifying
+                    this repository.
                   type: string
                 volumeNamespace:
-                  description: VolumeNamespace is the namespace this backup repository contains pod volume backups for.
+                  description: |-
+                    VolumeNamespace is the namespace this backup repository contains
+                    pod volume backups for.
                   type: string
               required:
                 - backupStorageLocation

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/backups.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/backups.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: backups.velero.io
@@ -20,13 +20,24 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: Backup is a Velero resource that represents the capture of Kubernetes cluster state at a point in time (API objects and associated volume state).
+          description: |-
+            Backup is a Velero resource that represents the capture of Kubernetes
+            cluster state at a point in time (API objects and associated volume state).
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -34,39 +45,63 @@ spec:
               description: BackupSpec defines the specification for a Velero backup.
               properties:
                 csiSnapshotTimeout:
-                  description: CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to ReadyToUse during creation, before returning error as timeout. The default value is 10 minute.
+                  description: |-
+                    CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                    ReadyToUse during creation, before returning error as timeout.
+                    The default value is 10 minute.
                   type: string
                 datamover:
-                  description: DataMover specifies the data mover to be used by the backup. If DataMover is "" or "velero", the built-in data mover will be used.
+                  description: |-
+                    DataMover specifies the data mover to be used by the backup.
+                    If DataMover is "" or "velero", the built-in data mover will be used.
                   type: string
                 defaultVolumesToFsBackup:
-                  description: DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used for all volumes by default.
+                  description: |-
+                    DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                    for all volumes by default.
                   nullable: true
                   type: boolean
                 defaultVolumesToRestic:
-                  description: "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead."
+                  description: |-
+                    DefaultVolumesToRestic specifies whether restic should be used to take a
+                    backup of all pod volumes by default.
+
+
+                    Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
                   nullable: true
                   type: boolean
                 excludedClusterScopedResources:
-                  description: ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to "*", all cluster-scoped resource types are excluded. The default value is empty.
+                  description: |-
+                    ExcludedClusterScopedResources is a slice of cluster-scoped
+                    resource type names to exclude from the backup.
+                    If set to "*", all cluster-scoped resource types are excluded.
+                    The default value is empty.
                   items:
                     type: string
                   nullable: true
                   type: array
                 excludedNamespaceScopedResources:
-                  description: ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to "*", all namespace-scoped resource types are excluded. The default value is empty.
+                  description: |-
+                    ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                    resource type names to exclude from the backup.
+                    If set to "*", all namespace-scoped resource types are excluded.
+                    The default value is empty.
                   items:
                     type: string
                   nullable: true
                   type: array
                 excludedNamespaces:
-                  description: ExcludedNamespaces contains a list of namespaces that are not included in the backup.
+                  description: |-
+                    ExcludedNamespaces contains a list of namespaces that are not
+                    included in the backup.
                   items:
                     type: string
                   nullable: true
                   type: array
                 excludedResources:
-                  description: ExcludedResources is a slice of resource names that are not included in the backup.
+                  description: |-
+                    ExcludedResources is a slice of resource names that are not
+                    included in the backup.
                   items:
                     type: string
                   nullable: true
@@ -77,7 +112,9 @@ spec:
                     resources:
                       description: Resources are hooks that should be executed when backing up individual instances of a resource.
                       items:
-                        description: BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on the rules defined for namespaces, resources, and label selector.
+                        description: |-
+                          BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                          the rules defined for namespaces, resources, and label selector.
                         properties:
                           excludedNamespaces:
                             description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
@@ -92,13 +129,17 @@ spec:
                             nullable: true
                             type: array
                           includedNamespaces:
-                            description: IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies to all namespaces.
+                            description: |-
+                              IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                              to all namespaces.
                             items:
                               type: string
                             nullable: true
                             type: array
                           includedResources:
-                            description: IncludedResources specifies the resources to which this hook spec applies. If empty, it applies to all resources.
+                            description: |-
+                              IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                              to all resources.
                             items:
                               type: string
                             nullable: true
@@ -110,16 +151,24 @@ spec:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -131,7 +180,10 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
@@ -139,7 +191,9 @@ spec:
                             description: Name is the name of this hook.
                             type: string
                           post:
-                            description: PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all "additional items" from item actions are processed.
+                            description: |-
+                              PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                              These are executed after all "additional items" from item actions are processed.
                             items:
                               description: BackupResourceHook defines a hook for a resource.
                               properties:
@@ -153,7 +207,9 @@ spec:
                                       minItems: 1
                                       type: array
                                     container:
-                                      description: Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.
+                                      description: |-
+                                        Container is the container in the pod where the command should be executed. If not specified,
+                                        the pod's first container is used.
                                       type: string
                                     onError:
                                       description: OnError specifies how Velero should behave if it encounters an error executing this hook.
@@ -162,7 +218,9 @@ spec:
                                         - Fail
                                       type: string
                                     timeout:
-                                      description: Timeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.
+                                      description: |-
+                                        Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                        considering the execution a failure.
                                       type: string
                                   required:
                                     - command
@@ -172,7 +230,9 @@ spec:
                               type: object
                             type: array
                           pre:
-                            description: PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any "additional items" from item actions are processed.
+                            description: |-
+                              PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                              These are executed before any "additional items" from item actions are processed.
                             items:
                               description: BackupResourceHook defines a hook for a resource.
                               properties:
@@ -186,7 +246,9 @@ spec:
                                       minItems: 1
                                       type: array
                                     container:
-                                      description: Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.
+                                      description: |-
+                                        Container is the container in the pod where the command should be executed. If not specified,
+                                        the pod's first container is used.
                                       type: string
                                     onError:
                                       description: OnError specifies how Velero should behave if it encounters an error executing this hook.
@@ -195,7 +257,9 @@ spec:
                                         - Fail
                                       type: string
                                     timeout:
-                                      description: Timeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.
+                                      description: |-
+                                        Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                        considering the execution a failure.
                                       type: string
                                   required:
                                     - command
@@ -211,53 +275,80 @@ spec:
                       type: array
                   type: object
                 includeClusterResources:
-                  description: IncludeClusterResources specifies whether cluster-scoped resources should be included for consideration in the backup.
+                  description: |-
+                    IncludeClusterResources specifies whether cluster-scoped resources
+                    should be included for consideration in the backup.
                   nullable: true
                   type: boolean
                 includedClusterScopedResources:
-                  description: IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to "*", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.
+                  description: |-
+                    IncludedClusterScopedResources is a slice of cluster-scoped
+                    resource type names to include in the backup.
+                    If set to "*", all cluster-scoped resource types are included.
+                    The default value is empty, which means only related
+                    cluster-scoped resources are included.
                   items:
                     type: string
                   nullable: true
                   type: array
                 includedNamespaceScopedResources:
-                  description: IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is "*".
+                  description: |-
+                    IncludedNamespaceScopedResources is a slice of namespace-scoped
+                    resource type names to include in the backup.
+                    The default value is "*".
                   items:
                     type: string
                   nullable: true
                   type: array
                 includedNamespaces:
-                  description: IncludedNamespaces is a slice of namespace names to include objects from. If empty, all namespaces are included.
+                  description: |-
+                    IncludedNamespaces is a slice of namespace names to include objects
+                    from. If empty, all namespaces are included.
                   items:
                     type: string
                   nullable: true
                   type: array
                 includedResources:
-                  description: IncludedResources is a slice of resource names to include in the backup. If empty, all resources are included.
+                  description: |-
+                    IncludedResources is a slice of resource names to include
+                    in the backup. If empty, all resources are included.
                   items:
                     type: string
                   nullable: true
                   type: array
                 itemOperationTimeout:
-                  description: ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations The default value is 1 hour.
+                  description: |-
+                    ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                    The default value is 4 hour.
                   type: string
                 labelSelector:
-                  description: LabelSelector is a metav1.LabelSelector to filter with when adding individual objects to the backup. If empty or nil, all objects are included. Optional.
+                  description: |-
+                    LabelSelector is a metav1.LabelSelector to filter with
+                    when adding individual objects to the backup. If empty
+                    or nil, all objects are included. Optional.
                   nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
@@ -269,7 +360,10 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
@@ -281,23 +375,39 @@ spec:
                       type: object
                   type: object
                 orLabelSelectors:
-                  description: OrLabelSelectors is list of metav1.LabelSelector to filter with when adding individual objects to the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in backup request, only one of them can be used.
+                  description: |-
+                    OrLabelSelectors is list of metav1.LabelSelector to filter with
+                    when adding individual objects to the backup. If multiple provided
+                    they will be joined by the OR operator. LabelSelector as well as
+                    OrLabelSelectors cannot co-exist in backup request, only one of them
+                    can be used.
                   items:
-                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -309,7 +419,10 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -318,14 +431,20 @@ spec:
                 orderedResources:
                   additionalProperties:
                     type: string
-                  description: OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                  description: |-
+                    OrderedResources specifies the backup order of resources of specific Kind.
+                    The map key is the resource name and value is a list of object names separated by commas.
+                    Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
                   nullable: true
                   type: object
                 resourcePolicy:
                   description: ResourcePolicy specifies the referenced resource policies that backup should follow
                   properties:
                     apiGroup:
-                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                      description: |-
+                        APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                        For any other third-party types, APIGroup is required.
                       type: string
                     kind:
                       description: Kind is the type of resource being referenced
@@ -343,15 +462,28 @@ spec:
                   nullable: true
                   type: boolean
                 snapshotVolumes:
-                  description: SnapshotVolumes specifies whether to take snapshots of any PV's referenced in the set of objects included in the Backup.
+                  description: |-
+                    SnapshotVolumes specifies whether to take snapshots
+                    of any PV's referenced in the set of objects included
+                    in the Backup.
                   nullable: true
                   type: boolean
                 storageLocation:
                   description: StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.
                   type: string
                 ttl:
-                  description: TTL is a time.Duration-parseable string describing how long the Backup should be retained for.
+                  description: |-
+                    TTL is a time.Duration-parseable string describing how long
+                    the Backup should be retained for.
                   type: string
+                uploaderConfig:
+                  description: UploaderConfig specifies the configuration for the uploader.
+                  nullable: true
+                  properties:
+                    parallelFilesUpload:
+                      description: ParallelFilesUpload is the number of files parallel uploads to perform when using the uploader.
+                      type: integer
+                  type: object
                 volumeSnapshotLocations:
                   description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.
                   items:
@@ -362,27 +494,44 @@ spec:
               description: BackupStatus captures the current status of a Velero backup.
               properties:
                 backupItemOperationsAttempted:
-                  description: BackupItemOperationsAttempted is the total number of attempted async BackupItemAction operations for this backup.
+                  description: |-
+                    BackupItemOperationsAttempted is the total number of attempted
+                    async BackupItemAction operations for this backup.
                   type: integer
                 backupItemOperationsCompleted:
-                  description: BackupItemOperationsCompleted is the total number of successfully completed async BackupItemAction operations for this backup.
+                  description: |-
+                    BackupItemOperationsCompleted is the total number of successfully completed
+                    async BackupItemAction operations for this backup.
                   type: integer
                 backupItemOperationsFailed:
-                  description: BackupItemOperationsFailed is the total number of async BackupItemAction operations for this backup which ended with an error.
+                  description: |-
+                    BackupItemOperationsFailed is the total number of async
+                    BackupItemAction operations for this backup which ended with an error.
                   type: integer
                 completionTimestamp:
-                  description: CompletionTimestamp records the time a backup was completed. Completion time is recorded even on failed backups. Completion time is recorded before uploading the backup object. The server's time is used for CompletionTimestamps
+                  description: |-
+                    CompletionTimestamp records the time a backup was completed.
+                    Completion time is recorded even on failed backups.
+                    Completion time is recorded before uploading the backup object.
+                    The server's time is used for CompletionTimestamps
                   format: date-time
                   nullable: true
                   type: string
                 csiVolumeSnapshotsAttempted:
-                  description: CSIVolumeSnapshotsAttempted is the total number of attempted CSI VolumeSnapshots for this backup.
+                  description: |-
+                    CSIVolumeSnapshotsAttempted is the total number of attempted
+                    CSI VolumeSnapshots for this backup.
                   type: integer
                 csiVolumeSnapshotsCompleted:
-                  description: CSIVolumeSnapshotsCompleted is the total number of successfully completed CSI VolumeSnapshots for this backup.
+                  description: |-
+                    CSIVolumeSnapshotsCompleted is the total number of successfully
+                    completed CSI VolumeSnapshots for this backup.
                   type: integer
                 errors:
-                  description: Errors is a count of all error messages that were generated during execution of the backup.  The actual errors are in the backup's log file in object storage.
+                  description: |-
+                    Errors is a count of all error messages that were generated during
+                    execution of the backup.  The actual errors are in the backup's log
+                    file in object storage.
                   type: integer
                 expiration:
                   description: Expiration is when this Backup is eligible for garbage-collection.
@@ -395,6 +544,20 @@ spec:
                 formatVersion:
                   description: FormatVersion is the backup format version, including major, minor, and patch version.
                   type: string
+                hookStatus:
+                  description: HookStatus contains information about the status of the hooks.
+                  nullable: true
+                  properties:
+                    hooksAttempted:
+                      description: |-
+                        HooksAttempted is the total number of attempted hooks
+                        Specifically, HooksAttempted represents the number of hooks that failed to execute
+                        and the number of hooks that executed successfully.
+                      type: integer
+                    hooksFailed:
+                      description: HooksFailed is the total number of hooks which ended with an error
+                      type: integer
+                  type: object
                 phase:
                   description: Phase is the current state of the Backup.
                   enum:
@@ -411,38 +574,62 @@ spec:
                     - Deleting
                   type: string
                 progress:
-                  description: Progress contains information about the backup's execution progress. Note that this information is best-effort only -- if Velero fails to update it during a backup for any reason, it may be inaccurate/stale.
+                  description: |-
+                    Progress contains information about the backup's execution progress. Note
+                    that this information is best-effort only -- if Velero fails to update it
+                    during a backup for any reason, it may be inaccurate/stale.
                   nullable: true
                   properties:
                     itemsBackedUp:
-                      description: ItemsBackedUp is the number of items that have actually been written to the backup tarball so far.
+                      description: |-
+                        ItemsBackedUp is the number of items that have actually been written to the
+                        backup tarball so far.
                       type: integer
                     totalItems:
-                      description: TotalItems is the total number of items to be backed up. This number may change throughout the execution of the backup due to plugins that return additional related items to back up, the velero.io/exclude-from-backup label, and various other filters that happen as items are processed.
+                      description: |-
+                        TotalItems is the total number of items to be backed up. This number may change
+                        throughout the execution of the backup due to plugins that return additional related
+                        items to back up, the velero.io/exclude-from-backup label, and various other
+                        filters that happen as items are processed.
                       type: integer
                   type: object
                 startTimestamp:
-                  description: StartTimestamp records the time a backup was started. Separate from CreationTimestamp, since that value changes on restores. The server's time is used for StartTimestamps
+                  description: |-
+                    StartTimestamp records the time a backup was started.
+                    Separate from CreationTimestamp, since that value changes
+                    on restores.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string
                 validationErrors:
-                  description: ValidationErrors is a slice of all validation errors (if applicable).
+                  description: |-
+                    ValidationErrors is a slice of all validation errors (if
+                    applicable).
                   items:
                     type: string
                   nullable: true
                   type: array
                 version:
-                  description: 'Version is the backup format major version. Deprecated: Please see FormatVersion'
+                  description: |-
+                    Version is the backup format major version.
+                    Deprecated: Please see FormatVersion
                   type: integer
                 volumeSnapshotsAttempted:
-                  description: VolumeSnapshotsAttempted is the total number of attempted volume snapshots for this backup.
+                  description: |-
+                    VolumeSnapshotsAttempted is the total number of attempted
+                    volume snapshots for this backup.
                   type: integer
                 volumeSnapshotsCompleted:
-                  description: VolumeSnapshotsCompleted is the total number of successfully completed volume snapshots for this backup.
+                  description: |-
+                    VolumeSnapshotsCompleted is the total number of successfully
+                    completed volume snapshots for this backup.
                   type: integer
                 warnings:
-                  description: Warnings is a count of all warning messages that were generated during execution of the backup. The actual warnings are in the backup's log file in object storage.
+                  description: |-
+                    Warnings is a count of all warning messages that were generated during
+                    execution of the backup. The actual warnings are in the backup's log
+                    file in object storage.
                   type: integer
               type: object
           type: object

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/backupstoragelocations.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/backupstoragelocations.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: backupstoragelocations.velero.io
@@ -41,10 +41,19 @@ spec:
           description: BackupStorageLocation is a location where Velero stores backup objects
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -73,7 +82,10 @@ spec:
                       description: The key of the secret to select from.  Must be a valid secret key.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                     optional:
                       description: Specify whether the Secret or its key must be defined
@@ -116,21 +128,36 @@ spec:
               description: BackupStorageLocationStatus defines the observed state of BackupStorageLocation
               properties:
                 accessMode:
-                  description: "AccessMode is an unused field. Deprecated: there is now an AccessMode field on the Spec and this field will be removed entirely as of v2.0."
+                  description: |-
+                    AccessMode is an unused field.
+
+
+                    Deprecated: there is now an AccessMode field on the Spec and this field
+                    will be removed entirely as of v2.0.
                   enum:
                     - ReadOnly
                     - ReadWrite
                   type: string
                 lastSyncedRevision:
-                  description: "LastSyncedRevision is the value of the `metadata/revision` file in the backup storage location the last time the BSL's contents were synced into the cluster. Deprecated: this field is no longer updated or used for detecting changes to the location's contents and will be removed entirely in v2.0."
+                  description: |-
+                    LastSyncedRevision is the value of the `metadata/revision` file in the backup
+                    storage location the last time the BSL's contents were synced into the cluster.
+
+
+                    Deprecated: this field is no longer updated or used for detecting changes to
+                    the location's contents and will be removed entirely in v2.0.
                   type: string
                 lastSyncedTime:
-                  description: LastSyncedTime is the last time the contents of the location were synced into the cluster.
+                  description: |-
+                    LastSyncedTime is the last time the contents of the location were synced into
+                    the cluster.
                   format: date-time
                   nullable: true
                   type: string
                 lastValidationTime:
-                  description: LastValidationTime is the last time the backup store location was validated the cluster.
+                  description: |-
+                    LastValidationTime is the last time the backup store location was validated
+                    the cluster.
                   format: date-time
                   nullable: true
                   type: string

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/datadownloads.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/datadownloads.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: datadownloads.velero.io
@@ -51,12 +51,22 @@ spec:
       name: v2alpha1
       schema:
         openAPIV3Schema:
+          description: DataDownload acts as the protocol between data mover plugins and data mover controller for the datamover restore operation
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -64,10 +74,14 @@ spec:
               description: DataDownloadSpec is the specification for a DataDownload.
               properties:
                 backupStorageLocation:
-                  description: BackupStorageLocation is the name of the backup storage location where the backup repository is stored.
+                  description: |-
+                    BackupStorageLocation is the name of the backup storage location
+                    where the backup repository is stored.
                   type: string
                 cancel:
-                  description: Cancel indicates request to cancel the ongoing DataDownload. It can be set when the DataDownload is in InProgress phase
+                  description: |-
+                    Cancel indicates request to cancel the ongoing DataDownload. It can be set
+                    when the DataDownload is in InProgress phase
                   type: boolean
                 dataMoverConfig:
                   additionalProperties:
@@ -75,16 +89,22 @@ spec:
                   description: DataMoverConfig is for data-mover-specific configuration fields.
                   type: object
                 datamover:
-                  description: DataMover specifies the data mover to be used by the backup. If DataMover is "" or "velero", the built-in data mover will be used.
+                  description: |-
+                    DataMover specifies the data mover to be used by the backup.
+                    If DataMover is "" or "velero", the built-in data mover will be used.
                   type: string
                 operationTimeout:
-                  description: OperationTimeout specifies the time used to wait internal operations, before returning error as timeout.
+                  description: |-
+                    OperationTimeout specifies the time used to wait internal operations,
+                    before returning error as timeout.
                   type: string
                 snapshotID:
                   description: SnapshotID is the ID of the Velero backup snapshot to be restored from.
                   type: string
                 sourceNamespace:
-                  description: SourceNamespace is the original namespace where the volume is backed up from. It may be different from SourcePVC's namespace if namespace is remapped during restore.
+                  description: |-
+                    SourceNamespace is the original namespace where the volume is backed up from.
+                    It may be different from SourcePVC's namespace if namespace is remapped during restore.
                   type: string
                 targetVolume:
                   description: TargetVolume is the information of the target PVC and PV.
@@ -114,7 +134,10 @@ spec:
               description: DataDownloadStatus is the current status of a DataDownload.
               properties:
                 completionTimestamp:
-                  description: CompletionTimestamp records the time a restore was completed. Completion time is recorded even on failed restores. The server's time is used for CompletionTimestamps
+                  description: |-
+                    CompletionTimestamp records the time a restore was completed.
+                    Completion time is recorded even on failed restores.
+                    The server's time is used for CompletionTimestamps
                   format: date-time
                   nullable: true
                   type: string
@@ -137,7 +160,10 @@ spec:
                     - Failed
                   type: string
                 progress:
-                  description: Progress holds the total number of bytes of the snapshot and the current number of restored bytes. This can be used to display progress information about the restore operation.
+                  description: |-
+                    Progress holds the total number of bytes of the snapshot and the current
+                    number of restored bytes. This can be used to display progress information
+                    about the restore operation.
                   properties:
                     bytesDone:
                       format: int64
@@ -147,7 +173,9 @@ spec:
                       type: integer
                   type: object
                 startTimestamp:
-                  description: StartTimestamp records the time a restore was started. The server's time is used for StartTimestamps
+                  description: |-
+                    StartTimestamp records the time a restore was started.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/datauploads.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/datauploads.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: datauploads.velero.io
@@ -51,12 +51,22 @@ spec:
       name: v2alpha1
       schema:
         openAPIV3Schema:
+          description: DataUpload acts as the protocol between data mover plugins and data mover controller for the datamover backup operation
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -64,10 +74,14 @@ spec:
               description: DataUploadSpec is the specification for a DataUpload.
               properties:
                 backupStorageLocation:
-                  description: BackupStorageLocation is the name of the backup storage location where the backup repository is stored.
+                  description: |-
+                    BackupStorageLocation is the name of the backup storage location
+                    where the backup repository is stored.
                   type: string
                 cancel:
-                  description: Cancel indicates request to cancel the ongoing DataUpload. It can be set when the DataUpload is in InProgress phase
+                  description: |-
+                    Cancel indicates request to cancel the ongoing DataUpload. It can be set
+                    when the DataUpload is in InProgress phase
                   type: boolean
                 csiSnapshot:
                   description: If SnapshotType is CSI, CSISnapshot provides the information of the CSI snapshot.
@@ -93,16 +107,22 @@ spec:
                   nullable: true
                   type: object
                 datamover:
-                  description: DataMover specifies the data mover to be used by the backup. If DataMover is "" or "velero", the built-in data mover will be used.
+                  description: |-
+                    DataMover specifies the data mover to be used by the backup.
+                    If DataMover is "" or "velero", the built-in data mover will be used.
                   type: string
                 operationTimeout:
-                  description: OperationTimeout specifies the time used to wait internal operations, before returning error as timeout.
+                  description: |-
+                    OperationTimeout specifies the time used to wait internal operations,
+                    before returning error as timeout.
                   type: string
                 snapshotType:
                   description: SnapshotType is the type of the snapshot to be backed up.
                   type: string
                 sourceNamespace:
-                  description: SourceNamespace is the original namespace where the volume is backed up from. It is the same namespace for SourcePVC and CSI namespaced objects.
+                  description: |-
+                    SourceNamespace is the original namespace where the volume is backed up from.
+                    It is the same namespace for SourcePVC and CSI namespaced objects.
                   type: string
                 sourcePVC:
                   description: SourcePVC is the name of the PVC which the snapshot is taken for.
@@ -118,7 +138,11 @@ spec:
               description: DataUploadStatus is the current status of a DataUpload.
               properties:
                 completionTimestamp:
-                  description: CompletionTimestamp records the time a backup was completed. Completion time is recorded even on failed backups. Completion time is recorded before uploading the backup object. The server's time is used for CompletionTimestamps
+                  description: |-
+                    CompletionTimestamp records the time a backup was completed.
+                    Completion time is recorded even on failed backups.
+                    Completion time is recorded before uploading the backup object.
+                    The server's time is used for CompletionTimestamps
                   format: date-time
                   nullable: true
                   type: string
@@ -150,7 +174,10 @@ spec:
                     - Failed
                   type: string
                 progress:
-                  description: Progress holds the total number of bytes of the volume and the current number of backed up bytes. This can be used to display progress information about the backup operation.
+                  description: |-
+                    Progress holds the total number of bytes of the volume and the current
+                    number of backed up bytes. This can be used to display progress information
+                    about the backup operation.
                   properties:
                     bytesDone:
                       format: int64
@@ -163,7 +190,11 @@ spec:
                   description: SnapshotID is the identifier for the snapshot in the backup repository.
                   type: string
                 startTimestamp:
-                  description: StartTimestamp records the time a backup was started. Separate from CreationTimestamp, since that value changes on restores. The server's time is used for StartTimestamps
+                  description: |-
+                    StartTimestamp records the time a backup was started.
+                    Separate from CreationTimestamp, since that value changes
+                    on restores.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/deletebackuprequests.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/deletebackuprequests.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: deletebackuprequests.velero.io
@@ -32,10 +32,19 @@ spec:
           description: DeleteBackupRequest is a request to delete one or more backups.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/downloadrequests.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/downloadrequests.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: downloadrequests.velero.io
@@ -20,13 +20,24 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: DownloadRequest is a request to download an artifact from backup object storage, such as a backup log file.
+          description: |-
+            DownloadRequest is a request to download an artifact from backup object storage, such as a backup
+            log file.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -51,6 +62,8 @@ spec:
                         - RestoreItemOperations
                         - CSIBackupVolumeSnapshots
                         - CSIBackupVolumeSnapshotContents
+                        - BackupVolumeInfos
+                        - RestoreVolumeInfo
                       type: string
                     name:
                       description: Name is the name of the Kubernetes resource with which the file is associated.

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/podvolumebackups.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/podvolumebackups.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: podvolumebackups.velero.io
@@ -38,10 +38,6 @@ spec:
           jsonPath: .spec.volume
           name: Volume
           type: string
-        - description: Backup repository identifier for this backup
-          jsonPath: .spec.repoIdentifier
-          name: Repository ID
-          type: string
         - description: The type of the uploader to handle data transfer
           jsonPath: .spec.uploaderType
           name: Uploader Type
@@ -58,10 +54,19 @@ spec:
         openAPIV3Schema:
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -69,7 +74,9 @@ spec:
               description: PodVolumeBackupSpec is the specification for a PodVolumeBackup.
               properties:
                 backupStorageLocation:
-                  description: BackupStorageLocation is the name of the backup storage location where the backup repository is stored.
+                  description: |-
+                    BackupStorageLocation is the name of the backup storage location
+                    where the backup repository is stored.
                   type: string
                 node:
                   description: Node is the name of the node that the Pod is running on.
@@ -81,22 +88,40 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -106,7 +131,17 @@ spec:
                 tags:
                   additionalProperties:
                     type: string
-                  description: Tags are a map of key-value pairs that should be applied to the volume backup as tags.
+                  description: |-
+                    Tags are a map of key-value pairs that should be applied to the
+                    volume backup as tags.
+                  type: object
+                uploaderSettings:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    UploaderSettings are a map of key-value pairs that should be applied to the
+                    uploader configuration.
+                  nullable: true
                   type: object
                 uploaderType:
                   description: UploaderType is the type of the uploader to handle the data transfer.
@@ -116,7 +151,9 @@ spec:
                     - ""
                   type: string
                 volume:
-                  description: Volume is the name of the volume within the Pod to be backed up.
+                  description: |-
+                    Volume is the name of the volume within the Pod to be backed
+                    up.
                   type: string
               required:
                 - backupStorageLocation
@@ -129,7 +166,11 @@ spec:
               description: PodVolumeBackupStatus is the current status of a PodVolumeBackup.
               properties:
                 completionTimestamp:
-                  description: CompletionTimestamp records the time a backup was completed. Completion time is recorded even on failed backups. Completion time is recorded before uploading the backup object. The server's time is used for CompletionTimestamps
+                  description: |-
+                    CompletionTimestamp records the time a backup was completed.
+                    Completion time is recorded even on failed backups.
+                    Completion time is recorded before uploading the backup object.
+                    The server's time is used for CompletionTimestamps
                   format: date-time
                   nullable: true
                   type: string
@@ -148,7 +189,10 @@ spec:
                     - Failed
                   type: string
                 progress:
-                  description: Progress holds the total number of bytes of the volume and the current number of backed up bytes. This can be used to display progress information about the backup operation.
+                  description: |-
+                    Progress holds the total number of bytes of the volume and the current
+                    number of backed up bytes. This can be used to display progress information
+                    about the backup operation.
                   properties:
                     bytesDone:
                       format: int64
@@ -161,7 +205,11 @@ spec:
                   description: SnapshotID is the identifier for the snapshot of the pod volume.
                   type: string
                 startTimestamp:
-                  description: StartTimestamp records the time a backup was started. Separate from CreationTimestamp, since that value changes on restores. The server's time is used for StartTimestamps
+                  description: |-
+                    StartTimestamp records the time a backup was started.
+                    Separate from CreationTimestamp, since that value changes
+                    on restores.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/podvolumerestores.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/podvolumerestores.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: podvolumerestores.velero.io
@@ -56,10 +56,19 @@ spec:
         openAPIV3Schema:
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -67,7 +76,9 @@ spec:
               description: PodVolumeRestoreSpec is the specification for a PodVolumeRestore.
               properties:
                 backupStorageLocation:
-                  description: BackupStorageLocation is the name of the backup storage location where the backup repository is stored.
+                  description: |-
+                    BackupStorageLocation is the name of the backup storage location
+                    where the backup repository is stored.
                   type: string
                 pod:
                   description: Pod is a reference to the pod containing the volume to be restored.
@@ -76,22 +87,40 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -104,6 +133,14 @@ spec:
                 sourceNamespace:
                   description: SourceNamespace is the original namespace for namaspace mapping.
                   type: string
+                uploaderSettings:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    UploaderSettings are a map of key-value pairs that should be applied to the
+                    uploader configuration.
+                  nullable: true
+                  type: object
                 uploaderType:
                   description: UploaderType is the type of the uploader to handle the data transfer.
                   enum:
@@ -126,7 +163,10 @@ spec:
               description: PodVolumeRestoreStatus is the current status of a PodVolumeRestore.
               properties:
                 completionTimestamp:
-                  description: CompletionTimestamp records the time a restore was completed. Completion time is recorded even on failed restores. The server's time is used for CompletionTimestamps
+                  description: |-
+                    CompletionTimestamp records the time a restore was completed.
+                    Completion time is recorded even on failed restores.
+                    The server's time is used for CompletionTimestamps
                   format: date-time
                   nullable: true
                   type: string
@@ -142,7 +182,10 @@ spec:
                     - Failed
                   type: string
                 progress:
-                  description: Progress holds the total number of bytes of the snapshot and the current number of restored bytes. This can be used to display progress information about the restore operation.
+                  description: |-
+                    Progress holds the total number of bytes of the snapshot and the current
+                    number of restored bytes. This can be used to display progress information
+                    about the restore operation.
                   properties:
                     bytesDone:
                       format: int64
@@ -152,7 +195,9 @@ spec:
                       type: integer
                   type: object
                 startTimestamp:
-                  description: StartTimestamp records the time a restore was started. The server's time is used for StartTimestamps
+                  description: |-
+                    StartTimestamp records the time a restore was started.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/restores.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/restores.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: restores.velero.io
@@ -20,13 +20,24 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: Restore is a Velero resource that represents the application of resources from a Velero backup to a target Kubernetes cluster.
+          description: |-
+            Restore is a Velero resource that represents the application of
+            resources from a Velero backup to a target Kubernetes cluster.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -34,16 +45,22 @@ spec:
               description: RestoreSpec defines the specification for a Velero restore.
               properties:
                 backupName:
-                  description: BackupName is the unique name of the Velero backup to restore from.
+                  description: |-
+                    BackupName is the unique name of the Velero backup to restore
+                    from.
                   type: string
                 excludedNamespaces:
-                  description: ExcludedNamespaces contains a list of namespaces that are not included in the restore.
+                  description: |-
+                    ExcludedNamespaces contains a list of namespaces that are not
+                    included in the restore.
                   items:
                     type: string
                   nullable: true
                   type: array
                 excludedResources:
-                  description: ExcludedResources is a slice of resource names that are not included in the restore.
+                  description: |-
+                    ExcludedResources is a slice of resource names that are not
+                    included in the restore.
                   items:
                     type: string
                   nullable: true
@@ -57,7 +74,9 @@ spec:
                   properties:
                     resources:
                       items:
-                        description: RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on the rules defined for namespaces, resources, and label selector.
+                        description: |-
+                          RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on
+                          the rules defined for namespaces, resources, and label selector.
                         properties:
                           excludedNamespaces:
                             description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
@@ -72,13 +91,17 @@ spec:
                             nullable: true
                             type: array
                           includedNamespaces:
-                            description: IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies to all namespaces.
+                            description: |-
+                              IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                              to all namespaces.
                             items:
                               type: string
                             nullable: true
                             type: array
                           includedResources:
-                            description: IncludedResources specifies the resources to which this hook spec applies. If empty, it applies to all resources.
+                            description: |-
+                              IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                              to all resources.
                             items:
                               type: string
                             nullable: true
@@ -90,16 +113,24 @@ spec:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
                                       description: key is the label key that the selector applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -111,7 +142,10 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
@@ -133,10 +167,14 @@ spec:
                                       minItems: 1
                                       type: array
                                     container:
-                                      description: Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.
+                                      description: |-
+                                        Container is the container in the pod where the command should be executed. If not specified,
+                                        the pod's first container is used.
                                       type: string
                                     execTimeout:
-                                      description: ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.
+                                      description: |-
+                                        ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                        considering the execution a failure.
                                       type: string
                                     onError:
                                       description: OnError specifies how Velero should behave if it encounters an error executing this hook.
@@ -144,8 +182,14 @@ spec:
                                         - Continue
                                         - Fail
                                       type: string
+                                    waitForReady:
+                                      description: WaitForReady ensures command will be launched when container is Ready instead of Running.
+                                      nullable: true
+                                      type: boolean
                                     waitTimeout:
-                                      description: WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready before attempting to run the command.
+                                      description: |-
+                                        WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready
+                                        before attempting to run the command.
                                       type: string
                                   required:
                                     - command
@@ -172,41 +216,61 @@ spec:
                       type: array
                   type: object
                 includeClusterResources:
-                  description: IncludeClusterResources specifies whether cluster-scoped resources should be included for consideration in the restore. If null, defaults to true.
+                  description: |-
+                    IncludeClusterResources specifies whether cluster-scoped resources
+                    should be included for consideration in the restore. If null, defaults
+                    to true.
                   nullable: true
                   type: boolean
                 includedNamespaces:
-                  description: IncludedNamespaces is a slice of namespace names to include objects from. If empty, all namespaces are included.
+                  description: |-
+                    IncludedNamespaces is a slice of namespace names to include objects
+                    from. If empty, all namespaces are included.
                   items:
                     type: string
                   nullable: true
                   type: array
                 includedResources:
-                  description: IncludedResources is a slice of resource names to include in the restore. If empty, all resources in the backup are included.
+                  description: |-
+                    IncludedResources is a slice of resource names to include
+                    in the restore. If empty, all resources in the backup are included.
                   items:
                     type: string
                   nullable: true
                   type: array
                 itemOperationTimeout:
-                  description: ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations The default value is 1 hour.
+                  description: |-
+                    ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations
+                    The default value is 4 hour.
                   type: string
                 labelSelector:
-                  description: LabelSelector is a metav1.LabelSelector to filter with when restoring individual objects from the backup. If empty or nil, all objects are included. Optional.
+                  description: |-
+                    LabelSelector is a metav1.LabelSelector to filter with
+                    when restoring individual objects from the backup. If empty
+                    or nil, all objects are included. Optional.
                   nullable: true
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
@@ -218,33 +282,56 @@ spec:
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 namespaceMapping:
                   additionalProperties:
                     type: string
-                  description: NamespaceMapping is a map of source namespace names to target namespace names to restore into. Any source namespaces not included in the map will be restored into namespaces of the same name.
+                  description: |-
+                    NamespaceMapping is a map of source namespace names
+                    to target namespace names to restore into. Any source
+                    namespaces not included in the map will be restored into
+                    namespaces of the same name.
                   type: object
                 orLabelSelectors:
-                  description: OrLabelSelectors is list of metav1.LabelSelector to filter with when restoring individual objects from the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in restore request, only one of them can be used
+                  description: |-
+                    OrLabelSelectors is list of metav1.LabelSelector to filter with
+                    when restoring individual objects from the backup. If multiple provided
+                    they will be joined by the OR operator. LabelSelector as well as
+                    OrLabelSelectors cannot co-exist in restore request, only one of them
+                    can be used
                   items:
-                    description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                         items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
                               description: key is the label key that the selector applies to.
                               type: string
                             operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
                               items:
                                 type: string
                               type: array
@@ -256,7 +343,10 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
@@ -271,7 +361,10 @@ spec:
                   nullable: true
                   properties:
                     apiGroup:
-                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                      description: |-
+                        APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                        For any other third-party types, APIGroup is required.
                       type: string
                     kind:
                       description: Kind is the type of resource being referenced
@@ -285,11 +378,15 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 restorePVs:
-                  description: RestorePVs specifies whether to restore all included PVs from snapshot
+                  description: |-
+                    RestorePVs specifies whether to restore all included
+                    PVs from snapshot
                   nullable: true
                   type: boolean
                 restoreStatus:
-                  description: RestoreStatus specifies which resources we should restore the status field. If nil, no objects are included. Optional.
+                  description: |-
+                    RestoreStatus specifies which resources we should restore the status
+                    field. If nil, no objects are included. Optional.
                   nullable: true
                   properties:
                     excludedResources:
@@ -299,32 +396,66 @@ spec:
                       nullable: true
                       type: array
                     includedResources:
-                      description: IncludedResources specifies the resources to which will restore the status. If empty, it applies to all resources.
+                      description: |-
+                        IncludedResources specifies the resources to which will restore the status.
+                        If empty, it applies to all resources.
                       items:
                         type: string
                       nullable: true
                       type: array
                   type: object
                 scheduleName:
-                  description: ScheduleName is the unique name of the Velero schedule to restore from. If specified, and BackupName is empty, Velero will restore from the most recent successful backup created from this schedule.
+                  description: |-
+                    ScheduleName is the unique name of the Velero schedule to restore
+                    from. If specified, and BackupName is empty, Velero will restore
+                    from the most recent successful backup created from this schedule.
                   type: string
-              required:
-                - backupName
+                uploaderConfig:
+                  description: UploaderConfig specifies the configuration for the restore.
+                  nullable: true
+                  properties:
+                    parallelFilesDownload:
+                      description: ParallelFilesDownload is the concurrency number setting for restore.
+                      type: integer
+                    writeSparseFiles:
+                      description: WriteSparseFiles is a flag to indicate whether write files sparsely or not.
+                      nullable: true
+                      type: boolean
+                  type: object
               type: object
             status:
               description: RestoreStatus captures the current status of a Velero restore
               properties:
                 completionTimestamp:
-                  description: CompletionTimestamp records the time the restore operation was completed. Completion time is recorded even on failed restore. The server's time is used for StartTimestamps
+                  description: |-
+                    CompletionTimestamp records the time the restore operation was completed.
+                    Completion time is recorded even on failed restore.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string
                 errors:
-                  description: Errors is a count of all error messages that were generated during execution of the restore. The actual errors are stored in object storage.
+                  description: |-
+                    Errors is a count of all error messages that were generated during
+                    execution of the restore. The actual errors are stored in object storage.
                   type: integer
                 failureReason:
                   description: FailureReason is an error that caused the entire restore to fail.
                   type: string
+                hookStatus:
+                  description: HookStatus contains information about the status of the hooks.
+                  nullable: true
+                  properties:
+                    hooksAttempted:
+                      description: |-
+                        HooksAttempted is the total number of attempted hooks
+                        Specifically, HooksAttempted represents the number of hooks that failed to execute
+                        and the number of hooks that executed successfully.
+                      type: integer
+                    hooksFailed:
+                      description: HooksFailed is the total number of hooks which ended with an error
+                      type: integer
+                  type: object
                 phase:
                   description: Phase is the current state of the Restore
                   enum:
@@ -336,40 +467,60 @@ spec:
                     - Completed
                     - PartiallyFailed
                     - Failed
+                    - Finalizing
+                    - FinalizingPartiallyFailed
                   type: string
                 progress:
-                  description: Progress contains information about the restore's execution progress. Note that this information is best-effort only -- if Velero fails to update it during a restore for any reason, it may be inaccurate/stale.
+                  description: |-
+                    Progress contains information about the restore's execution progress. Note
+                    that this information is best-effort only -- if Velero fails to update it
+                    during a restore for any reason, it may be inaccurate/stale.
                   nullable: true
                   properties:
                     itemsRestored:
                       description: ItemsRestored is the number of items that have actually been restored so far
                       type: integer
                     totalItems:
-                      description: TotalItems is the total number of items to be restored. This number may change throughout the execution of the restore due to plugins that return additional related items to restore
+                      description: |-
+                        TotalItems is the total number of items to be restored. This number may change
+                        throughout the execution of the restore due to plugins that return additional related
+                        items to restore
                       type: integer
                   type: object
                 restoreItemOperationsAttempted:
-                  description: RestoreItemOperationsAttempted is the total number of attempted async RestoreItemAction operations for this restore.
+                  description: |-
+                    RestoreItemOperationsAttempted is the total number of attempted
+                    async RestoreItemAction operations for this restore.
                   type: integer
                 restoreItemOperationsCompleted:
-                  description: RestoreItemOperationsCompleted is the total number of successfully completed async RestoreItemAction operations for this restore.
+                  description: |-
+                    RestoreItemOperationsCompleted is the total number of successfully completed
+                    async RestoreItemAction operations for this restore.
                   type: integer
                 restoreItemOperationsFailed:
-                  description: RestoreItemOperationsFailed is the total number of async RestoreItemAction operations for this restore which ended with an error.
+                  description: |-
+                    RestoreItemOperationsFailed is the total number of async
+                    RestoreItemAction operations for this restore which ended with an error.
                   type: integer
                 startTimestamp:
-                  description: StartTimestamp records the time the restore operation was started. The server's time is used for StartTimestamps
+                  description: |-
+                    StartTimestamp records the time the restore operation was started.
+                    The server's time is used for StartTimestamps
                   format: date-time
                   nullable: true
                   type: string
                 validationErrors:
-                  description: ValidationErrors is a slice of all validation errors (if applicable)
+                  description: |-
+                    ValidationErrors is a slice of all validation errors (if
+                    applicable)
                   items:
                     type: string
                   nullable: true
                   type: array
                 warnings:
-                  description: Warnings is a count of all warning messages that were generated during execution of the restore. The actual warnings are stored in object storage.
+                  description: |-
+                    Warnings is a count of all warning messages that were generated during
+                    execution of the restore. The actual warnings are stored in object storage.
                   type: integer
               type: object
           type: object

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/schedules.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/schedules.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: schedules.velero.io
@@ -39,13 +39,24 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: Schedule is a Velero resource that represents a pre-scheduled or periodic Backup that should be run.
+          description: |-
+            Schedule is a Velero resource that represents a pre-scheduled or
+            periodic Backup that should be run.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -56,45 +67,80 @@ spec:
                   description: Paused specifies whether the schedule is paused or not
                   type: boolean
                 schedule:
-                  description: Schedule is a Cron expression defining when to run the Backup.
+                  description: |-
+                    Schedule is a Cron expression defining when to run
+                    the Backup.
                   type: string
+                skipImmediately:
+                  description: |-
+                    SkipImmediately specifies whether to skip backup if schedule is due immediately from `schedule.status.lastBackup` timestamp when schedule is unpaused or if schedule is new.
+                    If true, backup will be skipped immediately when schedule is unpaused if it is due based on .Status.LastBackupTimestamp or schedule is new, and will run at next schedule time.
+                    If false, backup will not be skipped immediately when schedule is unpaused, but will run at next schedule time.
+                    If empty, will follow server configuration (default: false).
+                  type: boolean
                 template:
-                  description: Template is the definition of the Backup to be run on the provided schedule
+                  description: |-
+                    Template is the definition of the Backup to be run
+                    on the provided schedule
                   properties:
                     csiSnapshotTimeout:
-                      description: CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to ReadyToUse during creation, before returning error as timeout. The default value is 10 minute.
+                      description: |-
+                        CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to
+                        ReadyToUse during creation, before returning error as timeout.
+                        The default value is 10 minute.
                       type: string
                     datamover:
-                      description: DataMover specifies the data mover to be used by the backup. If DataMover is "" or "velero", the built-in data mover will be used.
+                      description: |-
+                        DataMover specifies the data mover to be used by the backup.
+                        If DataMover is "" or "velero", the built-in data mover will be used.
                       type: string
                     defaultVolumesToFsBackup:
-                      description: DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used for all volumes by default.
+                      description: |-
+                        DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used
+                        for all volumes by default.
                       nullable: true
                       type: boolean
                     defaultVolumesToRestic:
-                      description: "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead."
+                      description: |-
+                        DefaultVolumesToRestic specifies whether restic should be used to take a
+                        backup of all pod volumes by default.
+
+
+                        Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.
                       nullable: true
                       type: boolean
                     excludedClusterScopedResources:
-                      description: ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to "*", all cluster-scoped resource types are excluded. The default value is empty.
+                      description: |-
+                        ExcludedClusterScopedResources is a slice of cluster-scoped
+                        resource type names to exclude from the backup.
+                        If set to "*", all cluster-scoped resource types are excluded.
+                        The default value is empty.
                       items:
                         type: string
                       nullable: true
                       type: array
                     excludedNamespaceScopedResources:
-                      description: ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to "*", all namespace-scoped resource types are excluded. The default value is empty.
+                      description: |-
+                        ExcludedNamespaceScopedResources is a slice of namespace-scoped
+                        resource type names to exclude from the backup.
+                        If set to "*", all namespace-scoped resource types are excluded.
+                        The default value is empty.
                       items:
                         type: string
                       nullable: true
                       type: array
                     excludedNamespaces:
-                      description: ExcludedNamespaces contains a list of namespaces that are not included in the backup.
+                      description: |-
+                        ExcludedNamespaces contains a list of namespaces that are not
+                        included in the backup.
                       items:
                         type: string
                       nullable: true
                       type: array
                     excludedResources:
-                      description: ExcludedResources is a slice of resource names that are not included in the backup.
+                      description: |-
+                        ExcludedResources is a slice of resource names that are not
+                        included in the backup.
                       items:
                         type: string
                       nullable: true
@@ -105,7 +151,9 @@ spec:
                         resources:
                           description: Resources are hooks that should be executed when backing up individual instances of a resource.
                           items:
-                            description: BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on the rules defined for namespaces, resources, and label selector.
+                            description: |-
+                              BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
+                              the rules defined for namespaces, resources, and label selector.
                             properties:
                               excludedNamespaces:
                                 description: ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.
@@ -120,13 +168,17 @@ spec:
                                 nullable: true
                                 type: array
                               includedNamespaces:
-                                description: IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies to all namespaces.
+                                description: |-
+                                  IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies
+                                  to all namespaces.
                                 items:
                                   type: string
                                 nullable: true
                                 type: array
                               includedResources:
-                                description: IncludedResources specifies the resources to which this hook spec applies. If empty, it applies to all resources.
+                                description: |-
+                                  IncludedResources specifies the resources to which this hook spec applies. If empty, it applies
+                                  to all resources.
                                 items:
                                   type: string
                                 nullable: true
@@ -138,16 +190,24 @@ spec:
                                   matchExpressions:
                                     description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -159,7 +219,10 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -167,7 +230,9 @@ spec:
                                 description: Name is the name of this hook.
                                 type: string
                               post:
-                                description: PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all "additional items" from item actions are processed.
+                                description: |-
+                                  PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
+                                  These are executed after all "additional items" from item actions are processed.
                                 items:
                                   description: BackupResourceHook defines a hook for a resource.
                                   properties:
@@ -181,7 +246,9 @@ spec:
                                           minItems: 1
                                           type: array
                                         container:
-                                          description: Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.
+                                          description: |-
+                                            Container is the container in the pod where the command should be executed. If not specified,
+                                            the pod's first container is used.
                                           type: string
                                         onError:
                                           description: OnError specifies how Velero should behave if it encounters an error executing this hook.
@@ -190,7 +257,9 @@ spec:
                                             - Fail
                                           type: string
                                         timeout:
-                                          description: Timeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.
+                                          description: |-
+                                            Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                            considering the execution a failure.
                                           type: string
                                       required:
                                         - command
@@ -200,7 +269,9 @@ spec:
                                   type: object
                                 type: array
                               pre:
-                                description: PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any "additional items" from item actions are processed.
+                                description: |-
+                                  PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
+                                  These are executed before any "additional items" from item actions are processed.
                                 items:
                                   description: BackupResourceHook defines a hook for a resource.
                                   properties:
@@ -214,7 +285,9 @@ spec:
                                           minItems: 1
                                           type: array
                                         container:
-                                          description: Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.
+                                          description: |-
+                                            Container is the container in the pod where the command should be executed. If not specified,
+                                            the pod's first container is used.
                                           type: string
                                         onError:
                                           description: OnError specifies how Velero should behave if it encounters an error executing this hook.
@@ -223,7 +296,9 @@ spec:
                                             - Fail
                                           type: string
                                         timeout:
-                                          description: Timeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.
+                                          description: |-
+                                            Timeout defines the maximum amount of time Velero should wait for the hook to complete before
+                                            considering the execution a failure.
                                           type: string
                                       required:
                                         - command
@@ -239,53 +314,80 @@ spec:
                           type: array
                       type: object
                     includeClusterResources:
-                      description: IncludeClusterResources specifies whether cluster-scoped resources should be included for consideration in the backup.
+                      description: |-
+                        IncludeClusterResources specifies whether cluster-scoped resources
+                        should be included for consideration in the backup.
                       nullable: true
                       type: boolean
                     includedClusterScopedResources:
-                      description: IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to "*", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.
+                      description: |-
+                        IncludedClusterScopedResources is a slice of cluster-scoped
+                        resource type names to include in the backup.
+                        If set to "*", all cluster-scoped resource types are included.
+                        The default value is empty, which means only related
+                        cluster-scoped resources are included.
                       items:
                         type: string
                       nullable: true
                       type: array
                     includedNamespaceScopedResources:
-                      description: IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is "*".
+                      description: |-
+                        IncludedNamespaceScopedResources is a slice of namespace-scoped
+                        resource type names to include in the backup.
+                        The default value is "*".
                       items:
                         type: string
                       nullable: true
                       type: array
                     includedNamespaces:
-                      description: IncludedNamespaces is a slice of namespace names to include objects from. If empty, all namespaces are included.
+                      description: |-
+                        IncludedNamespaces is a slice of namespace names to include objects
+                        from. If empty, all namespaces are included.
                       items:
                         type: string
                       nullable: true
                       type: array
                     includedResources:
-                      description: IncludedResources is a slice of resource names to include in the backup. If empty, all resources are included.
+                      description: |-
+                        IncludedResources is a slice of resource names to include
+                        in the backup. If empty, all resources are included.
                       items:
                         type: string
                       nullable: true
                       type: array
                     itemOperationTimeout:
-                      description: ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations The default value is 1 hour.
+                      description: |-
+                        ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations
+                        The default value is 4 hour.
                       type: string
                     labelSelector:
-                      description: LabelSelector is a metav1.LabelSelector to filter with when adding individual objects to the backup. If empty or nil, all objects are included. Optional.
+                      description: |-
+                        LabelSelector is a metav1.LabelSelector to filter with
+                        when adding individual objects to the backup. If empty
+                        or nil, all objects are included. Optional.
                       nullable: true
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
                                 description: key is the label key that the selector applies to.
                                 type: string
                               operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
                                 items:
                                   type: string
                                 type: array
@@ -297,7 +399,10 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
@@ -309,23 +414,39 @@ spec:
                           type: object
                       type: object
                     orLabelSelectors:
-                      description: OrLabelSelectors is list of metav1.LabelSelector to filter with when adding individual objects to the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in backup request, only one of them can be used.
+                      description: |-
+                        OrLabelSelectors is list of metav1.LabelSelector to filter with
+                        when adding individual objects to the backup. If multiple provided
+                        they will be joined by the OR operator. LabelSelector as well as
+                        OrLabelSelectors cannot co-exist in backup request, only one of them
+                        can be used.
                       items:
-                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
                                   description: key is the label key that the selector applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -337,7 +458,10 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
@@ -346,14 +470,20 @@ spec:
                     orderedResources:
                       additionalProperties:
                         type: string
-                      description: OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
+                      description: |-
+                        OrderedResources specifies the backup order of resources of specific Kind.
+                        The map key is the resource name and value is a list of object names separated by commas.
+                        Each resource name has format "namespace/objectname".  For cluster resources, simply use "objectname".
                       nullable: true
                       type: object
                     resourcePolicy:
                       description: ResourcePolicy specifies the referenced resource policies that backup should follow
                       properties:
                         apiGroup:
-                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                          description: |-
+                            APIGroup is the group for the resource being referenced.
+                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                            For any other third-party types, APIGroup is required.
                           type: string
                         kind:
                           description: Kind is the type of resource being referenced
@@ -371,15 +501,28 @@ spec:
                       nullable: true
                       type: boolean
                     snapshotVolumes:
-                      description: SnapshotVolumes specifies whether to take snapshots of any PV's referenced in the set of objects included in the Backup.
+                      description: |-
+                        SnapshotVolumes specifies whether to take snapshots
+                        of any PV's referenced in the set of objects included
+                        in the Backup.
                       nullable: true
                       type: boolean
                     storageLocation:
                       description: StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.
                       type: string
                     ttl:
-                      description: TTL is a time.Duration-parseable string describing how long the Backup should be retained for.
+                      description: |-
+                        TTL is a time.Duration-parseable string describing how long
+                        the Backup should be retained for.
                       type: string
+                    uploaderConfig:
+                      description: UploaderConfig specifies the configuration for the uploader.
+                      nullable: true
+                      properties:
+                        parallelFilesUpload:
+                          description: ParallelFilesUpload is the number of files parallel uploads to perform when using the uploader.
+                          type: integer
+                      type: object
                     volumeSnapshotLocations:
                       description: VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.
                       items:
@@ -387,7 +530,9 @@ spec:
                       type: array
                   type: object
                 useOwnerReferencesInBackup:
-                  description: UseOwnerReferencesBackup specifies whether to use OwnerReferences on backups created by this Schedule.
+                  description: |-
+                    UseOwnerReferencesBackup specifies whether to use
+                    OwnerReferences on backups created by this Schedule.
                   nullable: true
                   type: boolean
               required:
@@ -398,7 +543,14 @@ spec:
               description: ScheduleStatus captures the current state of a Velero schedule
               properties:
                 lastBackup:
-                  description: LastBackup is the last time a Backup was run for this Schedule schedule
+                  description: |-
+                    LastBackup is the last time a Backup was run for this
+                    Schedule schedule
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastSkipped:
+                  description: LastSkipped is the last time a Schedule was skipped
                   format: date-time
                   nullable: true
                   type: string
@@ -410,7 +562,9 @@ spec:
                     - FailedValidation
                   type: string
                 validationErrors:
-                  description: ValidationErrors is a slice of all validation errors (if applicable)
+                  description: |-
+                    ValidationErrors is a slice of all validation errors (if
+                    applicable)
                   items:
                     type: string
                   type: array

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/serverstatusrequests.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/serverstatusrequests.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: serverstatusrequests.velero.io
@@ -22,13 +22,24 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: ServerStatusRequest is a request to access current status information about the Velero server.
+          description: |-
+            ServerStatusRequest is a request to access current status information about
+            the Velero server.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -60,7 +71,9 @@ spec:
                   nullable: true
                   type: array
                 processedTimestamp:
-                  description: ProcessedTimestamp is when the ServerStatusRequest was processed by the ServerStatusRequestController.
+                  description: |-
+                    ProcessedTimestamp is when the ServerStatusRequest was processed
+                    by the ServerStatusRequestController.
                   format: date-time
                   nullable: true
                   type: string

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/volumesnapshotlocations.yaml
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static/volumesnapshotlocations.yaml
@@ -1,10 +1,10 @@
-# This file has been generated with Velero v1.12.0. Do not edit.
+# This file has been generated with Velero v1.14.0. Do not edit.
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     component: velero
   name: volumesnapshotlocations.velero.io
@@ -25,10 +25,19 @@ spec:
           description: VolumeSnapshotLocation is a location where Velero stores volume snapshots.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -47,7 +56,10 @@ spec:
                       description: The key of the secret to select from.  Must be a valid secret key.
                       type: string
                     name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?
                       type: string
                     optional:
                       description: Specify whether the Secret or its key must be defined

--- a/pkg/test/e2e/cluster-backup/backup_test.go
+++ b/pkg/test/e2e/cluster-backup/backup_test.go
@@ -1,0 +1,354 @@
+//go:build e2e
+
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterbackup
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func env(key string) (string, error) {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return "", fmt.Errorf("no %s environment variable defined", key)
+	}
+
+	return value, nil
+}
+
+type backupCredentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	Bucket          string
+	Region          string
+}
+
+func (c *backupCredentials) AddFlags(fs *flag.FlagSet) {
+	// NOP
+}
+
+func (c *backupCredentials) Parse() (err error) {
+	if c.AccessKeyID, err = env("BACKUP_ACCESS_KEY_ID"); err != nil {
+		return err
+	}
+
+	if c.SecretAccessKey, err = env("BACKUP_SECRET_ACCESS_KEY"); err != nil {
+		return err
+	}
+
+	if c.Bucket, err = env("BACKUP_BUCKET"); err != nil {
+		return err
+	}
+
+	if c.Region, err = env("BACKUP_REGION"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const (
+	veleroNamespace    = "velero"
+	veleroDeployment   = "velero"
+	userClusterBSLName = "default-cluster-backup-bsl"
+)
+
+var (
+	credentials   jig.AWSCredentials
+	s3Credentials backupCredentials
+	logOptions    = utils.DefaultLogOptions
+
+	dummyObject = &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "canary",
+			Namespace: "kube-public",
+		},
+		Data: map[string]string{
+			"backups": "... are fun!",
+		},
+	}
+)
+
+func init() {
+	credentials.AddFlags(flag.CommandLine)
+	s3Credentials.AddFlags(flag.CommandLine)
+	jig.AddFlags(flag.CommandLine)
+	logOptions.AddFlags(flag.CommandLine)
+}
+
+func TestClusterBackupAndRestore(t *testing.T) {
+	ctx := context.Background()
+	rawLogger := log.NewFromOptions(logOptions)
+	logger := rawLogger.Sugar()
+
+	// set the logger used by sigs.k8s.io/controller-runtime
+	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLogger.WithOptions(zap.AddCallerSkip(1))))
+
+	if err := credentials.Parse(); err != nil {
+		t.Fatalf("Failed to get credentials: %v", err)
+	}
+
+	if err := s3Credentials.Parse(); err != nil {
+		t.Fatalf("Failed to get S3 credentials: %v", err)
+	}
+
+	seedClient, _, err := utils.GetClients()
+	if err != nil {
+		t.Fatalf("Failed to get client for seed cluster: %v", err)
+	}
+
+	// create test environment
+	testJig := jig.NewAWSCluster(seedClient, logger, credentials, 1, nil)
+	defer testJig.Cleanup(ctx, t, true)
+
+	testJig.ClusterJig.WithTestName("clusterbackup")
+
+	project, cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)
+	if err != nil {
+		t.Fatalf("Failed to setup test environment: %v", err)
+	}
+
+	cbslName, err := createBackupConfiguration(ctx, logger, seedClient, project, s3Credentials)
+	if err != nil {
+		t.Fatalf("Failed to setup backup config: %v", err)
+	}
+
+	// let the games begin
+
+	logger.Info("Enabling cluster backups...")
+	if err := setClusterBackupConfig(ctx, seedClient, cluster, cbslName); err != nil {
+		t.Fatalf("Failed to enable cluster backups: %v", err)
+	}
+
+	logger.Info("Waiting for Velero to be up and running...")
+	userClient, err := testJig.ClusterClient(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create user cluster client: %v", err)
+	}
+
+	if err := velerov1.AddToScheme(userClient.Scheme()); err != nil {
+		t.Fatalf("Failed to register velero/v1 scheme: %v", err)
+	}
+
+	if err := wait.PollImmediateLog(ctx, logger, 5*time.Second, 5*time.Minute, func(ctx context.Context) (transient error, terminal error) {
+		key := types.NamespacedName{Name: veleroDeployment, Namespace: veleroNamespace}
+		health, err := resources.HealthyDeployment(ctx, userClient, key, -1)
+		if err != nil {
+			return fmt.Errorf("failed to check health: %w", err), nil
+		}
+
+		if health != kubermaticv1.HealthStatusUp {
+			return fmt.Errorf("Velero is still %v", health), nil
+		}
+
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("Velero never became available: %v", err)
+	}
+
+	logger.Info("Waiting for BackupStorageLocation to be synced...")
+	if err := wait.PollImmediateLog(ctx, logger, 5*time.Second, 5*time.Minute, func(ctx context.Context) (transient error, terminal error) {
+		key := types.NamespacedName{Name: userClusterBSLName, Namespace: veleroNamespace}
+		userCBSL := &velerov1.BackupStorageLocation{}
+
+		return userClient.Get(ctx, key, userCBSL), nil
+	}); err != nil {
+		t.Fatalf("BSL never became available: %v", err)
+	}
+
+	logger.Info("Creating canary...")
+	canary := dummyObject.DeepCopy()
+	if err := userClient.Create(ctx, canary); err != nil {
+		t.Fatalf("Failed to create canary: %v", err)
+	}
+
+	logger.Info("Creating backup through Velero...")
+	clusterBackup := &velerov1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-backup",
+			Namespace: veleroNamespace,
+		},
+		Spec: velerov1.BackupSpec{
+			StorageLocation:    userClusterBSLName,
+			IncludedNamespaces: []string{canary.Namespace},
+			IncludedResources:  []string{"configmaps"},
+		},
+	}
+
+	if err := userClient.Create(ctx, clusterBackup); err != nil {
+		t.Fatalf("Failed to create backup: %v", err)
+	}
+
+	logger.Info("Waiting for backup to complete...")
+	if err := wait.PollImmediateLog(ctx, logger, 5*time.Second, 5*time.Minute, func(ctx context.Context) (transient error, terminal error) {
+		// refresh Backup information
+		if err := userClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(clusterBackup), clusterBackup); err != nil {
+			return err, nil
+		}
+
+		if phase := clusterBackup.Status.Phase; phase != velerov1.BackupPhaseCompleted {
+			return fmt.Errorf("backup is still %v", phase), nil
+		}
+
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("Backup never finished: %v", err)
+	}
+
+	logger.Info("Backup finished successfully.")
+
+	// make some modifications
+
+	logger.Info("Modifying cluster state...")
+	if err := userClient.Delete(ctx, canary); err != nil {
+		t.Fatalf("Failed to delete canary: %v", err)
+	}
+
+	// undo these changes using Velero
+
+	logger.Info("Creating restore through Velero...")
+	clusterRestore := &velerov1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-test-backup",
+			Namespace: veleroNamespace,
+		},
+		Spec: velerov1.RestoreSpec{
+			BackupName: clusterBackup.Name,
+		},
+	}
+
+	if err := userClient.Create(ctx, clusterRestore); err != nil {
+		t.Fatalf("Failed to create restore object: %v", err)
+	}
+
+	logger.Info("Waiting for restore to complete...")
+	if err := wait.PollImmediateLog(ctx, logger, 5*time.Second, 5*time.Minute, func(ctx context.Context) (transient error, terminal error) {
+		// refresh Restore information
+		if err := userClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(clusterRestore), clusterRestore); err != nil {
+			return err, nil
+		}
+
+		if phase := clusterRestore.Status.Phase; phase != velerov1.RestorePhaseCompleted {
+			return fmt.Errorf("restore is still %v", phase), nil
+		}
+
+		return nil, nil
+	}); err != nil {
+		t.Fatalf("Restore never finished: %v", err)
+	}
+
+	logger.Info("Restore finished successfully.")
+
+	// verify that the canary was resurrected
+
+	if err := userClient.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(canary), canary); err != nil {
+		t.Fatalf("Failed to get restored canary: %v", err)
+	}
+
+	logger.Info("Disabling cluster backups...")
+	if err := setClusterBackupConfig(ctx, seedClient, cluster, ""); err != nil {
+		t.Fatalf("Failed to disable cluster backups: %v", err)
+	}
+}
+
+func createBackupConfiguration(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, project *kubermaticv1.Project, creds backupCredentials) (string, error) {
+	log.Info("Creating backup configuration...")
+
+	credentials := &corev1.Secret{}
+	credentials.Name = "cluster-backup-e2e-credentials"
+	credentials.Namespace = resources.KubermaticNamespace
+
+	credentials.Data = map[string][]byte{
+		"accessKeyId":     []byte(creds.AccessKeyID),
+		"secretAccessKey": []byte(creds.SecretAccessKey),
+	}
+
+	if err := client.Create(ctx, credentials); err != nil {
+		return "", fmt.Errorf("failed to create credential secret: %w", err)
+	}
+
+	cbsl := &kubermaticv1.ClusterBackupStorageLocation{}
+	cbsl.Name = "cluster-backup-e2e"
+	cbsl.Namespace = credentials.Namespace
+	cbsl.Labels = map[string]string{
+		kubermaticv1.ProjectIDLabelKey: project.Name,
+	}
+	cbsl.Spec = velerov1.BackupStorageLocationSpec{
+		Provider: "aws",
+		Config: map[string]string{
+			"region": creds.Region,
+		},
+		StorageType: velerov1.StorageType{
+			ObjectStorage: &velerov1.ObjectStorageLocation{
+				Bucket: creds.Bucket,
+				Prefix: jig.BuildID(),
+			},
+		},
+		Credential: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: credentials.Name,
+			},
+			// KKP's controllers will later create a suitable Secret with a suitable key like this.
+			Key: "cloud-credentials",
+		},
+	}
+
+	if err := client.Create(ctx, cbsl); err != nil {
+		return "", fmt.Errorf("failed to create CBSL: %w", err)
+	}
+
+	return cbsl.Name, nil
+}
+
+func setClusterBackupConfig(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, cbslName string) error {
+	oldCluster := cluster.DeepCopy()
+
+	if cbslName == "" {
+		cluster.Spec.BackupConfig = nil
+	} else {
+		cluster.Spec.BackupConfig = &kubermaticv1.BackupConfig{
+			BackupStorageLocation: &corev1.LocalObjectReference{
+				Name: cbslName,
+			},
+		}
+	}
+
+	return client.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
+}

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -221,7 +221,7 @@ func (j *ClusterJig) ClusterClient(ctx context.Context) (ctrlruntimeclient.Clien
 	}
 
 	var clusterClient ctrlruntimeclient.Client
-	err = wait.Poll(ctx, 1*time.Second, 30*time.Second, func(ctx context.Context) (transient error, terminal error) {
+	err = wait.PollImmediate(ctx, 1*time.Second, 30*time.Second, func(ctx context.Context) (transient error, terminal error) {
 		clusterClient, transient = provider.GetClient(ctx, cluster)
 		return transient, nil
 	})
@@ -244,7 +244,7 @@ func (j *ClusterJig) ClusterRESTConfig(ctx context.Context) (*rest.Config, error
 	}
 
 	var clusterClient *rest.Config
-	err = wait.Poll(ctx, 1*time.Second, 30*time.Second, func(ctx context.Context) (transient error, terminal error) {
+	err = wait.PollImmediate(ctx, 1*time.Second, 30*time.Second, func(ctx context.Context) (transient error, terminal error) {
 		clusterClient, transient = provider.GetClientConfig(ctx, cluster)
 		return transient, nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
We identified a whole bunch of issues in my recent refactorings for the Cluster Backup feature and this PR is meant to prevent such situations in the future, plus this PR actually fixes _even more_ oversights on my end...

A new e2e test will now ensure that Velero gets installed correctly and can then process and restore a backup. The backups are stored in an S3 bucket at AWS, and that bucket has a policy attached to auto-delete every object after 24 hours.

In addition to the new test, this PR also fixes

* the CRDs were outdated and that caused issues like https://github.com/vmware-tanzu/velero/issues/8087
* the new flags on the usercluster-ctrl-mgr were never actually set because `cbsl` in the kubernetes controller was `nil`, which caused errors

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Cluster-Backup Velero CRDs
```

**Documentation**:
```documentation
NONE
```
