### PR TITLE
fix vsphere credential separation

### DIFF
--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -411,46 +411,18 @@ func createOrUpdateKubevirtSecret(ctx context.Context, seedClient ctrlruntimecli
 
 func createVSphereSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) (bool, error) {
 	spec := cluster.Spec.Cloud.VSphere
-	// for existing clusters we need to fetch existing credential data to set infra user and password if empty
-	// this is caused by a bug fix related to credential separation
-	// see https://github.com/kubermatic/kubermatic/issues/13534 and https://github.com/kubermatic/kubermatic/issues/13995
-	// for further information
-	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, seedClient)
 
-	if val, _ := secretKeySelector(spec.CredentialsReference, resources.VsphereInfraManagementUserUsername); val == "" {
-		if val, _ := secretKeySelector(spec.CredentialsReference, resources.VsphereUsername); val != "" {
-			spec.Username = val
-		}
-	}
-
-	if val, _ := secretKeySelector(spec.CredentialsReference, resources.VsphereInfraManagementUserPassword); val == "" {
-		if val, _ := secretKeySelector(spec.CredentialsReference, resources.VspherePassword); val != "" {
-			spec.Password = val
-		}
-	}
 	// already migrated
 	if spec.Username == "" && spec.Password == "" && spec.InfraManagementUser.Username == "" && spec.InfraManagementUser.Password == "" {
 		return false, nil
-	}
-
-	// if credentials for infrastructure management are set explicit we need to overwrite username and password with these
-	// to mount them properly to machine-controller and osm
-	vsphereInfraUser := spec.Username
-	if spec.InfraManagementUser.Username != "" {
-		vsphereInfraUser = spec.InfraManagementUser.Username
-	}
-
-	vsphereInfraPassword := spec.Password
-	if spec.InfraManagementUser.Password != "" {
-		vsphereInfraPassword = spec.InfraManagementUser.Password
 	}
 
 	// move credentials into dedicated Secret
 	credentialRef, err := ensureCredentialSecret(ctx, seedClient, cluster, map[string][]byte{
 		resources.VsphereUsername:                    []byte(spec.Username),
 		resources.VspherePassword:                    []byte(spec.Password),
-		resources.VsphereInfraManagementUserUsername: []byte(vsphereInfraUser),
-		resources.VsphereInfraManagementUserPassword: []byte(vsphereInfraPassword),
+		resources.VsphereInfraManagementUserUsername: []byte(spec.InfraManagementUser.Username),
+		resources.VsphereInfraManagementUserPassword: []byte(spec.InfraManagementUser.Password),
 	})
 	if err != nil {
 		return false, err

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -417,10 +417,22 @@ func createVSphereSecret(ctx context.Context, seedClient ctrlruntimeclient.Clien
 		return false, nil
 	}
 
+	// if credentials for infrastructure management are set explicit we need to overwrite username and password with these
+	// to mount them properly to machine-controller and osm
+	vsphereUser := spec.Username
+	if spec.InfraManagementUser.Username != "" {
+		vsphereUser = spec.InfraManagementUser.Username
+	}
+
+	vspherePassword := spec.Password
+	if spec.InfraManagementUser.Password != "" {
+		vspherePassword = spec.InfraManagementUser.Password
+	}
+
 	// move credentials into dedicated Secret
 	credentialRef, err := ensureCredentialSecret(ctx, seedClient, cluster, map[string][]byte{
-		resources.VsphereUsername:                    []byte(spec.Username),
-		resources.VspherePassword:                    []byte(spec.Password),
+		resources.VsphereUsername:                    []byte(vsphereUser),
+		resources.VspherePassword:                    []byte(vspherePassword),
 		resources.VsphereInfraManagementUserUsername: []byte(spec.InfraManagementUser.Username),
 		resources.VsphereInfraManagementUserPassword: []byte(spec.InfraManagementUser.Password),
 	})

--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -699,38 +699,40 @@ func GetVSphereCredentials(data CredentialsData) (VSphereCredentials, error) {
 	var username, password string
 	var err error
 
-	if spec.InfraManagementUser.Username != "" {
-		username = spec.InfraManagementUser.Username
+	if spec.Username != "" {
+		username = spec.Username
 	} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereInfraManagementUserUsername)
+		username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereUsername)
 		if err != nil {
 			return VSphereCredentials{}, err
 		}
 	}
+
 	if username == "" {
-		if spec.Username != "" {
-			username = spec.Username
+		if spec.InfraManagementUser.Username != "" {
+			username = spec.InfraManagementUser.Username
 		} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-			username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereUsername)
+			username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereInfraManagementUserUsername)
 			if err != nil {
 				return VSphereCredentials{}, err
 			}
 		}
 	}
 
-	if spec.InfraManagementUser.Password != "" {
-		password = spec.InfraManagementUser.Password
+	if spec.Password != "" {
+		password = spec.Password
 	} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereInfraManagementUserPassword)
+		password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VspherePassword)
 		if err != nil {
 			return VSphereCredentials{}, err
 		}
 	}
+
 	if password == "" {
-		if spec.Password != "" {
-			password = spec.Password
+		if spec.InfraManagementUser.Password != "" {
+			password = spec.InfraManagementUser.Password
 		} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-			password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VspherePassword)
+			password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereInfraManagementUserPassword)
 			if err != nil {
 				return VSphereCredentials{}, err
 			}

--- a/pkg/resources/credentials_test.go
+++ b/pkg/resources/credentials_test.go
@@ -177,7 +177,7 @@ func TestGetVsphereCredentials(t *testing.T) {
 			name:    "valid spec with values - auth with infraManagementUser",
 			spec:    &kubermaticv1.VSphereCloudSpec{Username: "user", Password: "pass", InfraManagementUser: kubermaticv1.VSphereCredentials{Username: "infraUser", Password: "infraPass"}},
 			mock:    test.ShouldNotBeCalled,
-			want:    VSphereCredentials{Username: "infraUser", Password: "infraPass"},
+			want:    VSphereCredentials{Username: "user", Password: "pass"},
 			wantErr: false,
 		},
 		{
@@ -209,7 +209,7 @@ func TestGetVsphereCredentials(t *testing.T) {
 				},
 			},
 			mock:    test.DefaultOrOverride(map[string]interface{}{VsphereUsername: "user", VspherePassword: "pass", VsphereInfraManagementUserUsername: "infraUser", VsphereInfraManagementUserPassword: "infraPass"}),
-			want:    VSphereCredentials{Username: "infraUser", Password: "infraPass"},
+			want:    VSphereCredentials{Username: "user", Password: "pass"},
 			wantErr: false,
 		},
 	}

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -802,8 +802,8 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 	}
 	if cluster.Spec.Cloud.VSphere != nil {
 		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: dc.Spec.VSphere.Endpoint})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", ValueFrom: refTo(VsphereUsername)})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", ValueFrom: refTo(VspherePassword)})
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", ValueFrom: refTo(VsphereInfraManagementUserUsername)})
+		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", ValueFrom: refTo(VsphereInfraManagementUserPassword)})
 	}
 	if cluster.Spec.Cloud.Baremetal != nil {
 		if cluster.Spec.Cloud.Baremetal.Tinkerbell != nil {

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -801,9 +801,20 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "DO_TOKEN", ValueFrom: refTo(DigitaloceanToken)})
 	}
 	if cluster.Spec.Cloud.VSphere != nil {
+		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(data.ctx, data.client)
+		spec := cluster.Spec.Cloud.VSphere
 		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: dc.Spec.VSphere.Endpoint})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", ValueFrom: refTo(VsphereInfraManagementUserUsername)})
-		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", ValueFrom: refTo(VsphereInfraManagementUserPassword)})
+		if val, _ := secretKeySelector(spec.CredentialsReference, VsphereInfraManagementUserUsername); val != "" {
+			vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", ValueFrom: refTo(VsphereInfraManagementUserUsername)})
+		} else {
+			vars = append(vars, corev1.EnvVar{Name: "VSPHERE_USERNAME", ValueFrom: refTo(VsphereUsername)})
+		}
+
+		if val, _ := secretKeySelector(spec.CredentialsReference, VsphereInfraManagementUserPassword); val != "" {
+			vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", ValueFrom: refTo(VsphereInfraManagementUserPassword)})
+		} else {
+			vars = append(vars, corev1.EnvVar{Name: "VSPHERE_PASSWORD", ValueFrom: refTo(VspherePassword)})
+		}
 	}
 	if cluster.Spec.Cloud.Baremetal != nil {
 		if cluster.Spec.Cloud.Baremetal.Tinkerbell != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request correct the handling of given vsphere credentials. Until now the infra credentials always overide other credentials for all purposes including cloud config for ccm and csi plugin. With these changes the infra user will only be used for the machine controller if specified and user credentials for cloud configs. When no infra credentials given the user credentials will be used for everything.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13534 and #13995

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[Breaking Changes] Vsphere credentials are now handled properly. For existing usercluster this will change the credentials in machine-controller and osm to `infraManagementUser` and  `infraManagementPassword` instead of `username` and `password` when specified. The latter one was always mounted to the before mentioned deployments in the past.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
