### PR TITLE
remove unnecessary mock objects from installer code

### DIFF
--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -59,7 +59,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
-	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
@@ -502,150 +501,49 @@ func getImagesFromPodSpec(spec corev1.PodSpec) (images []string) {
 
 func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle, seed *kubermaticv1.Seed) (*resources.TemplateData, error) {
 	// We need listers and a set of objects to not have our deployment/statefulset creators fail
-	caBundleConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.CABundleConfigMapName,
-			Namespace: mockNamespaceName,
+	mockObjects := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.ApiserverServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{NodePort: 99}},
+				ClusterIP: "192.0.2.10",
+			},
 		},
-	}
-	prometheusConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.PrometheusConfigConfigMapName,
-			Namespace: mockNamespaceName,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNServerServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{NodePort: 96}},
+				ClusterIP: "192.0.2.2",
+			},
 		},
-	}
-	dnsResolverConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.DNSResolverConfigMapName,
-			Namespace: mockNamespaceName,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.DNSResolverServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{NodePort: 98}},
+				ClusterIP: "192.0.2.11",
+			},
 		},
-	}
-	openvpnClientConfigsConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.OpenVPNClientConfigsConfigMapName,
-			Namespace: mockNamespaceName,
-		},
-	}
-	auditConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.AuditConfigMapName,
-			Namespace: mockNamespaceName,
-		},
-	}
-	admissionControlConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.AdmissionControlConfigMapName,
-			Namespace: mockNamespaceName,
-		},
-	}
-	konnectivityKubeApiserverEgressConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.KonnectivityKubeApiserverEgress,
-			Namespace: mockNamespaceName,
-		},
-	}
-	configMapList := &corev1.ConfigMapList{
-		Items: []corev1.ConfigMap{
-			caBundleConfigMap,
-			prometheusConfigMap,
-			dnsResolverConfigMap,
-			openvpnClientConfigsConfigMap,
-			auditConfigMap,
-			admissionControlConfigMap,
-			konnectivityKubeApiserverEgressConfigMap,
-		},
-	}
-	apiServerService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.ApiserverServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 99}},
-			ClusterIP: "192.0.2.10",
-		},
-	}
-	openvpnserverService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.OpenVPNServerServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 96}},
-			ClusterIP: "192.0.2.2",
-		},
-	}
-	dnsService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.DNSResolverServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 98}},
-			ClusterIP: "192.0.2.11",
-		},
-	}
-	konnectivityService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.KonnectivityProxyServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
-			ClusterIP: "192.0.2.20",
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityProxyServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
+				ClusterIP: "192.0.2.20",
+			},
 		},
 	}
 
-	serviceList := &corev1.ServiceList{
-		Items: []corev1.Service{
-			apiServerService,
-			openvpnserverService,
-			dnsService,
-			konnectivityService,
-		},
-	}
-	secretList := createNamedSecrets([]string{
-		resources.CloudConfigSeedSecretName,
-		resources.CASecretName,
-		resources.TokensSecretName,
-		resources.ApiserverTLSSecretName,
-		resources.KubeletClientCertificatesSecretName,
-		resources.ServiceAccountKeySecretName,
-		resources.ApiserverEtcdClientCertificateSecretName,
-		resources.ApiserverFrontProxyClientCertificateSecretName,
-		resources.EtcdTLSCertificateSecretName,
-		resources.MachineControllerKubeconfigSecretName,
-		resources.ControllerManagerKubeconfigSecretName,
-		resources.SchedulerKubeconfigSecretName,
-		resources.KubeStateMetricsKubeconfigSecretName,
-		resources.OpenVPNCASecretName,
-		resources.OpenVPNServerCertificatesSecretName,
-		resources.OpenVPNClientCertificatesSecretName,
-		resources.FrontProxyCASecretName,
-		resources.KubeletDnatControllerKubeconfigSecretName,
-		resources.PrometheusApiserverClientCertificateSecretName,
-		resources.MetricsServerKubeconfigSecretName,
-		resources.MachineControllerWebhookServingCertSecretName,
-		resources.InternalUserClusterAdminKubeconfigSecretName,
-		resources.KubernetesDashboardKubeconfigSecretName,
-		metricsserver.ServingCertSecretName,
-		resources.UserSSHKeys,
-		resources.AdminKubeconfigSecretName,
-		resources.GatekeeperWebhookServerCertSecretName,
-		resources.OperatingSystemManagerKubeconfigSecretName,
-		resources.KonnectivityKubeconfigSecretName,
-		resources.KonnectivityProxyTLSSecretName,
-		resources.OperatingSystemManagerWebhookKubeconfigSecretName,
-		resources.OperatingSystemManagerWebhookServingCertSecretName,
-		resources.KubeVirtCSISecretName,
-		resources.KubeVirtInfraSecretName,
-		resources.GoogleServiceAccountSecretName,
-		resources.VMwareCloudDirectorCSIKubeconfigSecretName,
-		resources.CSICloudConfigSecretName,
-		resources.VMwareCloudDirectorCSISecretName,
-		resources.KubeLBCCMKubeconfigSecretName,
-		resources.KubeLBManagerKubeconfigSecretName,
-	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{
 			Anexia:              &kubermaticv1.DatacenterSpecAnexia{},
@@ -658,12 +556,12 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 			VSphere:             &kubermaticv1.DatacenterSpecVSphere{},
 		},
 	}
-	objects := []runtime.Object{configMapList, secretList, serviceList}
 
 	clusterSemver, err := ksemver.NewSemver(clusterVersion.Version.String())
 	if err != nil {
 		return nil, err
 	}
+
 	fakeCluster := &kubermaticv1.Cluster{}
 	fakeCluster.Labels = map[string]string{kubermaticv1.ProjectIDLabelKey: "project"}
 	fakeCluster.Spec.Cloud = cloudSpec
@@ -681,8 +579,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		Enabled: true,
 	}
 
-	if fakeCluster.Spec.Cloud.Openstack != nil || fakeCluster.Spec.Cloud.Hetzner != nil || fakeCluster.Spec.Cloud.Azure != nil ||
-		fakeCluster.Spec.Cloud.VSphere != nil || fakeCluster.Spec.Cloud.Anexia != nil || fakeCluster.Spec.Cloud.Kubevirt != nil {
+	if cloudSpec.Openstack != nil || cloudSpec.Hetzner != nil || cloudSpec.Azure != nil || cloudSpec.VSphere != nil || cloudSpec.Anexia != nil || cloudSpec.Kubevirt != nil {
 		if fakeCluster.Spec.Features == nil {
 			fakeCluster.Spec.Features = make(map[string]bool)
 		}
@@ -700,7 +597,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	fakeCluster.Status.Versions.ControllerManager = *clusterSemver
 	fakeCluster.Status.Versions.Scheduler = *clusterSemver
 
-	fakeDynamicClient := fake.NewClientBuilder().WithRuntimeObjects(objects...).Build()
+	fakeDynamicClient := fake.NewClientBuilder().WithRuntimeObjects(mockObjects...).Build()
 
 	meteringConfig := &kubermaticv1.MeteringConfiguration{
 		RetentionDays:    defaulting.DefaultMeteringRetentionDays,
@@ -728,20 +625,6 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		WithCABundle(caBundle).
 		WithKonnectivityEnabled(konnectivityEnabled).
 		Build(), nil
-}
-
-func createNamedSecrets(secretNames []string) *corev1.SecretList {
-	secretList := corev1.SecretList{}
-	for _, secretName := range secretNames {
-		secret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: mockNamespaceName,
-			},
-		}
-		secretList.Items = append(secretList.Items, secret)
-	}
-	return &secretList
 }
 
 func GetVersions(log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, versionFilter string) ([]*version.Version, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since #13703, volume revision labels are no longer created by their respective reconciler funcs, but instead by the dedicated VolumeRevisionLabelModifier middleware. Since the reconcilers don't need access to the Secrets anymore, we can simply remove the setup code in the `images` command of the installer.

This became apparent when the #14068 backport failed because the fluentbit-audit secret was not being set by #14063.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
