### PR TITLE
[release/v2.27] Set cilium-envoy enabled to false in the application definition reconciler 

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -272,35 +272,73 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 
 			// we want to allow overriding the default values, so reconcile them only if nil
 			if app.Spec.DefaultValuesBlock == "" || app.Spec.DefaultValuesBlock == "{}" {
-				defaultValues := map[string]any{
-					"operator": map[string]any{
-						"replicas": 1,
-					},
-					"envoy": map[string]any{
-						"enabled": false,
-					},
-					"hubble": map[string]any{
-						"relay": map[string]any{
-							"enabled": true,
-						},
-						"ui": map[string]any{
-							"enabled": true,
-						},
-						// cronJob TLS cert gen method needs to be used for backward compatibility with older KKP
-						"tls": map[string]any{
-							"auto": map[string]any{
-								"method": "cronJob",
-							},
-						},
-					},
+				if err := setDefaultValues(app); err != nil {
+					return app, err
 				}
+				return app, nil
+			}
+
+			defaultValues, err := app.Spec.GetParsedDefaultValues()
+			if err != nil {
+				return app, fmt.Errorf("failed to unmarshal CNI values: %w", err)
+			}
+
+			if defaultValues != nil {
+				sanitizeValues(defaultValues)
 				rawValues, err := yaml.Marshal(defaultValues)
 				if err != nil {
-					return app, fmt.Errorf("failed to marshall default CNI values: %w", err)
+					return app, fmt.Errorf("failed to marshal CNI values: %w", err)
 				}
+
 				app.Spec.DefaultValuesBlock = string(rawValues)
 			}
+
 			return app, nil
+		}
+	}
+}
+
+// setDefaultValues sets the default values for the application.
+func setDefaultValues(app *appskubermaticv1.ApplicationDefinition) error {
+	defaultValues := map[string]any{
+		"operator": map[string]any{
+			"replicas": 1,
+		},
+		"envoy": map[string]any{
+			"enabled": false,
+		},
+		"hubble": map[string]any{
+			"relay": map[string]any{
+				"enabled": true,
+			},
+			"ui": map[string]any{
+				"enabled": true,
+			},
+			"tls": map[string]any{
+				"auto": map[string]any{
+					"method": "cronJob",
+				},
+			},
+		},
+	}
+	rawValues, err := yaml.Marshal(defaultValues)
+	if err != nil {
+		return fmt.Errorf("failed to marshal default CNI values: %w", err)
+	}
+	app.Spec.DefaultValuesBlock = string(rawValues)
+	return nil
+}
+
+func sanitizeValues(values map[string]any) {
+	// If not specified, set envoy.enabled to false
+	// https://github.com/cilium/cilium/commit/471f19a16593e1e9342c31bf3e26e5383737cb0a
+	if envoy, ok := values["envoy"].(map[string]any); ok {
+		if _, ok := envoy["enabled"]; !ok {
+			envoy["enabled"] = false
+		}
+	} else {
+		values["envoy"] = map[string]any{
+			"enabled": false,
 		}
 	}
 }

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -360,13 +360,6 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 				return app, fmt.Errorf("failed to merge CNI values: %w", err)
 			}
 
-			// Remove deprecated value from older installations
-			if cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCilium {
-				ipam := values["ipam"].(map[string]any)
-				operator := ipam["operator"].(map[string]any)
-				delete(operator, "clusterPoolIPv4PodCIDR")
-			}
-
 			// Set new values
 			rawValues, err := yaml.Marshal(values)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed to add https://github.com/kubermatic/kubermatic/pull/14173 and https://github.com/kubermatic/kubermatic/pull/14196 manually.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14165

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind regression
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable cilium-envoy daemonset, if it was not specified in the chart values.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
