### PR TITLE
Mirror system application helm chart images

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -21,11 +21,9 @@ docker:
 .PHONY: aws-node-termination-handler
 aws-node-termination-handler: OUTPUT_FILE=aws-node-termination-handler/aws-node-termination-handler.yaml
 aws-node-termination-handler:
-	helm repo add eks https://aws.github.io/eks-charts/ || true
-	helm repo update
 	cat aws-node-termination-handler/_header.txt > $(OUTPUT_FILE)
-	helm template aws-node-termination-handler eks/aws-node-termination-handler \
-	  --version 0.21.0 \
+	helm template aws-node-termination-handler oci://public.ecr.aws/aws-ec2/helm/aws-node-termination-handler \
+	  --version 0.26.0 \
 	  --namespace kube-system \
 	  --values values-aws-node-termination-handler.yaml \
 	  >> $(OUTPUT_FILE)

--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -26,10 +26,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.19.0"
+    app.kubernetes.io/version: "1.24.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.21.0
+    helm.sh/chart: aws-node-termination-handler-0.26.0
 ---
 # Source: aws-node-termination-handler/templates/clusterrole.yaml
 kind: ClusterRole
@@ -39,10 +39,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.19.0"
+    app.kubernetes.io/version: "1.24.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.21.0
+    helm.sh/chart: aws-node-termination-handler-0.26.0
 rules:
 - apiGroups:
     - ""
@@ -87,10 +87,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.19.0"
+    app.kubernetes.io/version: "1.24.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.21.0
+    helm.sh/chart: aws-node-termination-handler-0.26.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -109,10 +109,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.19.0"
+    app.kubernetes.io/version: "1.24.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.21.0
+    helm.sh/chart: aws-node-termination-handler-0.26.0
     app.kubernetes.io/component: daemonset
 spec:
   updateStrategy:
@@ -150,7 +150,7 @@ spec:
             runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
-          image: {{ Image "public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.19.0" }}
+          image: {{ Image "public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.24.0" }}
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME
@@ -202,6 +202,8 @@ spec:
             - name: EMIT_KUBERNETES_EVENTS
               value: "false"
             - name: ENABLE_SPOT_INTERRUPTION_DRAINING
+              value: "true"
+            - name: ENABLE_ASG_LIFECYCLE_DRAINING
               value: "true"
             - name: ENABLE_SCHEDULED_EVENT_DRAINING
               value: "true"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module k8c.io/kubermatic/v2
 
-go 1.22.8
+go 1.23.0
 
-toolchain go1.23.3
+toolchain go1.23.6
 
 require (
 	dario.cat/mergo v1.0.1
@@ -39,7 +39,7 @@ require (
 	github.com/go-git/go-git/v5 v5.13.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/go-test/deep v1.1.1
-	github.com/gobuffalo/flect v1.0.2
+	github.com/gobuffalo/flect v1.0.3
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.20.2
 	github.com/google/uuid v1.6.0
@@ -77,7 +77,7 @@ require (
 	golang.org/x/crypto v0.31.0
 	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sys v0.28.0
-	golang.org/x/tools v0.25.0
+	golang.org/x/tools v0.26.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	google.golang.org/api v0.197.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1
@@ -93,7 +93,7 @@ require (
 	k8c.io/operating-system-manager v1.6.1-0.20241118134103-5db575f65108
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.31.2
-	k8s.io/apiextensions-apiserver v0.31.1
+	k8s.io/apiextensions-apiserver v0.31.2
 	k8s.io/apimachinery v0.31.2
 	k8s.io/apiserver v0.31.2
 	k8s.io/autoscaler/vertical-pod-autoscaler v1.0.0
@@ -109,7 +109,7 @@ require (
 	kubevirt.io/api v1.3.1
 	kubevirt.io/containerized-data-importer-api v1.60.3
 	sigs.k8s.io/controller-runtime v0.19.0
-	sigs.k8s.io/controller-tools v0.16.1
+	sigs.k8s.io/controller-tools v0.16.5
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -237,7 +237,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
-	github.com/fatih/color v1.17.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
-github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -566,8 +566,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA=
-github.com/gobuffalo/flect v1.0.2/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
+github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=
+github.com/gobuffalo/flect v1.0.3/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/gobuffalo/logger v1.0.6 h1:nnZNpxYo0zx+Aj9RfMPBm+x9zAU2OayFh/xrAWi34HU=
 github.com/gobuffalo/logger v1.0.6/go.mod h1:J31TBEHR1QLV2683OXTAItYIg8pv2JMHnF/quuAbMjs=
 github.com/gobuffalo/packd v1.0.1 h1:U2wXfRr4E9DH8IdsDLlRFwTZTK7hLfq9qT/QHXGVe/0=
@@ -1675,8 +1675,8 @@ golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/tools v0.23.0/go.mod h1:pnu6ufv6vQkll6szChhK3C3L/ruaIv5eBeztNG8wtsI=
 golang.org/x/tools v0.24.0/go.mod h1:YhNqVBIfWHdzvTLs0d8LCuMhkKUgSUKldakyV7W/WDQ=
-golang.org/x/tools v0.25.0 h1:oFU9pkj/iJgs+0DT+VMHrx+oBKs/LJMV+Uvg78sl+fE=
-golang.org/x/tools v0.25.0/go.mod h1:/vtpO8WL1N9cQC3FN5zPqb//fRXskFHbLKk4OW1Q7rg=
+golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
+golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1837,8 +1837,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsA
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.19.0 h1:nWVM7aq+Il2ABxwiCizrVDSlmDcshi9llbaFbC0ji/Q=
 sigs.k8s.io/controller-runtime v0.19.0/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
-sigs.k8s.io/controller-tools v0.16.1 h1:gvIsZm+2aimFDIBiDKumR7EBkc+oLxljoUVfRbDI6RI=
-sigs.k8s.io/controller-tools v0.16.1/go.mod h1:0I0xqjR65YTfoO12iR+mZR6s6UAVcUARgXRlsu0ljB0=
+sigs.k8s.io/controller-tools v0.16.5 h1:5k9FNRqziBPwqr17AMEPPV/En39ZBplLAdOwwQHruP4=
+sigs.k8s.io/controller-tools v0.16.5/go.mod h1:8vztuRVzs8IuuJqKqbXCSlXcw+lkAv/M2sTpg55qjMY=
 sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
 sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -35,6 +35,12 @@ $sed -i "s/Copyright YEAR/Copyright $currentYear/g" $reconcileHelpers
 CRD_DIR=pkg/crd/k8c.io
 
 echodate "Generating openAPI v3 CRDs"
+
+export GODEBUG=gotypesalias=0
+# see https://github.com/kubernetes-sigs/controller-tools/issues/1123
+# and https://github.com/kubernetes-sigs/controller-tools/pull/1122
+#
+# To fix this we will need to update controller-tools at least to v0.17.1+ which pull main kubernetes updates
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   crd \
   object:headerFile=./hack/boilerplate/ce/boilerplate.go.txt \

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: applicationdefinitions.apps.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: usercluster
   name: applicationinstallations.apps.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master
   name: addonconfigs.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: addons.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master
   name: admissionplugins.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: alertmanagers.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master
   name: allowedregistries.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusterbackupstoragelocations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusterbackupstoragelocations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: clusterbackupstoragelocations.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: clusters.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: clustertemplateinstances.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: clustertemplates.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: constraints.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: constrainttemplates.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: etcdbackupconfigs.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: etcdrestores.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master
   name: externalclusters.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: groupprojectbindings.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: ipamallocations.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: ipampools.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: kubermaticconfigurations.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master
   name: kubermaticsettings.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: mlaadminsettings.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_policybindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_policybindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: seed
   name: policybindings.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_policytemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_policytemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: policytemplates.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: presets.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_projects.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_projects.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: projects.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: resourcequotas.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: rulegroups.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: seeds.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: userprojectbindings.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: users.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.16.5
     kubermatic.k8c.io/location: master,seed
   name: usersshkeys.kubermatic.k8c.io
 spec:

--- a/pkg/install/images/addons.go
+++ b/pkg/install/images/addons.go
@@ -30,9 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-var (
-	serializer = json.NewSerializerWithOptions(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, json.SerializerOptions{})
-)
+var serializer = json.NewSerializerWithOptions(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, json.SerializerOptions{})
 
 func getImagesFromAddons(log logrus.FieldLogger, addons map[string]*addon.Addon, cluster *kubermaticv1.Cluster) ([]string, error) {
 	credentials := resources.Credentials{}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -339,7 +339,7 @@ func CopyImages(ctx context.Context, log logrus.FieldLogger, dryRun bool, images
 	}
 
 	for index, image := range imageList {
-		if err := copyImage(ctx, log, image, userAgent); err != nil {
+		if err := copyImage(ctx, log.WithField("image", fmt.Sprintf("%d/%d", index+1, len(imageList))), image, userAgent); err != nil {
 			return index, len(imageList), fmt.Errorf("failed copying image %s: %w", image.Source, err)
 		}
 	}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -204,7 +204,7 @@ func extractAddonsFromArchive(dir string, reader *tar.Reader) error {
 			// we only want to extract the addons folder and thus we skip
 			// everything else in the image archive.
 			if strings.HasPrefix(header.Name, "addons") {
-				if err = os.MkdirAll(path, 0755); err != nil {
+				if err = os.MkdirAll(path, 0o755); err != nil {
 					return err
 				}
 			}
@@ -283,7 +283,7 @@ func LoadImages(ctx context.Context, log logrus.FieldLogger, archivePath string,
 		return fmt.Errorf("failed to load manifest: %w", err)
 	}
 
-	var repositoryToRefToImage = make(map[string]map[name.Reference]remote.Taggable)
+	repositoryToRefToImage := make(map[string]map[name.Reference]remote.Taggable)
 	for _, descriptor := range indexManifest {
 		for _, tagStr := range descriptor.RepoTags {
 			repoTag, err := name.NewTag(tagStr)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13137

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Update aws-node-termination-handler to v1.24.0
* `kubermatic-installer mirror-images` command now also mirrors system applications helm charts
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
