### PR TITLE
Fix getVesions from kubermatic configuration

### DIFF
--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -892,8 +892,6 @@ func getVersionsFromKubermaticConfiguration(config *kubermaticv1.KubermaticConfi
 		versions = append(versions, &version.Version{
 			Version: v.Semver(),
 		})
-
-		return versions
 	}
 
 	return versions


### PR DESCRIPTION
**What this PR does / why we need it**:
When using mirrored images, only images for a single Kubernetes version are mirrored. This PR will fix the issue

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix mirroring the images of a single Kubernetes version. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
