### PR TITLE
[EE] fix kubeLB cleanup not being performed when clusters are deleted

### DIFF
--- a/pkg/ee/kubelb/cleanup.go
+++ b/pkg/ee/kubelb/cleanup.go
@@ -49,6 +49,7 @@ func (r *reconciler) handleKubeLBCleanup(ctx context.Context, cluster *kubermati
 	if err := r.ensureKubeLBManagementClusterResourcesAreRemoved(ctx, cluster); err != nil {
 		return err
 	}
+
 	return kuberneteshelper.TryRemoveFinalizer(ctx, r, cluster, CleanupFinalizer)
 }
 

--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -101,7 +101,7 @@ func Add(mgr manager.Manager, numWorkers int, workerName string, overwriteRegist
 	clusterIsAlive := predicateutil.Factory(func(o ctrlruntimeclient.Object) bool {
 		cluster := o.(*kubermaticv1.Cluster)
 		// Only watch clusters that are in a state where they can be reconciled.
-		return !cluster.Spec.Pause && cluster.DeletionTimestamp == nil && cluster.Status.NamespaceName != ""
+		return !cluster.Spec.Pause && cluster.Status.NamespaceName != ""
 	})
 
 	_, err := builder.ControllerManagedBy(mgr).
@@ -116,6 +116,9 @@ func Add(mgr manager.Manager, numWorkers int, workerName string, overwriteRegist
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request.Name)
+	log.Debug("Reconciling")
+
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, request.NamespacedName, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -127,7 +130,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Resource is marked for deletion.
 	if cluster.DeletionTimestamp != nil {
 		if kuberneteshelper.HasFinalizer(cluster, CleanupFinalizer) {
-			r.log.Debugw("Cleaning up kubeLB resources", "cluster", cluster.Name)
+			log.Debug("Cleaning up kubeLB resources")
 			return reconcile.Result{}, r.handleKubeLBCleanup(ctx, cluster)
 		}
 		// Finalizer doesn't exist so clean up is already done.
@@ -136,7 +139,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// Kubelb was disabled after it was enabled. Clean up resources.
 	if kuberneteshelper.HasFinalizer(cluster, CleanupFinalizer) && !cluster.Spec.IsKubeLBEnabled() {
-		r.log.Debugw("Cleaning up kubeLB resources", "cluster", cluster.Name)
+		log.Debug("Cleaning up kubeLB resources")
 		return reconcile.Result{}, r.handleKubeLBCleanup(ctx, cluster)
 	}
 
@@ -146,12 +149,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if cluster.Status.NamespaceName == "" {
-		r.log.Debug("Skipping cluster reconciling because it has no namespace yet")
+		log.Debug("Skipping cluster reconciling because it has no namespace yet")
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}
 
 	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
-		r.log.Debugf("API server is not running, trying again in %v", healthCheckPeriod)
+		log.Debugf("API server is not running, trying again in %v", healthCheckPeriod)
 		return reconcile.Result{RequeueAfter: healthCheckPeriod}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When a cluster is being deleted, it was not being reconciled anymore and so the cleanup logic never ran.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[EE] fix kubeLB cleanup not being performed when clusters are deleted
```

**Documentation**:
```documentation
NONE
```
