### PR TITLE
Replace `golang.org/x/exp/maps` with stdlib `maps`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	go.etcd.io/etcd/etcdutl/v3 v3.5.13
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.31.0
-	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0
 	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sys v0.28.0
 	golang.org/x/tools v0.25.0
@@ -471,6 +470,7 @@ require (
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
+	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -18,9 +18,8 @@ package cilium
 
 import (
 	"fmt"
+	"maps"
 	"strings"
-
-	"golang.org/x/exp/maps"
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"


### PR DESCRIPTION


**What this PR does / why we need it**:

The experimental functions in `golang.org/x/exp/maps` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#maps

**Which issue(s) this PR fixes**:

**What type of PR is this?**

/kind cleanup

**Special notes for your reviewer**:

3 lines are affected only:

https://github.com/kubermatic/kubermatic/blob/c1a031f78faae975f461b54df6a7d6dbc814aa6e/pkg/cni/cilium/cilium.go#L340-L341

https://github.com/kubermatic/kubermatic/blob/c1a031f78faae975f461b54df6a7d6dbc814aa6e/pkg/cni/cilium/cilium.go#L408

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
