### PR TITLE
[release/v2.25] fix changelog links (#13926)

### DIFF
--- a/docs/changelogs/CHANGELOG-2.24.md
+++ b/docs/changelogs/CHANGELOG-2.24.md
@@ -18,7 +18,7 @@
 
 ## v2.24.14
 
-**GitHub release: [2.24.14](https://github.com/kubermatic/kubermatic/releases/tag/2.24.14)**
+**GitHub release: [v2.24.14](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.14)**
 
 ### Bugfixes
 

--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -16,7 +16,7 @@
 
 ## v2.25.12
 
-**GitHub release: [2.25.12](https://github.com/kubermatic/kubermatic/releases/tag/2.25.12)**
+**GitHub release: [v2.25.12](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.12)**
 
 ### Bugfixes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #13926.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
