### PR TITLE
Monitoring for master/seed etcd

### DIFF
--- a/charts/monitoring/grafana/dashboards/kubernetes/etcd-objects.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/etcd-objects.json
@@ -274,7 +274,7 @@
     ]
   },
   "timezone": "",
-  "title": "etcd Objects",
+  "title": "Etcd Objects",
   "uid": "mafnVWWZk",
   "version": 1,
   "weekStart": ""

--- a/charts/monitoring/grafana/dashboards/kubernetes/etcd-user-cluster.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/etcd-user-cluster.json
@@ -44,6 +44,92 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 28,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "job:etcd_server_has_leader:sum{cluster=\"$cluster\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "job:etcd_server_has_leader:sum",
+          "refId": "A",
+          "step": 20
+        }
+      ],
+      "timeRegions": [],
+      "title": "Up",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -94,9 +180,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
+        "h": 8,
+        "w": 7,
+        "x": 3,
         "y": 1
       },
       "id": 46,
@@ -118,11 +204,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:process_cpu_seconds_total:rate5m{instance=~\"etcd-.+\"}) by (cluster)",
+          "expr": "job:process_cpu_seconds_total:rate5m{cluster=\"$cluster\",instance=~\"etcd-.+\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "process_resident_memory_bytes",
           "refId": "A",
           "step": 4
@@ -191,9 +277,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
+        "h": 8,
+        "w": 7,
+        "x": 10,
         "y": 1
       },
       "id": 29,
@@ -215,11 +301,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:process_resident_memory_bytes:clone{instance=~\"etcd-.+\"}) by (cluster)",
+          "expr": "job:process_resident_memory_bytes:clone{cluster=\"$cluster\",instance=~\"etcd-.+\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "process_resident_memory_bytes",
           "refId": "A",
           "step": 4
@@ -288,9 +374,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
+        "h": 8,
+        "w": 7,
+        "x": 17,
         "y": 1
       },
       "id": 47,
@@ -312,11 +398,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:process_open_fds:clone{instance=~\"etcd-.+\"}) by (cluster)",
+          "expr": "job:process_open_fds:clone{cluster=\"$cluster\",instance=~\"etcd-.+\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "process_resident_memory_bytes",
           "refId": "A",
           "step": 4
@@ -324,105 +410,6 @@
       ],
       "timeRegions": [],
       "title": "Open File Descriptors",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 0,
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "locale"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 1
-      },
-      "id": 60,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:etcd_server_has_leader:sum",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
-          "metric": "process_resident_memory_bytes",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Cluster Members",
       "transparent": true,
       "type": "timeseries"
     },
@@ -436,7 +423,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 53,
       "panels": [],
@@ -513,7 +500,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 10
       },
       "id": 1,
       "options": {
@@ -534,12 +521,12 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_mvcc_db_total_size_in_bytes:clone) by (cluster)",
+          "expr": "job:etcd_mvcc_db_total_size_in_bytes:clone{cluster=\"$cluster\"}",
           "format": "time_series",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "",
           "refId": "A",
           "step": 4
@@ -611,7 +598,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 9
+        "y": 10
       },
       "id": 3,
       "interval": "30s",
@@ -633,11 +620,12 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile) by (cluster)",
+          "expr": "job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile{cluster=\"$cluster\"}",
           "format": "time_series",
           "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "{{ cluster }} WAL fsync",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} WAL fsync",
           "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
           "refId": "A",
           "step": 4
@@ -646,10 +634,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile) by (cluster)",
+          "expr": "job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile{cluster=\"$cluster\"}",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ cluster }} DB fsync",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} DB fsync",
           "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
           "refId": "B",
           "step": 4
@@ -670,7 +659,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 18
       },
       "id": 49,
       "panels": [],
@@ -747,7 +736,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 18
+        "y": 19
       },
       "id": 22,
       "options": {
@@ -768,11 +757,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_network_client_grpc_received_bytes_total:rate5m) by (cluster)",
+          "expr": "job:etcd_network_client_grpc_received_bytes_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -844,7 +833,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 18
+        "y": 19
       },
       "id": 21,
       "options": {
@@ -865,11 +854,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_network_client_grpc_sent_bytes_total:rate5m) by (cluster)",
+          "expr": "job:etcd_network_client_grpc_sent_bytes_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_sent_bytes_total",
           "refId": "A",
           "step": 4
@@ -941,7 +930,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 18
+        "y": 19
       },
       "id": 20,
       "options": {
@@ -962,11 +951,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_network_peer_received_bytes_total:rate5msum) by (cluster)",
+          "expr": "job:etcd_network_peer_received_bytes_total:rate5msum{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_peer_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1038,7 +1027,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 18
+        "y": 19
       },
       "id": 16,
       "options": {
@@ -1059,12 +1048,12 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_network_peer_sent_bytes_total:rate5msum) by (cluster)",
+          "expr": "job:etcd_network_peer_sent_bytes_total:rate5msum{cluster=\"$cluster\"}",
           "format": "time_series",
           "hide": false,
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_peer_sent_bytes_total",
           "refId": "A",
           "step": 4
@@ -1072,6 +1061,238 @@
       ],
       "timeRegions": [],
       "title": "Peer Traffic Out",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 28,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "job:etcd_server_proposals_failed_total:rate5msum{cluster=\"$cluster\"}",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Proposal Failure Rate",
+          "metric": "etcd_server_proposals_failed_total",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "job:etcd_server_proposals_pending:sum{cluster=\"$cluster\"}",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Proposal Pending Total",
+          "metric": "etcd_server_proposals_pending",
+          "refId": "B",
+          "step": 2
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "job:etcd_server_proposals_committed_total:rate5msum{cluster=\"$cluster\"}",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Proposal Commit Rate",
+          "metric": "etcd_server_proposals_committed_total",
+          "refId": "C",
+          "step": 2
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "job:etcd_server_proposals_applied_total:rate5msum{cluster=\"$cluster\"}",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Proposal Apply Rate",
+          "refId": "D",
+          "step": 2
+        }
+      ],
+      "timeRegions": [],
+      "title": "Raft Proposals",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 28,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "job:etcd_server_leader_changes_seen_total:changes1d{cluster=\"$cluster\"}",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "metric": "etcd_server_leader_changes_seen_total",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "timeRegions": [],
+      "title": "Total Leader Elections Per Day",
       "transparent": true,
       "type": "timeseries"
     },
@@ -1085,7 +1306,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 35
       },
       "id": 55,
       "panels": [],
@@ -1162,7 +1383,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 27
+        "y": 36
       },
       "id": 45,
       "options": {
@@ -1183,11 +1404,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_mvcc_txn_total:rate5m) by (cluster)",
+          "expr": "job:etcd_mvcc_txn_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1259,7 +1480,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 27
+        "y": 36
       },
       "id": 42,
       "options": {
@@ -1280,11 +1501,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_mvcc_put_total:rate5m) by (cluster)",
+          "expr": "job:etcd_mvcc_put_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1356,7 +1577,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 27
+        "y": 36
       },
       "id": 57,
       "options": {
@@ -1377,11 +1598,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_mvcc_range_total:rate5m) by (cluster)",
+          "expr": "job:etcd_mvcc_range_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1453,7 +1674,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 27
+        "y": 36
       },
       "id": 44,
       "options": {
@@ -1474,11 +1695,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_mvcc_delete_total:rate5m) by (cluster)",
+          "expr": "job:etcd_mvcc_delete_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1550,7 +1771,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "id": 43,
       "options": {
@@ -1571,11 +1792,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_debugging_mvcc_keys_total:clone) by (cluster)",
+          "expr": "job:etcd_debugging_mvcc_keys_total:clone{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1647,7 +1868,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 35
+        "y": 44
       },
       "id": 56,
       "options": {
@@ -1668,11 +1889,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_debugging_store_reads_total:rate5m) by (cluster, action)",
+          "expr": "job:etcd_debugging_store_reads_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }} {{ action }} ops",
+          "legendFormat": "{{ instance }} {{ action }} ops",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1744,7 +1965,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 35
+        "y": 44
       },
       "id": 58,
       "options": {
@@ -1765,11 +1986,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_debugging_store_writes_total:rate5m) by (cluster, action)",
+          "expr": "job:etcd_debugging_store_writes_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }} {{ action }} ops",
+          "legendFormat": "{{ instance }} {{ action }} ops",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1841,7 +2062,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 35
+        "y": 44
       },
       "id": 59,
       "options": {
@@ -1862,11 +2083,11 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum(job:etcd_debugging_store_expires_total:rate5m) by (cluster)",
+          "expr": "job:etcd_debugging_store_expires_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
           "step": 4
@@ -1897,6 +2118,31 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": "User Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(job:etcd_server_has_leader:sum, cluster)",
+          "refId": "prometheus-cluster-Variable-Query"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       },
       {
         "auto": false,
@@ -2001,8 +2247,8 @@
     ]
   },
   "timezone": "",
-  "title": "etcd Cluster Overview",
-  "uid": "aa6e22781c60",
+  "title": "Etcd (User Cluster)",
+  "uid": "df15188d34cc",
   "version": 1,
   "weekStart": ""
 }

--- a/charts/monitoring/grafana/dashboards/kubernetes/etcd.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/etcd.json
@@ -2,9 +2,10 @@
   "annotations": {
     "list": []
   },
-  "description": "etcd metrics",
+  "description": "Etcd Cluster Overview showing details scraped from the etcd Prometheus metrics endpoint.",
   "editable": true,
   "fiscalYearStartMonth": 0,
+  "gnetId": 15308,
   "graphTooltip": 1,
   "hideControls": false,
   "links": [],
@@ -13,8 +14,8 @@
     {
       "collapsed": false,
       "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
+        "type": "loki",
+        "uid": "P982945308D3682D1"
       },
       "gridPos": {
         "h": 1,
@@ -22,23 +23,23 @@
         "x": 0,
         "y": 0
       },
-      "id": 51,
+      "id": 88,
       "panels": [],
       "targets": [
         {
           "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
+            "type": "loki",
+            "uid": "P982945308D3682D1"
           },
           "refId": "A"
         }
       ],
-      "title": "Overview",
+      "title": "Status",
       "type": "row"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -46,59 +47,69 @@
           "color": {
             "mode": "thresholds"
           },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "N/A"
-                }
-              },
-              "type": "special"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(245, 54, 54, 0.9)",
+                "color": "transparent",
                 "value": null
-              },
-              {
-                "color": "rgba(237, 129, 40, 0.89)",
-                "value": 1
-              },
-              {
-                "color": "rgba(50, 172, 45, 0.97)",
-                "value": 2
               }
             ]
-          },
-          "unit": "none"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Has Leader"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "yellow",
+                        "index": 1,
+                        "text": "No"
+                      },
+                      "1": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 3,
+        "h": 3,
+        "w": 2,
         "x": 0,
         "y": 1
       },
-      "id": 28,
-      "maxDataPoints": 100,
+      "id": 90,
       "options": {
         "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "mean"
+            "lastNotNull"
           ],
           "fields": "",
           "values": false
         },
         "showPercentChange": false,
+        "text": {},
         "textMode": "auto",
         "wideLayout": true
       },
@@ -106,65 +117,139 @@
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_server_has_leader:sum{cluster=\"$cluster\"}",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "",
-          "metric": "job:etcd_server_has_leader:sum",
-          "refId": "A",
-          "step": 20
+          "exemplar": true,
+          "expr": "max(etcd_server_has_leader{instance=~\"$instance\",job=~\"$job\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Has Leader",
+          "refId": "D"
         }
       ],
       "timeRegions": [],
-      "title": "Up",
+      "title": "Has Leader",
       "transparent": true,
       "type": "stat"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "dark-purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Has Leader"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "yellow",
+                        "index": 1,
+                        "text": "No"
+                      },
+                      "1": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 2,
+        "y": 1
+      },
+      "id": 93,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(etcd_server_id{instance=~\"$instance\",job=~\"$job\"})",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Members",
+          "refId": "C"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Members",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "inspect": false
           },
-          "links": [],
+          "decimals": 2,
+          "displayName": "",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -172,502 +257,778 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "none"
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DB Used Space"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 45
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 129
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Mem Used"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Mem Used"
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "auto"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "# Keys"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "# Keys"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals"
+              },
+              {
+                "id": "custom.width",
+                "value": 65
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WAL Sync 99p"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 200
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 400
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DB Sync 99p"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "dark-green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 200
+                    },
+                    {
+                      "color": "dark-red",
+                      "value": 400
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Is Leader?"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "#37872d80",
+                        "index": 1,
+                        "text": "No"
+                      },
+                      "1": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Compacted Keys"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 133
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Instance"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "auto"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Urgent Defragmentation"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "from": 0,
+                      "result": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "No"
+                      },
+                      "to": 80
+                    },
+                    "type": "range"
+                  },
+                  {
+                    "options": {
+                      "from": 80,
+                      "result": {
+                        "color": "dark-red",
+                        "index": 1,
+                        "text": "Yes"
+                      },
+                      "to": 100
+                    },
+                    "type": "range"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 184
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DB Capacity"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.width",
+                "value": 115
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DB Quota"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 7,
-        "x": 3,
+        "h": 6,
+        "w": 18,
+        "x": 6,
         "y": 1
       },
-      "id": 46,
+      "id": 74,
+      "maxDataPoints": 100,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
+        "showHeader": true,
+        "sortBy": []
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "10.4.1",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:process_cpu_seconds_total:rate5m{cluster=\"$cluster\",instance=~\"etcd-.+\"}",
-          "format": "time_series",
-          "interval": "$interval",
+          "exemplar": false,
+          "expr": "(etcd_mvcc_db_total_size_in_bytes{instance=~\"$instance\",job=~\"$job\"} / etcd_server_quota_backend_bytes{instance=~\"$instance\",job=~\"$job\"})*100",
+          "format": "table",
+          "instant": true,
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "process_resident_memory_bytes",
-          "refId": "A",
-          "step": 4
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": false,
+          "expr": "process_resident_memory_bytes{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": false,
+          "expr": "sum(etcd_debugging_mvcc_keys_total{instance=~\"$instance\",job=~\"$job\"}) by (instance)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\",job=~\"$job\"}[5m])) by (instance, le))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\",job=~\"$job\"}[5m])) by (instance, le))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(etcd_server_is_leader{instance=~\"$instance\",job=~\"$job\"}) by (instance)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": false,
+          "expr": "sum(etcd_debugging_mvcc_db_compaction_keys_total{instance=~\"$instance\",job=~\"$job\"}) by (instance)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "(etcd_mvcc_db_total_size_in_bytes{instance=~\"$instance\",job=~\"$job\"} / etcd_server_quota_backend_bytes{instance=~\"$instance\",job=~\"$job\"})*100",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Urgent Defragmentation",
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_server_quota_backend_bytes{instance=~\"$instance\",job=~\"$job\"} - etcd_mvcc_db_total_size_in_bytes{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "DB Capacity",
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_server_quota_backend_bytes{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "J"
         }
       ],
       "timeRegions": [],
-      "title": "CPU Usage",
+      "title": "Status",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {
+            "reducers": []
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value #A": 8,
+              "Value #B": 6,
+              "Value #C": 9,
+              "Value #D": 10,
+              "Value #E": 11,
+              "Value #F": 2,
+              "Value #G": 12,
+              "Value #H": 13,
+              "Value #I": 4,
+              "__name__": 7,
+              "etcd_server_quota_backend_bytes{instance=\"poller01.tylephony.com:2379\", job=\"etcd\"}": 5,
+              "instance": 1,
+              "job": 3
+            },
+            "renameByName": {
+              "Urgent Defragmentation": "",
+              "Value #A": "Mem Used",
+              "Value #B": "DB Used Space",
+              "Value #C": "# Keys",
+              "Value #D": "WAL Sync 99p",
+              "Value #E": "DB Sync 99p",
+              "Value #F": "Is Leader?",
+              "Value #G": "Compacted Keys",
+              "Value #H": "Urgent Defragmentation",
+              "Value #I": "DB Capacity",
+              "__name__": "",
+              "etcd_server_quota_backend_bytes{instance=\"poller01.tylephony.com:2379\", job=\"etcd\"}": "DB Quota",
+              "instance": "Instance",
+              "job": ""
+            }
+          }
+        }
+      ],
       "transparent": true,
-      "type": "timeseries"
+      "type": "table"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
+      "description": "",
       "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "light-blue",
+            "mode": "fixed"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "transparent",
                 "value": null
               }
             ]
-          },
-          "unit": "bytes"
+          }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 7,
-        "x": 10,
-        "y": 1
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:process_resident_memory_bytes:clone{cluster=\"$cluster\",instance=~\"etcd-.+\"}",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "process_resident_memory_bytes",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Resident Memory",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Has Leader"
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+            "properties": [
               {
-                "color": "green",
-                "value": null
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "yellow",
+                        "index": 1,
+                        "text": "No"
+                      },
+                      "1": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
               }
             ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 7,
-        "x": 17,
-        "y": 1
-      },
-      "id": 47,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:process_open_fds:clone{cluster=\"$cluster\",instance=~\"etcd-.+\"}",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "process_resident_memory_bytes",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Open File Descriptors",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
+        "h": 3,
+        "w": 3,
         "x": 0,
-        "y": 9
+        "y": 4
       },
-      "id": 53,
-      "panels": [],
+      "id": 91,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
       "targets": [
         {
           "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
+            "uid": "${datasource}"
           },
+          "exemplar": true,
+          "expr": "max(etcd_server_leader_changes_seen_total{instance=~\"$instance\",job=~\"$job\"})",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Leader Changes",
           "refId": "A"
         }
       ],
-      "title": "Disk Usage",
-      "type": "row"
+      "timeRegions": [],
+      "title": "Leader Changes",
+      "transparent": true,
+      "type": "stat"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
+      "description": "",
       "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "fixedColor": "light-blue",
+            "mode": "fixed"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "transparent",
                 "value": null
               }
             ]
-          },
-          "unit": "bytes"
+          }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 10
-      },
-      "id": 1,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:etcd_mvcc_db_total_size_in_bytes:clone{cluster=\"$cluster\"}",
-          "format": "time_series",
-          "hide": false,
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Database Size",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Has Leader"
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+            "properties": [
               {
-                "color": "green",
-                "value": null
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "yellow",
+                        "index": 1,
+                        "text": "No"
+                      },
+                      "1": {
+                        "color": "dark-green",
+                        "index": 0,
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
               }
             ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 10
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 4
       },
-      "id": 3,
-      "interval": "30s",
+      "id": 92,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "10.4.1",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_disk_wal_fsync_duration_seconds_bucket:99percentile{cluster=\"$cluster\"}",
-          "format": "time_series",
+          "exemplar": true,
+          "expr": "max(etcd_server_leader_changes_seen_total{instance=~\"$instance\",job=~\"$job\"})",
           "hide": false,
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} WAL fsync",
-          "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
-          "refId": "A",
-          "step": 4
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:etcd_disk_backend_commit_duration_seconds_bucket:99percentile{cluster=\"$cluster\"}",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} DB fsync",
-          "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
-          "refId": "B",
-          "step": 4
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Failed Proposals",
+          "refId": "B"
         }
       ],
       "timeRegions": [],
-      "title": "Disk Sync Duration",
+      "title": "Failed Proposals",
       "transparent": true,
-      "type": "timeseries"
+      "type": "stat"
     },
     {
       "collapsed": false,
       "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
+        "type": "loki",
+        "uid": "P982945308D3682D1"
       },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 7
       },
-      "id": 49,
+      "id": 95,
       "panels": [],
       "targets": [
         {
           "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
+            "type": "loki",
+            "uid": "P982945308D3682D1"
           },
           "refId": "A"
         }
@@ -677,7 +1038,7 @@
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -693,7 +1054,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -701,14 +1062,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -717,7 +1078,6 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -725,6 +1085,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -733,38 +1097,40 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 6,
         "x": 0,
-        "y": 19
+        "y": 8
       },
       "id": 22,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_network_client_grpc_received_bytes_total:rate5m{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "rate(etcd_network_client_grpc_received_bytes_total{instance=~\"$instance\",job=~\"$job\"}[5m])",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "interval": "",
+          "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_received_bytes_total",
           "refId": "A",
-          "step": 4
+          "step": 120
         }
       ],
       "timeRegions": [],
@@ -774,7 +1140,7 @@
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -790,7 +1156,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -798,14 +1164,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -814,7 +1180,6 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -822,6 +1187,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -830,38 +1199,40 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 6,
         "x": 6,
-        "y": 19
+        "y": 8
       },
       "id": 21,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_network_client_grpc_sent_bytes_total:rate5m{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{instance=~\"$instance\",job=~\"$job\"}[5m])",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "interval": "",
+          "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "metric": "etcd_network_client_grpc_sent_bytes_total",
           "refId": "A",
-          "step": 4
+          "step": 120
         }
       ],
       "timeRegions": [],
@@ -871,7 +1242,7 @@
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -887,7 +1258,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -895,14 +1266,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -911,7 +1282,6 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -919,6 +1289,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -927,38 +1301,40 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 6,
         "x": 12,
-        "y": 19
+        "y": 8
       },
       "id": 20,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_network_peer_received_bytes_total:rate5msum{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_network_peer_received_bytes_total{instance=~\"$instance\",job=~\"$job\"}[5m])) by (instance)",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "interval": "",
+          "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "metric": "etcd_network_peer_received_bytes_total",
           "refId": "A",
-          "step": 4
+          "step": 120
         }
       ],
       "timeRegions": [],
@@ -968,7 +1344,7 @@
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -984,7 +1360,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -992,14 +1368,14 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1008,7 +1384,6 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1016,6 +1391,10 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -1024,39 +1403,41 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 7,
         "w": 6,
         "x": 18,
-        "y": 19
+        "y": 8
       },
       "id": 16,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_network_peer_sent_bytes_total:rate5msum{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_network_peer_sent_bytes_total{instance=~\"$instance\",job=~\"$job\"}[5m])) by (instance)",
           "format": "time_series",
           "hide": false,
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "interval": "",
+          "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "metric": "etcd_network_peer_sent_bytes_total",
           "refId": "A",
-          "step": 4
+          "step": 120
         }
       ],
       "timeRegions": [],
@@ -1065,8 +1446,34 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
       "datasource": {
-        "uid": "$datasource"
+        "type": "loki",
+        "uid": "P982945308D3682D1"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 97,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P982945308D3682D1"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Keys",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -1082,7 +1489,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
@@ -1090,7 +1497,109 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 16
+      },
+      "id": 58,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_debugging_mvcc_keys_total{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Keys (Stacked)",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -1106,7 +1615,6 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1114,6 +1622,118 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 9,
+        "y": 16
+      },
+      "id": 52,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "rate(etcd_debugging_mvcc_put_total{instance=~\"$instance\",job=~\"$job\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} puts/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "rate(etcd_debugging_mvcc_delete_total{instance=~\"$instance\",job=~\"$job\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} deletes/s",
+          "refId": "B"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Key Operations",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -1122,76 +1742,1020 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 27
+        "h": 7,
+        "w": 7,
+        "x": 17,
+        "y": 16
       },
-      "id": 40,
+      "id": 48,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_server_proposals_failed_total:rate5msum{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "etcd_debugging_mvcc_db_compaction_keys_total{instance=~\"$instance\",job=~\"$job\"}",
           "format": "time_series",
-          "interval": "$interval",
+          "interval": "",
           "intervalFactor": 1,
+          "legendFormat": "{{ instance  }}",
+          "refId": "A"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Compaction Keys",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "loki",
+        "uid": "P982945308D3682D1"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 76,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P982945308D3682D1"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "General Info",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 29,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "process_resident_memory_bytes{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }}",
+          "metric": "process_resident_memory_bytes",
+          "refId": "A",
+          "step": 120
+        }
+      ],
+      "timeRegions": [],
+      "title": "Process Resident Memory",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 1,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_mvcc_db_total_size_in_bytes{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }} Total Size",
+          "metric": "",
+          "refId": "A",
+          "step": 120
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_mvcc_db_total_size_in_use_in_bytes{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} In Use",
+          "refId": "B"
+        }
+      ],
+      "timeRegions": [],
+      "title": "DB Total Size",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 29,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 31
+      },
+      "id": 7,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "rate(etcd_disk_wal_fsync_duration_seconds_sum{instance=~\"$instance\",job=~\"$job\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }} WAL fsync",
+          "refId": "A",
+          "step": 30
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "rate(etcd_disk_backend_commit_duration_seconds_sum{instance=~\"$instance\",job=~\"$job\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }} backend commit",
+          "refId": "B",
+          "step": 30
+        }
+      ],
+      "timeRegions": [],
+      "title": "Disks Operations",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 31
+      },
+      "id": 3,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{instance=~\"$instance\",job=~\"$job\"}[5m])) by (instance, le))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }} WAL fsync",
+          "metric": "etcd_disk_wal_fsync_duration_seconds_bucket",
+          "refId": "A",
+          "step": 120
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{instance=~\"$instance\",job=~\"$job\"}[5m])) by (instance, le))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }} DB fsync",
+          "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
+          "refId": "B",
+          "step": 120
+        }
+      ],
+      "timeRegions": [],
+      "title": "Disk Sync Duration",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 31
+      },
+      "id": 60,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "etcd_server_heartbeat_send_failures_total{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} heartbeat  failures",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "etcd_server_health_failures{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} health failures",
+          "refId": "B"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Failures",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "id": 62,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_server_slow_apply_total{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} Slow Applies",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "etcd_server_slow_read_indexes_total{instance=~\"$instance\",job=~\"$job\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} Slow Read Indexes",
+          "refId": "B"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Slow Operations",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 41
+      },
+      "id": 56,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "rate(etcd_disk_backend_defrag_duration_seconds_sum{instance=~\"$instance\",job=~\"$job\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Defrag Duration",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "description": "Abnormally high snapshot duration (snapshot_save_total_duration_seconds) indicates disk issues and might cause the cluster to be unstable.",
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 41
+      },
+      "id": 9,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(etcd_debugging_snap_save_total_duration_seconds_sum{instance=~\"$instance\",job=~\"$job\"}[1m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "The Total Latency Distributions of Save Called by Snapshot",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "timeRegions": [],
+      "title": "Snapshot Duration",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 41
+      },
+      "id": 40,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(etcd_server_proposals_failed_total{instance=~\"$instance\",job=~\"$job\"}[5m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
           "legendFormat": "Proposal Failure Rate",
           "metric": "etcd_server_proposals_failed_total",
           "refId": "A",
-          "step": 2
+          "step": 60
         },
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_server_proposals_pending:sum{cluster=\"$cluster\"}",
+          "expr": "sum(etcd_server_proposals_pending{instance=~\"$instance\",job=~\"$job\"})",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "intervalFactor": 2,
           "legendFormat": "Proposal Pending Total",
           "metric": "etcd_server_proposals_pending",
           "refId": "B",
-          "step": 2
+          "step": 60
         },
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_server_proposals_committed_total:rate5msum{cluster=\"$cluster\"}",
+          "expr": "sum(rate(etcd_server_proposals_committed_total{instance=~\"$instance\",job=~\"$job\"}[5m]))",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "intervalFactor": 2,
           "legendFormat": "Proposal Commit Rate",
           "metric": "etcd_server_proposals_committed_total",
           "refId": "C",
-          "step": 2
+          "step": 60
         },
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_server_proposals_applied_total:rate5msum{cluster=\"$cluster\"}",
+          "expr": "sum(rate(etcd_server_proposals_applied_total{instance=~\"$instance\",job=~\"$job\"}[5m]))",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "intervalFactor": 2,
           "legendFormat": "Proposal Apply Rate",
           "refId": "D",
-          "step": 2
+          "step": 60
         }
       ],
       "timeRegions": [],
@@ -1201,7 +2765,7 @@
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -1210,22 +2774,124 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 41
+      },
+      "id": 41,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\",instance=~\"$instance\",job=~\"$job\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\",instance=~\"$instance\",job=~\"$job\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Watch Streams",
+          "metric": "grpc_server_handled_total",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\",instance=~\"$instance\",job=~\"$job\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\",instance=~\"$instance\",job=~\"$job\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Lease Streams",
+          "metric": "grpc_server_handled_total",
+          "refId": "B",
+          "step": 60
+        }
+      ],
+      "timeRegions": [],
+      "title": "Active Streams",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -1241,14 +2907,110 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 47
+      },
+      "id": 54,
+      "interval": "$interval",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.2.5",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "rate(etcd_debugging_mvcc_db_compaction_keys_total{instance=~\"$instance\",job=~\"$job\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} compact/s",
+          "refId": "A"
+        }
+      ],
+      "timeRegions": [],
+      "title": "Compaction Rate",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${datasource}"
+      },
+      "editable": true,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -1257,38 +3019,39 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 27
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 47
       },
       "id": 19,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "none"
+          "mode": "multi"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_server_leader_changes_seen_total:changes1d{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "changes(etcd_server_leader_changes_seen_total{instance=~\"$instance\",job=~\"$job\"}[1d])",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
+          "interval": "",
+          "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
           "metric": "etcd_server_leader_changes_seen_total",
           "refId": "A",
-          "step": 2
+          "step": 60
         }
       ],
       "timeRegions": [],
@@ -1297,35 +3060,10 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
       "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
+        "uid": "${datasource}"
       },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 55,
-      "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Internals",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
+      "description": "indicates how many proposals are queued to commit. Rising pending proposals suggests there is a high client load or the member cannot commit proposals.",
       "editable": true,
       "fieldConfig": {
         "defaults": {
@@ -1333,22 +3071,18 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -1364,111 +3098,16 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 36
-      },
-      "id": 45,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:etcd_mvcc_txn_total:rate5m{cluster=\"$cluster\"}",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Transactions",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+                "color": "green"
+              },
               {
-                "color": "green",
-                "value": null
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -1477,146 +3116,50 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 36
-      },
-      "id": 42,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:etcd_mvcc_put_total:rate5m{cluster=\"$cluster\"}",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "PUT Requests",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 6,
         "x": 12,
-        "y": 36
+        "y": 47
       },
-      "id": 57,
+      "id": 5,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "none"
+          "mode": "multi"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_mvcc_range_total:rate5m{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "sum(etcd_server_proposals_pending{instance=~\"$instance\",job=~\"$job\"})",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Proposals Pending",
           "refId": "A",
-          "step": 4
+          "step": 60
         }
       ],
       "timeRegions": [],
-      "title": "RANGE Requests",
+      "title": "Proposals Pending",
       "transparent": true,
       "type": "timeseries"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
+      "description": "proposals_committed_total records the total number of consensus proposals committed. This gauge should increase over time if the cluster is healthy. Several healthy members of an etcd cluster may have different total committed proposals at once. This discrepancy may be due to recovering from peers after starting, lagging behind the leader, or being the leader and therefore having the most commits. It is important to monitor this metric across all the members in the cluster; a consistently large lag between a single member and its leader indicates that member is slow or unhealthy.\n\nproposals_applied_total records the total number of consensus proposals applied. The etcd server applies every committed proposal asynchronously. The difference between proposals_committed_total and proposals_applied_total should usually be small (within a few thousands even under high load). If the difference between them continues to rise, it indicates that the etcd server is overloaded. This might happen when applying expensive queries like heavy range queries or large txn operations.",
       "editable": true,
       "fieldConfig": {
         "defaults": {
@@ -1624,22 +3167,18 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -1655,14 +3194,16 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -1671,48 +3212,67 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 6,
         "x": 18,
-        "y": 36
+        "y": 47
       },
-      "id": 44,
+      "id": 2,
+      "interval": "$interval",
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "none"
+          "mode": "multi"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_mvcc_delete_total:rate5m{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_server_proposals_committed_total{instance=~\"$instance\",job=~\"$job\"}[5m]))",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Committed",
+          "metric": "",
           "refId": "A",
-          "step": 4
+          "step": 60
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(etcd_server_proposals_applied_total{instance=~\"$instance\",job=~\"$job\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Total Applied",
+          "metric": "",
+          "refId": "B",
+          "step": 60
         }
       ],
       "timeRegions": [],
-      "title": "DELETE Requests",
+      "title": "The Total Number of Consensus Proposals Committed",
       "transparent": true,
       "type": "timeseries"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -1721,29 +3281,25 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
             "showPoints": "never",
-            "spanNulls": true,
+            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
@@ -1752,64 +3308,77 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "short"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
+        "h": 6,
+        "w": 12,
         "x": 0,
-        "y": 44
+        "y": 53
       },
-      "id": 43,
+      "id": 23,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "none"
+          "mode": "multi"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_debugging_mvcc_keys_total:clone{cluster=\"$cluster\"}",
+          "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\",instance=~\"$instance\",job=~\"$job\"}[5m]))",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
+          "intervalFactor": 2,
+          "legendFormat": "RPC Rate",
+          "metric": "grpc_server_started_total",
           "refId": "A",
-          "step": 4
+          "step": 60
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(grpc_server_handled_total{grpc_type=\"unary\",grpc_code!=\"OK\",instance=~\"$instance\",job=~\"$job\"}[5m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "RPC Failed Rate",
+          "metric": "grpc_server_handled_total",
+          "refId": "B",
+          "step": 60
         }
       ],
       "timeRegions": [],
-      "title": "Total Keys",
+      "title": "RPC Rate",
       "transparent": true,
       "type": "timeseries"
     },
     {
       "datasource": {
-        "uid": "$datasource"
+        "uid": "${datasource}"
       },
       "editable": true,
       "fieldConfig": {
@@ -1818,22 +3387,18 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 28,
+            "fillOpacity": 30,
             "gradientMode": "opacity",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -1849,14 +3414,16 @@
               "mode": "off"
             }
           },
-          "links": [],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -1865,242 +3432,60 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 44
-      },
-      "id": 56,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "expr": "job:etcd_debugging_store_reads_total:rate5m{cluster=\"$cluster\"}",
-          "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} {{ action }} ops",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
-          "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Reads",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
+        "h": 6,
+        "w": 12,
         "x": 12,
-        "y": 44
+        "y": 53
       },
-      "id": 58,
+      "id": 8,
+      "interval": "$interval",
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "none"
+          "mode": "multi"
         }
       },
-      "pluginVersion": "9.4.3",
+      "pluginVersion": "8.2.5",
       "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_debugging_store_writes_total:rate5m{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total{instance=~\"$instance\",job=~\"$job\"}[1m]))",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} {{ action }} ops",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Received",
           "refId": "A",
-          "step": 4
-        }
-      ],
-      "timeRegions": [],
-      "title": "Writes",
-      "transparent": true,
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "uid": "$datasource"
-      },
-      "editable": true,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 28,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
+          "step": 30
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 44
-      },
-      "id": 59,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "9.4.3",
-      "targets": [
         {
           "datasource": {
-            "uid": "$datasource"
+            "uid": "${datasource}"
           },
-          "expr": "job:etcd_debugging_store_expires_total:rate5m{cluster=\"$cluster\"}",
+          "exemplar": true,
+          "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total{instance=~\"$instance\",job=~\"$job\"}[1m]))",
           "format": "time_series",
-          "interval": "$interval",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "metric": "etcd_network_client_grpc_received_bytes_total",
-          "refId": "A",
-          "step": 4
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Sent",
+          "refId": "B",
+          "step": 30
         }
       ],
       "timeRegions": [],
-      "title": "Expires",
+      "title": "GRPC Network",
       "transparent": true,
       "type": "timeseries"
     }
   ],
   "refresh": "30s",
-  "revision": 1,
   "schemaVersion": 39,
   "tags": [],
   "templating": {
@@ -2109,11 +3494,12 @@
         "current": {},
         "hide": 0,
         "includeAll": false,
-        "label": "Datasource",
+        "label": "Data Source",
         "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2122,30 +3508,56 @@
       {
         "current": {},
         "datasource": {
-          "uid": "$datasource"
+          "uid": "${datasource}"
         },
-        "definition": "",
+        "definition": "label_values(etcd_cluster_version,job)",
         "hide": 0,
         "includeAll": false,
-        "label": "User Cluster",
+        "label": "Job",
         "multi": false,
-        "name": "cluster",
+        "name": "job",
         "options": [],
         "query": {
-          "query": "label_values(job:etcd_server_has_leader:sum, cluster)",
-          "refId": "prometheus-cluster-Variable-Query"
+          "query": "label_values(etcd_cluster_version,job)",
+          "refId": "StandardVariableQuery"
         },
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 5,
         "tagValuesQuery": "",
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "auto": false,
+        "current": {},
+        "datasource": {
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(etcd_server_id{job=\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(etcd_server_id{job=\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "auto": true,
         "auto_count": 30,
         "auto_min": "10s",
         "current": {},
@@ -2153,6 +3565,16 @@
         "label": "Interval",
         "name": "interval",
         "options": [
+          {
+            "selected": false,
+            "text": "auto",
+            "value": "$__auto_interval_interval"
+          },
+          {
+            "selected": false,
+            "text": "15s",
+            "value": "15s"
+          },
           {
             "selected": true,
             "text": "1m",
@@ -2180,6 +3602,11 @@
           },
           {
             "selected": false,
+            "text": "3h",
+            "value": "3h"
+          },
+          {
+            "selected": false,
             "text": "6h",
             "value": "6h"
           },
@@ -2192,24 +3619,10 @@
             "selected": false,
             "text": "1d",
             "value": "1d"
-          },
-          {
-            "selected": false,
-            "text": "7d",
-            "value": "7d"
-          },
-          {
-            "selected": false,
-            "text": "14d",
-            "value": "14d"
-          },
-          {
-            "selected": false,
-            "text": "30d",
-            "value": "30d"
           }
         ],
-        "query": "1m,5m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "query": "15s,1m,5m,10m,30m,1h,3h,6h,12h,1d",
+        "queryValue": "",
         "refresh": 2,
         "skipUrlSync": false,
         "type": "interval"
@@ -2221,7 +3634,6 @@
     "to": "now"
   },
   "timepicker": {
-    "now": true,
     "refresh_intervals": [
       "5s",
       "10s",
@@ -2247,8 +3659,8 @@
     ]
   },
   "timezone": "",
-  "title": "etcd",
-  "uid": "df15188d34cc",
+  "title": "Etcd",
+  "uid": "hzhXdzznZn",
   "version": 1,
   "weekStart": ""
 }

--- a/charts/monitoring/prometheus/config/scraping/etcd.yaml
+++ b/charts/monitoring/prometheus/config/scraping/etcd.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.prometheus.scraping.etcd.tls.crt .Values.prometheus.scraping.etcd.tls.key }}
+job_name: etcd
+scheme: https
+kubernetes_sd_configs:
+- role: pod
+relabel_configs:
+- action: keep
+  source_labels:
+  - __meta_kubernetes_namespace
+  - __meta_kubernetes_pod_name
+  separator: '/'
+  regex: 'kube-system/etcd.+'
+- source_labels:
+  - __address__
+  action: replace
+  target_label: __address__
+  regex: (.+?)(\\:\\d)?
+  replacement: $1:2379
+tls_config:
+  cert_file: /etc/prometheus/etcd-certs/client.crt
+  key_file: /etc/prometheus/etcd-certs/client.key
+  insecure_skip_verify: true
+{{ else }}
+job_name: etcd
+{{ end }}

--- a/charts/monitoring/prometheus/rules/general-etcd.yaml
+++ b/charts/monitoring/prometheus/rules/general-etcd.yaml
@@ -1,0 +1,111 @@
+# This file has been generated, DO NOT EDIT.
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - name: etcd
+    rules:
+      - alert: EtcdInsufficientMembers
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+        expr: |
+          sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+        for: 15m
+        labels:
+          severity: critical
+      - alert: EtcdNoLeader
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+        expr: |
+          etcd_server_has_leader{job="etcd"} == 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: EtcdHighNumberOfLeaderChanges
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+        expr: |
+          rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+        for: 15m
+        labels:
+          severity: warning
+      - alert: EtcdGRPCRequestsSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+          > 0.15
+        for: 10m
+        labels:
+          severity: critical
+      - alert: EtcdMemberCommunicationSlow
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+          > 0.15
+        for: 10m
+        labels:
+          severity: warning
+      - alert: EtcdHighNumberOfFailedProposals
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+        expr: |
+          rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+        for: 15m
+        labels:
+          severity: warning
+      - alert: EtcdHighFsyncDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+      - alert: EtcdHighCommitDurations
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        expr: |
+          histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+          > 0.25
+        for: 10m
+        labels:
+          severity: warning
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
+        for: 10m
+        labels:
+          severity: warning

--- a/charts/monitoring/prometheus/rules/src/general/etcd.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/etcd.yaml
@@ -1,0 +1,119 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+groups:
+  - name: etcd
+    rules:
+    - alert: EtcdInsufficientMembers
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+      expr: |
+        sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+      for: 15m
+      labels:
+        severity: critical
+
+    - alert: EtcdNoLeader
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+      expr: |
+        etcd_server_has_leader{job="etcd"} == 0
+      for: 15m
+      labels:
+        severity: critical
+
+    - alert: EtcdHighNumberOfLeaderChanges
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+      expr: |
+        rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: EtcdGRPCRequestsSlow
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+      expr: |
+        histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+        > 0.15
+      for: 10m
+      labels:
+        severity: critical
+
+    - alert: EtcdMemberCommunicationSlow
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+      expr: |
+        histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+        > 0.15
+      for: 10m
+      labels:
+        severity: warning
+
+    - alert: EtcdHighNumberOfFailedProposals
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+      expr: |
+        rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: EtcdHighFsyncDurations
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+      expr: |
+        histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+        > 0.5
+      for: 10m
+      labels:
+        severity: warning
+
+    - alert: EtcdHighCommitDurations
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+      expr: |
+        histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+        > 0.25
+      for: 10m
+      labels:
+        severity: warning
+
+    - alert: EtcdDatabaseQuotaLowSpace
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+      expr: |
+        (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+      for: 10m
+      labels:
+        severity: critical
+
+    - alert: EtcdExcessiveDatabaseGrowth
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+      expr: |
+        predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+      for: 10m
+      labels:
+        severity: warning
+
+    - alert: EtcdDatabaseHighFragmentationRatio
+      annotations:
+        message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+      expr: |
+        (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
+      for: 10m
+      labels:
+        severity: warning

--- a/charts/monitoring/prometheus/templates/etcd-secret.yaml
+++ b/charts/monitoring/prometheus/templates/etcd-secret.yaml
@@ -1,0 +1,23 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if and .Values.prometheus.scraping.etcd.tls.crt .Values.prometheus.scraping.etcd.tls.key }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ template "name" . }}-etcd-certs'
+data:
+  client.crt: {{ .Values.prometheus.scraping.etcd.tls.crt | b64enc | quote }}
+  client.key: {{ .Values.prometheus.scraping.etcd.tls.key | b64enc | quote }}
+{{- end}}

--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -114,6 +114,11 @@ spec:
           mountPath: /var/prometheus/data
           readOnly: false
           subPath: prometheus-db
+        {{- if and .Values.prometheus.scraping.etcd.tls.crt .Values.prometheus.scraping.etcd.tls.key }}
+        - name: etcd-certs
+          mountPath: /etc/prometheus/etcd-certs/
+          readOnly: false
+        {{- end }}
         {{- if .Values.prometheus.volumes }}
         {{- range .Values.prometheus.volumes }}
         - name: {{ .name }}
@@ -190,6 +195,11 @@ spec:
       - name: rules
         configMap:
           name: '{{ template "name" . }}-rules'
+      {{- if and .Values.prometheus.scraping.etcd.tls.crt .Values.prometheus.scraping.etcd.tls.key }}
+      - name: etcd-certs
+        secret:
+          secretName: '{{ template "name" . }}-etcd-certs'
+      {{- end }}
       {{- if .Values.prometheus.volumes }}
       {{- range .Values.prometheus.volumes }}
       - name: {{ .name }}

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -86,6 +86,7 @@ data:
     - {"job_name":"blackbox-exporter-user-cluster-apiservers"}
     - {"bearer_token_file":"/var/run/secrets/kubernetes.io/serviceaccount/token","job_name":"cadvisor","kubernetes_sd_configs":[{"role":"node"}],"relabel_configs":[{"action":"labelmap","regex":"__meta_kubernetes_node_label_(.+)"},{"replacement":"kubernetes.default.svc:443","target_label":"__address__"},{"regex":"(.+)","replacement":"/api/v1/nodes/${1}/proxy/metrics/cadvisor","source_labels":["__meta_kubernetes_node_name"],"target_label":"__metrics_path__"}],"scheme":"https","tls_config":{"ca_file":"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}}
     - {"honor_labels":true,"job_name":"clusters","kubernetes_sd_configs":[{"role":"endpoints"}],"metrics_path":"/federate","params":{"match[]":["{kubermatic=\"federate\"}"]},"relabel_configs":[{"action":"keep","regex":"user","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_label_cluster"]},{"action":"keep","regex":"web","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_endpoint_port_name"]},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_namespace"],"target_label":"namespace"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_pod_name"],"target_label":"pod"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"service"},{"action":"replace","regex":"(.*)","replacement":"web","separator":";","target_label":"endpoint"}],"scheme":"http"}
+    - {"job_name":"etcd"}
     - {"honor_labels":true,"job_name":"kube-state-metrics","kubernetes_sd_configs":[{"api_server":null,"namespaces":{"names":["default"]},"role":"endpoints"}],"metric_relabel_configs":[{"action":"drop","regex":".*prow-(e2e|kubermatic)-.*","source_labels":["namespace"]},{"action":"replace","regex":"cluster-([a-z0-9]+)","replacement":"$1","source_labels":["namespace"],"target_label":"cluster"}],"metrics_path":"/metrics","relabel_configs":[{"action":"keep","regex":"kube-state-metrics","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_label_app_kubernetes_io_name"]},{"action":"keep","regex":"http-metrics","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_endpoint_port_name"]},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_namespace"],"target_label":"namespace"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_pod_name"],"target_label":"pod"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"service"},{"action":"replace","regex":"(.*)","replacement":"${1}","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"job"},{"action":"replace","regex":"(.+)","replacement":"${1}","separator":";","source_labels":["__meta_kubernetes_service_label_app_kubernetes_io_name"],"target_label":"job"},{"action":"replace","regex":"(.*)","replacement":"http-metrics","separator":";","target_label":"endpoint"}],"scrape_interval":"1m","scrape_timeout":"30s"}
     - {"bearer_token_file":"/var/run/secrets/kubernetes.io/serviceaccount/token","job_name":"kubelet","kubernetes_sd_configs":[{"role":"node"}],"relabel_configs":[{"action":"labelmap","regex":"__meta_kubernetes_node_label_(.+)"},{"replacement":"kubernetes.default.svc:443","target_label":"__address__"},{"regex":"(.+)","replacement":"/api/v1/nodes/${1}/proxy/metrics","source_labels":["__meta_kubernetes_node_name"],"target_label":"__metrics_path__"}],"scheme":"https","tls_config":{"ca_file":"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}}
     - {"job_name":"minio-job"}
@@ -229,6 +230,119 @@ data:
               severity: critical
               resource: "{{ $labels.name }}"
               service: cert-manager
+    
+  general-etcd.yaml: |
+    # This file has been generated, DO NOT EDIT.
+    
+    # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    groups:
+      - name: etcd
+        rules:
+          - alert: EtcdInsufficientMembers
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+            expr: |
+              sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+            for: 15m
+            labels:
+              severity: critical
+          - alert: EtcdNoLeader
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+            expr: |
+              etcd_server_has_leader{job="etcd"} == 0
+            for: 15m
+            labels:
+              severity: critical
+          - alert: EtcdHighNumberOfLeaderChanges
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+            expr: |
+              rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+            for: 15m
+            labels:
+              severity: warning
+          - alert: EtcdGRPCRequestsSlow
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+              > 0.15
+            for: 10m
+            labels:
+              severity: critical
+          - alert: EtcdMemberCommunicationSlow
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+              > 0.15
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdHighNumberOfFailedProposals
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+            expr: |
+              rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+            for: 15m
+            labels:
+              severity: warning
+          - alert: EtcdHighFsyncDurations
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+              > 0.5
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdHighCommitDurations
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+              > 0.25
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdDatabaseQuotaLowSpace
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+            expr: |
+              (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+            for: 10m
+            labels:
+              severity: critical
+          - alert: EtcdExcessiveDatabaseGrowth
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+            expr: |
+              predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdDatabaseHighFragmentationRatio
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+            expr: |
+              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
+            for: 10m
+            labels:
+              severity: warning
     
   general-helm-exporter.yaml: |
     # This file has been generated, DO NOT EDIT.
@@ -2249,3 +2363,18 @@ spec:
         requests:
           storage: 100Gi
       storageClassName: kubermatic-fast
+---
+# Source: prometheus/templates/etcd-secret.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -31,6 +31,28 @@ kind: ServiceAccount
 metadata:
   name: 'release-name'
 ---
+# Source: prometheus/templates/etcd-secret.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'release-name-etcd-certs'
+data:
+  client.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+  client.key: "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQ=="
+---
 # Source: prometheus/templates/configmaps.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #
@@ -86,6 +108,7 @@ data:
     - {"job_name":"blackbox-exporter-user-cluster-apiservers"}
     - {"bearer_token_file":"/var/run/secrets/kubernetes.io/serviceaccount/token","job_name":"cadvisor","kubernetes_sd_configs":[{"role":"node"}],"relabel_configs":[{"action":"labelmap","regex":"__meta_kubernetes_node_label_(.+)"},{"replacement":"kubernetes.default.svc:443","target_label":"__address__"},{"regex":"(.+)","replacement":"/api/v1/nodes/${1}/proxy/metrics/cadvisor","source_labels":["__meta_kubernetes_node_name"],"target_label":"__metrics_path__"}],"scheme":"https","tls_config":{"ca_file":"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}}
     - {"honor_labels":true,"job_name":"clusters","kubernetes_sd_configs":[{"role":"endpoints"}],"metrics_path":"/federate","params":{"match[]":["{kubermatic=\"federate\"}"]},"relabel_configs":[{"action":"keep","regex":"user","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_label_cluster"]},{"action":"keep","regex":"web","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_endpoint_port_name"]},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_namespace"],"target_label":"namespace"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_pod_name"],"target_label":"pod"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"service"},{"action":"replace","regex":"(.*)","replacement":"web","separator":";","target_label":"endpoint"}],"scheme":"http"}
+    - {"job_name":"etcd","kubernetes_sd_configs":[{"role":"pod"}],"relabel_configs":[{"action":"keep","regex":"kube-system/etcd.+","separator":"/","source_labels":["__meta_kubernetes_namespace","__meta_kubernetes_pod_name"]},{"action":"replace","regex":"(.+?)(\\\\:\\\\d)?","replacement":"$1:2379","source_labels":["__address__"],"target_label":"__address__"}],"scheme":"https","tls_config":{"cert_file":"/etc/prometheus/etcd-certs/client.crt","insecure_skip_verify":true,"key_file":"/etc/prometheus/etcd-certs/client.key"}}
     - {"honor_labels":true,"job_name":"kube-state-metrics","kubernetes_sd_configs":[{"api_server":null,"namespaces":{"names":["default"]},"role":"endpoints"}],"metric_relabel_configs":[{"action":"drop","regex":".*prow-(e2e|kubermatic)-.*","source_labels":["namespace"]},{"action":"replace","regex":"cluster-([a-z0-9]+)","replacement":"$1","source_labels":["namespace"],"target_label":"cluster"}],"metrics_path":"/metrics","relabel_configs":[{"action":"keep","regex":"kube-state-metrics","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_label_app_kubernetes_io_name"]},{"action":"keep","regex":"http-metrics","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_endpoint_port_name"]},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_namespace"],"target_label":"namespace"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_pod_name"],"target_label":"pod"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"service"},{"action":"replace","regex":"(.*)","replacement":"${1}","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"job"},{"action":"replace","regex":"(.+)","replacement":"${1}","separator":";","source_labels":["__meta_kubernetes_service_label_app_kubernetes_io_name"],"target_label":"job"},{"action":"replace","regex":"(.*)","replacement":"http-metrics","separator":";","target_label":"endpoint"}],"scrape_interval":"1m","scrape_timeout":"30s"}
     - {"bearer_token_file":"/var/run/secrets/kubernetes.io/serviceaccount/token","job_name":"kubelet","kubernetes_sd_configs":[{"role":"node"}],"relabel_configs":[{"action":"labelmap","regex":"__meta_kubernetes_node_label_(.+)"},{"replacement":"kubernetes.default.svc:443","target_label":"__address__"},{"regex":"(.+)","replacement":"/api/v1/nodes/${1}/proxy/metrics","source_labels":["__meta_kubernetes_node_name"],"target_label":"__metrics_path__"}],"scheme":"https","tls_config":{"ca_file":"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}}
     - {"job_name":"minio-job"}
@@ -229,6 +252,119 @@ data:
               severity: critical
               resource: "{{ $labels.name }}"
               service: cert-manager
+    
+  general-etcd.yaml: |
+    # This file has been generated, DO NOT EDIT.
+    
+    # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    groups:
+      - name: etcd
+        rules:
+          - alert: EtcdInsufficientMembers
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+            expr: |
+              sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+            for: 15m
+            labels:
+              severity: critical
+          - alert: EtcdNoLeader
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+            expr: |
+              etcd_server_has_leader{job="etcd"} == 0
+            for: 15m
+            labels:
+              severity: critical
+          - alert: EtcdHighNumberOfLeaderChanges
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+            expr: |
+              rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+            for: 15m
+            labels:
+              severity: warning
+          - alert: EtcdGRPCRequestsSlow
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+              > 0.15
+            for: 10m
+            labels:
+              severity: critical
+          - alert: EtcdMemberCommunicationSlow
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+              > 0.15
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdHighNumberOfFailedProposals
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+            expr: |
+              rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+            for: 15m
+            labels:
+              severity: warning
+          - alert: EtcdHighFsyncDurations
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+              > 0.5
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdHighCommitDurations
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+              > 0.25
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdDatabaseQuotaLowSpace
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+            expr: |
+              (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+            for: 10m
+            labels:
+              severity: critical
+          - alert: EtcdExcessiveDatabaseGrowth
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+            expr: |
+              predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdDatabaseHighFragmentationRatio
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+            expr: |
+              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
+            for: 10m
+            labels:
+              severity: warning
     
   general-helm-exporter.yaml: |
     # This file has been generated, DO NOT EDIT.
@@ -2166,6 +2302,9 @@ spec:
           mountPath: /var/prometheus/data
           readOnly: false
           subPath: prometheus-db
+        - name: etcd-certs
+          mountPath: /etc/prometheus/etcd-certs/
+          readOnly: false
 
       - name: reloader
         image: 'ghcr.io/jimmidyson/configmap-reload:v0.12.0'
@@ -2224,6 +2363,9 @@ spec:
       - name: rules
         configMap:
           name: 'release-name-rules'
+      - name: etcd-certs
+        secret:
+          secretName: 'release-name-etcd-certs'
       - name: backup
         emptyDir: {}
       nodeSelector:

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -86,6 +86,7 @@ data:
     - {"job_name":"blackbox-exporter-user-cluster-apiservers"}
     - {"bearer_token_file":"/var/run/secrets/kubernetes.io/serviceaccount/token","job_name":"cadvisor","kubernetes_sd_configs":[{"role":"node"}],"relabel_configs":[{"action":"labelmap","regex":"__meta_kubernetes_node_label_(.+)"},{"replacement":"kubernetes.default.svc:443","target_label":"__address__"},{"regex":"(.+)","replacement":"/api/v1/nodes/${1}/proxy/metrics/cadvisor","source_labels":["__meta_kubernetes_node_name"],"target_label":"__metrics_path__"}],"scheme":"https","tls_config":{"ca_file":"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}}
     - {"honor_labels":true,"job_name":"clusters","kubernetes_sd_configs":[{"role":"endpoints"}],"metrics_path":"/federate","params":{"match[]":["{kubermatic=\"federate\"}"]},"relabel_configs":[{"action":"keep","regex":"user","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_label_cluster"]},{"action":"keep","regex":"web","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_endpoint_port_name"]},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_namespace"],"target_label":"namespace"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_pod_name"],"target_label":"pod"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"service"},{"action":"replace","regex":"(.*)","replacement":"web","separator":";","target_label":"endpoint"}],"scheme":"http"}
+    - {"job_name":"etcd"}
     - {"honor_labels":true,"job_name":"kube-state-metrics","kubernetes_sd_configs":[{"api_server":null,"namespaces":{"names":["default"]},"role":"endpoints"}],"metric_relabel_configs":[{"action":"drop","regex":".*prow-(e2e|kubermatic)-.*","source_labels":["namespace"]},{"action":"replace","regex":"cluster-([a-z0-9]+)","replacement":"$1","source_labels":["namespace"],"target_label":"cluster"}],"metrics_path":"/metrics","relabel_configs":[{"action":"keep","regex":"kube-state-metrics","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_label_app_kubernetes_io_name"]},{"action":"keep","regex":"http-metrics","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_endpoint_port_name"]},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_namespace"],"target_label":"namespace"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_pod_name"],"target_label":"pod"},{"action":"replace","regex":"(.*)","replacement":"$1","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"service"},{"action":"replace","regex":"(.*)","replacement":"${1}","separator":";","source_labels":["__meta_kubernetes_service_name"],"target_label":"job"},{"action":"replace","regex":"(.+)","replacement":"${1}","separator":";","source_labels":["__meta_kubernetes_service_label_app_kubernetes_io_name"],"target_label":"job"},{"action":"replace","regex":"(.*)","replacement":"http-metrics","separator":";","target_label":"endpoint"}],"scrape_interval":"1m","scrape_timeout":"30s"}
     - {"bearer_token_file":"/var/run/secrets/kubernetes.io/serviceaccount/token","job_name":"kubelet","kubernetes_sd_configs":[{"role":"node"}],"relabel_configs":[{"action":"labelmap","regex":"__meta_kubernetes_node_label_(.+)"},{"replacement":"kubernetes.default.svc:443","target_label":"__address__"},{"regex":"(.+)","replacement":"/api/v1/nodes/${1}/proxy/metrics","source_labels":["__meta_kubernetes_node_name"],"target_label":"__metrics_path__"}],"scheme":"https","tls_config":{"ca_file":"/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"}}
     - {"job_name":"minio-job"}
@@ -229,6 +230,119 @@ data:
               severity: critical
               resource: "{{ $labels.name }}"
               service: cert-manager
+    
+  general-etcd.yaml: |
+    # This file has been generated, DO NOT EDIT.
+    
+    # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    groups:
+      - name: etcd
+        rules:
+          - alert: EtcdInsufficientMembers
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).'
+            expr: |
+              sum(up{job="etcd"} == bool 1) by (job) < ((count(up{job="etcd"}) by (job) + 1) / 2)
+            for: 15m
+            labels:
+              severity: critical
+          - alert: EtcdNoLeader
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.'
+            expr: |
+              etcd_server_has_leader{job="etcd"} == 0
+            for: 15m
+            labels:
+              severity: critical
+          - alert: EtcdHighNumberOfLeaderChanges
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour.'
+            expr: |
+              rate(etcd_server_leader_changes_seen_total{job="etcd"}[15m]) > 3
+            for: 15m
+            labels:
+              severity: warning
+          - alert: EtcdGRPCRequestsSlow
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job="etcd", grpc_type="unary"}[5m])) by (job, instance, grpc_service, grpc_method, le))
+              > 0.15
+            for: 10m
+            labels:
+              severity: critical
+          - alert: EtcdMemberCommunicationSlow
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="etcd"}[5m]))
+              > 0.15
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdHighNumberOfFailedProposals
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last hour on etcd instance {{ $labels.instance }}.'
+            expr: |
+              rate(etcd_server_proposals_failed_total{job="etcd"}[15m]) > 5
+            for: 15m
+            labels:
+              severity: warning
+          - alert: EtcdHighFsyncDurations
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))
+              > 0.5
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdHighCommitDurations
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.'
+            expr: |
+              histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))
+              > 0.25
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdDatabaseQuotaLowSpace
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+            expr: |
+              (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+            for: 10m
+            labels:
+              severity: critical
+          - alert: EtcdExcessiveDatabaseGrowth
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+            expr: |
+              predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+            for: 10m
+            labels:
+              severity: warning
+          - alert: EtcdDatabaseHighFragmentationRatio
+            annotations:
+              message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+            expr: |
+              (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5 and etcd_mvcc_db_total_size_in_use_in_bytes > 104857600
+            for: 10m
+            labels:
+              severity: warning
     
   general-helm-exporter.yaml: |
     # This file has been generated, DO NOT EDIT.
@@ -2249,3 +2363,18 @@ spec:
         requests:
           storage: 100Gi
       storageClassName: kubermatic-fast
+---
+# Source: prometheus/templates/etcd-secret.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -80,7 +80,11 @@ prometheus:
       # Change values if minio running in different namespace and having different label. default is is set to minio.
       #namespace: minio
       #appLabel: minio
-
+    # Master/seed etcd metrics scraping can be enabled by providing the etcd client cert & key, this is required for prometheus to scrape metrics using TLS.
+    etcd:
+      tls:
+        crt: ''
+        key: ''
   # Similarly to the scraping config, you can configure the
   # target alertmanagers here.
   alerting:

--- a/charts/values.example.ce.yaml
+++ b/charts/values.example.ce.yaml
@@ -81,3 +81,14 @@ telemetry:
   # This field is required and will print an error message when that entry is missing.
   # You can generate uuid using command `uuidgen` on your linux machine
   uuid: ""
+prometheus:
+  scraping:
+    # Master/seed etcd metrics scraping can be enabled by providing the etcd client cert & key, this is required for prometheus to scrape metrics using TLS.
+    etcd:
+      tls:
+        crt: |
+          -----BEGIN CERTIFICATE-----
+          -----END CERTIFICATE-----
+        key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          -----END RSA PRIVATE KEY-----


### PR DESCRIPTION


**What this PR does / why we need it**:
Provide an option to configure scraping for master/seed etcd metrics, add etcd alert rules & add grafana dashboard for master/seed etcd. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14019

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
The existing etcd grafana dashboards have been renamed to differentiate between the master/seed & user cluster etcd dashboards. Below are the snaps of current and  suggested etcd dashboards name.

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/7fc479dc-cccd-499d-b15c-d50c57e73531" />
<img width="1050" alt="image" src="https://github.com/user-attachments/assets/69bea736-4a8e-49c2-ba6c-074950a8d47a" />



**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Option to configure prometheus to scrape metrics of master/seed etcd.
 Etcd grafana dashboards have been renamed, 'etcd Cluster Overview' --> 'Etcd', 'etcd' --> 'Etcd (User Cluster)', 'etcd Objects --> 'Etcd Objects'
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
