### PR TITLE
Mirror cilium-envoy image

### DIFF
--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -33,6 +33,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	"sigs.k8s.io/yaml"
 )
 
 func GetImagesFromSystemApplicationDefinitions(
@@ -107,15 +109,37 @@ func SystemAppsHelmCharts(
 			values, err := appDef.Spec.GetDefaultValues()
 			if err != nil {
 				yield(nil, err)
-
 				return
 			}
+
+			if appName == kubermaticv1.CNIPluginTypeCilium.String() {
+				// For Cilium, we'll use the default values from the Helm chart but will mutate the values to ensure that additional images are also mirrored.
+				defaultValues, err := appDef.Spec.GetParsedDefaultValues()
+				if err != nil {
+					yield(nil, fmt.Errorf("failed to unmarshal CNI values: %w", err))
+					return
+				}
+				// Enable `cilium-envoy` to ensure that the additional images are also mirrored.
+				if envoy, ok := defaultValues["envoy"].(map[string]any); ok {
+					envoy["enabled"] = true
+				} else {
+					defaultValues["envoy"] = map[string]any{
+						"enabled": true,
+					}
+				}
+
+				values, err = yaml.Marshal(defaultValues)
+				if err != nil {
+					yield(nil, fmt.Errorf("failed to marshal CNI values: %w", err))
+					return
+				}
+			}
+
 			if values != nil {
 				valuesFile = path.Join(tmpDir, "values.yaml")
 				err = os.WriteFile(valuesFile, values, 0o644)
 				if err != nil {
 					yield(nil, fmt.Errorf("failed to create values file: %w", err))
-
 					return
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `cilium-envoy` image to mirrored images. 

**NOTE: Cilium-envoy is [disabled by default](https://github.com/kubermatic/kubermatic/blob/release/v2.27/pkg/cni/cilium/cilium.go#L337) in KKP. However, since we have already added support for [override registry ](https://github.com/kubermatic/kubermatic/pull/14164) for that image/deployment, It's a _nice to have_ to mirror it as a default.**

From logs:

```sh
INFO[0003] Image found                                   source-image="quay.io/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5@sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88" target-image="0.0.0.0:5505/cilium/cilium-envoy:v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5"
```

Works fine.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include `cilium-envoy` image in the mirrored images 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
