### PR TITLE
Support KubeVirt Storage Class Infra Cluster Filtration 

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -399,6 +399,7 @@ metadata:
 spec:
   storageClasses:
 {{- range  .Cluster.KubeVirtInfraStorageClasses }}
+{{- if ne .VolumeProvisioner "infra-csi-driver" }}
    - infraStorageClassName: {{ .Name }}
      isDefaultClass: {{ .IsDefaultClass }}
 {{- if .VolumeBindingMode  }}
@@ -421,6 +422,7 @@ spec:
      labels:
 {{- range $key, $value := .Labels }}
        {{ $key }}: {{ $value }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -931,6 +931,9 @@ type KubeVirtVolumeProvisioner string
 const (
 	// KubeVirtCSIDriver indicates that the volume of a storage class will be provisioned by the KubeVirt CSI driver.
 	KubeVirtCSIDriver KubeVirtVolumeProvisioner = "kubevirt-csi-driver"
+	// InfraCSIDriver indicates that the volume of a storage class will be provisioned volumes for the Virtual Machine
+	// disk images by the infra cluster CSI driver.
+	InfraCSIDriver KubeVirtVolumeProvisioner = "infra-csi-driver"
 )
 
 // KubeVirtImageSources represents KubeVirt image sources.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new value for the field `volumeProvisioner` for the KubeVirt CSI Driver. The new value is called `infra-csi-driver` which denote that, the storage class should be used by the infra csi driver to create volumes or the kubevirt csi driver should be used in the user cluster to create volumes. For example, users can mark an infraStorageClasses in the seed with `infra-csi-driver` to create VM disk images that the csi driver in the infra cluster creates and infraStorageClasses that are marked with `kubevirt-csi-driver` will be only exported to the user cluster and won't be shown in the UI.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support `infra-csi-driver` as a `volumeProvisioner` for the KubeVirt CSI Driver  
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
