### PR TITLE
Expand the description of KubeletDown alert.

### DIFF
--- a/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
@@ -19,7 +19,7 @@ groups:
     rules:
       - alert: KubeletDown
         annotations:
-          message: Kubelet has disappeared from Prometheus target discovery.
+          message: All Kubelet instances have disappeared from Prometheus target discovery.
           runbook_url: https://docs.kubermatic.com/kubermatic/latest/cheat-sheets/alerting-runbook/#alert-kubeletdown
         expr: absent(up{job="kubelet"} == 1)
         for: 15m

--- a/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
@@ -17,7 +17,7 @@ groups:
     rules:
       - alert: KubeletDown
         annotations:
-          message: Kubelet has disappeared from Prometheus target discovery.
+          message: All Kubelet instances have disappeared from Prometheus target discovery.
           runbook_url: https://docs.kubermatic.com/kubermatic/latest/cheat-sheets/alerting-runbook/#alert-kubeletdown
         expr: absent(up{job="kubelet"} == 1)
         for: 15m

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -382,7 +382,7 @@ data:
         rules:
           - alert: KubeletDown
             annotations:
-              message: Kubelet has disappeared from Prometheus target discovery.
+              message: All Kubelet instances have disappeared from Prometheus target discovery.
               runbook_url: https://docs.kubermatic.com/kubermatic/latest/cheat-sheets/alerting-runbook/#alert-kubeletdown
             expr: absent(up{job="kubelet"} == 1)
             for: 15m

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -382,7 +382,7 @@ data:
         rules:
           - alert: KubeletDown
             annotations:
-              message: Kubelet has disappeared from Prometheus target discovery.
+              message: All Kubelet instances have disappeared from Prometheus target discovery.
               runbook_url: https://docs.kubermatic.com/kubermatic/latest/cheat-sheets/alerting-runbook/#alert-kubeletdown
             expr: absent(up{job="kubelet"} == 1)
             for: 15m

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -382,7 +382,7 @@ data:
         rules:
           - alert: KubeletDown
             annotations:
-              message: Kubelet has disappeared from Prometheus target discovery.
+              message: All Kubelet instances have disappeared from Prometheus target discovery.
               runbook_url: https://docs.kubermatic.com/kubermatic/latest/cheat-sheets/alerting-runbook/#alert-kubeletdown
             expr: absent(up{job="kubelet"} == 1)
             for: 15m


### PR DESCRIPTION
**What this PR does / why we need it**:
As pointed out recently, the description doesn't clearly state that the alert triggers on a failure of all discovered kubelets and not just a single instance. This improves the alert and runbook message.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
