### PR TITLE
Include the External Provider in the Machine Resources

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -101,7 +101,7 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 
 	var quotaUsage *ResourceDetails
 	switch config.CloudProvider {
-	case types.CloudProviderFake:
+	case types.CloudProviderFake, types.CloudProviderExternal:
 		quotaUsage, err = getFakeQuotaRequest(config)
 	case types.CloudProviderAWS:
 		quotaUsage, err = getAWSResourceRequirements(ctx, userClient, config)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the user cluster controller manager is failing with an error that, the external provider is unknown. This PR convers the external provider as well.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
