### PR TITLE
Fix the router-subnet-link cleanup issue in OpenStack

### DIFF
--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -524,7 +524,7 @@ func reconcileRouter(ctx context.Context, netClient *gophercloud.ServiceClient, 
 		}
 		if router != nil {
 			// Router found, attach subnets if not already attached
-			err = attachSubnetsIfNeeded(netClient, cluster)
+			err = attachSubnetsIfNeeded(ctx, netClient, cluster, update)
 			return cluster, err
 		}
 	}
@@ -543,7 +543,7 @@ func reconcileRouter(ctx context.Context, netClient *gophercloud.ServiceClient, 
 		if err != nil {
 			return nil, fmt.Errorf("failed to update RouterID in the cluster spec: %w", err)
 		}
-		err = attachSubnetsIfNeeded(netClient, cluster)
+		err = attachSubnetsIfNeeded(ctx, netClient, cluster, update)
 		return cluster, err
 	}
 	var routerID string
@@ -588,15 +588,15 @@ func reconcileRouter(ctx context.Context, netClient *gophercloud.ServiceClient, 
 	}
 
 	// Attach the new router to subnets
-	err = attachSubnetsIfNeeded(netClient, cluster)
+	err = attachSubnetsIfNeeded(ctx, netClient, cluster, update)
 
 	return cluster, err
 }
 
-func attachSubnetsIfNeeded(netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster) error {
+func attachSubnetsIfNeeded(ctx context.Context, netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) error {
 	// Check if the router is already attached to the IPv4 subnet and attach to missing subnet if necessary
 	if cluster.Spec.Cloud.Openstack.SubnetID != "" {
-		err := linkSubnetToRouter(netClient, cluster, cluster.Spec.Cloud.Openstack.SubnetID, cluster.Spec.Cloud.Openstack.RouterID, RouterSubnetLinkCleanupFinalizer)
+		err := linkSubnetToRouter(ctx, netClient, cluster, cluster.Spec.Cloud.Openstack.SubnetID, cluster.Spec.Cloud.Openstack.RouterID, RouterSubnetLinkCleanupFinalizer, update)
 		if err != nil {
 			return err
 		}
@@ -604,7 +604,7 @@ func attachSubnetsIfNeeded(netClient *gophercloud.ServiceClient, cluster *kuberm
 
 	// Check if the router is already attached to the IPv6 subnetand attach to missing subnet if necessary
 	if cluster.Spec.Cloud.Openstack.IPv6SubnetID != "" {
-		err := linkSubnetToRouter(netClient, cluster, cluster.Spec.Cloud.Openstack.IPv6SubnetID, cluster.Spec.Cloud.Openstack.RouterID, RouterIPv6SubnetLinkCleanupFinalizer)
+		err := linkSubnetToRouter(ctx, netClient, cluster, cluster.Spec.Cloud.Openstack.IPv6SubnetID, cluster.Spec.Cloud.Openstack.RouterID, RouterIPv6SubnetLinkCleanupFinalizer, update)
 		if err != nil {
 			return err
 		}
@@ -613,7 +613,7 @@ func attachSubnetsIfNeeded(netClient *gophercloud.ServiceClient, cluster *kuberm
 	return nil
 }
 
-func linkSubnetToRouter(netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, subnetID string, routerID string, finalizer string) error {
+func linkSubnetToRouter(ctx context.Context, netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, subnetID string, routerID string, finalizer string, update provider.ClusterUpdater) error {
 	var ipAttached bool
 	router, err := getRouterIDForSubnet(netClient, subnetID)
 	ipAttached = err == nil && router != ""
@@ -622,7 +622,14 @@ func linkSubnetToRouter(netClient *gophercloud.ServiceClient, cluster *kubermati
 		if err != nil {
 			return err
 		}
-		kubernetes.AddFinalizer(cluster, finalizer)
+		// Add the Link finalizer
+		_, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+			kubernetes.AddFinalizer(cluster, finalizer)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add RouterSubnetLinkCleanupFinalizer in the cluster spec: %w", err)
+		}
+
 	}
 	return nil
 }

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -629,8 +629,8 @@ func linkSubnetToRouter(ctx context.Context, netClient *gophercloud.ServiceClien
 		if err != nil {
 			return fmt.Errorf("failed to add RouterSubnetLinkCleanupFinalizer in the cluster spec: %w", err)
 		}
-
 	}
+
 	return nil
 }
 

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -627,7 +627,7 @@ func linkSubnetToRouter(ctx context.Context, netClient *gophercloud.ServiceClien
 			kubernetes.AddFinalizer(cluster, finalizer)
 		})
 		if err != nil {
-			return fmt.Errorf("failed to add RouterSubnetLinkCleanupFinalizer in the cluster spec: %w", err)
+			return fmt.Errorf("failed to add %s in the cluster spec: %w", finalizer, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses the router-subnet-link cleanup issue in OpenStack when creating a user cluster with an existing network and subnet. The primary cause of the problem is that the cluster resource lacks the `kubermatic.k8c.io/cleanup-openstack-router-subnet-link-v2` finalizer, which is essential for ensuring that links attached to the router are properly cleaned up. As a result, when attempting to delete the cluster, the router fails to be deleted due to lingering ports still attached to it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14050

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed router-subnet-link cleanup for OpenStack user clusters created with existing networks and subnets.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
