### PR TITLE
add condition to wait on nodes to schedule app workloads

### DIFF
--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -330,9 +330,9 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 			}
 			app.Spec.DeployOptions = &appskubermaticv1.DeployOptions{
 				Helm: &appskubermaticv1.HelmDeployOptions{
-					// Use non-atomic deployment, as atomic (with fixed retries count) potentially brings more issues
-					// than benefit for CNI, e.g. during the cluster bring-up when the worker nodes join cluster too late.
-					Atomic: false,
+					// Use atomic deployment, as atomic (with fixed retries count) migitates breaking the etcd due to creating events
+					// when retrying on failure without a limit
+					Atomic: true,
 					Wait:   true,
 					Timeout: metav1.Duration{
 						Duration: 10 * time.Minute, // use longer timeout, as it may take some time for the CNI to be fully up

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -18,7 +18,6 @@ package applicationinstallationcontroller
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -156,7 +155,8 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, appI
 		return fmt.Errorf("failed to check if nodes are available: %w", err)
 	}
 	if !nodesAvailable {
-		return errors.New("waiting for nodes to be joined to be able to schedule workloads")
+		r.log.Debug("waiting for nodes to be joined to be able to schedule workloads")
+		return nil
 	}
 
 	appHasBeenInstalled := appInstallation.Status.ApplicationVersion != nil

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -389,6 +389,14 @@ func genApplicationInstallation(name string, appNamespace *appskubermaticv1.AppN
 	}
 }
 
+func genNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
 func TestHasLimitedRetries(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/pkg/controller/util/util.go
+++ b/pkg/controller/util/util.go
@@ -244,3 +244,15 @@ func IsCNIApplicationReady(ctx context.Context, userClusterClient ctrlruntimecli
 	// Check if the application is deployed and status is updated with app version.
 	return cniApp != nil && cniApp.Status.ApplicationVersion != nil, nil
 }
+
+// NodesAvailable checks if any node object is already created.
+func NodesAvailable(ctx context.Context, userClusterClient ctrlruntimeclient.Client) (bool, error) {
+	nodeList := &corev1.NodeList{}
+	if err := userClusterClient.List(ctx, nodeList, &ctrlruntimeclient.ListOptions{}); err != nil {
+		return false, err
+	}
+	if len(nodeList.Items) < 1 {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr migitate problems observed in #13933. With these changes helm releases managed by applicaton installation resources will first be deployed to clusters when at least one node object is registered. Therefore we can enable atomic release flag for cilium cni app without having concerns because initial nodes are taking too much time. This is required to limit the retries on failure to not break the cluster etcd which can happen without a limitation on retry.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Helm releases managed by application installation resources are first deployed when there is at least one node registered to the user cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
