### PR TITLE
set rollback revision explicit to last deployed for helm releases managed by applicationinstallations

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -465,7 +465,7 @@ func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
 	client := action.NewGetMetadata(h.actionConfig)
 	res, err := client.Run(releaseName)
 	if err != nil {
-		return nil, fmt.Errorf("Could not retrieve metadata for release %q: %w", releaseName, err)
+		return nil, fmt.Errorf("could not retrieve metadata for release %q: %w", releaseName, err)
 	}
 	return res, nil
 }
@@ -478,12 +478,12 @@ func (h HelmClient) Rollback(releaseName string) error {
 	// on upgrade actions
 	latestDeployedRelease, err := h.actionConfig.Releases.Deployed(releaseName)
 	if err != nil {
-		return fmt.Errorf("Could not fetch last successful release %q: %w", releaseName, err)
+		return fmt.Errorf("could not fetch last successful release %q: %w", releaseName, err)
 	}
 	client.Version = latestDeployedRelease.Version
 	err = client.Run(releaseName)
 	if err != nil {
-		return fmt.Errorf("Could not rollback release %q: %w", releaseName, err)
+		return fmt.Errorf("could not rollback release %q: %w", releaseName, err)
 	}
 	return nil
 }

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -473,6 +473,9 @@ func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
 // Rollback wraps helms Rollback command to be used with our ActionConfig.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
+	// we need to set the last successful deployed revision explicit because otherwise it would be the current revision minus 1
+	// which could lead to errors due to missing revisions when the latest ones failed because we configure history limits
+	// on upgrade actions
 	latestDeployedRelease, err := h.actionConfig.Releases.Deployed(releaseName)
 	if err != nil {
 		return fmt.Errorf("Could not fetch last successful release %q: %w", releaseName, err)

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -473,7 +473,12 @@ func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
 // Rollback wraps helms Rollback command to be used with our ActionConfig.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
-	err := client.Run(releaseName)
+	latestDeployedRelease, err := h.actionConfig.Releases.Deployed(releaseName)
+	if err != nil {
+		return fmt.Errorf("Could not fetch last successful release %q: %w", releaseName, err)
+	}
+	client.Version = latestDeployedRelease.Version
+	err = client.Run(releaseName)
 	if err != nil {
 		return fmt.Errorf("Could not rollback release %q: %w", releaseName, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds logic for using the last successful deployed revision for a rollback of a helm release managed by application installation controller if needed. The default revision for a rollback if not set is the current minus one which could lead to issues as described in #13915.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13915

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The rollback revision is now set explicit to the last deployed revision when a helm release managed by an application installation fails and a rollback is executed to avoid errors when the last deployed revision is not the current minus 1 and history limit is set to 1.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
