### PR TITLE
Set cilium-envoy enabled to false in the application definition reconciler

### DIFF
--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -360,20 +360,6 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 				return app, fmt.Errorf("failed to merge CNI values: %w", err)
 			}
 
-			// Remove deprecated value from older installations
-			if cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCilium {
-				ipam := values["ipam"].(map[string]any)
-				operator := ipam["operator"].(map[string]any)
-				delete(operator, "clusterPoolIPv4PodCIDR")
-
-				// If not specified, set envoy.enabled to false
-				// https://github.com/cilium/cilium/commit/471f19a16593e1e9342c31bf3e26e5383737cb0a
-				envoy := values["envoy"].(map[string]any)
-				if _, ok := envoy["enabled"]; !ok {
-					envoy["enabled"] = false
-				}
-			}
-
 			// Set new values
 			rawValues, err := yaml.Marshal(values)
 			if err != nil {

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -365,6 +365,13 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 				ipam := values["ipam"].(map[string]any)
 				operator := ipam["operator"].(map[string]any)
 				delete(operator, "clusterPoolIPv4PodCIDR")
+
+				// If not specified, set envoy.enabled to false
+				// https://github.com/cilium/cilium/commit/471f19a16593e1e9342c31bf3e26e5383737cb0a
+				envoy := values["envoy"].(map[string]any)
+				if _, ok := envoy["enabled"]; !ok {
+					envoy["enabled"] = false
+				}
 			}
 
 			// Set new values


### PR DESCRIPTION
**What this PR does / why we need it**:
Cilium 1.16.6 brought the enabled cilium-envoy daemon set for every new installation.
We wanted to keep the previous behaviour, but with the https://github.com/kubermatic/kubermatic/pull/14048 default values were not changed during upgrade from previous KKP version.

This PR will disable explicitly the cilium-envoy daemon set if it was not specified in the values and move the sanitizing to application definition reconciler.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable cilium-envoy daemonset, if it was not specified in the chart values.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
