### PR TITLE
Fix Node Label Overwriting in Initial Machine Deployment Controller

### DIFF
--- a/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/machinedeployment.go
+++ b/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/machinedeployment.go
@@ -64,8 +64,14 @@ func CompleteMachineDeployment(md *clusterv1alpha1.MachineDeployment, cluster *k
 	md.Spec.Selector.MatchLabels = map[string]string{
 		"machine": fmt.Sprintf("md-%s-%s", cluster.Name, rand.String(10)),
 	}
+
 	md.Spec.Template.Labels = md.Spec.Selector.MatchLabels
-	md.Spec.Template.Spec.Labels = md.Spec.Template.Labels
+
+	// Merge MatchLabels with Template Spec Labels.
+	if md.Spec.Template.Spec.Labels == nil {
+		md.Spec.Template.Spec.Labels = make(map[string]string)
+	}
+	md.Spec.Template.Spec.Labels["machine"] = md.Spec.Template.Labels["machine"]
 
 	// Do not confuse the convenience labels with the labels inside the
 	// providerSpec, which ultimately get applied on the cloud provider resources.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where labels were being unintentionally overwritten in MachineDeployment objects by the `initial-machinedeployment-controller`. Previously, the MatchLabels, Template.Labels, and Template.Spec.Labels were being replaced, causing labels to be lost.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14004

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed node label overwriting issue with the initial Machine Deployment
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
