### PR TITLE
[release/v2.24] Mark domain as optional field for OpenStack preset

### DIFF
--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -305,7 +305,7 @@ type Openstack struct {
 	Project string `json:"project,omitempty"`
 	// ProjectID, formally known as tenantID.
 	ProjectID string `json:"projectID,omitempty"`
-	Domain    string `json:"domain"`
+	Domain    string `json:"domain,omitempty"`
 
 	// Network holds the name of the internal network When specified, all worker nodes will be attached to this network. If not specified, a network, subnet & router will be created.
 	Network        string `json:"network,omitempty"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -387,8 +387,6 @@ spec:
                       type: boolean
                     username:
                       type: string
-                  required:
-                    - domain
                   type: object
                 packet:
                   description: Access data for Packet Cloud.

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Manual backport of https://github.com/kubermatic/kubermatic/pull/13948

```release-note
Mark domain as optional field for OpenStack preset
```
