### PR TITLE
fix kubevirt tenant rbac

### DIFF
--- a/pkg/provider/cloud/kubevirt/csi.go
+++ b/pkg/provider/cloud/kubevirt/csi.go
@@ -62,7 +62,7 @@ func csiRoleReconciler(name string) reconciling.NamedRoleReconcilerFactory {
 				{
 					APIGroups: []string{"kubevirt.io"},
 					Resources: []string{"virtualmachineinstances"},
-					Verbs:     []string{"list"},
+					Verbs:     []string{"get", "list"},
 				},
 				{
 					APIGroups: []string{"subresources.kubevirt.io"},

--- a/pkg/resources/csi/kubevirt/rbac.go
+++ b/pkg/resources/csi/kubevirt/rbac.go
@@ -170,7 +170,7 @@ func ControllerRoleBindingReconciler(c *kubermaticv1.Cluster) reconciling.NamedR
 			r.RoleRef = rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     resources.KubeVirtCSIClusterRoleName,
+				Name:     resources.KubeVirtCSIControllerName,
 			}
 
 			return r, nil

--- a/pkg/resources/csi/kubevirt/rbac.go
+++ b/pkg/resources/csi/kubevirt/rbac.go
@@ -170,7 +170,7 @@ func ControllerRoleBindingReconciler(c *kubermaticv1.Cluster) reconciling.NamedR
 			r.RoleRef = rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "ClusterRole",
-				Name:     resources.KubeVirtCSIControllerName,
+				Name:     resources.KubeVirtCSIClusterRoleName,
 			}
 
 			return r, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes rbac issues for kubevirt provider.

* add "get" for vmis for kubevirt-csi role
* ~~fix roleRef for csi-controller binding~~

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13966

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The created RBAC Role for the csi-driver now grants get for VirtualMachineInstances.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
