### PR TITLE
Fix CA bundle for kubermatic-operator

### DIFF
--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         kubermatic.io/chart: kubermatic-operator
         fluentbit.io/parser: json_iso
     spec:
+      volumes:
+        - name: ca-bundle
+          configMap:
+            name: ca-bundle
       serviceAccountName: kubermatic-operator
       imagePullSecrets:
       - name: dockercfg
@@ -60,6 +64,8 @@ spec:
         - -enable-leader-election
         {{- end }}
         env:
+        - name: SSL_CERT_FILE
+          value: /opt/ca-bundle/ca-bundle.pem
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -79,6 +85,10 @@ spec:
           capabilities:
             drop:
             - ALL
+        volumeMounts:
+          - name: ca-bundle
+            readOnly: true
+            mountPath: /opt/ca-bundle/
       securityContext:
         fsGroup: 65534
         runAsUser: 65534


### PR DESCRIPTION
**What this PR does / why we need it**:
While kubermatic-operator will internally use created ca-bundle ConfigMap, it itself is missing using provided CA bundle for own http client.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CA bundle for kubermatic-operator
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
