### PR TITLE
Add VolumeProvisioner Field to KubeVirtCloudSpec in the Seed

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -215,6 +215,13 @@ spec:
               # VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
               # VolumeBindingImmediate is used.
               volumeBindingMode: null
+              # VolumeProvisioner The **Provider** field specifies whether a storage class will be utilized by the Containerized
+              # Data Importer (CDI) to create VM disk images and/or by the KubeVirt CSI Driver to provision volumes in the
+              # infrastructure cluster. If no storage class in the seed object has this value set, the storage class will be used
+              # for both purposes: CDI will create VM disk images, and the CSI driver will provision and attach volumes in the user
+              # cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
+              # image creation.
+              volumeProvisioner: ""
               # Zones represent a logical failure domain. It is common for Kubernetes clusters to span multiple zones
               # for increased availability
               zones: null

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -215,6 +215,12 @@ spec:
               # Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
               # to span multiple regions
               regions: null
+              # VolumeProvisioner indicates whether this storage class will be used by the Containerized Data Importer to create the
+              # VM disk image and/or will be used by the KubeVirt CSI Driver to create volumes in the infra cluster. If this value
+              # isn't set for any storage class in the seed object, that storage class will be used by both, CDI to create disk
+              # images for the VMs or the CSI driver to create and attach volumes. If the value is set to csi-storage-target, the
+              # storage class cannot be used as a vm disk image by CDI.
+              volumeProvisioner: ""
               # VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
               # VolumeBindingImmediate is used.
               volumeBindingMode: null

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -215,15 +215,16 @@ spec:
               # Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
               # to span multiple regions
               regions: null
-              # VolumeProvisioner indicates whether this storage class will be used by the Containerized Data Importer to create the
-              # VM disk image and/or will be used by the KubeVirt CSI Driver to create volumes in the infra cluster. If this value
-              # isn't set for any storage class in the seed object, that storage class will be used by both, CDI to create disk
-              # images for the VMs or the CSI driver to create and attach volumes. If the value is set to csi-storage-target, the
-              # storage class cannot be used as a vm disk image by CDI.
-              volumeProvisioner: ""
               # VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
               # VolumeBindingImmediate is used.
               volumeBindingMode: null
+              # VolumeProvisioner The **Provider** field specifies whether a storage class will be utilized by the Containerized
+              # Data Importer (CDI) to create VM disk images and/or by the KubeVirt CSI Driver to provision volumes in the
+              # infrastructure cluster. If no storage class in the seed object has this value set, the storage class will be used
+              # for both purposes: CDI will create VM disk images, and the CSI driver will provision and attach volumes in the user
+              # cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
+              # image creation.
+              volumeProvisioner: ""
               # Zones represent a logical failure domain. It is common for Kubernetes clusters to span multiple zones
               # for increased availability
               zones: null

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -895,6 +895,13 @@ type KubeVirtInfraStorageClass struct {
 	// Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
 	// to span multiple regions
 	Regions []string `json:"regions,omitempty"`
+	// VolumeProvisioner The **Provider** field specifies whether a storage class will be utilized by the Containerized
+	// Data Importer (CDI) to create VM disk images and/or by the KubeVirt CSI Driver to provision volumes in the
+	// infrastructure cluster. If no storage class in the seed object has this value set, the storage class will be used
+	// for both purposes: CDI will create VM disk images, and the CSI driver will provision and attach volumes in the user
+	// cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
+	// image creation.
+	VolumeProvisioner KubeVirtVolumeProvisioner `json:"volumeProvisioner,omitempty"`
 }
 
 // CustomNetworkPolicy contains a name and the Spec of a NetworkPolicy.
@@ -912,6 +919,15 @@ var (
 		providerconfig.OperatingSystemFlatcar:    nil,
 		providerconfig.OperatingSystemRockyLinux: nil,
 	}
+)
+
+// KubeVirtVolumeProvisioner represents what is the provisioner of the storage class volume, whether it will be the csi driver
+// and/or CDI for disk images.
+type KubeVirtVolumeProvisioner string
+
+const (
+	// KubeVirtCSIDriver indicates that the volume of a storage class will be provisioned by the KubeVirt CSI driver.
+	KubeVirtCSIDriver KubeVirtVolumeProvisioner = "kubevirt-csi-driver"
 )
 
 // KubeVirtImageSources represents KubeVirt image sources.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1009,6 +1009,15 @@ spec:
                                   VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
                                   VolumeBindingImmediate is used.
                                 type: string
+                              volumeProvisioner:
+                                description: |-
+                                  VolumeProvisioner The **Provider** field specifies whether a storage class will be utilized by the Containerized
+                                  Data Importer (CDI) to create VM disk images and/or by the KubeVirt CSI Driver to provision volumes in the
+                                  infrastructure cluster. If no storage class in the seed object has this value set, the storage class will be used
+                                  for both purposes: CDI will create VM disk images, and the CSI driver will provision and attach volumes in the user
+                                  cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
+                                  image creation.
+                                type: string
                               zones:
                                 description: |-
                                   Zones represent a logical failure domain. It is common for Kubernetes clusters to span multiple zones

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1003,6 +1003,15 @@ spec:
                                   VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
                                   VolumeBindingImmediate is used.
                                 type: string
+                              volumeProvisioner:
+                                description: |-
+                                  VolumeProvisioner The **Provider** field specifies whether a storage class will be utilized by the Containerized
+                                  Data Importer (CDI) to create VM disk images and/or by the KubeVirt CSI Driver to provision volumes in the
+                                  infrastructure cluster. If no storage class in the seed object has this value set, the storage class will be used
+                                  for both purposes: CDI will create VM disk images, and the CSI driver will provision and attach volumes in the user
+                                  cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
+                                  image creation.
+                                type: string
                               zones:
                                 description: |-
                                   Zones represent a logical failure domain. It is common for Kubernetes clusters to span multiple zones

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1008,6 +1008,15 @@ spec:
                                         VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
                                         VolumeBindingImmediate is used.
                                       type: string
+                                    volumeProvisioner:
+                                      description: |-
+                                        VolumeProvisioner The **Provider** field specifies whether a storage class will be utilized by the Containerized
+                                        Data Importer (CDI) to create VM disk images and/or by the KubeVirt CSI Driver to provision volumes in the
+                                        infrastructure cluster. If no storage class in the seed object has this value set, the storage class will be used
+                                        for both purposes: CDI will create VM disk images, and the CSI driver will provision and attach volumes in the user
+                                        cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
+                                        image creation.
+                                      type: string
                                     zones:
                                       description: |-
                                         Zones represent a logical failure domain. It is common for Kubernetes clusters to span multiple zones


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new field for the KubeVirt InfraStorageClasses which is `VolumeProvisioner`. This field makes sure that, if a storga class will be used by either CDI or/and the CSI Driver. If the VolumeProvisioner is not set, then the Storage Class will be used by both the CDI to create and attach the VM disk images and it will be used by the CSI Driver in the user cluster to create volumes in the user clusters. However if the field is set to KubeVirtCSIDriver, then the storage class will only be used in the user cluster to provision volumes for the workload. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VolumeProvisioner field in the InfraStorageClasses for the KubeVirt provider in the seed, to indicate whether the storage class can be used by the CSI or the CDI
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
