### PR TITLE
Fix namespace for cluster-autoscaler's additional ClusterRoleBindings

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler.yaml
@@ -43,6 +43,7 @@ spec:
     autoDiscovery:
       namespace: kube-system
     image:
+      # `Cluster.AutoscalerVersion` is injected by KKP based on the Kubernetes version of the cluster.
       tag: '{{ .Cluster.AutoscalerVersion }}'
     extraEnv:
       CAPI_GROUP: cluster.k8s.io
@@ -84,7 +85,8 @@ spec:
       subjects:
       - kind: ServiceAccount
         name: cluster-autoscaler-clusterapi-cluster-autoscaler
-        namespace: kube-system
+        # `Release.Namespace` is injected by Helm.
+        namespace: '{{ `{{.Release.Namespace}}` }}'
   documentationURL: https://github.com/kubernetes/autoscaler
   sourceURL: https://kubernetes.github.io/autoscaler
   logo: |+


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't want to restrict `cluster-autoscaler` Application to any specific namespace since the limitation of it being always installed in `kube-system` is currently a side-effect of the extra objects/resources that we are adding to the application.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
No release note since `cluster-autoscaler` application is an unreleased change.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
