### PR TITLE
Disable `/metrics` endpoint in both Grafana charts

### DIFF
--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -38,6 +38,8 @@ data:
     url = https://grafana.net
     [log]
     mode = console
+    [metrics]
+    enabled = false
     [paths]
     data = /var/lib/grafana/
     logs = /var/log/grafana
@@ -5992,7 +5994,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 8997fd5ca74c33b72bd846e819cdfcb264695817096f1d9b867a7fcee5556f6f
+        checksum/config: 911498eb26e4e6fbb4c3712a71f0848926acb1e28b6cfbfcb1f353a4f38c092d
         checksum/dashboards-json-config: d5dd01108fc9173e77bb0988f2610b9d96b581a55ef53741e3a14a1178c825f5
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -38,6 +38,8 @@ data:
     url = https://grafana.net
     [log]
     mode = console
+    [metrics]
+    enabled = false
     [paths]
     data = /var/lib/grafana/
     logs = /var/log/grafana
@@ -5992,7 +5994,7 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: 8997fd5ca74c33b72bd846e819cdfcb264695817096f1d9b867a7fcee5556f6f
+        checksum/config: 911498eb26e4e6fbb4c3712a71f0848926acb1e28b6cfbfcb1f353a4f38c092d
         checksum/dashboards-json-config: d5dd01108fc9173e77bb0988f2610b9d96b581a55ef53741e3a14a1178c825f5
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         kubectl.kubernetes.io/default-container: grafana

--- a/charts/mla/grafana/values.yaml
+++ b/charts/mla/grafana/values.yaml
@@ -200,3 +200,7 @@ grafana:
       header_name: "X-Forwarded-Email"
       header_property: "username"
       auto_sign_up: "true"
+    metrics:
+      # Grafana does not support a custom port for metrics, and as such exposes metrics
+      # on the main HTTP endpoint accessible to users.
+      enabled: false

--- a/charts/monitoring/grafana/config/grafana.ini
+++ b/charts/monitoring/grafana/config/grafana.ini
@@ -24,3 +24,8 @@ auto_assign_org_role = {{ .Values.grafana.provisioning.configuration.auto_assign
 [server]
 root_url = {{ .Values.grafana.provisioning.configuration.root_url | quote }}
 {{- end }}
+
+[metrics]
+# Grafana does not support a custom port for metrics, and as such exposes metrics
+# on the main HTTP endpoint accessible to users.
+enabled = false


### PR DESCRIPTION
**What this PR does / why we need it**:

Apparently Grafana thinks that it's a good idea to:

1. Put your `/metrics` endpoint by default on your HTTP endpoint that is accessible by end users, without authentication by default.
2. Not even have a configuration option to expose it on a separate port.

Since we don't scrape Grafana's `/metrics` endpoints anywhere as far as I can say, the easiest solution to this problem is - right now - to simply disable metrics. We don't want that information exposed to end users.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Disable `/metrics` endpoint in master/seed MLA and user cluster MLA charts for Grafana
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
