### PR TITLE
Add `mla-skip-logging` option into `kubermatic-installer`

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -83,6 +83,7 @@ type DeployOptions struct {
 	MLASkipMinioLifecycleMgr bool
 	MLAForceMLASecrets       bool
 	MLAIncludeIap            bool
+	MLASkipLogging           bool
 
 	DeployDefaultAppCatalog bool
 
@@ -147,6 +148,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *
 	cmd.PersistentFlags().BoolVar(&opt.MLASkipMinioLifecycleMgr, "mla-skip-minio-lifecycle-mgr", false, "(UserCluster MLA) skip installation of userCluster MLA Minio Bucket Lifecycle Manager")
 	cmd.PersistentFlags().BoolVar(&opt.MLAForceMLASecrets, "mla-force-secrets", false, "(UserCluster MLA) force reinstallation of mla-secrets Helm chart")
 	cmd.PersistentFlags().BoolVar(&opt.MLAIncludeIap, "mla-include-iap", false, "(UserCluster MLA) Include Identity-Aware Proxy installation")
+	cmd.PersistentFlags().BoolVar(&opt.MLASkipLogging, "mla-skip-logging", false, "Skip logging stack installation")
 
 	wrapDeployFlags(cmd.PersistentFlags(), &opt)
 
@@ -212,6 +214,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 			MLASkipMinioLifecycleMgr:           opt.MLASkipMinioLifecycleMgr,
 			MLAForceSecrets:                    opt.MLAForceMLASecrets,
 			MLAIncludeIap:                      opt.MLAIncludeIap,
+			MLASkipLogging:                     opt.MLASkipLogging,
 			Versions:                           versions,
 			SkipCharts:                         opt.SkipCharts,
 			DeployDefaultAppCatalog:            opt.DeployDefaultAppCatalog,

--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -425,7 +425,7 @@ func deployIap(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntime
 }
 
 func deployLoki(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
-	if slices.Contains(opt.SkipCharts, LokiChartName) {
+	if slices.Contains(opt.SkipCharts, LokiChartName) || opt.MLASkipLogging {
 		logger.Info("⭕ Skipping Loki deployment.")
 		return nil
 	}
@@ -457,7 +457,7 @@ func deployLoki(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntim
 }
 
 func deployPromtail(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
-	if slices.Contains(opt.SkipCharts, PromtailChartName) {
+	if slices.Contains(opt.SkipCharts, PromtailChartName) || opt.MLASkipLogging {
 		logger.Info("⭕ Skipping Promtail deployment.")
 		return nil
 	}

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -63,6 +63,7 @@ type DeployOptions struct {
 	MLASkipMinioLifecycleMgr bool
 	MLAForceSecrets          bool
 	MLAIncludeIap            bool
+	MLASkipLogging           bool
 
 	DeployDefaultAppCatalog bool
 

--- a/pkg/install/stack/usercluster-mla/stack.go
+++ b/pkg/install/stack/usercluster-mla/stack.go
@@ -309,6 +309,11 @@ func deployGrafana(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrun
 }
 
 func deployLoki(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if opt.MLASkipLogging {
+		logger.Info("⭕ Skipping Loki deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Loki…")
 	sublogger := log.Prefix(logger, "   ")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new CLI option, `-mla-skip-logging`, to allow admins to skip the logging stack installation as part of the MLA (Monitoring, Logging, and Alerting) setup.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14021

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `mla-skip-logging` option into `kubermatic-installer` to exclude the logging stack from installation
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
 The new `--mla-skip-logging` option lets you exclude the logging stack (e.g., Loki, Promtail) from the installation process, giving you the flexibility to install a custom logging solution.
```
