### PR TITLE
minor changes to values.yaml for velero so that default install of velero works without errors

### DIFF
--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -343,7 +343,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.29"
+          image: "docker.io/bitnami/kubectl:1.30"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -108,102 +108,6 @@ spec:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: release-name
 ---
-# Source: velero/charts/velero/templates/node-agent-daemonset.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: node-agent
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  selector:
-    matchLabels:
-      name: node-agent
-  template:
-    metadata:
-      labels:
-        name: node-agent
-        app.kubernetes.io/name: velero
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: velero-7.1.0
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
-        checksum/secret: b9754ca4d83dab2f2e3ce5d2f763c69ed92c2298dc2737084680716557250af3
-    spec:
-      serviceAccountName: release-name-velero-server
-      securityContext:
-        runAsUser: 0
-      terminationGracePeriodSeconds: 3600
-      volumes:
-        - name: cloud-credentials
-          secret:
-            secretName: release-name-velero
-        - name: host-pods
-          hostPath:
-            path: /var/lib/kubelet/pods
-        - name: scratch
-          emptyDir: {}
-      dnsPolicy: ClusterFirst
-      containers:
-        - name: node-agent
-          image: "velero/velero:v1.14.0"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http-monitoring
-              containerPort: 8085
-          command:
-            - /velero
-          args:
-            - node-agent
-            - server
-          volumeMounts:
-            - name: cloud-credentials
-              mountPath: /credentials
-            - name: host-pods
-              mountPath: /host_pods
-              mountPropagation: HostToContainer
-            - name: scratch
-              mountPath: /scratch
-          env:
-            - name: VELERO_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: VELERO_SCRATCH_DIR
-              value: /scratch
-            - name: AWS_SHARED_CREDENTIALS_FILE
-              value: /credentials/cloud
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /credentials/cloud
-            - name: AZURE_CREDENTIALS_FILE
-              value: /credentials/cloud
-            - name: ALIBABA_CLOUD_CREDENTIALS_FILE
-              value: /credentials/cloud
-          securityContext:
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 512Mi
-      tolerations:
-        - effect: NoExecute
-          operator: Exists
-        - effect: NoSchedule
-          operator: Exists
----
 # Source: velero/charts/velero/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -327,24 +231,6 @@ spec:
                 - stable
             weight: 100
 ---
-# Source: velero/charts/velero/templates/backupstoragelocation.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  credential:
-  provider: 
-  accessMode: ReadWrite
-  objectStorage:
-    bucket:
----
 # Source: velero/charts/velero/templates/schedule.yaml
 apiVersion: velero.io/v1
 kind: Schedule
@@ -365,21 +251,6 @@ spec:
     - '*'
     snapshotVolumes: false
     ttl: 168h
----
-# Source: velero/charts/velero/templates/volumesnapshotlocation.yaml
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: default
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  credential:
-  provider:
 ---
 # Source: velero/charts/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
 apiVersion: v1
@@ -472,7 +343,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.30"
+          image: "docker.io/bitnami/kubectl:1.29"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -343,7 +343,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.29"
+          image: "docker.io/bitnami/kubectl:1.30"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -108,102 +108,6 @@ spec:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: release-name
 ---
-# Source: velero/charts/velero/templates/node-agent-daemonset.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: node-agent
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  selector:
-    matchLabels:
-      name: node-agent
-  template:
-    metadata:
-      labels:
-        name: node-agent
-        app.kubernetes.io/name: velero
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: velero-7.1.0
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
-        checksum/secret: b9754ca4d83dab2f2e3ce5d2f763c69ed92c2298dc2737084680716557250af3
-    spec:
-      serviceAccountName: release-name-velero-server
-      securityContext:
-        runAsUser: 0
-      terminationGracePeriodSeconds: 3600
-      volumes:
-        - name: cloud-credentials
-          secret:
-            secretName: release-name-velero
-        - name: host-pods
-          hostPath:
-            path: /var/lib/kubelet/pods
-        - name: scratch
-          emptyDir: {}
-      dnsPolicy: ClusterFirst
-      containers:
-        - name: node-agent
-          image: "velero/velero:v1.14.0"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http-monitoring
-              containerPort: 8085
-          command:
-            - /velero
-          args:
-            - node-agent
-            - server
-          volumeMounts:
-            - name: cloud-credentials
-              mountPath: /credentials
-            - name: host-pods
-              mountPath: /host_pods
-              mountPropagation: HostToContainer
-            - name: scratch
-              mountPath: /scratch
-          env:
-            - name: VELERO_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: VELERO_SCRATCH_DIR
-              value: /scratch
-            - name: AWS_SHARED_CREDENTIALS_FILE
-              value: /credentials/cloud
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /credentials/cloud
-            - name: AZURE_CREDENTIALS_FILE
-              value: /credentials/cloud
-            - name: ALIBABA_CLOUD_CREDENTIALS_FILE
-              value: /credentials/cloud
-          securityContext:
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 512Mi
-      tolerations:
-        - effect: NoExecute
-          operator: Exists
-        - effect: NoSchedule
-          operator: Exists
----
 # Source: velero/charts/velero/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -327,24 +231,6 @@ spec:
                 - stable
             weight: 100
 ---
-# Source: velero/charts/velero/templates/backupstoragelocation.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  credential:
-  provider: 
-  accessMode: ReadWrite
-  objectStorage:
-    bucket:
----
 # Source: velero/charts/velero/templates/schedule.yaml
 apiVersion: velero.io/v1
 kind: Schedule
@@ -365,21 +251,6 @@ spec:
     - '*'
     snapshotVolumes: false
     ttl: 168h
----
-# Source: velero/charts/velero/templates/volumesnapshotlocation.yaml
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: default
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  credential:
-  provider:
 ---
 # Source: velero/charts/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
 apiVersion: v1
@@ -472,7 +343,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.30"
+          image: "docker.io/bitnami/kubectl:1.29"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -343,7 +343,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.29"
+          image: "docker.io/bitnami/kubectl:1.30"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -108,102 +108,6 @@ spec:
     app.kubernetes.io/name: velero
     app.kubernetes.io/instance: release-name
 ---
-# Source: velero/charts/velero/templates/node-agent-daemonset.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: node-agent
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  selector:
-    matchLabels:
-      name: node-agent
-  template:
-    metadata:
-      labels:
-        name: node-agent
-        app.kubernetes.io/name: velero
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: velero-7.1.0
-      annotations:
-        prometheus.io/path: /metrics
-        prometheus.io/port: "8085"
-        prometheus.io/scrape: "true"
-        checksum/secret: b9754ca4d83dab2f2e3ce5d2f763c69ed92c2298dc2737084680716557250af3
-    spec:
-      serviceAccountName: release-name-velero-server
-      securityContext:
-        runAsUser: 0
-      terminationGracePeriodSeconds: 3600
-      volumes:
-        - name: cloud-credentials
-          secret:
-            secretName: release-name-velero
-        - name: host-pods
-          hostPath:
-            path: /var/lib/kubelet/pods
-        - name: scratch
-          emptyDir: {}
-      dnsPolicy: ClusterFirst
-      containers:
-        - name: node-agent
-          image: "velero/velero:v1.14.0"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http-monitoring
-              containerPort: 8085
-          command:
-            - /velero
-          args:
-            - node-agent
-            - server
-          volumeMounts:
-            - name: cloud-credentials
-              mountPath: /credentials
-            - name: host-pods
-              mountPath: /host_pods
-              mountPropagation: HostToContainer
-            - name: scratch
-              mountPath: /scratch
-          env:
-            - name: VELERO_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: VELERO_SCRATCH_DIR
-              value: /scratch
-            - name: AWS_SHARED_CREDENTIALS_FILE
-              value: /credentials/cloud
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /credentials/cloud
-            - name: AZURE_CREDENTIALS_FILE
-              value: /credentials/cloud
-            - name: ALIBABA_CLOUD_CREDENTIALS_FILE
-              value: /credentials/cloud
-          securityContext:
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 512Mi
-      tolerations:
-        - effect: NoExecute
-          operator: Exists
-        - effect: NoSchedule
-          operator: Exists
----
 # Source: velero/charts/velero/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -327,24 +231,6 @@ spec:
                 - stable
             weight: 100
 ---
-# Source: velero/charts/velero/templates/backupstoragelocation.yaml
-apiVersion: velero.io/v1
-kind: BackupStorageLocation
-metadata:
-  name: default
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  credential:
-  provider: 
-  accessMode: ReadWrite
-  objectStorage:
-    bucket:
----
 # Source: velero/charts/velero/templates/schedule.yaml
 apiVersion: velero.io/v1
 kind: Schedule
@@ -365,21 +251,6 @@ spec:
     - '*'
     snapshotVolumes: false
     ttl: 168h
----
-# Source: velero/charts/velero/templates/volumesnapshotlocation.yaml
-apiVersion: velero.io/v1
-kind: VolumeSnapshotLocation
-metadata:
-  name: default
-  namespace: default
-  labels:
-    app.kubernetes.io/name: velero
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: velero-7.1.0
-spec:
-  credential:
-  provider:
 ---
 # Source: velero/charts/velero/templates/upgrade-crds/serviceaccount-upgrade.yaml
 apiVersion: v1
@@ -472,7 +343,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.30"
+          image: "docker.io/bitnami/kubectl:1.29"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -13,8 +13,17 @@
 # limitations under the License.
 
 velero:
+  # whether to enable etcd backups?
+  # if you set this as true, you must provide valid configuration for velero.configuration.backupStorageLocation[0]
+  backupsEnabled: false
+
+  # whether to enable volume backups?
+  # if you set this as true, you must provide valid configuration for velero.configuration.volumeSnapshotLocation[0]
+  snapshotsEnabled: false
+  # see more about config options here: https://github.com/vmware-tanzu/helm-charts/blob/velero-7.1.0/charts/velero/values.yaml#L316C1-L360
+
   # Whether to deploy the node-agent daemonset.
-  deployNodeAgent: true
+  deployNodeAgent: false
 
   # Init containers to add to the Velero deployment's pod spec. At least one plugin provider image is required.
   # If the value is a string then it is evaluated as a template.


### PR DESCRIPTION
**What this PR does / why we need it**:
Turned of velero backups as well as snapshots by default so that velero chart can get installed with empty values.yaml

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13912 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind chore
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* If you have provided configuration for new velero chart in KKP 2.26 for creating etcd backups and/or volume backups, please ensure to set `velero.backupsEnabled: true` and `velero.snapshotsEnabled: true` explicitly in your custom `values.yaml`
* The node-agent daemonset is by default disabled. If you had configured volume backups via `velero.snapshotsEnabled: true`, you also need to enabled `velero.deployNodeAgent: true` for volume backups to work.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
