### PR TITLE
Use mirror.gcr.io as a default mirror for docker.io

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -65,30 +65,28 @@ const (
 	DefaultKubeconfigFieldPath = "kubeconfig"
 )
 
-var (
-	SupportedProviders = []ProviderType{
-		AKSCloudProvider,
-		AlibabaCloudProvider,
-		AnexiaCloudProvider,
-		AWSCloudProvider,
-		AzureCloudProvider,
-		BaremetalCloudProvider,
-		BringYourOwnCloudProvider,
-		DigitaloceanCloudProvider,
-		EdgeCloudProvider,
-		EKSCloudProvider,
-		FakeCloudProvider,
-		GCPCloudProvider,
-		GKECloudProvider,
-		HetznerCloudProvider,
-		KubevirtCloudProvider,
-		NutanixCloudProvider,
-		OpenstackCloudProvider,
-		PacketCloudProvider,
-		VMwareCloudDirectorCloudProvider,
-		VSphereCloudProvider,
-	}
-)
+var SupportedProviders = []ProviderType{
+	AKSCloudProvider,
+	AlibabaCloudProvider,
+	AnexiaCloudProvider,
+	AWSCloudProvider,
+	AzureCloudProvider,
+	BaremetalCloudProvider,
+	BringYourOwnCloudProvider,
+	DigitaloceanCloudProvider,
+	EdgeCloudProvider,
+	EKSCloudProvider,
+	FakeCloudProvider,
+	GCPCloudProvider,
+	GKECloudProvider,
+	HetznerCloudProvider,
+	KubevirtCloudProvider,
+	NutanixCloudProvider,
+	OpenstackCloudProvider,
+	PacketCloudProvider,
+	VMwareCloudDirectorCloudProvider,
+	VSphereCloudProvider,
+}
 
 func IsProviderSupported(name string) bool {
 	for _, provider := range SupportedProviders {
@@ -209,6 +207,19 @@ func (s *Seed) SetDefaults() {
 		for key, dc := range s.Spec.Datacenters {
 			if dc.Node == nil {
 				dc.Node = &NodeSettings{}
+			}
+
+			if dc.Node.ContainerdRegistryMirrors == nil {
+				dc.Node.ContainerdRegistryMirrors = &ContainerRuntimeContainerd{}
+			}
+
+			if dc.Node.ContainerdRegistryMirrors.Registries == nil {
+				dc.Node.ContainerdRegistryMirrors.Registries = map[string]ContainerdRegistry{}
+			}
+			if _, found := dc.Node.ContainerdRegistryMirrors.Registries["docker.io"]; !found {
+				dc.Node.ContainerdRegistryMirrors.Registries["docker.io"] = ContainerdRegistry{
+					Mirrors: []string{"https://mirror.gcr.io"},
+				}
 			}
 			s.Spec.ProxySettings.Merge(&dc.Node.ProxySettings)
 			s.Spec.Datacenters[key] = dc
@@ -498,46 +509,44 @@ type DatacenterSpec struct {
 	APIServerServiceType *corev1.ServiceType `json:"apiServerServiceType,omitempty"`
 }
 
-var (
-	// knownIPv6CloudProviders configures which providers have IPv6 and if it's enabled for all datacenters.
-	knownIPv6CloudProviders = map[ProviderType]struct {
-		ipv6EnabledForAllDatacenters bool
-	}{
-		AWSCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		AzureCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		BaremetalCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		BringYourOwnCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		EdgeCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		DigitaloceanCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		GCPCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		HetznerCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		OpenstackCloudProvider: {
-			ipv6EnabledForAllDatacenters: false,
-		},
-		PacketCloudProvider: {
-			ipv6EnabledForAllDatacenters: true,
-		},
-		VSphereCloudProvider: {
-			ipv6EnabledForAllDatacenters: false,
-		},
-	}
-)
+// knownIPv6CloudProviders configures which providers have IPv6 and if it's enabled for all datacenters.
+var knownIPv6CloudProviders = map[ProviderType]struct {
+	ipv6EnabledForAllDatacenters bool
+}{
+	AWSCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	AzureCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	BaremetalCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	BringYourOwnCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	EdgeCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	DigitaloceanCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	GCPCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	HetznerCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	OpenstackCloudProvider: {
+		ipv6EnabledForAllDatacenters: false,
+	},
+	PacketCloudProvider: {
+		ipv6EnabledForAllDatacenters: true,
+	},
+	VSphereCloudProvider: {
+		ipv6EnabledForAllDatacenters: false,
+	},
+}
 
 func (cloudProvider ProviderType) IsIPv6KnownProvider() bool {
 	_, isIPv6KnownProvider := knownIPv6CloudProviders[cloudProvider]
@@ -738,14 +747,12 @@ type DatacenterSpecBaremetal struct {
 	Tinkerbell *DatacenterSpecTinkerbell `json:"tinkerbell,omitempty"`
 }
 
-var (
-	SupportedTinkerbellOS = map[providerconfig.OperatingSystem]*struct{}{
-		providerconfig.OperatingSystemUbuntu:     nil,
-		providerconfig.OperatingSystemRHEL:       nil,
-		providerconfig.OperatingSystemFlatcar:    nil,
-		providerconfig.OperatingSystemRockyLinux: nil,
-	}
-)
+var SupportedTinkerbellOS = map[providerconfig.OperatingSystem]*struct{}{
+	providerconfig.OperatingSystemUbuntu:     nil,
+	providerconfig.OperatingSystemRHEL:       nil,
+	providerconfig.OperatingSystemFlatcar:    nil,
+	providerconfig.OperatingSystemRockyLinux: nil,
+}
 
 // DatacenterSepcTinkerbell contains spec for tinkerbell provider.
 type DatacenterSpecTinkerbell struct {
@@ -766,12 +773,10 @@ type TinkerbellHTTPSource struct {
 }
 
 // DatacenterSpecBringYourOwn describes a datacenter our of bring your own nodes.
-type DatacenterSpecBringYourOwn struct {
-}
+type DatacenterSpecBringYourOwn struct{}
 
 // DatacenterSpecEdge describes a datacenter of edge nodes.
-type DatacenterSpecEdge struct {
-}
+type DatacenterSpecEdge struct{}
 
 // DatacenterSpecPacket describes a Packet datacenter.
 type DatacenterSpecPacket struct {
@@ -915,14 +920,12 @@ type CustomNetworkPolicy struct {
 	Spec networkingv1.NetworkPolicySpec `json:"spec"`
 }
 
-var (
-	SupportedKubeVirtOS = map[providerconfig.OperatingSystem]*struct{}{
-		providerconfig.OperatingSystemUbuntu:     nil,
-		providerconfig.OperatingSystemRHEL:       nil,
-		providerconfig.OperatingSystemFlatcar:    nil,
-		providerconfig.OperatingSystemRockyLinux: nil,
-	}
-)
+var SupportedKubeVirtOS = map[providerconfig.OperatingSystem]*struct{}{
+	providerconfig.OperatingSystemUbuntu:     nil,
+	providerconfig.OperatingSystemRHEL:       nil,
+	providerconfig.OperatingSystemFlatcar:    nil,
+	providerconfig.OperatingSystemRockyLinux: nil,
+}
 
 // KubeVirtVolumeProvisioner represents what is the provisioner of the storage class volume, whether it will be the csi driver
 // and/or CDI for disk images.

--- a/pkg/apis/kubermatic/v1/datacenter_test.go
+++ b/pkg/apis/kubermatic/v1/datacenter_test.go
@@ -53,26 +53,56 @@ func TestSetSeedDefaults(t *testing.T) {
 						NoProxy:   NewProxyValue("seed-no-proxy"),
 					},
 					Datacenters: map[string]Datacenter{
-						"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-							HTTPProxy: NewProxyValue("dc-proxy"),
-							NoProxy:   NewProxyValue("dc-no-proxy"),
-						}}},
-						"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-							HTTPProxy: NewProxyValue("dc-proxy"),
-							NoProxy:   NewProxyValue("dc-no-proxy"),
-						}}},
+						"a": {
+							Node: &NodeSettings{
+								ProxySettings: ProxySettings{
+									HTTPProxy: NewProxyValue("dc-proxy"),
+									NoProxy:   NewProxyValue("dc-no-proxy"),
+								},
+							},
+						},
+						"b": {
+							Node: &NodeSettings{
+								ProxySettings: ProxySettings{
+									HTTPProxy: NewProxyValue("dc-proxy"),
+									NoProxy:   NewProxyValue("dc-no-proxy"),
+								},
+							},
+						},
 					},
 				},
 			},
 			expected: map[string]Datacenter{
-				"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("dc-proxy"),
-					NoProxy:   NewProxyValue("dc-no-proxy"),
-				}}},
-				"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("dc-proxy"),
-					NoProxy:   NewProxyValue("dc-no-proxy"),
-				}}},
+				"a": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("dc-proxy"),
+							NoProxy:   NewProxyValue("dc-no-proxy"),
+						},
+					},
+				},
+				"b": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("dc-proxy"),
+							NoProxy:   NewProxyValue("dc-no-proxy"),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -90,14 +120,36 @@ func TestSetSeedDefaults(t *testing.T) {
 				},
 			},
 			expected: map[string]Datacenter{
-				"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("seed-proxy"),
-					NoProxy:   NewProxyValue("seed-no-proxy"),
-				}}},
-				"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("seed-proxy"),
-					NoProxy:   NewProxyValue("seed-no-proxy"),
-				}}},
+				"a": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("seed-proxy"),
+							NoProxy:   NewProxyValue("seed-no-proxy"),
+						},
+					},
+				},
+				"b": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("seed-proxy"),
+							NoProxy:   NewProxyValue("seed-no-proxy"),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -109,24 +161,54 @@ func TestSetSeedDefaults(t *testing.T) {
 						NoProxy:   NewProxyValue("seed-no-proxy"),
 					},
 					Datacenters: map[string]Datacenter{
-						"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-							NoProxy: NewProxyValue("dc-no-proxy"),
-						}}},
-						"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-							NoProxy: NewProxyValue("dc-no-proxy"),
-						}}},
+						"a": {
+							Node: &NodeSettings{
+								ProxySettings: ProxySettings{
+									NoProxy: NewProxyValue("dc-no-proxy"),
+								},
+							},
+						},
+						"b": {
+							Node: &NodeSettings{
+								ProxySettings: ProxySettings{
+									NoProxy: NewProxyValue("dc-no-proxy"),
+								},
+							},
+						},
 					},
 				},
 			},
 			expected: map[string]Datacenter{
-				"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("seed-proxy"),
-					NoProxy:   NewProxyValue("dc-no-proxy"),
-				}}},
-				"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("seed-proxy"),
-					NoProxy:   NewProxyValue("dc-no-proxy"),
-				}}},
+				"a": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("seed-proxy"),
+							NoProxy:   NewProxyValue("dc-no-proxy"),
+						},
+					},
+				},
+				"b": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("seed-proxy"),
+							NoProxy:   NewProxyValue("dc-no-proxy"),
+						},
+					},
+				},
 			},
 		},
 		{
@@ -138,24 +220,54 @@ func TestSetSeedDefaults(t *testing.T) {
 						NoProxy:   NewProxyValue("seed-no-proxy"),
 					},
 					Datacenters: map[string]Datacenter{
-						"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-							HTTPProxy: NewProxyValue("dc-proxy"),
-						}}},
-						"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-							HTTPProxy: NewProxyValue("dc-proxy"),
-						}}},
+						"a": {
+							Node: &NodeSettings{
+								ProxySettings: ProxySettings{
+									HTTPProxy: NewProxyValue("dc-proxy"),
+								},
+							},
+						},
+						"b": {
+							Node: &NodeSettings{
+								ProxySettings: ProxySettings{
+									HTTPProxy: NewProxyValue("dc-proxy"),
+								},
+							},
+						},
 					},
 				},
 			},
 			expected: map[string]Datacenter{
-				"a": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("dc-proxy"),
-					NoProxy:   NewProxyValue("seed-no-proxy"),
-				}}},
-				"b": {Node: &NodeSettings{ProxySettings: ProxySettings{
-					HTTPProxy: NewProxyValue("dc-proxy"),
-					NoProxy:   NewProxyValue("seed-no-proxy"),
-				}}},
+				"a": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("dc-proxy"),
+							NoProxy:   NewProxyValue("seed-no-proxy"),
+						},
+					},
+				},
+				"b": {
+					Node: &NodeSettings{
+						ContainerdRegistryMirrors: &ContainerRuntimeContainerd{
+							Registries: map[string]ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"https://mirror.gcr.io"},
+								},
+							},
+						},
+						ProxySettings: ProxySettings{
+							HTTPProxy: NewProxyValue("dc-proxy"),
+							NoProxy:   NewProxyValue("seed-no-proxy"),
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Docker registry is about to introduce new limitation: https://www.docker.com/blog/revisiting-docker-hub-policies-prioritizing-developer-experience/

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use mirror.gcr.io as a default mirror for docker.io
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
