### PR TITLE
Bump latest patch release for supported k8s versions

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -537,12 +537,12 @@ spec:
       - v1.29.2
       - v1.29.4
       - v1.29.9
-      - v1.29.12
+      - v1.29.13
       - v1.30.5
-      - v1.30.8
+      - v1.30.9
       - v1.31.1
-      - v1.31.4
-      - v1.32.0
+      - v1.31.5
+      - v1.32.1
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -537,8 +537,11 @@ spec:
       - v1.29.2
       - v1.29.4
       - v1.29.9
+      - v1.29.12
       - v1.30.5
+      - v1.30.8
       - v1.31.1
+      - v1.31.4
       - v1.32.0
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -537,12 +537,12 @@ spec:
       - v1.29.2
       - v1.29.4
       - v1.29.9
-      - v1.29.12
+      - v1.29.13
       - v1.30.5
-      - v1.30.8
+      - v1.30.9
       - v1.31.1
-      - v1.31.4
-      - v1.32.0
+      - v1.31.5
+      - v1.32.1
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -537,8 +537,11 @@ spec:
       - v1.29.2
       - v1.29.4
       - v1.29.9
+      - v1.29.12
       - v1.30.5
+      - v1.30.8
       - v1.31.1
+      - v1.31.4
       - v1.32.0
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -231,15 +231,15 @@ var (
 			newSemver("v1.29.2"),
 			newSemver("v1.29.4"),
 			newSemver("v1.29.9"),
-			newSemver("v1.29.12"),
+			newSemver("v1.29.13"),
 			// Kubernetes 1.30
 			newSemver("v1.30.5"),
-			newSemver("v1.30.8"),
+			newSemver("v1.30.9"),
 			// Kubernetes 1.31
 			newSemver("v1.31.1"),
-			newSemver("v1.31.4"),
+			newSemver("v1.31.5"),
 			// Kubernetes 1.32
-			newSemver("v1.32.0"),
+			newSemver("v1.32.1"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.28 =======

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -231,10 +231,13 @@ var (
 			newSemver("v1.29.2"),
 			newSemver("v1.29.4"),
 			newSemver("v1.29.9"),
+			newSemver("v1.29.12"),
 			// Kubernetes 1.30
 			newSemver("v1.30.5"),
+			newSemver("v1.30.8"),
 			// Kubernetes 1.31
 			newSemver("v1.31.1"),
+			newSemver("v1.31.4"),
 			// Kubernetes 1.32
 			newSemver("v1.32.0"),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add the support for the latest k8s patch versions (1.32.1/1.31.5/1.30.9/1.29.13).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add 1.32.1/1.31.5/1.30.9/1.29.13 to the list of supported Kubernetes releases.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
