### PR TITLE
Disable Storage Classes Filtering

### DIFF
--- a/pkg/provider/cloud/kubevirt/storage_class.go
+++ b/pkg/provider/cloud/kubevirt/storage_class.go
@@ -46,6 +46,16 @@ func ListStorageClasses(ctx context.Context, client ctrlruntimeclient.Client, an
 }
 
 func updateInfraStorageClassesInfo(ctx context.Context, client ctrlruntimeclient.Client, spec *kubermaticv1.KubevirtCloudSpec, dc *kubermaticv1.DatacenterSpecKubevirt) error {
+	// TODO(mq): this function seems a bit out of place as there could be use cases where storage class exists in the cluster
+	// and doesn't exist in the infra cluster such local path provisioner. Thus should be removed in the future.
+
+	// If the Namespaced mode is enabled, kkp has no access on cluster-scoped resources such as storage classes. Thus,
+	// this function will fail to list storage classes which means it will fail to create the cluster.
+	if dc.NamespacedMode.Enabled {
+		// considering the storage classes in the dc object as the only canonical truth and skip filtering storage classes.
+		return nil
+	}
+
 	infraStorageClassList, err := ListStorageClasses(ctx, client, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
In KubeVirt Namespaced mode, KKP has no access whatsoever to the global(cluster-scoped) resources and it must consider the settings in the Seed object as the only canonical truth. This PR removes the necessity to filter storage classes when a new KubeVirt cluster is created. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove storage classes filtration in KubeVirt Namespaced mode. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
