### PR TITLE
[release/v2.26] chores(ccm): update openstack version for 1.30 and 1.31 (#13899)

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -127,9 +127,9 @@ func OpenStackCCMTag(version semver.Semver) (string, error) {
 	case v129:
 		return "v1.29.0", nil
 	case v130:
-		fallthrough
+		return "v1.30.2", nil
 	case v131:
-		return "v1.30.0", nil
+		return "v1.31.2", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.0
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.2
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.30.0
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.31.2
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13899. Since we never backported #13854 to 2.26, the cherrypick failed.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack CCM: Kubernetes 1.30 now uses CCM v1.30.2 and Kubernetes 1.31 was upgraded and now uses CCM v1.31.2.
```

**Documentation**:
```documentation
NONE
```
