### PR TITLE
chore: remove Cilium app install sanitization for unsupported value

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -329,11 +329,6 @@ func setDefaultValues(app *appskubermaticv1.ApplicationDefinition) error {
 }
 
 func sanitizeValues(values map[string]any) {
-	// Remove deprecated values from the "ipam.operator" section
-	ipam := values["ipam"].(map[string]any)
-	operator := ipam["operator"].(map[string]any)
-	delete(operator, "clusterPoolIPv4PodCIDR")
-
 	// If not specified, set envoy.enabled to false
 	// https://github.com/cilium/cilium/commit/471f19a16593e1e9342c31bf3e26e5383737cb0a
 	if envoy, ok := values["envoy"].(map[string]any); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added for https://github.com/kubermatic/kubermatic/issues/12840, sanitization for this deprecated app install value that we added as overrides, was needed to unblock upgrade to KKP 2.23, between Cilium 1.13 and 1.14.
I readded it by mistake in the https://github.com/kubermatic/kubermatic/pull/14173, but in the application definition, which is set to nil in the default values.

This PR will remove the problematic codeblock.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
