### PR TITLE
Fix for auditLogging overwritting on Cluster level

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -96,6 +96,10 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 
 	// Enforce audit logging
 	if datacenter.Spec.EnforceAuditLogging {
+		if spec.AuditLogging != nil {
+			spec.AuditLogging.Enabled = true
+		}
+
 		spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{
 			Enabled: true,
 		}

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -96,13 +96,10 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 
 	// Enforce audit logging
 	if datacenter.Spec.EnforceAuditLogging {
-		if spec.AuditLogging != nil {
-			spec.AuditLogging.Enabled = true
+		if spec.AuditLogging == nil {
+			spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
 		}
-
-		spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{
-			Enabled: true,
-		}
+		spec.AuditLogging.Enabled = true
 	}
 
 	// Enforce audit webhook backend


### PR DESCRIPTION
**What this PR does / why we need it**:
There is no sidecar field in the Seed CRD, but it is available in the Cluster CRD. However, if you enable auditLogging in the Seed CR, you cannot add a sidecar config in the Cluster CR, as it gets overwritten.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14141

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
It is now possible to configure the sidecar configuration for a given cluster while the auditLogging field is enabled at the Seed level. Previously, if the auditLogging field was enabled at the Seed level, it would override the same field at the Cluster level, resulting in the removal of the sidecar configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
