### PR TITLE
Add mirror registries to the Seed example

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -56,7 +56,7 @@ func main() {
 	target := flag.Arg(1)
 
 	if _, err := os.Stat(target); err != nil {
-		if err := os.MkdirAll(target, 0755); err != nil {
+		if err := os.MkdirAll(target, 0o755); err != nil {
 			log.Fatalf("Failed to create target directory %s: %v", target, err)
 		}
 	}
@@ -156,6 +156,13 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 						ProxySettings:      proxySettings,
 						InsecureRegistries: []string{},
 						RegistryMirrors:    []string{},
+						ContainerdRegistryMirrors: &kubermaticv1.ContainerRuntimeContainerd{
+							Registries: map[string]kubermaticv1.ContainerdRegistry{
+								"docker.io": {
+									Mirrors: []string{"mirror.gcr.io"},
+								},
+							},
+						},
 					},
 					Spec: kubermaticv1.DatacenterSpec{
 						ProviderReconciliationInterval: &metav1.Duration{Duration: defaulting.DefaultCloudProviderReconciliationInterval},
@@ -222,10 +229,11 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 									},
 								},
 							},
-							InfraStorageClasses: []kubermaticv1.KubeVirtInfraStorageClass{{
-								Name:           "rook-ceph-block",
-								IsDefaultClass: ptr.To(true),
-							},
+							InfraStorageClasses: []kubermaticv1.KubeVirtInfraStorageClass{
+								{
+									Name:           "rook-ceph-block",
+									IsDefaultClass: ptr.To(true),
+								},
 							},
 						},
 						Alibaba: &kubermaticv1.DatacenterSpecAlibaba{},

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -24,7 +24,13 @@ spec:
       # not specified here.
       node:
         # Optional: ContainerdRegistryMirrors configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors.
-        containerdRegistryMirrors: null
+        containerdRegistryMirrors:
+          # A map of registries to use to render configs and mirrors for containerd registries
+          registries:
+            docker.io:
+              # List of registry mirrors to use
+              mirrors:
+                - mirror.gcr.io
         # Optional: If set, this proxy will be configured for both HTTP and HTTPS.
         httpProxy: ""
         # Optional: These image registries will be configured as insecure

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -24,7 +24,13 @@ spec:
       # not specified here.
       node:
         # Optional: ContainerdRegistryMirrors configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors.
-        containerdRegistryMirrors: null
+        containerdRegistryMirrors:
+          # A map of registries to use to render configs and mirrors for containerd registries
+          registries:
+            docker.io:
+              # List of registry mirrors to use
+              mirrors:
+                - mirror.gcr.io
         # Optional: If set, this proxy will be configured for both HTTP and HTTPS.
         httpProxy: ""
         # Optional: These image registries will be configured as insecure


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds some example for configuring Seed with mirror registry for docker.io.

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/kkp-configuration/
```
