### PR TITLE
add templating for pre defined app values

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -421,7 +421,7 @@ func main() {
 		log.Info("Registered constraintsyncer controller")
 	}
 
-	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace}); err != nil {
+	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace, ClusterName: runOp.clusterName}); err != nil {
 		log.Fatalw("Failed to add user Application Installation controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered Application Installation controller")

--- a/codegen/godoc/main.go
+++ b/codegen/godoc/main.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/tools/go/packages"
 
 	"k8c.io/kubermatic/v2/pkg/addon"
+	"k8c.io/kubermatic/v2/pkg/ee/applications"
 	"k8c.io/kubermatic/v2/pkg/resources/prometheus"
 )
 
@@ -39,6 +40,11 @@ var packageCache = map[string]*packages.Package{}
 func main() {
 	// document addon template data
 	if err := generate("zz_generated.addondata.go.txt", addon.TemplateData{}); err != nil {
+		log.Fatalf("Failed to create documentation: %v", err)
+	}
+
+	// document application template data
+	if err := generate("zz_generated.applicationdata.go.txt", applications.TemplateData{}); err != nil {
 		log.Fatalf("Failed to create documentation: %v", err)
 	}
 

--- a/docs/zz_generated.applicationdata.go.txt
+++ b/docs/zz_generated.applicationdata.go.txt
@@ -1,0 +1,48 @@
+// TemplateData is the root context injected into each application values.
+type TemplateData struct {
+	Cluster ClusterData
+}
+
+// ClusterData contains data related to the user cluster
+// the application is rendered for.
+type ClusterData struct {
+	Name string
+	// HumanReadableName is the user-specified cluster name.
+	HumanReadableName string
+	// OwnerEmail is the owner's e-mail address.
+	OwnerEmail string
+	// ClusterAddress stores access and address information of a cluster.
+	Address kubermaticv1.ClusterAddress
+	// Version is the exact current cluster version.
+	Version string
+	// MajorMinorVersion is a shortcut for common testing on "Major.Minor" on the
+	// current cluster version.
+	MajorMinorVersion string
+}
+
+// ClusterAddress stores access and address information of a cluster.
+type ClusterAddress struct {
+	// URL under which the Apiserver is available
+	// +optional
+	URL string `json:"url"`
+	// Port is the port the API server listens on
+	// +optional
+	Port int32 `json:"port"`
+	// ExternalName is the DNS name for this cluster
+	// +optional
+	ExternalName string `json:"externalName"`
+	// InternalName is the seed cluster internal absolute DNS name to the API server
+	// +optional
+	InternalName string `json:"internalURL"`
+	// AdminToken is the token for the kubeconfig, the user can download
+	// +optional
+	AdminToken string `json:"adminToken"`
+	// IP is the external IP under which the apiserver is available
+	// +optional
+	IP string `json:"ip"`
+	// APIServerExternalAddress is the external address of the API server (IP or DNS name)
+	// This field is populated only when the API server service is of type LoadBalancer. If set, this address will be used in the
+	// kubeconfig for the user cluster that can be downloaded from the KKP UI.
+	// +optional
+	APIServerExternalAddress string `json:"apiServerExternalAddress,omitempty"`
+}

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -56,6 +56,7 @@ for resource in seed kubermaticConfiguration applicationDefinition applicationIn
 done
 
 cp ../docs/zz_generated.addondata.go.txt content/kubermatic/main/data/addondata.go
+cp ../docs/zz_generated.applicationdata.go.txt content/kubermatic/main/data/applicationdata.go
 cp ../docs/zz_generated.prometheusdata.go.txt content/kubermatic/main/data/prometheusdata.go
 cp ../addonresources.json content/kubermatic/main/data/addonresources.json
 

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -62,6 +62,9 @@ type ApplicationManager struct {
 
 	// Namespace where credentials secrets are stored.
 	SecretNamespace string
+
+	// ClusterName of the user-cluster
+	ClusterName string
 }
 
 func (a *ApplicationManager) GetAppCache() string {
@@ -85,7 +88,7 @@ func (a *ApplicationManager) DownloadSource(ctx context.Context, log *zap.Sugare
 
 // Apply creates the namespace where the application will be installed (if necessary) and installs the application.
 func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return util.NoStatusUpdate, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
@@ -99,7 +102,7 @@ func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, 
 
 // Delete uninstalls the application where the application was installed if necessary.
 func (a *ApplicationManager) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return util.NoStatusUpdate, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
@@ -147,7 +150,7 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 
 // IsStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries.
 func (a *ApplicationManager) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return false, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
@@ -157,7 +160,7 @@ func (a *ApplicationManager) IsStuck(ctx context.Context, log *zap.SugaredLogger
 
 // Rollback rolls an Application back to the previous release.
 func (a *ApplicationManager) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
-	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to initialize template provider: %w", err)
 	}

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -49,6 +49,9 @@ type HelmTemplate struct {
 	// Namespace where credential secrets are stored.
 	SecretNamespace string
 
+	// ClusterName of the user-cluster
+	ClusterName string
+
 	// SeedClient to seed cluster.
 	SeedClient ctrlruntimeclient.Client
 }
@@ -96,10 +99,10 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, appDefinition *appskuber
 		return util.NoStatusUpdate, fmt.Errorf("failed to unmarshal values: %w", err)
 	}
 
-	renderedValues, err := h.parsePreDefinedValues(values)
+	renderedValues, err := h.templatePreDefinedValues(values)
 
 	if err != nil {
-		return util.NoStatusUpdate, fmt.Errorf("failed to render pre defined values: %w", err)
+		return util.NoStatusUpdate, fmt.Errorf("failed to render pre-defined values: %w", err)
 	}
 
 	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), renderedValues, *deployOpts, auth)

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -96,7 +96,13 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, appDefinition *appskuber
 		return util.NoStatusUpdate, fmt.Errorf("failed to unmarshal values: %w", err)
 	}
 
-	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), values, *deployOpts, auth)
+	renderedValues, err := h.parsePreDefinedValues(values)
+
+	if err != nil {
+		return util.NoStatusUpdate, fmt.Errorf("failed to render pre defined values: %w", err)
+	}
+
+	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), renderedValues, *deployOpts, auth)
 	statusUpdater := util.NoStatusUpdate
 
 	// In some case, even if an error occurred, the helmRelease is updated.

--- a/pkg/applications/providers/template/helm_integration_test.go
+++ b/pkg/applications/providers/template/helm_integration_test.go
@@ -245,6 +245,7 @@ func TestHelmProvider(t *testing.T) {
 					Log:             kubermaticlog.Logger,
 					SecretNamespace: "default",
 					SeedClient:      client,
+					ClusterName:     "cluster-default",
 				}
 
 				statusUpdater, err := template.InstallOrUpgrade(exampleV2ChartLoc, &appskubermaticv1.ApplicationDefinition{}, app)
@@ -283,6 +284,7 @@ func TestHelmProvider(t *testing.T) {
 					Log:             kubermaticlog.Logger,
 					SecretNamespace: "default",
 					SeedClient:      client,
+					ClusterName:     "cluster-default",
 				}
 
 				statusUpdater, err := template.InstallOrUpgrade(exampleV2ChartLoc, &appskubermaticv1.ApplicationDefinition{Spec: appskubermaticv1.ApplicationDefinitionSpec{DefaultDeployOptions: deployOpts}}, app)
@@ -339,6 +341,7 @@ func installOrUpgradeTest(t *testing.T, ctx context.Context, client ctrlruntimec
 		CacheDir:        t.TempDir(),
 		Log:             kubermaticlog.Logger,
 		SecretNamespace: "default",
+		ClusterName:     "cluster-default",
 		SeedClient:      client,
 	}
 

--- a/pkg/applications/providers/template/helm_integration_test.go
+++ b/pkg/applications/providers/template/helm_integration_test.go
@@ -85,6 +85,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application is created with no values, it should install app with default values",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "", nil)
 
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, test.DefaultVersionLabel, 1, false)
@@ -94,6 +95,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application is created with customCmData, it should install app with customCmData",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				customCmData := map[string]string{"hello": "world", "a": "b"}
 				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), "", nil)
 
@@ -105,6 +107,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application is created with custom versionLabel, it should install app into user cluster with custom versionLabel",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				// its check that scalar values overwrite default  scalar values
 				customVersionLabel := "1.2.3"
 				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.VersionLabelKey, customVersionLabel), "", nil)
@@ -116,6 +119,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application is is updated with customCmData, should update app with new data",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				customCmData := map[string]string{"hello": "world", "a": "b"}
 				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), "", nil)
 
@@ -133,6 +137,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application removed, it should uninstall app",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				customCmData := map[string]string{"hello": "world", "a": "b"}
 				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), "", nil)
 
@@ -174,6 +179,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				chartFullPath := createChartWithDependency(t, registryUrl)
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "", nil)
 
 				app.Status.ApplicationVersion.Template.DependencyCredentials = &appskubermaticv1.DependencyCredentials{HelmCredentials: &appskubermaticv1.HelmCredentials{RegistryConfigFile: &corev1.SecretKeySelector{
@@ -203,6 +209,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				chartFullPath := createChartWithDependency(t, registryUrl)
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "", nil)
 
 				template := HelmTemplate{
@@ -225,6 +232,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "application installation should fail when timeout is exceeded (timeout is defined at application Installation Level)",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: true, Timeout: metav1.Duration{Duration: 5 * time.Second}, Atomic: false}}
 
 				// Create an application that deploy a LB service that will never get public ip -> helm release will not be be successful.
@@ -262,6 +270,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "application installation should fail when timeout is exceeded (timeout is defined at applicationDefinition Level)",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: true, Timeout: metav1.Duration{Duration: 5 * time.Second}, Atomic: false}}
 
 				// Create an application that deploy a LB service that will never get public ip -> helm release will not be be successful.
@@ -300,6 +309,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: false, Timeout: metav1.Duration{Duration: 0}, Atomic: false, EnableDNS: true}}
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "", deployOpts)
 
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, test.DefaultVersionLabel, 1, true)
@@ -309,6 +319,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application is created with valuesBlock, it is installed with values from valuesBlock",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "key: value", nil)
 
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, test.DefaultVersionLabel, 1, false)

--- a/pkg/applications/providers/template/wrappers_ce.go
+++ b/pkg/applications/providers/template/wrappers_ce.go
@@ -1,7 +1,7 @@
 //go:build !ee
 
 /*
-Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,6 @@ limitations under the License.
 
 package template
 
-func (h *HelmTemplate) parsePreDefinedValues(applicationValues map[string]interface{}) (map[string]interface{}, error) {
+func (h *HelmTemplate) templatePreDefinedValues(applicationValues map[string]any) (map[string]any, error) {
 	return applicationValues, nil
 }

--- a/pkg/applications/providers/template/wrappers_ce.go
+++ b/pkg/applications/providers/template/wrappers_ce.go
@@ -1,0 +1,23 @@
+//go:build !ee
+
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+func (h *HelmTemplate) parsePreDefinedValues(applicationValues map[string]interface{}) (map[string]interface{}, error) {
+	return applicationValues, nil
+}

--- a/pkg/applications/providers/template/wrappers_ee.go
+++ b/pkg/applications/providers/template/wrappers_ee.go
@@ -1,7 +1,7 @@
 //go:build ee
 
 /*
-Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import (
 	eeutil "k8c.io/kubermatic/v2/pkg/ee/applications"
 )
 
-func (h *HelmTemplate) parsePreDefinedValues(applicationValues map[string]interface{}) (map[string]interface{}, error) {
-	templateData, err := eeutil.GetTemplateData(h.Ctx, h.SeedClient, h.SecretNamespace)
+func (h *HelmTemplate) templatePreDefinedValues(applicationValues map[string]any) (map[string]any, error) {
+	templateData, err := eeutil.GetTemplateData(h.Ctx, h.SeedClient, h.ClusterName)
 
 	if err != nil {
 		return nil, err

--- a/pkg/applications/providers/template/wrappers_ee.go
+++ b/pkg/applications/providers/template/wrappers_ee.go
@@ -1,0 +1,32 @@
+//go:build ee
+
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	eeutil "k8c.io/kubermatic/v2/pkg/ee/applications"
+)
+
+func (h *HelmTemplate) parsePreDefinedValues(applicationValues map[string]interface{}) (map[string]interface{}, error) {
+	templateData, err := eeutil.GetTemplateData(h.Ctx, h.SeedClient, h.SecretNamespace)
+
+	if err != nil {
+		return nil, err
+	}
+	return eeutil.RenderValueTemplate(applicationValues, templateData)
+}

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -68,10 +68,10 @@ type TemplateProvider interface {
 }
 
 // NewTemplateProvider return the concrete implementation of TemplateProvider according to the templateMethod.
-func NewTemplateProvider(ctx context.Context, seedClient ctrlruntimeclient.Client, kubeconfig string, cacheDir string, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation, secretNamespace string) (TemplateProvider, error) {
+func NewTemplateProvider(ctx context.Context, seedClient ctrlruntimeclient.Client, clusterName string, kubeconfig string, cacheDir string, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation, secretNamespace string) (TemplateProvider, error) {
 	switch appInstallation.Status.Method {
 	case appskubermaticv1.HelmTemplateMethod:
-		return template.HelmTemplate{Ctx: ctx, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, SecretNamespace: secretNamespace, SeedClient: seedClient}, nil
+		return template.HelmTemplate{Ctx: ctx, Kubeconfig: kubeconfig, CacheDir: cacheDir, Log: log, SecretNamespace: secretNamespace, ClusterName: clusterName, SeedClient: seedClient}, nil
 	default:
 		return nil, fmt.Errorf("template method '%v' not implemented", appInstallation.Status.Method)
 	}

--- a/pkg/applications/test/kubernetes.go
+++ b/pkg/applications/test/kubernetes.go
@@ -71,7 +71,7 @@ func CreateNamespaceWithCleanup(t *testing.T, ctx context.Context, client ctrlru
 func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client) {
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "default",
+			Name: "cluster-default",
 		},
 		Spec: kubermaticv1.ClusterSpec{
 			HumanReadableName: "humanreadable-cluster-name",
@@ -88,7 +88,7 @@ func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlrunt
 		},
 	}
 	if err := client.Create(ctx, cluster); err != nil {
-		t.Fatalf("failed to create test cluster: %s", err)
+		t.Fatalf("failed to create test cluster: %v", err)
 	}
 	cluster.Status = kubermaticv1.ClusterStatus{
 		UserEmail: "owner@email.com",
@@ -99,25 +99,18 @@ func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlrunt
 		Versions: kubermaticv1.ClusterVersionsStatus{
 			ControlPlane: semver.Semver("v1.30.5"),
 		},
-		NamespaceName: "default",
+		NamespaceName: "cluster-default",
 	}
 
 	if err := client.Status().Update(ctx, cluster); err != nil {
-		t.Fatalf("failed to update testcluster status: %v", err)
+		t.Fatalf("failed to update test cluster status: %v", err)
 	}
 
 	t.Cleanup(func() {
 		if err := client.Delete(ctx, cluster); err != nil {
-			t.Fatalf("failed to cleanup test namespace: %s", err)
+			t.Fatalf("failed to cleanup test cluster: %s", err)
 		}
 	})
-
-	if !utils.WaitFor(ctx, time.Second*1, time.Second*10, func() bool {
-		c := &kubermaticv1.Cluster{}
-		return client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(cluster), c) == nil
-	}) {
-		t.Fatalf("timeout waiting for namespace creation")
-	}
 }
 
 // StartTestEnvWithCleanup bootstraps the testing environment and return the to the kubeconfig. It also registers a hook on T.Cleanup to

--- a/pkg/applications/test/kubernetes.go
+++ b/pkg/applications/test/kubernetes.go
@@ -66,6 +66,8 @@ func CreateNamespaceWithCleanup(t *testing.T, ctx context.Context, client ctrlru
 	return ns
 }
 
+// EnsureClusterWithCleanup creates a cluster resource with a static name "default" and needed status fields for fetching it
+// based on the namespacedname and registers a hook on T.Cleanup that removes it at the end of the test.
 func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client) {
 	cluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,7 +88,7 @@ func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlrunt
 		},
 	}
 	if err := client.Create(ctx, cluster); err != nil {
-		t.Fatalf("failed to create test namespace: %s", err)
+		t.Fatalf("failed to create test cluster: %s", err)
 	}
 	cluster.Status = kubermaticv1.ClusterStatus{
 		UserEmail: "owner@email.com",
@@ -101,7 +103,7 @@ func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlrunt
 	}
 
 	if err := client.Status().Update(ctx, cluster); err != nil {
-		t.Fatalf("failed to update testcluster: %v", err)
+		t.Fatalf("failed to update testcluster status: %v", err)
 	}
 
 	t.Cleanup(func() {

--- a/pkg/applications/test/kubernetes.go
+++ b/pkg/applications/test/kubernetes.go
@@ -108,7 +108,7 @@ func EnsureClusterWithCleanup(t *testing.T, ctx context.Context, client ctrlrunt
 
 	t.Cleanup(func() {
 		if err := client.Delete(ctx, cluster); err != nil {
-			t.Fatalf("failed to cleanup test cluster: %s", err)
+			t.Fatalf("failed to cleanup test cluster: %v", err)
 		}
 	})
 }

--- a/pkg/ee/applications/util.go
+++ b/pkg/ee/applications/util.go
@@ -28,9 +28,8 @@ import (
 	"fmt"
 	"html/template"
 
-	"gopkg.in/yaml.v3"
-
 	semverlib "github.com/Masterminds/semver/v3"
+	"gopkg.in/yaml.v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubernetesutil "k8c.io/kubermatic/v2/pkg/provider/kubernetes"

--- a/pkg/ee/applications/util.go
+++ b/pkg/ee/applications/util.go
@@ -1,7 +1,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2024 Kubermatic GmbH
+                     Copyright © 2025 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent

--- a/pkg/ee/applications/util.go
+++ b/pkg/ee/applications/util.go
@@ -1,0 +1,116 @@
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2024 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package applications
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+
+	"gopkg.in/yaml.v3"
+
+	semverlib "github.com/Masterminds/semver/v3"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubernetesutil "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var ErrNoClusterForTemplating = fmt.Errorf("no cluster found for template data")
+
+// TemplateData is the root context injected into each application values.
+type TemplateData struct {
+	Cluster ClusterData
+}
+
+// ClusterData contains data related to the user cluster
+// the application is rendered for.
+type ClusterData struct {
+	Name string
+	// HumanReadableName is the user-specified cluster name.
+	HumanReadableName string
+	// OwnerEmail is the owner's e-mail address.
+	OwnerEmail string
+	// ClusterAddress stores access and address information of a cluster.
+	Address kubermaticv1.ClusterAddress
+	// Version is the exact current cluster version.
+	Version string
+	// MajorMinorVersion is a shortcut for common testing on "Major.Minor" on the
+	// current cluster version.
+	MajorMinorVersion string
+}
+
+// GetTemplateData fetches the related cluster object by the given cluster namespace, parses pre defined values to a template data struct.
+func GetTemplateData(ctx context.Context, seedClient ctrlruntimeclient.Client, clusterNamespace string) (*TemplateData, error) {
+	cluster, err := kubernetesutil.ClusterFromNamespace(ctx, seedClient, clusterNamespace)
+	if err != nil {
+		return nil, err
+	}
+	if cluster == nil {
+		return nil, ErrNoClusterForTemplating
+	}
+	var clusterVersion *semverlib.Version
+	if s := cluster.Status.Versions.ControlPlane.Semver(); s != nil {
+		clusterVersion = s
+	} else {
+		clusterVersion = cluster.Spec.Version.Semver()
+	}
+	return &TemplateData{
+		Cluster: ClusterData{
+			Name:              cluster.Name,
+			HumanReadableName: cluster.Spec.HumanReadableName,
+			OwnerEmail:        cluster.Status.UserEmail,
+			Address:           cluster.Status.Address,
+			Version:           fmt.Sprintf("%d.%d.%d", clusterVersion.Major(), clusterVersion.Minor(), clusterVersion.Patch()),
+			MajorMinorVersion: fmt.Sprintf("%d.%d", clusterVersion.Major(), clusterVersion.Minor()),
+		},
+	}, nil
+}
+
+// RenderValueTemplate is rendering the given template data into the given map of values an error is returned when undefined values are used in the values map values.
+func RenderValueTemplate(applicationValues map[string]interface{}, templateData *TemplateData) (map[string]interface{}, error) {
+	yamlData, err := yaml.Marshal(applicationValues)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := template.New("application-pre-defined-values")
+	parsed, err := parser.Parse(string(yamlData))
+	if err != nil {
+		return nil, err
+	}
+
+	var buffer bytes.Buffer
+	if err := parsed.Execute(&buffer, templateData); err != nil {
+		return nil, fmt.Errorf("failed to render template: %w", err)
+	}
+
+	parsedMap := make(map[string]interface{})
+	err = yaml.Unmarshal(buffer.Bytes(), parsedMap)
+	if err != nil {
+		return nil, err
+	}
+	return parsedMap, nil
+}

--- a/pkg/ee/applications/util_test.go
+++ b/pkg/ee/applications/util_test.go
@@ -1,0 +1,198 @@
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2024 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package applications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/semver"
+
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var clusterNamespace = "test"
+
+func TestGetTemplateData(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		seedClient ctrlruntimeclient.Client
+		want       *TemplateData
+		wantErr    error
+	}{
+		{
+			name:      "case 1: fetching template data should succeed with a valid cluster resource",
+			namespace: "test",
+			seedClient: fake.
+				NewClientBuilder().WithObjects(&kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					HumanReadableName: "humanreadable-cluster-name",
+				},
+				Status: kubermaticv1.ClusterStatus{
+					UserEmail: "owner@email.com",
+					Address: kubermaticv1.ClusterAddress{
+						URL:  "https://cluster.seed.kkp",
+						Port: 6443,
+					},
+					Versions: kubermaticv1.ClusterVersionsStatus{
+						ControlPlane: semver.Semver("v1.30.5"),
+					},
+					NamespaceName: "test",
+				},
+			}).Build(),
+			want: &TemplateData{
+				ClusterData{
+					Name:              "test-cluster",
+					HumanReadableName: "humanreadable-cluster-name",
+					OwnerEmail:        "owner@email.com",
+					Address: kubermaticv1.ClusterAddress{
+						URL:  "https://cluster.seed.kkp",
+						Port: 6443,
+					},
+					Version:           "1.30.5",
+					MajorMinorVersion: "1.30",
+				},
+			},
+		},
+		{
+			name:      "case 2: fetching template data should fail when cluster cannot be fetched",
+			namespace: clusterNamespace,
+			seedClient: fake.
+				NewClientBuilder().WithObjects().Build(),
+			want:    nil,
+			wantErr: ErrNoClusterForTemplating,
+		},
+		{
+			name:      "case 3: fetching template data should fail when cluster has no valid version",
+			namespace: "test",
+			seedClient: fake.
+				NewClientBuilder().WithObjects(&kubermaticv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: kubermaticv1.ClusterSpec{
+					HumanReadableName: "humanreadable-cluster-name",
+				},
+				Status: kubermaticv1.ClusterStatus{
+					UserEmail: "owner@email.com",
+					Address: kubermaticv1.ClusterAddress{
+						URL:  "https://cluster.seed.kkp",
+						Port: 6443,
+					},
+					Versions: kubermaticv1.ClusterVersionsStatus{
+						ControlPlane: semver.Semver("vinvalid"),
+					},
+				},
+			}).Build(),
+			want:    nil,
+			wantErr: ErrNoClusterForTemplating,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetTemplateData(context.TODO(), tt.seedClient, tt.namespace)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("getTemplateData() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getTemplateData() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderValueTemplate(t *testing.T) {
+	tests := []struct {
+		name         string
+		values       map[string]any
+		templateData TemplateData
+		want         map[string]any
+		wantErr      error
+	}{
+		{
+			name: "case 1: rendering for cluster name and version should succeed",
+			values: map[string]any{
+				"key1": "value1",
+				"key2": "{{ .Cluster.Name }}",
+				"key3": map[string]any{
+					"nestedkey": "{{ .Cluster.Version }}",
+				},
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Name:    "test",
+					Version: "9.9.9",
+				},
+			},
+			want: map[string]any{
+				"key1": "value1",
+				"key2": "test",
+				"key3": map[string]any{
+					"nestedkey": "9.9.9",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "case 2: parsing unknown variables should lead to an error",
+			values: map[string]any{
+				"key1": "value1",
+				"key2": "{{ .Foo.Name }}",
+				"key3": map[string]any{
+					"nestedkey": "{{ .Foo.Version }}",
+				},
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Name:    "test",
+					Version: "9.9.9",
+				},
+			},
+			want:    nil,
+			wantErr: fmt.Errorf("failed to render template: "),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RenderValueTemplate(tt.values, &tt.templateData)
+			if (err != nil) && !strings.Contains(err.Error(), tt.wantErr.Error()) {
+				t.Fatalf("getTemplateData() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getTemplateData() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ee/applications/util_test.go
+++ b/pkg/ee/applications/util_test.go
@@ -25,20 +25,24 @@ package applications
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
-	"strings"
 	"testing"
+	"text/template"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/semver"
+	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var clusterNamespace = "test"
+var (
+	clusterNamespace          = "test-cluster"
+	ErrNoClusterForTemplating = errors.New("failed to get cluster \"test-cluster\": clusters.kubermatic.k8c.io \"test-cluster\" not found")
+	ErrNoValidClusterVersion  = errors.New("failed to parse semver version for cluster \"test-cluster\"")
+)
 
 func TestGetTemplateData(t *testing.T) {
 	tests := []struct {
@@ -50,7 +54,7 @@ func TestGetTemplateData(t *testing.T) {
 	}{
 		{
 			name:      "case 1: fetching template data should succeed with a valid cluster resource",
-			namespace: "test",
+			namespace: "test-cluster",
 			seedClient: fake.
 				NewClientBuilder().WithObjects(&kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -68,7 +72,7 @@ func TestGetTemplateData(t *testing.T) {
 					Versions: kubermaticv1.ClusterVersionsStatus{
 						ControlPlane: semver.Semver("v1.30.5"),
 					},
-					NamespaceName: "test",
+					NamespaceName: "test-cluster",
 				},
 			}).Build(),
 			want: &TemplateData{
@@ -95,7 +99,7 @@ func TestGetTemplateData(t *testing.T) {
 		},
 		{
 			name:      "case 3: fetching template data should fail when cluster has no valid version",
-			namespace: "test",
+			namespace: "test-cluster",
 			seedClient: fake.
 				NewClientBuilder().WithObjects(&kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -116,17 +120,17 @@ func TestGetTemplateData(t *testing.T) {
 				},
 			}).Build(),
 			want:    nil,
-			wantErr: ErrNoClusterForTemplating,
+			wantErr: ErrNoValidClusterVersion,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetTemplateData(context.TODO(), tt.seedClient, tt.namespace)
-			if !errors.Is(err, tt.wantErr) {
-				t.Fatalf("getTemplateData() error = %v, wantErr %v", err, tt.wantErr)
+			got, err := GetTemplateData(context.Background(), tt.seedClient, tt.namespace)
+			if err != nil && diff.StringDiff(err.Error(), tt.wantErr.Error()) != "" {
+				t.Fatalf("GetTemplateData() diff: %s", diff.StringDiff(err.Error(), tt.wantErr.Error()))
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("getTemplateData() got = %v, want %v", got, tt.want)
+				t.Fatalf("GetTemplateData() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -138,7 +142,6 @@ func TestRenderValueTemplate(t *testing.T) {
 		values       map[string]any
 		templateData TemplateData
 		want         map[string]any
-		wantErr      error
 	}{
 		{
 			name: "case 1: rendering for cluster name and version should succeed",
@@ -162,7 +165,6 @@ func TestRenderValueTemplate(t *testing.T) {
 					"nestedkey": "9.9.9",
 				},
 			},
-			wantErr: nil,
 		},
 		{
 			name: "case 2: parsing unknown variables should lead to an error",
@@ -179,18 +181,17 @@ func TestRenderValueTemplate(t *testing.T) {
 					Version: "9.9.9",
 				},
 			},
-			want:    nil,
-			wantErr: fmt.Errorf("failed to render template: "),
+			want: nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := RenderValueTemplate(tt.values, &tt.templateData)
-			if (err != nil) && !strings.Contains(err.Error(), tt.wantErr.Error()) {
-				t.Fatalf("getTemplateData() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil && !errors.As(err, &template.ExecError{}) {
+				t.Fatalf("RenderValueTemplate() error is not of expected type. error: %v", err)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("getTemplateData() got = %v, want %v", got, tt.want)
+				t.Fatalf("RenderValueTemplate() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/ee/applications/util_test.go
+++ b/pkg/ee/applications/util_test.go
@@ -32,7 +32,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/semver"
-
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds the possiblity to use pre defined values in applicationdefinition and applicationinstallation resources for configuring the related helm release values.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12530

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
It's now possible to use pre defined values in enterprise edition for applicationdefinition and applicationinstallation resources to specify cluster related values in helm release value configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
