### PR TITLE
fix(release): include dex and gitops chart in ci release

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -250,6 +250,8 @@ for buildTarget in $RELEASE_PLATFORMS; do
     _build/kubermatic-installer* \
     charts/backup \
     charts/cert-manager \
+    charts/dex \
+    charts/gitops \
     charts/iap \
     charts/kubermatic-operator \
     charts/local-kubevirt \
@@ -291,6 +293,8 @@ for buildTarget in $RELEASE_PLATFORMS; do
     _build/kubermatic-installer* \
     charts/backup \
     charts/cert-manager \
+    charts/dex \
+    charts/gitops \
     charts/iap \
     charts/kubermatic-operator \
     charts/local-kubevirt \


### PR DESCRIPTION
**What this PR does / why we need it**:
- Include dex and gitops chart in ci release

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14191 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added dex and gitops charts to the CI release pipeline for inclusion in the release tar.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
