### PR TITLE
move autoscaler from addons to applications

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -421,7 +421,7 @@ func main() {
 		log.Info("Registered constraintsyncer controller")
 	}
 
-	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace, ClusterName: runOp.clusterName}); err != nil {
+	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, runOp.namespace, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace, ClusterName: runOp.clusterName}); err != nil {
 		log.Fatalw("Failed to add user Application Installation controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered Application Installation controller")

--- a/docs/zz_generated.applicationdata.go.txt
+++ b/docs/zz_generated.applicationdata.go.txt
@@ -18,6 +18,8 @@ type ClusterData struct {
 	// MajorMinorVersion is a shortcut for common testing on "Major.Minor" on the
 	// current cluster version.
 	MajorMinorVersion string
+	// AutoscalerVersion is the tag which should be used for the cluster autoscaler
+	AutoscalerVersion string
 }
 
 // ClusterAddress stores access and address information of a cluster.

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -385,7 +385,7 @@ func startTestEnvWithCleanup(t *testing.T, applicationInstaller *fake.Applicatio
 
 	isClusterPausedFunc := func(ctx context.Context) (bool, error) { return false, nil }
 
-	if err := Add(ctx, kubermaticlog.Logger, mgr, mgr, isClusterPausedFunc, applicationInstaller); err != nil {
+	if err := Add(ctx, kubermaticlog.Logger, mgr, mgr, isClusterPausedFunc, ns.Name, applicationInstaller); err != nil {
 		t.Fatalf("failed to add controller to manager: %s", err)
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ce.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ce.go
@@ -1,0 +1,31 @@
+//go:build !ee
+
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func handleAddonCleanup(ctx context.Context, applicationName string, seedClusterNamespace string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+	return nil
+}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ee.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ee.go
@@ -1,0 +1,33 @@
+//go:build ee
+
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	eeutil "k8c.io/kubermatic/v2/pkg/ee/applications"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func handleAddonCleanup(ctx context.Context, applicationName string, seedClusterNamespace string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+	return eeutil.HandleAddonCleanup(ctx, applicationName, seedClusterNamespace, seedClient, log)
+}

--- a/pkg/ee/applications/util.go
+++ b/pkg/ee/applications/util.go
@@ -58,6 +58,8 @@ type ClusterData struct {
 	// MajorMinorVersion is a shortcut for common testing on "Major.Minor" on the
 	// current cluster version.
 	MajorMinorVersion string
+	// AutoscalerVersion is the tag which should be used for the cluster autoscaler
+	AutoscalerVersion string
 }
 
 var ErrBadTemplate = errors.New("failed to render template:")
@@ -75,6 +77,10 @@ func GetTemplateData(ctx context.Context, seedClient ctrlruntimeclient.Client, c
 		clusterVersion = cluster.Spec.Version.Semver()
 	}
 	if clusterVersion != nil {
+		clusterAutoscalerVersion, err := getAutoscalerImageTag(fmt.Sprintf("%d.%d", clusterVersion.Major(), clusterVersion.Minor()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse autoscaler version for cluster %q", clusterName)
+		}
 		return &TemplateData{
 			Cluster: ClusterData{
 				Name:              cluster.Name,
@@ -83,6 +89,7 @@ func GetTemplateData(ctx context.Context, seedClient ctrlruntimeclient.Client, c
 				Address:           cluster.Status.Address,
 				Version:           fmt.Sprintf("%d.%d.%d", clusterVersion.Major(), clusterVersion.Minor(), clusterVersion.Patch()),
 				MajorMinorVersion: fmt.Sprintf("%d.%d", clusterVersion.Major(), clusterVersion.Minor()),
+				AutoscalerVersion: clusterAutoscalerVersion,
 			},
 		}, nil
 	}
@@ -114,4 +121,18 @@ func RenderValueTemplate(applicationValues map[string]interface{}, templateData 
 		return nil, err
 	}
 	return parsedMap, nil
+}
+
+func getAutoscalerImageTag(majorMinorVersion string) (string, error) {
+	switch majorMinorVersion {
+	case "1.29":
+		return "v1.29.5", nil
+	case "1.30":
+		return "v1.30.3", nil
+	case "1.31":
+		return "v1.31.1", nil
+	case "1.32":
+		return "v1.32.0", nil
+	}
+	return "", fmt.Errorf("could not find cluster autoscaler tag for cluster minor-major version %v", majorMinorVersion)
 }

--- a/pkg/ee/applications/util_test.go
+++ b/pkg/ee/applications/util_test.go
@@ -84,6 +84,7 @@ func TestGetTemplateData(t *testing.T) {
 					},
 					Version:           "1.30.5",
 					MajorMinorVersion: "1.30",
+					AutoscalerVersion: "v1.30.3",
 				},
 			},
 		},

--- a/pkg/ee/applications/util_test.go
+++ b/pkg/ee/applications/util_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
@@ -40,6 +41,11 @@ import (
 
 var (
 	clusterNamespace = "test-cluster"
+	testObjectName   = "cluster-autoscaler"
+	testObjectMeta   = metav1.ObjectMeta{
+		Name:      testObjectName,
+		Namespace: clusterNamespace,
+	}
 )
 
 func TestGetTemplateData(t *testing.T) {
@@ -176,6 +182,91 @@ func TestRenderValueTemplate(t *testing.T) {
 
 			if changes := diff.ObjectDiff(got, tt.want); changes != "" {
 				t.Fatalf("Got unexpected result. diff: %s", changes)
+			}
+		})
+	}
+}
+
+func TestHandleAddonCleanup(t *testing.T) {
+	tests := []struct {
+		name         string
+		appName      string
+		appNamespace string
+		seedClient   ctrlruntimeclient.Client
+		wantErr      error
+		wantAPIErr   error
+	}{
+		{
+			name:         "case 1: no error occurs when cleaning up the existing addon configured without reconciliation",
+			appName:      "cluster-autoscaler",
+			appNamespace: "test-app",
+			seedClient: fake.
+				NewClientBuilder().WithObjects(
+				&kubermaticv1.Addon{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testObjectName,
+						Namespace: clusterNamespace,
+						Labels: map[string]string{
+							"kubermatic-addon": "cluster-autoscaler",
+						},
+					},
+				},
+			).Build(),
+			wantErr:    nil,
+			wantAPIErr: apierrors.NewNotFound(schema.GroupResource{Group: "kubermatic.k8c.io", Resource: "addons"}, "cluster-autoscaler"),
+		},
+		{
+			name:         "case 2: no error occurs when no addon needs to be cleaned up",
+			appName:      "cluster-autoscaler",
+			appNamespace: "test-app",
+			seedClient: fake.
+				NewClientBuilder().WithObjects().Build(),
+			wantErr:    nil,
+			wantAPIErr: apierrors.NewNotFound(schema.GroupResource{Group: "kubermatic.k8c.io", Resource: "addons"}, "cluster-autoscaler"),
+		},
+		{
+			name:         "case 3: an error occurs when cleaning up the existing addon configured with reconciliation",
+			appName:      "cluster-autoscaler",
+			appNamespace: "test-app",
+			seedClient: fake.
+				NewClientBuilder().WithObjects(
+				&kubermaticv1.Addon{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testObjectName,
+						Namespace: clusterNamespace,
+						Labels: map[string]string{
+							"kubermatic-addon": "cluster-autoscaler",
+							AddonEnforcedLabel: "true",
+						},
+					},
+				},
+			).Build(),
+			wantErr:    ErrExistingAddon,
+			wantAPIErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := HandleAddonCleanup(context.Background(), tt.appName, clusterNamespace, tt.seedClient, kubermaticlog.Logger)
+			if err != nil && tt.wantErr == nil {
+				t.Fatalf("Got unexpected error. %v", err)
+			}
+			if err == nil && tt.wantErr != nil {
+				t.Fatalf("Got no error when one is expected. %v", tt.wantErr)
+			}
+
+			serviceAccount := &kubermaticv1.Addon{
+				ObjectMeta: testObjectMeta,
+			}
+			err = tt.seedClient.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(serviceAccount), serviceAccount)
+			if err != nil {
+				if compare := diff.StringDiff(tt.wantAPIErr.Error(), err.Error()); compare != "" {
+					t.Fatalf("Got unexpected when fetching addon resource. %v", err)
+				}
+			}
+
+			if err == nil && tt.wantAPIErr != nil {
+				t.Fatalf("Got no error when one is expected from kube apiserver. %v", tt.wantAPIErr)
 			}
 		})
 	}

--- a/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler.yaml
@@ -1,0 +1,92 @@
+#                Kubermatic Enterprise Read-Only License
+#                       Version 1.0 ("KERO-1.0”)
+#                   Copyright © 2025 Kubermatic GmbH
+#
+# 1.	You may only view, read and display for studying purposes the source
+#    code of the software licensed under this license, and, to the extent
+#    explicitly provided under this license, the binary code.
+# 2.	Any use of the software which exceeds the foregoing right, including,
+#    without limitation, its execution, compilation, copying, modification
+#    and distribution, is expressly prohibited.
+# 3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+#    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+#    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+#    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+#    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# END OF TERMS AND CONDITIONS
+
+apiVersion: apps.kubermatic.k8c.io/v1
+kind: ApplicationDefinition
+metadata:
+  name: cluster-autoscaler
+spec:
+  description: Cluster autoscaler -  a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes.
+  displayName: Cluster autoscaler
+  defaultNamespace:
+    name: kube-system
+    create: false
+  method: helm
+  versions:
+    - template:
+        source:
+          helm:
+            chartName: cluster-autoscaler
+            chartVersion: 9.45.1
+            url: https://kubernetes.github.io/autoscaler
+      version: 1.32.0
+  defaultValuesBlock: |
+    cloudProvider: clusterapi
+    clusterAPIMode: incluster-incluster
+    autoDiscovery:
+      namespace: kube-system
+    image:
+      tag: '{{ .Cluster.AutoscalerVersion }}'
+    extraEnv:
+      CAPI_GROUP: cluster.k8s.io
+    rbac:
+      create: true
+      pspEnabled: false
+      clusterScoped: true
+      serviceAccount:
+        annotations: {}
+        create: true
+        name: "cluster-autoscaler-clusterapi-cluster-autoscaler"
+        automountServiceAccountToken: true
+    extraObjects:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: cluster-autoscaler-management
+        namespace: kube-system
+      rules:
+      - apiGroups:
+        - cluster.k8s.io
+        resources:
+        - machinedeployments
+        - machinedeployments/scale
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - update
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: cluster-autoscaler-clusterapi-cluser-autoscaler
+        namespace: kube-system
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: cluster-autoscaler-management
+        namespace: kube-system
+      subjects:
+      - kind: ServiceAccount
+        name: cluster-autoscaler-clusterapi-cluster-autoscaler
+        namespace: kube-system
+  documentationURL: https://github.com/kubernetes/autoscaler
+  sourceURL: https://kubernetes.github.io/autoscaler

--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -81,6 +81,16 @@ func RoleReconciler() (string, reconciling.RoleReconciler) {
 					"update",
 				},
 			},
+			{
+				APIGroups: []string{"kubermatic.k8c.io"},
+				Resources: []string{"addons"},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"delete",
+				},
+			},
 		}
 		return r, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds an application definition for cluster autoscaler and removes the cluster autoscaler addon directory. This is required to be able to deploy the cluster autoscaler on cluster creation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13913

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If autoscaler should continue to be managed by kkp the cluster autoscaler app have to be installed to usercluster. A purge of addon resources will be done before installing the app with helm.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
Cluster autoscaler is removed from addons and added to the ee default application catalog. 
```
