### PR TITLE
Add field to configure default ApplicationInstallation namespace

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -220,9 +220,17 @@ type ApplicationDefinitionSpec struct {
 	// DefaultValuesBlock specifies default values for the UI which are passed to helm templating when creating an application. Comments are preserved.
 	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 
-	// DefaultNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	// +kubebuilder:validation:MaxLength:=63
+	// +kubebuilder:validation:Type=string
+
+	// DefaultNamespace specifies the default namespace which is used in a referencing ApplicationInstallation.
 	// If unset, the name of the ApplicationDefinition is being used instead.
-	DefaultNamespace *AppNamespaceSpec `json:"defaultNamespace,omitempty"`
+	DefaultNamespace string `json:"defaultNamespace,omitempty"`
+
+	// DefaultAppNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
+	// If unset, the name of the ApplicationDefinition is being used instead.
+	DefaultAppNamespace *AppNamespaceSpec `json:"defaultAppNamespace,omitempty"`
 
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.
 	// These settings can be overridden in applicationInstallation.

--- a/pkg/apis/apps.kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps.kubermatic/v1/zz_generated.deepcopy.go
@@ -120,8 +120,8 @@ func (in *ApplicationDefinitionSpec) DeepCopyInto(out *ApplicationDefinitionSpec
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.DefaultNamespace != nil {
-		in, out := &in.DefaultNamespace, &out.DefaultNamespace
+	if in.DefaultAppNamespace != nil {
+		in, out := &in.DefaultAppNamespace, &out.DefaultAppNamespace
 		*out = new(AppNamespaceSpec)
 		(*in).DeepCopyInto(*out)
 	}

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -48,6 +48,40 @@ spec:
                     not enforced and users can update/delete them. KKP will only install them during cluster creation if the user didn't explicitly
                     opt out from installing default applications.
                   type: boolean
+                defaultAppNamespace:
+                  description: |-
+                    DefaultAppNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
+                    If unset, the name of the ApplicationDefinition is being used instead.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Annotations of the namespace
+                        More info: http://kubernetes.io/docs/user-guide/annotations
+                      type: object
+                    create:
+                      default: true
+                      description: Create defines whether the namespace should be created if it does not exist. Defaults to true
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Labels of the namespace
+                        More info: http://kubernetes.io/docs/user-guide/labels
+                      type: object
+                    name:
+                      description: |-
+                        Name is the namespace to deploy the Application into.
+                        Should be a valid lowercase RFC1123 domain name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                    - create
+                    - name
+                  type: object
                 defaultDeployOptions:
                   description: |-
                     DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.
@@ -81,38 +115,11 @@ spec:
                   type: object
                 defaultNamespace:
                   description: |-
-                    DefaultNamespace specifies the default namespace which is used if a referencing ApplicationInstallation has no target namespace defined.
+                    DefaultNamespace specifies the default namespace which is used in a referencing ApplicationInstallation.
                     If unset, the name of the ApplicationDefinition is being used instead.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Annotations of the namespace
-                        More info: http://kubernetes.io/docs/user-guide/annotations
-                      type: object
-                    create:
-                      default: true
-                      description: Create defines whether the namespace should be created if it does not exist. Defaults to true
-                      type: boolean
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        Labels of the namespace
-                        More info: http://kubernetes.io/docs/user-guide/labels
-                      type: object
-                    name:
-                      description: |-
-                        Name is the namespace to deploy the Application into.
-                        Should be a valid lowercase RFC1123 domain name
-                      maxLength: 63
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                  required:
-                    - create
-                    - name
-                  type: object
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
                 defaultValues:
                   description: |-
                     DefaultValues specify default values for the UI which are passed to helm templating when creating an application. Comments are not preserved.


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a field to applicationdefinition crd to be able to configure a default namespace for referenced applicationinstallations and renames the field for default helm release namespace from `defaultNamespace` to `defaultAppNamespace` with also changing the type to string because it is always ensured that the appicationinstallation namespace is created before applying the resource.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
