### PR TITLE
Provide k8sgpt-operator instead of k8sgpt app

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-app.yaml
@@ -21,26 +21,19 @@
 apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
-  name: k8sgpt
+  name: k8sgpt-operator
 spec:
-  description: K8sGPT is a tool for scanning your Kubernetes clusters, diagnosing and triaging issues in simple English.
-  displayName: K8sGPT
+  description: K8sGPT Operator is designed to enable K8sGPT within a Kubernetes cluster. It will allow you to create a custom resource that defines the behaviour and scope of a managed K8sGPT workload.
+  displayName: K8sGPT Operator
   method: helm
   versions:
     - template:
         source:
           helm:
             chartName: k8sgpt-operator
-            chartVersion: 0.1.0
+            chartVersion: 0.2.6
             url: https://charts.k8sgpt.ai/
-      version: v0.3.26
-    - template:
-        source:
-          helm:
-            chartName: k8sgpt-operator
-            chartVersion: 0.1.0
-            url: https://charts.k8sgpt.ai/
-      version: v0.3.48
+      version: 0.0.26
   defaultValuesBlock: |
     serviceMonitor:
       enabled: false
@@ -57,8 +50,8 @@ spec:
       label:
         key: grafana_dashboard
         value: "1"
-  documentationURL: https://docs.k8sgpt.ai/
-  sourceURL: https://github.com/k8sgpt-ai/k8sgpt
+  documentationURL: https://docs.k8sgpt.ai/getting-started/in-cluster-operator/
+  sourceURL: https://github.com/k8sgpt-ai/k8sgpt-operator
   logo: |+
     iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAAXNSR0IArs4c6QAAAARnQU1BAACx
     jwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAABVuSURBVGhD5Vr5b1zXdf7e/maf4XBfREkWSUmU

--- a/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-operator-app.yaml
@@ -21,26 +21,19 @@
 apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
-  name: k8sgpt
+  name: k8sgpt-operator
 spec:
-  description: (Deprecated in favor of k8sgpt-operator application and will be removed in future KKP release) K8sGPT is a tool for scanning your Kubernetes clusters, diagnosing and triaging issues in simple English.
-  displayName: K8sGPT
+  description: K8sGPT Operator is designed to enable K8sGPT within a Kubernetes cluster. It will allow you to create a custom resource that defines the behaviour and scope of a managed K8sGPT workload.
+  displayName: K8sGPT Operator
   method: helm
   versions:
     - template:
         source:
           helm:
             chartName: k8sgpt-operator
-            chartVersion: 0.1.0
+            chartVersion: 0.2.6
             url: https://charts.k8sgpt.ai/
-      version: v0.3.26
-    - template:
-        source:
-          helm:
-            chartName: k8sgpt-operator
-            chartVersion: 0.1.0
-            url: https://charts.k8sgpt.ai/
-      version: v0.3.48
+      version: 0.0.26
   defaultValuesBlock: |
     serviceMonitor:
       enabled: false
@@ -57,8 +50,8 @@ spec:
       label:
         key: grafana_dashboard
         value: "1"
-  documentationURL: https://docs.k8sgpt.ai/
-  sourceURL: https://github.com/k8sgpt-ai/k8sgpt
+  documentationURL: https://docs.k8sgpt.ai/getting-started/in-cluster-operator/
+  sourceURL: https://github.com/k8sgpt-ai/k8sgpt-operator
   logo: |+
     iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAAXNSR0IArs4c6QAAAARnQU1BAACx
     jwv8YQUAAAAJcEhZcwAAFiUAABYlAUlSJPAAABVuSURBVGhD5Vr5b1zXdf7e/maf4XBfREkWSUmU

--- a/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-operator-app.yaml
@@ -1,6 +1,6 @@
 #                Kubermatic Enterprise Read-Only License
 #                       Version 1.0 ("KERO-1.0”)
-#                   Copyright © 2024 Kubermatic GmbH
+#                   Copyright © 2025 Kubermatic GmbH
 #
 # 1.	You may only view, read and display for studying purposes the source
 #    code of the software licensed under this license, and, to the extent


### PR DESCRIPTION
**What this PR does / why we need it**:
Added k8sgpt-operator app definition and deprecate k8sgpt app definition, as k8sgpt-operator is what we want to provide in the default app catalog. The helm chart for k8sgpt operator [here](https://github.com/k8sgpt-ai/k8sgpt-operator/blob/main/chart/operator/values.yaml).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14115

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
K8sgpt-operator has been introduced to replace the now deprecated k8sgpt(non-operator) application. K8sgpt application will be removed in the future releases.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
