### PR TITLE
Download KKP Installer Charts Dependencies

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -458,6 +458,16 @@ set_helm_charts_version() {
       continue
     fi
 
+    # download all charts dependencies
+    chartRepoURL=$(yq eval '.dependencies[0].repository' $chartFile)
+    if [ "$chartRepoURL" != "null" ]; then
+      chartDepName=$(yq eval '.dependencies[0].name' $chartFile)
+      helm repo add $chartDepName $chartRepoURL
+
+      chartDirParent=$(dirname "$chartFile")
+      helm dependency build $chartDirParent --skip-refresh
+    fi
+
     yq --inplace ".version = \"$semver\"" "$chartFile"
     if [ "$chart" = "kubermatic-operator" ]; then
       yq --inplace ".appVersion = \"$version\"" "$chartFile"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR download all kubermatic-installer charts dependencies except the MLA charts. This is quite helpful when running the kubermatic-installer in an offline envs. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The download archives on GitHub now include the dependencies of all included Helm charts.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
