### PR TITLE
Mount synced `ca-bundle` ConfigMap into kubermatic-seed-controller-manager

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/kubermatic.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,8 +28,7 @@ import (
 )
 
 const (
-	serviceAccountName    = "kubermatic-seed"
-	caBundleConfigMapName = "ca-bundle"
+	serviceAccountName = "kubermatic-seed"
 )
 
 func ClusterRoleBindingName(cfg *kubermaticv1.KubermaticConfiguration) string {
@@ -69,7 +69,7 @@ func ClusterRoleBindingReconciler(cfg *kubermaticv1.KubermaticConfiguration, see
 
 func CABundleConfigMapReconciler(caBundle *corev1.ConfigMap) reconciling.NamedConfigMapReconcilerFactory {
 	return func() (string, reconciling.ConfigMapReconciler) {
-		return caBundleConfigMapName, func(c *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+		return resources.CABundleConfigMapName, func(c *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			c.Data = caBundle.Data
 
 			return c, nil

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -129,7 +129,7 @@ func SeedControllerManagerDeploymentReconciler(workerName string, versions kuber
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: cfg.Spec.CABundle.Name,
+								Name: resources.CABundleConfigMapName,
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:

It looks like we had a bug in our custom CA handling going all the way back to #6538:

- We allow configuring a custom CA bundle in `KubermaticConfiguration`. This is a `ConfigMap` reference, the default CA bundle we ship is called `ca-bundle`, but the reference doesn't require that name (in fact, our docs recommend a different name).
- This configured CA bundle is synced from master to seeds [here](https://github.com/kubermatic/kubermatic/blob/2827152ad017054e2af357fb5d5d2b118ceb5bb5/pkg/controller/operator/seed/reconciler.go#L503). The reconciler is hardcoded to a constant that uses `ca-bundle` for the `ConfigMap` name it should create on the seed.
- The reconciler for the kubermatic-seed-controller-manager `Deployment` references the `ConfigMap` reference that is configured in the `KubermaticConfiguration` singleton. This works fine if master and seed are on the same cluster (since the source `ConfigMap` exists there), but explodes once master and seed are separate environments (because the sync always creates `ca-bundle` on the seed cluster).

TL;DR: YAMSB (Yet Another Master/Seed Bug).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13937

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mount correct `ca-bundle` ConfigMap in kubermatic-seed-controller-manager Deployment on dedicated master/seed environments
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
