### PR TITLE
Sync changelogs for KKP patch releases for March 2025

### DIFF
--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -14,6 +14,21 @@
 - [v2.25.11](#v22511)
 - [v2.25.12](#v22512)
 - [v2.25.13](#v22513)
+- [v2.25.14](#v22514)
+
+## v2.25.14
+
+**GitHub release: [v2.25.14](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.14)**
+
+### Bugfixes
+
+- Fix a bug where ca-bundle was not being used to communicate to minio for metering ([#14072](https://github.com/kubermatic/kubermatic/pull/14072))
+- Fix datacenter creation for Edge provider ([#7167](https://github.com/kubermatic/dashboard/pull/7167))
+- Fix wrong GCP machine deployment values in Edit Machine Deployment dialog ([#7169](https://github.com/kubermatic/dashboard/pull/7169))
+
+### Updates
+
+- Update go-git to 5.13.0 [CVE-2025-21613, CVE-2025-21614] ([#14152](https://github.com/kubermatic/kubermatic/pull/14152))
 
 ## v2.25.13
 

--- a/docs/changelogs/CHANGELOG-2.26.md
+++ b/docs/changelogs/CHANGELOG-2.26.md
@@ -5,6 +5,33 @@
 - [v2.26.2](#v2262)
 - [v2.26.3](#v2263)
 - [v2.26.4](#v2264)
+- [v2.26.5](#v2265)
+
+## v2.26.5
+
+**GitHub release: [v2.26.5](https://github.com/kubermatic/kubermatic/releases/tag/v2.26.5)**
+
+### Supported Kubernetes versions
+
+- Add 1.31.5/1.30.9/1.29.13 to the list of supported Kubernetes releases ([#14069](https://github.com/kubermatic/kubermatic/pull/14069))
+
+### New Features
+
+- Add KubeVirt DS in the charts repo to generate images for the mirrored images command ([#14064](https://github.com/kubermatic/kubermatic/pull/14064))
+
+### Bugfixes
+
+- Fix a bug where ca-bundle was not being used to communicate to minio for metering ([#14072](https://github.com/kubermatic/kubermatic/pull/14072))
+- Fix node label overwriting issue with the initial Machine Deployment ([#14033](https://github.com/kubermatic/kubermatic/pull/14033))
+- Include KubeVirt CCM and Fluent-Bit images in the mirror-images command ([#14063](https://github.com/kubermatic/kubermatic/pull/14063))
+- Fix datacenter creation for Edge provider ([#7165](https://github.com/kubermatic/dashboard/pull/7165))
+- Fix wrong GCP machine deployment values in Edit Machine Deployment dialog ([#7169](https://github.com/kubermatic/dashboard/pull/7169))
+- In the cluster backup feature, fix the issue with restoring a backup that includes all namespaces and add the option to restore all namespaces from a backup ([#7168](https://github.com/kubermatic/dashboard/pull/7168))
+- VSphere: fix a bug where updating replicas of machine deployments was causing machine rotation ([#7130](https://github.com/kubermatic/dashboard/pull/7130))
+
+### Updates
+
+- Update go-git to 5.13.0 [CVE-2025-21613, CVE-2025-21614] ([#14151](https://github.com/kubermatic/kubermatic/pull/14151))
 
 ## v2.26.4
 

--- a/docs/changelogs/CHANGELOG-2.27.md
+++ b/docs/changelogs/CHANGELOG-2.27.md
@@ -1,6 +1,26 @@
 # Kubermatic 2.27
 
 - [v2.27.0](#v2270)
+- [v2.27.1](#v2271)
+
+## v2.27.1
+
+**GitHub release: [v2.27.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.27.1)**
+
+### New Features
+
+- Support `infra-csi-driver` as a `volumeProvisioner` for the KubeVirt CSI Driver ([#14199](https://github.com/kubermatic/kubermatic/pull/14199))
+
+### Bugfixes
+
+- Add dex and gitops charts to the CI release pipeline for inclusion in the release tar ([#14192](https://github.com/kubermatic/kubermatic/pull/14192))
+- Apply override registry configuration to cilium-envoy images ([#14164](https://github.com/kubermatic/kubermatic/pull/14164))
+- Include the etcd backup restore and delete images in the kubermatic-installer mirror-images command ([#14220](https://github.com/kubermatic/kubermatic/pull/14220))
+
+### Updates
+
+- Disable cilium-envoy daemonset, if it was not specified in the chart values ([#14203](https://github.com/kubermatic/kubermatic/pull/14203))
+- Update KubeVirt CSI Driver Operator to v0.4.3 ([#14178](https://github.com/kubermatic/kubermatic/pull/14178))
 
 ## v2.27.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to sync changelogs for KKP patch releases 2.27.1, 2.26.5 and 2.25.14 for March 2025. 
/hold until the KKP releases are out.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
