### PR TITLE
change rbac to cluster scoped for autoscaler extra objects

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler.yaml
@@ -57,10 +57,9 @@ spec:
         automountServiceAccountToken: true
     extraObjects:
     - apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
+      kind: ClusterRole
       metadata:
         name: cluster-autoscaler-management
-        namespace: kube-system
       rules:
       - apiGroups:
         - cluster.k8s.io
@@ -75,15 +74,13 @@ spec:
         - update
         - watch
     - apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
+      kind: ClusterRoleBinding
       metadata:
         name: cluster-autoscaler-clusterapi-cluser-autoscaler
-        namespace: kube-system
       roleRef:
         apiGroup: rbac.authorization.k8s.io
-        kind: Role
+        kind: ClusterRole
         name: cluster-autoscaler-management
-        namespace: kube-system
       subjects:
       - kind: ServiceAccount
         name: cluster-autoscaler-clusterapi-cluster-autoscaler


### PR DESCRIPTION
**What this PR does / why we need it**:

Compared to the cluster autoscaler addon the authorization role `cluster-autoscaler-management` should be cluster-scoped. This pr change this for the application definition accordingly to the addon manifests.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
