### PR TITLE
MC health status is not required for Edge provider

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1551,7 +1551,9 @@ func (h *ExtendedClusterHealth) ControlPlaneHealthy() bool {
 // crucial for cluster functioning.
 func (h *ExtendedClusterHealth) AllHealthy() bool {
 	return h.ControlPlaneHealthy() &&
-		h.MachineController == HealthStatusUp &&
+		// MachineController is not deployed/supported on Edge clusters and the health status is empty. For all the other
+		// providers, the health status is set to "down" when Cluster Health is initialized so it's never empty.
+		(h.MachineController == HealthStatusUp || h.MachineController == "") &&
 		h.CloudProviderInfrastructure == HealthStatusUp &&
 		h.UserClusterControllerManager == HealthStatusUp
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
MC is not deployed for Edge providers. However, we still maintain its health status in the Cluster Status. This leads to the Edge clusters being stuck inthe  `Creating` phase as MC never becomes healthy.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13859

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Edge Provider: Fix a bug where clusters were stuck in `creating` phase due to wrongfully waiting for Machine Controller's health status
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
