### PR TITLE
include missing images for the kubermatic installer

### DIFF
--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -678,8 +678,12 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	if enabled, exists := config.Spec.FeatureGates[kubermaticv1.ClusterFeatureEtcdLauncher]; exists && !enabled {
 		fakeCluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] = false
 	}
+	fakeCluster.Spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{
+		Enabled: true,
+	}
 
-	if fakeCluster.Spec.Cloud.Openstack != nil || fakeCluster.Spec.Cloud.Hetzner != nil || fakeCluster.Spec.Cloud.Azure != nil || fakeCluster.Spec.Cloud.VSphere != nil || fakeCluster.Spec.Cloud.Anexia != nil {
+	if fakeCluster.Spec.Cloud.Openstack != nil || fakeCluster.Spec.Cloud.Hetzner != nil || fakeCluster.Spec.Cloud.Azure != nil ||
+		fakeCluster.Spec.Cloud.VSphere != nil || fakeCluster.Spec.Cloud.Anexia != nil || fakeCluster.Spec.Cloud.Kubevirt != nil {
 		if fakeCluster.Spec.Features == nil {
 			fakeCluster.Spec.Features = make(map[string]bool)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that the KubeVirt CCM and the FluentBit images are added to the kubermatic installer for the mirror images command as currently those images are ignored.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include KubeVirt CCM and Fluent-Bit images in the mirror-images command. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
