### PR TITLE
Remove redundant storage classes from OpenStack CSI addon

### DIFF
--- a/addons/csi/openstack/driver.yaml
+++ b/addons/csi/openstack/driver.yaml
@@ -54,22 +54,6 @@ spec:
         - ipBlock:
             cidr: 0.0.0.0/0
 {{ end }}
-allowVolumeExpansion: true
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: csi-cinder-sc-delete
-provisioner: cinder.csi.openstack.org
-reclaimPolicy: Delete
----
-allowVolumeExpansion: true
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: csi-cinder-sc-retain
-provisioner: cinder.csi.openstack.org
-reclaimPolicy: Retain
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/addons/csi/openstack/helm-values
+++ b/addons/csi/openstack/helm-values
@@ -11,6 +11,10 @@ secret:
   name: cloud-config-csi
   filename: config # key inside the cloud-config-csi Secret
 
+# Storage classes are not installed through this addon. They are managed using the `default-storage-class` addon.
+storageClass:
+  enabled: false
+
 csi:
   plugin:
     volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
Storage classes are installed through `default-storage-class` addon, but for OpenStack CSI drivers we unknowingly added the storage classes to the CSI driver addon itself in https://github.com/kubermatic/kubermatic/pull/13578

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13887

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove redundant storage classes from OpenStack CSI addon
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign
/cherry-pick release/v2.26