### PR TITLE
do not add InTree*Unregister feature gates to clusters on Kubernetes 1.30+

### DIFF
--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -725,8 +725,10 @@ func GetCSIMigrationFeatureGates(cluster *kubermaticv1.Cluster, version *semverl
 
 	if metav1.HasAnnotation(cluster.ObjectMeta, kubermaticv1.CSIMigrationNeededAnnotation) {
 		// The CSIMigrationNeededAnnotation is removed when all kubelets have
-		// been migrated.
-		if cluster.Status.Conditions[kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted].Status == corev1.ConditionTrue {
+		// been migrated. Both of these feature gates have already been removed in Kubernetes 1.30+.
+		migrationCompleted := cluster.Status.Conditions[kubermaticv1.ClusterConditionCSIKubeletMigrationCompleted].Status == corev1.ConditionTrue
+
+		if migrationCompleted && cluster.Spec.Version.Semver().Minor() < 30 {
 			if cluster.Spec.Cloud.Openstack != nil {
 				featureFlags = append(featureFlags, "InTreePluginOpenStackUnregister=true")
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
These gates do not exist anymore: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates-removed/

**Which issue(s) this PR fixes**:
Fixes #13936

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Do not add `InTree*Unregister` feature gates to clusters on Kubernetes 1.30+
```

**Documentation**:
```documentation
NONE
```
