### PR TITLE
[release/v2.24] set rollback revision explicit to last deployed for helm releases managed by applicationinstallations (#13953)

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -349,9 +349,17 @@ func (h HelmClient) GetMetadata(releaseName string) (*release.Release, error) {
 // Rollback wraps helms Rollback command to be used with our ActionConfig.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
-	err := client.Run(releaseName)
+	// we need to set the last successful deployed revision explicit because otherwise it would be the current revision minus 1
+	// which could lead to errors due to missing revisions when the latest ones failed because we configure history limits
+	// on upgrade actions
+	latestDeployedRelease, err := h.actionConfig.Releases.Deployed(releaseName)
 	if err != nil {
-		return fmt.Errorf("Could not rollback release %q: %w", releaseName, err)
+		return fmt.Errorf("could not fetch last successful release %q: %w", releaseName, err)
+	}
+	client.Version = latestDeployedRelease.Version
+	err = client.Run(releaseName)
+	if err != nil {
+		return fmt.Errorf("could not rollback release %q: %w", releaseName, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13953.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The rollback revision is now set explicit to the last deployed revision when a helm release managed by an application installation fails and a rollback is executed to avoid errors when the last deployed revision is not the current minus 1 and history limit is set to 1.
```

**Documentation**:
```documentation
NONE
```
