### PR TITLE
[release/v2.26]: backport CBSL status fix 

### DIFF
--- a/cmd/master-controller-manager/wrappers_ee.go
+++ b/cmd/master-controller-manager/wrappers_ee.go
@@ -25,6 +25,7 @@ import (
 
 	seedcontrollerlifecycle "k8c.io/kubermatic/v2/pkg/controller/shared/seed-controller-lifecycle"
 	allowedregistrycontroller "k8c.io/kubermatic/v2/pkg/ee/allowed-registry-controller"
+	storagelocationcontroller "k8c.io/kubermatic/v2/pkg/ee/cluster-backup/master/storage-location-controller"
 	storagelocationsynccontroller "k8c.io/kubermatic/v2/pkg/ee/cluster-backup/master/sync-controller"
 	eemasterctrlmgr "k8c.io/kubermatic/v2/pkg/ee/cmd/master-controller-manager"
 	groupprojectbinding "k8c.io/kubermatic/v2/pkg/ee/group-project-binding/controller"
@@ -62,6 +63,10 @@ func setupControllers(ctrlCtx *controllerContext) error {
 
 	if err := resourcequotadefaultcontroller.Add(ctrlCtx.mgr, ctrlCtx.log, 1); err != nil {
 		return fmt.Errorf("failed to create default project resource quota controller: %w", err)
+	}
+
+	if err := storagelocationcontroller.Add(ctrlCtx.mgr, ctrlCtx.workerCount, ctrlCtx.log); err != nil {
+		return fmt.Errorf("failed to create storage location controller: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
This PR backports the fix from #14243 to the release/2.26.
- This fixes the issue where the CBSL status was not updating because the cluster-backup-storage-controller was not added to the master controller manager. As a result, the controller was not running, and reconciliation for the status did not occur.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue where the CBSL status was not updating due to the missing cluster-backup-storage-controller in the master controller manager.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
