### PR TITLE
Introduce --list-images-only in kubermatic-installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-
 	"path/filepath"
 	"strings"
 	"time"
@@ -33,11 +32,9 @@ import (
 	addonutil "k8c.io/kubermatic/v2/pkg/addon"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
-
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/images"
 	"k8c.io/kubermatic/v2/pkg/resources"
-
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version"

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -116,7 +116,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
 	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
 	cmd.PersistentFlags().BoolVar(&opt.ListImagesOnly, "list-images-only", false, "If set, only list the images without performing any other actions.")
-	cmd.PersistentFlags().StringVarP(&opt.OutputFile, "output-file", "o", "", "Save the collected image list to the specified file (requires --list-images-only).")
+	cmd.PersistentFlags().StringVarP(&opt.OutputFile, "output-file", "f", "", "Save the collected image list to the specified file (requires --list-images-only).")
 	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
 	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
 

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -32,9 +32,11 @@ import (
 	addonutil "k8c.io/kubermatic/v2/pkg/addon"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/images"
 	"k8c.io/kubermatic/v2/pkg/resources"
+
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/validation"
 	"k8c.io/kubermatic/v2/pkg/version"
@@ -57,6 +59,7 @@ type MirrorImagesOptions struct {
 	LoadFrom                  string
 	DryRun                    bool
 	ListImagesOnly            bool
+	OutputFile                string
 
 	AddonsPath  string
 	AddonsImage string
@@ -115,6 +118,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
 	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
 	cmd.PersistentFlags().BoolVar(&opt.ListImagesOnly, "list-images-only", false, "If set, only list the images without performing any other actions.")
+	cmd.PersistentFlags().StringVarP(&opt.OutputFile, "output-file", "o", "", "Save the collected image list to the specified file (requires --list-images-only).")
 	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
 	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
 
@@ -248,6 +252,10 @@ func CollectImageMatrix(
 
 func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions, options *MirrorImagesOptions) cobraFuncE {
 	return handleErrors(logger, func(cmd *cobra.Command, args []string) error {
+		if options.OutputFile != "" && !options.ListImagesOnly {
+			return fmt.Errorf("--output-file can only be used with --list-images-only")
+		}
+
 		ctx := cmd.Context()
 		userAgent := fmt.Sprintf("kubermatic-installer/%s", versions.Kubermatic)
 
@@ -353,13 +361,24 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 				imageSet.Insert(sysChart.WorkloadImages...)
 			}
 
-			// Log all collected images if ListOnly is enabled
+			// Log or save all collected images if ListImagesOnly is enabled
 			if options.ListImagesOnly {
 				var imageList string
 				for _, image := range sets.List(imageSet) {
 					imageList += fmt.Sprintf("  - %s\n", image)
 				}
-				logger.Info("📋 Listing all collected images:\n", imageList)
+
+				// If --output-file is specified, save to file; otherwise, log to console
+				if options.OutputFile != "" {
+					logger.Info("📋 Saving collected images to file: ", options.OutputFile)
+					err := os.WriteFile(options.OutputFile, []byte(imageList), 0o644)
+					if err != nil {
+						return fmt.Errorf("failed to save image list to file: %w", err)
+					}
+				} else {
+					logger.Info("📋 Listing all collected images:\n", imageList)
+				}
+
 				logger.Info("✅ Finished listing images.")
 				return nil
 			}

--- a/cmd/kubermatic-installer/main.go
+++ b/cmd/kubermatic-installer/main.go
@@ -87,7 +87,7 @@ func main() {
 	})
 
 	rootCmd.PersistentFlags().BoolVarP(&options.Verbose, "verbose", "v", options.Verbose, "enable more verbose output")
-	rootCmd.PersistentFlags().VarP(&options.LogFormat, "output", "o", fmt.Sprintf("write logs in a specific output format. supported formats: %s", log.AvailableLogrusFormats.String()))
+	rootCmd.PersistentFlags().Var(&options.LogFormat, "log-format", fmt.Sprintf("write logs in a specific output format. supported formats: %s", log.AvailableLogrusFormats.String()))
 	rootCmd.PersistentFlags().StringVar(&options.ChartsDirectory, "charts-directory", "", "filesystem path to the Kubermatic Helm charts (defaults to charts/)")
 
 	addCommands(rootCmd, logger, versions)

--- a/cmd/kubermatic-installer/main.go
+++ b/cmd/kubermatic-installer/main.go
@@ -87,7 +87,7 @@ func main() {
 	})
 
 	rootCmd.PersistentFlags().BoolVarP(&options.Verbose, "verbose", "v", options.Verbose, "enable more verbose output")
-	rootCmd.PersistentFlags().Var(&options.LogFormat, "log-format", fmt.Sprintf("write logs in a specific output format. supported formats: %s", log.AvailableLogrusFormats.String()))
+	rootCmd.PersistentFlags().VarP(&options.LogFormat, "output", "o", fmt.Sprintf("write logs in a specific output format. supported formats: %s", log.AvailableLogrusFormats.String()))
 	rootCmd.PersistentFlags().StringVar(&options.ChartsDirectory, "charts-directory", "", "filesystem path to the Kubermatic Helm charts (defaults to charts/)")
 
 	addCommands(rootCmd, logger, versions)


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduce a `--list-images-only` flag to the `mirror-images` command, enabling users to list all collected images without performing any further actions. Enhances usability by providing a quick way to inspect images and verify the collection process.

![image](https://github.com/user-attachments/assets/90c43539-28d9-4cea-9935-712905d73c08)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14237

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce `--list-images-only` in kubermatic-installer `mirror-images` to list the images 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
