### PR TITLE
make policy binding available in master after caching rules

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -85,7 +85,7 @@ locationMap='{
   "verticalpodautoscalercheckpoints.autoscaling.k8s.io": "seed",
 
   "policytemplates.kubermatic.k8c.io": "master,seed",
-  "policybindings.kubermatic.k8c.io": "seed"
+  "policybindings.kubermatic.k8c.io": "master,seed"
 }'
 
 failure=false

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -48,45 +48,47 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   output:crd:dir=./$CRD_DIR
 
 annotation="kubermatic.k8c.io/location"
-locationMap='{
-  "applicationdefinitions.apps.kubermatic.k8c.io": "master,seed",
-  "applicationinstallations.apps.kubermatic.k8c.io": "usercluster",
-  "addonconfigs.kubermatic.k8c.io": "master",
-  "addons.kubermatic.k8c.io": "master,seed",
-  "admissionplugins.kubermatic.k8c.io": "master",
-  "alertmanagers.kubermatic.k8c.io": "master,seed",
-  "allowedregistries.kubermatic.k8c.io": "master",
-  "clusters.kubermatic.k8c.io": "master,seed",
-  "clustertemplateinstances.kubermatic.k8c.io": "master,seed",
-  "clustertemplates.kubermatic.k8c.io": "master,seed",
-  "constraints.kubermatic.k8c.io": "master,seed",
-  "constrainttemplates.kubermatic.k8c.io": "master,seed",
-  "customoperatingsystemprofiles.operatingsystemmanager.k8c.io": "master,seed",
-  "etcdbackupconfigs.kubermatic.k8c.io": "master,seed",
-  "etcdrestores.kubermatic.k8c.io": "master,seed",
-  "externalclusters.kubermatic.k8c.io": "master",
-  "groupprojectbindings.kubermatic.k8c.io": "master,seed",
-  "ipamallocations.kubermatic.k8c.io": "master,seed",
-  "ipampools.kubermatic.k8c.io": "master,seed",
-  "kubermaticconfigurations.kubermatic.k8c.io": "master,seed",
-  "kubermaticsettings.kubermatic.k8c.io": "master",
-  "mlaadminsettings.kubermatic.k8c.io": "master,seed",
-  "presets.kubermatic.k8c.io": "master,seed",
-  "projects.kubermatic.k8c.io": "master,seed",
-  "resourcequotas.kubermatic.k8c.io": "master,seed",
-  "rulegroups.kubermatic.k8c.io": "master,seed",
-  "seeds.kubermatic.k8c.io": "master,seed",
-  "userprojectbindings.kubermatic.k8c.io": "master,seed",
-  "usersshkeys.kubermatic.k8c.io": "master,seed",
-  "users.kubermatic.k8c.io": "master,seed",
-  "clusterbackupstoragelocations.kubermatic.k8c.io": "master,seed",
+declare -A locationMap=(
+  ["applicationdefinitions.apps.kubermatic.k8c.io"]="master,seed"
+  ["applicationinstallations.apps.kubermatic.k8c.io"]="usercluster"
+  ["addonconfigs.kubermatic.k8c.io"]="master"
+  ["addons.kubermatic.k8c.io"]="master,seed"
+  ["admissionplugins.kubermatic.k8c.io"]="master"
+  ["alertmanagers.kubermatic.k8c.io"]="master,seed"
+  ["allowedregistries.kubermatic.k8c.io"]="master"
+  ["clusters.kubermatic.k8c.io"]="master,seed"
+  ["clustertemplateinstances.kubermatic.k8c.io"]="master,seed"
+  ["clustertemplates.kubermatic.k8c.io"]="master,seed"
+  ["constraints.kubermatic.k8c.io"]="master,seed"
+  ["constrainttemplates.kubermatic.k8c.io"]="master,seed"
+  ["customoperatingsystemprofiles.operatingsystemmanager.k8c.io"]="master,seed"
+  ["etcdbackupconfigs.kubermatic.k8c.io"]="master,seed"
+  ["etcdrestores.kubermatic.k8c.io"]="master,seed"
+  ["externalclusters.kubermatic.k8c.io"]="master"
+  ["groupprojectbindings.kubermatic.k8c.io"]="master,seed"
+  ["ipamallocations.kubermatic.k8c.io"]="master,seed"
+  ["ipampools.kubermatic.k8c.io"]="master,seed"
+  ["kubermaticconfigurations.kubermatic.k8c.io"]="master,seed"
+  ["kubermaticsettings.kubermatic.k8c.io"]="master"
+  ["mlaadminsettings.kubermatic.k8c.io"]="master,seed"
+  ["presets.kubermatic.k8c.io"]="master,seed"
+  ["projects.kubermatic.k8c.io"]="master,seed"
+  ["resourcequotas.kubermatic.k8c.io"]="master,seed"
+  ["rulegroups.kubermatic.k8c.io"]="master,seed"
+  ["seeds.kubermatic.k8c.io"]="master,seed"
+  ["userprojectbindings.kubermatic.k8c.io"]="master,seed"
+  ["usersshkeys.kubermatic.k8c.io"]="master,seed"
+  ["users.kubermatic.k8c.io"]="master,seed"
+  ["clusterbackupstoragelocations.kubermatic.k8c.io"]="master,seed"
 
-  "verticalpodautoscalers.autoscaling.k8s.io": "seed",
-  "verticalpodautoscalercheckpoints.autoscaling.k8s.io": "seed",
+  ["verticalpodautoscalers.autoscaling.k8s.io"]="seed"
+  ["verticalpodautoscalercheckpoints.autoscaling.k8s.io"]="seed"
 
-  "policytemplates.kubermatic.k8c.io": "master,seed",
-  "policybindings.kubermatic.k8c.io": "master,seed"
-}'
+  ["policytemplates.kubermatic.k8c.io"]="master,seed"
+  # PolicyBindings will be deployed on master clusters although they are primarily used on seed clusters.
+  # This is because the KKP API (running on master) sets up caching rules for PolicyBindings.
+  ["policybindings.kubermatic.k8c.io"]="master,seed"
+)
 
 failure=false
 echodate "Annotating CRDs"
@@ -94,7 +96,7 @@ echodate "Annotating CRDs"
 cleanup_dir() {
   for filename in $1/*.yaml; do
     crdName="$(yq '.metadata.name' "$filename")"
-    location="$(echo "$locationMap" | jq -r -c --arg key "$crdName" '.[$key]')"
+    location="${locationMap[$crdName]}"
 
     if [ "$location" == "null" ]; then
       echodate "Error: No location defined for CRD $crdName"

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_policybindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_policybindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    kubermatic.k8c.io/location: seed
+    kubermatic.k8c.io/location: master,seed
   name: policybindings.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds PolicyBinding in master clusters because of the caching rules that KKP API has on master.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind bug
-->
/kind bug
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
