### PR TITLE
remove ee-only part from default app install namespace description

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -381,7 +381,7 @@ spec:
       dockerTagSuffix: ""
     # APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
     apiserverReplicas: 2
-    # Applications contains configuration for default Application settings. This is an ee-only feature.
+    # Applications contains configuration for default Application settings.
     applications:
       # Namespace is the namespace which is set as the default for applications installed via ui
       # If left empty the default for the application installation namespace is the name of the resource itself

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -381,7 +381,7 @@ spec:
       dockerTagSuffix: ""
     # APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
     apiserverReplicas: 2
-    # Applications contains configuration for default Application settings. This is an ee-only feature.
+    # Applications contains configuration for default Application settings.
     applications:
       # Namespace is the namespace which is set as the default for applications installed via ui
       # If left empty the default for the application installation namespace is the name of the resource itself

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -261,7 +261,7 @@ type KubermaticUserClusterConfiguration struct {
 	Addons KubermaticAddonsConfiguration `json:"addons,omitempty"`
 	// SystemApplications contains configuration for system Applications (such as CNI).
 	SystemApplications SystemApplicationsConfiguration `json:"systemApplications,omitempty"`
-	// Applications contains configuration for default Application settings. This is an ee-only feature.
+	// Applications contains configuration for default Application settings.
 	Applications ApplicationsConfiguration `json:"applications,omitempty"`
 	// NodePortRange is the port range for user clusters - this must match the NodePort
 	// range of the seed cluster.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -2323,7 +2323,7 @@ spec:
                       format: int32
                       type: integer
                     applications:
-                      description: Applications contains configuration for default Application settings. This is an ee-only feature.
+                      description: Applications contains configuration for default Application settings.
                       properties:
                         namespace:
                           description: |-


### PR DESCRIPTION
**What this PR does / why we need it**:

In the description of the field `spec.userCluster.applications.namespace` in the kubermaticconfiguration is a hint that this is an enterprise only feature which is wrong. This pr removes that from the description.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
