### PR TITLE
add default namespace spec to appdef crd

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -220,6 +220,9 @@ type ApplicationDefinitionSpec struct {
 	// DefaultValuesBlock specifies default values for the UI which are passed to helm templating when creating an application. Comments are preserved.
 	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 
+	// DefaultNamespace specifies default namespace for the UI which are passed to helm templating when creating an application. Comments are preserved.
+	DefaultNamespace AppNamespaceSpec `json:"defaultNamespace,omitempty"`
+
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.
 	// These settings can be overridden in applicationInstallation.
 	DefaultDeployOptions *DeployOptions `json:"defaultDeployOptions,omitempty"`

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -220,7 +220,8 @@ type ApplicationDefinitionSpec struct {
 	// DefaultValuesBlock specifies default values for the UI which are passed to helm templating when creating an application. Comments are preserved.
 	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 
-	// DefaultNamespace specifies default namespace for the UI which are passed to helm templating when creating an application. Comments are preserved.
+	// DefaultNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
+	// If unset, the name of the ApplicationDefinition is being used instead.
 	DefaultNamespace AppNamespaceSpec `json:"defaultNamespace,omitempty"`
 
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -222,7 +222,7 @@ type ApplicationDefinitionSpec struct {
 
 	// DefaultNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
 	// If unset, the name of the ApplicationDefinition is being used instead.
-	DefaultNamespace AppNamespaceSpec `json:"defaultNamespace,omitempty"`
+	DefaultNamespace *AppNamespaceSpec `json:"defaultNamespace,omitempty"`
 
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.
 	// These settings can be overridden in applicationInstallation.

--- a/pkg/apis/apps.kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps.kubermatic/v1/zz_generated.deepcopy.go
@@ -120,7 +120,11 @@ func (in *ApplicationDefinitionSpec) DeepCopyInto(out *ApplicationDefinitionSpec
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	in.DefaultNamespace.DeepCopyInto(&out.DefaultNamespace)
+	if in.DefaultNamespace != nil {
+		in, out := &in.DefaultNamespace, &out.DefaultNamespace
+		*out = new(AppNamespaceSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DefaultDeployOptions != nil {
 		in, out := &in.DefaultDeployOptions, &out.DefaultDeployOptions
 		*out = new(DeployOptions)

--- a/pkg/apis/apps.kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps.kubermatic/v1/zz_generated.deepcopy.go
@@ -120,6 +120,7 @@ func (in *ApplicationDefinitionSpec) DeepCopyInto(out *ApplicationDefinitionSpec
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
+	in.DefaultNamespace.DeepCopyInto(&out.DefaultNamespace)
 	if in.DefaultDeployOptions != nil {
 		in, out := &in.DefaultDeployOptions, &out.DefaultDeployOptions
 		*out = new(DeployOptions)

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -79,6 +79,38 @@ spec:
                           type: boolean
                       type: object
                   type: object
+                defaultNamespace:
+                  description: DefaultNamespace specifies default namespace for the UI which are passed to helm templating when creating an application. Comments are preserved.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Annotations of the namespace
+                        More info: http://kubernetes.io/docs/user-guide/annotations
+                      type: object
+                    create:
+                      default: true
+                      description: Create defines whether the namespace should be created if it does not exist. Defaults to true
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Labels of the namespace
+                        More info: http://kubernetes.io/docs/user-guide/labels
+                      type: object
+                    name:
+                      description: |-
+                        Name is the namespace to deploy the Application into.
+                        Should be a valid lowercase RFC1123 domain name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                    - create
+                    - name
+                  type: object
                 defaultValues:
                   description: |-
                     DefaultValues specify default values for the UI which are passed to helm templating when creating an application. Comments are not preserved.

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -80,7 +80,9 @@ spec:
                       type: object
                   type: object
                 defaultNamespace:
-                  description: DefaultNamespace specifies default namespace for the UI which are passed to helm templating when creating an application. Comments are preserved.
+                  description: |-
+                    DefaultNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
+                    If unset, the name of the ApplicationDefinition is being used instead.
                   properties:
                     annotations:
                       additionalProperties:


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds a field to applicationdefinition crd to be able to configure a default namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
