### PR TITLE
Fix DigitalOcean support

### DIFF
--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -101,6 +101,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-do-ubuntu-1.31
     decorate: true
+    run_if_changed: "(digitalocean.go|/digitalocean/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-digitalocean: "true"

--- a/pkg/resources/cloudcontroller/digitalocean.go
+++ b/pkg/resources/cloudcontroller/digitalocean.go
@@ -138,6 +138,6 @@ func DigitaloceanCCMVersion(version semver.Semver) string {
 		fallthrough
 	default:
 		// This should always be the latest version.
-		return "v0.1.57"
+		return "v0.1.56"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.57
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.57
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.57
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -50,7 +50,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.57
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.56
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
CCM 0.1.57 switched to InstancesV2, which is currently broken / not supported. This PR would be the quickest workaround by simply downgrading the CCM a notch. We bumped but not tested it in #13984 because the ProwJobs had no triggers defined.

**Which issue(s) this PR fixes**:
Fixes #14148

**What type of PR is this?**
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Downgrade DigitalOcean CCM from 0.1.57 to 0.1.56 to work around machine-controller limitation.
```

**Documentation**:
```documentation
NONE
```
