### PR TITLE
[fix] Suppress consent screen in dex post iap chart upgrade in 2.26

### DIFF
--- a/charts/iap/templates/configmaps.yaml
+++ b/charts/iap/templates/configmaps.yaml
@@ -20,6 +20,9 @@ metadata:
   name: iap-{{ .name }}-configmap
 data:
   config.toml: |
+{{- if eq $.Values.iap.approval_prompt "none"}}
+    approval_prompt = "none"
+{{- end }}
 {{- with .config }}
 {{ toToml . | indent 4 }}
 {{ end }}

--- a/charts/iap/test/values.custom-approval-prompt-force.yaml
+++ b/charts/iap/test/values.custom-approval-prompt-force.yaml
@@ -1,0 +1,77 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iap:
+  approval_prompt: force
+  deployments:
+    alertmanager:
+      name: alertmanager
+      replicas: 3
+      client_id: alertmanager
+      client_secret: xxx
+      encryption_key: xxx
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## example configuration allowing access only to the mygroup from mygithuborg organization
+        github_org: mygithuborg
+        github_team: mygroup
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/-/healthy'
+      upstream_service: alertmanager.monitoring.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        ## optional name of an existing TLS secret that needs to attached with ingress for this iap deployment.
+        tlsSecretName: ""
+        host: "alertmanager.kubermatic.tld"
+        annotations: {}
+        ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+        class: "nginx"
+    #
+    grafana:
+      name: grafana
+      client_id: grafana
+      client_secret: xxx
+      encryption_key: xxx
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/api/health'
+        ## auto-register users based on their email address
+        ## Grafana is configured to look for the X-Forwarded-Email header
+        pass_user_headers: true
+      upstream_service: grafana.monitoring.svc.cluster.local
+      upstream_port: 3000
+      ingress:
+        host: "grafana.kubermatic.tld"
+        annotations: {}
+        ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+        class: "nginx"
+
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 25Mi
+    limits:
+      cpu: 100m
+      memory: 50Mi

--- a/charts/iap/test/values.custom-approval-prompt-force.yaml.out
+++ b/charts/iap/test/values.custom-approval-prompt-force.yaml.out
@@ -54,7 +54,6 @@ metadata:
   name: iap-alertmanager-configmap
 data:
   config.toml: |
-    approval_prompt = "none"
     email_domains = ["*"]
     github_org = "mygithuborg"
     github_team = "mygroup"
@@ -68,7 +67,6 @@ metadata:
   name: iap-grafana-configmap
 data:
   config.toml: |
-    approval_prompt = "none"
     email_domains = ["*"]
     pass_user_headers = true
     scope = "groups openid email"
@@ -134,7 +132,7 @@ spec:
         app: iap
         target: alertmanager
       annotations:
-        checksum/config: bfef6acd1069e36a2f1d4de5289a013d7ac9a961289aa780a3c1486bcfe75314
+        checksum/config: 17ed91a5ca15d5e382000192ade7030736b5f2037cc9fbe9020535cef3dbf750
         checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
     spec:
       containers:
@@ -235,7 +233,7 @@ spec:
         app: iap
         target: grafana
       annotations:
-        checksum/config: bfef6acd1069e36a2f1d4de5289a013d7ac9a961289aa780a3c1486bcfe75314
+        checksum/config: 17ed91a5ca15d5e382000192ade7030736b5f2037cc9fbe9020535cef3dbf750
         checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
     spec:
       containers:

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -30,6 +30,7 @@ metadata:
   name: iap-grafana-configmap
 data:
   config.toml: |
+    approval_prompt = "none"
     email_domains = ["*"]
     pass_user_headers = true
     scope = "groups openid email"
@@ -75,7 +76,7 @@ spec:
         app: iap
         target: grafana
       annotations:
-        checksum/config: 3eb19f22de67d07022b88471775d905239c8243cc606e074e23ed5ef0cf460e3
+        checksum/config: 55e92a9f9dd10b926515346f93654125cab26b0141c58802188dd70203431561
         checksum/secrets: a61bd91da5fb2369cbc0ba73e52178417ac106a21ef3621f1f212c7a49665749
     spec:
       containers:

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -33,6 +33,12 @@ iap:
   # to override this
   replicas: 2
 
+  # avoid consent screen shown by Dex for applications secured via IAP. e.g. prometheus, grafana, etc
+  # Below setting will affect all deployments controlled by seed and user-cluster MLA IAP.
+  # But the consent is mandatorily required to proceed and hence showing one extra screen for it just a nuisance.
+  # If you want the consent to be shown.. set approval_prompt: force as override.
+  approval_prompt: none
+
   deployments:
     # alertmanager:
     #   name: alertmanager


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to IAP chart upgrade as part of 2.26, we did not used to get any consent screen after dex login for IAP secured applications like prometheus. But new IAP release brought new defaults which meant, user must make additional click to accept the consent.

This PR restores older behavior - which is after providing credentials, users are taken directly to actual applications.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14086

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
