### PR TITLE
change auth handling when deploying app installation

### DIFF
--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -64,8 +64,8 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, appDefinition *appskuber
 	}
 	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
 
+	var auth = helmclient.AuthSettings{}
 	source := applicationInstallation.Status.ApplicationVersion.Template.Source.Helm
-	var auth = util.NewAuthSettingsFromHelmSource(source)
 	if applicationInstallation.Status.ApplicationVersion.Template.DependencyCredentials != nil {
 		auth, err = util.HelmAuthFromCredentials(h.Ctx, h.SeedClient, path.Join(helmCacheDir, "reg-creg"), h.SecretNamespace, source, applicationInstallation.Status.ApplicationVersion.Template.DependencyCredentials.HelmCredentials)
 		if err != nil {

--- a/pkg/applications/providers/util/util.go
+++ b/pkg/applications/providers/util/util.go
@@ -84,7 +84,10 @@ func HelmAuthFromCredentials(
 	source *appskubermaticv1.HelmSource,
 	credentials *appskubermaticv1.HelmCredentials,
 ) (helmclient.AuthSettings, error) {
-	auth := NewAuthSettingsFromHelmSource(source)
+	auth := helmclient.AuthSettings{}
+	if source != nil {
+		auth = NewAuthSettingsFromHelmSource(source)
+	}
 	if credentials != nil {
 		if credentials.Username != nil {
 			username, err := GetCredentialFromSecret(ctx, client, secretNamespace, credentials.Username.Name, credentials.Username.Key)


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr fixes a bug observed when using git as the source in an application installation. We do not necessarily need helm credentials when installing or upgrading a chart. So helm source can be nil in the application installation status. This is only required for dependencies when the main chart is fetched from a git repository.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14177

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TBD
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
