### PR TITLE
[release/v2.27] Improve mirror-images experience

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -34,8 +34,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/images"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/validation"
+	"k8c.io/kubermatic/v2/pkg/version"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -198,6 +200,51 @@ func getAddonsPath(ctx context.Context, logger *logrus.Logger, options *MirrorIm
 	return tempDir, nil
 }
 
+// CollectImageMatrix aggregates images for all cluster versions, cloud providers, and CNI plugins,
+// including both Konnectivity and non-Konnectivity configurations.
+func CollectImageMatrix(
+	logger logrus.FieldLogger,
+	clusterVersions []*version.Version,
+	kubermaticConfig *kubermaticv1.KubermaticConfiguration,
+	allAddons map[string]*addonutil.Addon,
+	versions kubermaticversion.Versions,
+	caBundle resources.CABundle,
+	registryPrefix string,
+) ([]string, error) {
+	var imageList []string
+	for _, clusterVersion := range clusterVersions {
+		for _, cloudSpec := range images.GetCloudSpecs() {
+			for _, cniPlugin := range images.GetCNIPlugins() {
+				versionLogger := logger.WithFields(logrus.Fields{
+					"version":     clusterVersion.Version.String(),
+					"provider":    cloudSpec.ProviderName,
+					"cni-plugin":  string(cniPlugin.Type),
+					"cni-version": cniPlugin.Version,
+				})
+
+				versionLogger.Debug("Collecting images…")
+				imagesWithKonnectivity, err := images.GetImagesForVersion(
+					versionLogger,
+					clusterVersion,
+					cloudSpec,
+					cniPlugin,
+					true,
+					kubermaticConfig,
+					allAddons,
+					versions,
+					caBundle,
+					registryPrefix,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get images: %w", err)
+				}
+				imageList = append(imageList, imagesWithKonnectivity...)
+			}
+		}
+	}
+	return imageList, nil
+}
+
 func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions, options *MirrorImagesOptions) cobraFuncE {
 	return handleErrors(logger, func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
@@ -236,57 +283,12 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 
 			// Using a set here for deduplication
 			imageSet := sets.New[string]()
-			for _, clusterVersion := range clusterVersions {
-				for _, cloudSpec := range images.GetCloudSpecs() {
-					for _, cniPlugin := range images.GetCNIPlugins() {
-						versionLogger := logger.WithFields(logrus.Fields{
-							"version":     clusterVersion.Version.String(),
-							"provider":    cloudSpec.ProviderName,
-							"cni-plugin":  string(cniPlugin.Type),
-							"cni-version": cniPlugin.Version,
-						})
 
-						versionLogger.Debug("Collecting images…")
-
-						// Collect images without & with Konnectivity, as Konnecctivity / OpenVPN can be switched in clusters
-						// at any time. Remove the non-Konnectivity option once OpenVPN option is finally removed.
-
-						imagesWithoutKonnectivity, err := images.GetImagesForVersion(
-							versionLogger,
-							clusterVersion,
-							cloudSpec,
-							cniPlugin,
-							false,
-							kubermaticConfig,
-							allAddons,
-							versions,
-							caBundle,
-							options.RegistryPrefix,
-						)
-						if err != nil {
-							return fmt.Errorf("failed to get images: %w", err)
-						}
-						imageSet.Insert(imagesWithoutKonnectivity...)
-
-						imagesWithKonnectivity, err := images.GetImagesForVersion(
-							versionLogger,
-							clusterVersion,
-							cloudSpec,
-							cniPlugin,
-							true,
-							kubermaticConfig,
-							allAddons,
-							versions,
-							caBundle,
-							options.RegistryPrefix,
-						)
-						if err != nil {
-							return fmt.Errorf("failed to get images: %w", err)
-						}
-						imageSet.Insert(imagesWithKonnectivity...)
-					}
-				}
+			imageList, err := CollectImageMatrix(logger, clusterVersions, kubermaticConfig, allAddons, versions, caBundle, options.RegistryPrefix)
+			if err != nil {
+				return err
 			}
+			imageSet.Insert(imageList...)
 
 			// Populate the imageSet with images specified in the KubermaticConfiguration's MirrorImages field.
 			// This ensures that all required images for mirroring are included in the set for further processing.

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -60,6 +60,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
+	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
@@ -338,13 +339,21 @@ func CopyImages(ctx context.Context, log logrus.FieldLogger, dryRun bool, images
 		return 0, len(imageList), nil
 	}
 
+	var failedImages []string
+
 	for index, image := range imageList {
 		if err := copyImage(ctx, log.WithField("image", fmt.Sprintf("%d/%d", index+1, len(imageList))), image, userAgent); err != nil {
-			return index, len(imageList), fmt.Errorf("failed copying image %s: %w", image.Source, err)
+			log.Errorf("Failed to copy image: %v", err)
+			failedImages = append(failedImages, fmt.Sprintf("  - %s", image.Source))
 		}
 	}
 
-	return len(imageList), len(imageList), nil
+	successCount := len(imageList) - len(failedImages)
+	if len(failedImages) > 0 {
+		return successCount, len(imageList), fmt.Errorf("failed images:\n%s", strings.Join(failedImages, "\n"))
+	}
+
+	return successCount, len(imageList), nil
 }
 
 func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDest, userAgent string) error {
@@ -362,7 +371,7 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 
 	numTries := 0
 	backoff := wait.Backoff{
-		Steps:    10,
+		Steps:    3,
 		Duration: 500 * time.Millisecond,
 		Factor:   1.0,
 		Jitter:   0.1,
@@ -557,49 +566,150 @@ func getImagesFromPodSpec(spec corev1.PodSpec) (images []string) {
 
 func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle, seed *kubermaticv1.Seed) (*resources.TemplateData, error) {
 	// We need listers and a set of objects to not have our deployment/statefulset creators fail
-	mockObjects := []runtime.Object{
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.ApiserverServiceName,
-				Namespace: mockNamespaceName,
-			},
-			Spec: corev1.ServiceSpec{
-				Ports:     []corev1.ServicePort{{NodePort: 99}},
-				ClusterIP: "192.0.2.10",
-			},
+	caBundleConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.CABundleConfigMapName,
+			Namespace: mockNamespaceName,
 		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.OpenVPNServerServiceName,
-				Namespace: mockNamespaceName,
-			},
-			Spec: corev1.ServiceSpec{
-				Ports:     []corev1.ServicePort{{NodePort: 96}},
-				ClusterIP: "192.0.2.2",
-			},
+	}
+	prometheusConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.PrometheusConfigConfigMapName,
+			Namespace: mockNamespaceName,
 		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.DNSResolverServiceName,
-				Namespace: mockNamespaceName,
-			},
-			Spec: corev1.ServiceSpec{
-				Ports:     []corev1.ServicePort{{NodePort: 98}},
-				ClusterIP: "192.0.2.11",
-			},
+	}
+	dnsResolverConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.DNSResolverConfigMapName,
+			Namespace: mockNamespaceName,
 		},
-		&corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      resources.KonnectivityProxyServiceName,
-				Namespace: mockNamespaceName,
-			},
-			Spec: corev1.ServiceSpec{
-				Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
-				ClusterIP: "192.0.2.20",
-			},
+	}
+	openvpnClientConfigsConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.OpenVPNClientConfigsConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
+	auditConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.AuditConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
+	admissionControlConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.AdmissionControlConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
+	konnectivityKubeApiserverEgressConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.KonnectivityKubeApiserverEgress,
+			Namespace: mockNamespaceName,
+		},
+	}
+	configMapList := &corev1.ConfigMapList{
+		Items: []corev1.ConfigMap{
+			caBundleConfigMap,
+			prometheusConfigMap,
+			dnsResolverConfigMap,
+			openvpnClientConfigsConfigMap,
+			auditConfigMap,
+			admissionControlConfigMap,
+			konnectivityKubeApiserverEgressConfigMap,
+		},
+	}
+	apiServerService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.ApiserverServiceName,
+			Namespace: mockNamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:     []corev1.ServicePort{{NodePort: 99}},
+			ClusterIP: "192.0.2.10",
+		},
+	}
+	openvpnserverService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.OpenVPNServerServiceName,
+			Namespace: mockNamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:     []corev1.ServicePort{{NodePort: 96}},
+			ClusterIP: "192.0.2.2",
+		},
+	}
+	dnsService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.DNSResolverServiceName,
+			Namespace: mockNamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:     []corev1.ServicePort{{NodePort: 98}},
+			ClusterIP: "192.0.2.11",
+		},
+	}
+	konnectivityService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.KonnectivityProxyServiceName,
+			Namespace: mockNamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
+			ClusterIP: "192.0.2.20",
 		},
 	}
 
+	serviceList := &corev1.ServiceList{
+		Items: []corev1.Service{
+			apiServerService,
+			openvpnserverService,
+			dnsService,
+			konnectivityService,
+		},
+	}
+	secretList := createNamedSecrets([]string{
+		resources.CloudConfigSeedSecretName,
+		resources.CASecretName,
+		resources.TokensSecretName,
+		resources.ApiserverTLSSecretName,
+		resources.KubeletClientCertificatesSecretName,
+		resources.ServiceAccountKeySecretName,
+		resources.ApiserverEtcdClientCertificateSecretName,
+		resources.ApiserverFrontProxyClientCertificateSecretName,
+		resources.EtcdTLSCertificateSecretName,
+		resources.MachineControllerKubeconfigSecretName,
+		resources.ControllerManagerKubeconfigSecretName,
+		resources.SchedulerKubeconfigSecretName,
+		resources.KubeStateMetricsKubeconfigSecretName,
+		resources.OpenVPNCASecretName,
+		resources.OpenVPNServerCertificatesSecretName,
+		resources.OpenVPNClientCertificatesSecretName,
+		resources.FrontProxyCASecretName,
+		resources.KubeletDnatControllerKubeconfigSecretName,
+		resources.PrometheusApiserverClientCertificateSecretName,
+		resources.MetricsServerKubeconfigSecretName,
+		resources.MachineControllerWebhookServingCertSecretName,
+		resources.InternalUserClusterAdminKubeconfigSecretName,
+		resources.KubernetesDashboardKubeconfigSecretName,
+		metricsserver.ServingCertSecretName,
+		resources.UserSSHKeys,
+		resources.AdminKubeconfigSecretName,
+		resources.GatekeeperWebhookServerCertSecretName,
+		resources.OperatingSystemManagerKubeconfigSecretName,
+		resources.KonnectivityKubeconfigSecretName,
+		resources.KonnectivityProxyTLSSecretName,
+		resources.OperatingSystemManagerWebhookKubeconfigSecretName,
+		resources.OperatingSystemManagerWebhookServingCertSecretName,
+		resources.KubeVirtCSISecretName,
+		resources.KubeVirtInfraSecretName,
+		resources.GoogleServiceAccountSecretName,
+		resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+		resources.CSICloudConfigSecretName,
+		resources.VMwareCloudDirectorCSISecretName,
+		resources.KubeLBCCMKubeconfigSecretName,
+		resources.KubeLBManagerKubeconfigSecretName,
+	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{
 			Anexia:              &kubermaticv1.DatacenterSpecAnexia{},
@@ -612,12 +722,12 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 			VSphere:             &kubermaticv1.DatacenterSpecVSphere{},
 		},
 	}
+	objects := []runtime.Object{configMapList, secretList, serviceList}
 
 	clusterSemver, err := ksemver.NewSemver(clusterVersion.Version.String())
 	if err != nil {
 		return nil, err
 	}
-
 	fakeCluster := &kubermaticv1.Cluster{}
 	fakeCluster.Labels = map[string]string{kubermaticv1.ProjectIDLabelKey: "project"}
 	fakeCluster.Spec.Cloud = cloudSpec
@@ -635,7 +745,8 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		Enabled: true,
 	}
 
-	if cloudSpec.Openstack != nil || cloudSpec.Hetzner != nil || cloudSpec.Azure != nil || cloudSpec.VSphere != nil || cloudSpec.Anexia != nil || cloudSpec.Kubevirt != nil {
+	if fakeCluster.Spec.Cloud.Openstack != nil || fakeCluster.Spec.Cloud.Hetzner != nil || fakeCluster.Spec.Cloud.Azure != nil ||
+		fakeCluster.Spec.Cloud.VSphere != nil || fakeCluster.Spec.Cloud.Anexia != nil || fakeCluster.Spec.Cloud.Kubevirt != nil {
 		if fakeCluster.Spec.Features == nil {
 			fakeCluster.Spec.Features = make(map[string]bool)
 		}
@@ -653,7 +764,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	fakeCluster.Status.Versions.ControllerManager = *clusterSemver
 	fakeCluster.Status.Versions.Scheduler = *clusterSemver
 
-	fakeDynamicClient := fake.NewClientBuilder().WithRuntimeObjects(mockObjects...).Build()
+	fakeDynamicClient := fake.NewClientBuilder().WithRuntimeObjects(objects...).Build()
 
 	meteringConfig := &kubermaticv1.MeteringConfiguration{
 		RetentionDays:    defaulting.DefaultMeteringRetentionDays,
@@ -681,6 +792,20 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		WithCABundle(caBundle).
 		WithKonnectivityEnabled(konnectivityEnabled).
 		Build(), nil
+}
+
+func createNamedSecrets(secretNames []string) *corev1.SecretList {
+	secretList := corev1.SecretList{}
+	for _, secretName := range secretNames {
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: mockNamespaceName,
+			},
+		}
+		secretList.Items = append(secretList.Items, secret)
+	}
+	return &secretList
 }
 
 func GetVersions(log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, versionFilter string) ([]*version.Version, error) {
@@ -892,6 +1017,8 @@ func getVersionsFromKubermaticConfiguration(config *kubermaticv1.KubermaticConfi
 		versions = append(versions, &version.Version{
 			Version: v.Semver(),
 		})
+
+		return versions
 	}
 
 	return versions

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -60,7 +60,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
 	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
-	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
@@ -339,13 +338,21 @@ func CopyImages(ctx context.Context, log logrus.FieldLogger, dryRun bool, images
 		return 0, len(imageList), nil
 	}
 
+	var failedImages []string
+
 	for index, image := range imageList {
 		if err := copyImage(ctx, log.WithField("image", fmt.Sprintf("%d/%d", index+1, len(imageList))), image, userAgent); err != nil {
-			return index, len(imageList), fmt.Errorf("failed copying image %s: %w", image.Source, err)
+			log.Errorf("Failed to copy image: %v", err)
+			failedImages = append(failedImages, fmt.Sprintf("  - %s", image.Source))
 		}
 	}
 
-	return len(imageList), len(imageList), nil
+	successCount := len(imageList) - len(failedImages)
+	if len(failedImages) > 0 {
+		return successCount, len(imageList), fmt.Errorf("failed images:\n%s", strings.Join(failedImages, "\n"))
+	}
+
+	return successCount, len(imageList), nil
 }
 
 func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDest, userAgent string) error {
@@ -363,7 +370,7 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 
 	numTries := 0
 	backoff := wait.Backoff{
-		Steps:    10,
+		Steps:    3,
 		Duration: 500 * time.Millisecond,
 		Factor:   1.0,
 		Jitter:   0.1,
@@ -558,150 +565,49 @@ func getImagesFromPodSpec(spec corev1.PodSpec) (images []string) {
 
 func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle, seed *kubermaticv1.Seed) (*resources.TemplateData, error) {
 	// We need listers and a set of objects to not have our deployment/statefulset creators fail
-	caBundleConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.CABundleConfigMapName,
-			Namespace: mockNamespaceName,
+	mockObjects := []runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.ApiserverServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{NodePort: 99}},
+				ClusterIP: "192.0.2.10",
+			},
 		},
-	}
-	prometheusConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.PrometheusConfigConfigMapName,
-			Namespace: mockNamespaceName,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.OpenVPNServerServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{NodePort: 96}},
+				ClusterIP: "192.0.2.2",
+			},
 		},
-	}
-	dnsResolverConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.DNSResolverConfigMapName,
-			Namespace: mockNamespaceName,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.DNSResolverServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{NodePort: 98}},
+				ClusterIP: "192.0.2.11",
+			},
 		},
-	}
-	openvpnClientConfigsConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.OpenVPNClientConfigsConfigMapName,
-			Namespace: mockNamespaceName,
-		},
-	}
-	auditConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.AuditConfigMapName,
-			Namespace: mockNamespaceName,
-		},
-	}
-	admissionControlConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.AdmissionControlConfigMapName,
-			Namespace: mockNamespaceName,
-		},
-	}
-	konnectivityKubeApiserverEgressConfigMap := corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.KonnectivityKubeApiserverEgress,
-			Namespace: mockNamespaceName,
-		},
-	}
-	configMapList := &corev1.ConfigMapList{
-		Items: []corev1.ConfigMap{
-			caBundleConfigMap,
-			prometheusConfigMap,
-			dnsResolverConfigMap,
-			openvpnClientConfigsConfigMap,
-			auditConfigMap,
-			admissionControlConfigMap,
-			konnectivityKubeApiserverEgressConfigMap,
-		},
-	}
-	apiServerService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.ApiserverServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 99}},
-			ClusterIP: "192.0.2.10",
-		},
-	}
-	openvpnserverService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.OpenVPNServerServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 96}},
-			ClusterIP: "192.0.2.2",
-		},
-	}
-	dnsService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.DNSResolverServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{NodePort: 98}},
-			ClusterIP: "192.0.2.11",
-		},
-	}
-	konnectivityService := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      resources.KonnectivityProxyServiceName,
-			Namespace: mockNamespaceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
-			ClusterIP: "192.0.2.20",
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KonnectivityProxyServiceName,
+				Namespace: mockNamespaceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
+				ClusterIP: "192.0.2.20",
+			},
 		},
 	}
 
-	serviceList := &corev1.ServiceList{
-		Items: []corev1.Service{
-			apiServerService,
-			openvpnserverService,
-			dnsService,
-			konnectivityService,
-		},
-	}
-	secretList := createNamedSecrets([]string{
-		resources.CloudConfigSeedSecretName,
-		resources.CASecretName,
-		resources.TokensSecretName,
-		resources.ApiserverTLSSecretName,
-		resources.KubeletClientCertificatesSecretName,
-		resources.ServiceAccountKeySecretName,
-		resources.ApiserverEtcdClientCertificateSecretName,
-		resources.ApiserverFrontProxyClientCertificateSecretName,
-		resources.EtcdTLSCertificateSecretName,
-		resources.MachineControllerKubeconfigSecretName,
-		resources.ControllerManagerKubeconfigSecretName,
-		resources.SchedulerKubeconfigSecretName,
-		resources.KubeStateMetricsKubeconfigSecretName,
-		resources.OpenVPNCASecretName,
-		resources.OpenVPNServerCertificatesSecretName,
-		resources.OpenVPNClientCertificatesSecretName,
-		resources.FrontProxyCASecretName,
-		resources.KubeletDnatControllerKubeconfigSecretName,
-		resources.PrometheusApiserverClientCertificateSecretName,
-		resources.MetricsServerKubeconfigSecretName,
-		resources.MachineControllerWebhookServingCertSecretName,
-		resources.InternalUserClusterAdminKubeconfigSecretName,
-		resources.KubernetesDashboardKubeconfigSecretName,
-		metricsserver.ServingCertSecretName,
-		resources.UserSSHKeys,
-		resources.AdminKubeconfigSecretName,
-		resources.GatekeeperWebhookServerCertSecretName,
-		resources.OperatingSystemManagerKubeconfigSecretName,
-		resources.KonnectivityKubeconfigSecretName,
-		resources.KonnectivityProxyTLSSecretName,
-		resources.OperatingSystemManagerWebhookKubeconfigSecretName,
-		resources.OperatingSystemManagerWebhookServingCertSecretName,
-		resources.KubeVirtCSISecretName,
-		resources.KubeVirtInfraSecretName,
-		resources.GoogleServiceAccountSecretName,
-		resources.VMwareCloudDirectorCSIKubeconfigSecretName,
-		resources.CSICloudConfigSecretName,
-		resources.VMwareCloudDirectorCSISecretName,
-		resources.KubeLBCCMKubeconfigSecretName,
-		resources.KubeLBManagerKubeconfigSecretName,
-	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{
 			Anexia:              &kubermaticv1.DatacenterSpecAnexia{},
@@ -714,12 +620,12 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 			VSphere:             &kubermaticv1.DatacenterSpecVSphere{},
 		},
 	}
-	objects := []runtime.Object{configMapList, secretList, serviceList}
 
 	clusterSemver, err := ksemver.NewSemver(clusterVersion.Version.String())
 	if err != nil {
 		return nil, err
 	}
+
 	fakeCluster := &kubermaticv1.Cluster{}
 	fakeCluster.Labels = map[string]string{kubermaticv1.ProjectIDLabelKey: "project"}
 	fakeCluster.Spec.Cloud = cloudSpec
@@ -737,8 +643,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		Enabled: true,
 	}
 
-	if fakeCluster.Spec.Cloud.Openstack != nil || fakeCluster.Spec.Cloud.Hetzner != nil || fakeCluster.Spec.Cloud.Azure != nil ||
-		fakeCluster.Spec.Cloud.VSphere != nil || fakeCluster.Spec.Cloud.Anexia != nil || fakeCluster.Spec.Cloud.Kubevirt != nil {
+	if cloudSpec.Openstack != nil || cloudSpec.Hetzner != nil || cloudSpec.Azure != nil || cloudSpec.VSphere != nil || cloudSpec.Anexia != nil || cloudSpec.Kubevirt != nil {
 		if fakeCluster.Spec.Features == nil {
 			fakeCluster.Spec.Features = make(map[string]bool)
 		}
@@ -756,7 +661,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	fakeCluster.Status.Versions.ControllerManager = *clusterSemver
 	fakeCluster.Status.Versions.Scheduler = *clusterSemver
 
-	fakeDynamicClient := fake.NewClientBuilder().WithRuntimeObjects(objects...).Build()
+	fakeDynamicClient := fake.NewClientBuilder().WithRuntimeObjects(mockObjects...).Build()
 
 	meteringConfig := &kubermaticv1.MeteringConfiguration{
 		RetentionDays:    defaulting.DefaultMeteringRetentionDays,
@@ -784,20 +689,6 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		WithCABundle(caBundle).
 		WithKonnectivityEnabled(konnectivityEnabled).
 		Build(), nil
-}
-
-func createNamedSecrets(secretNames []string) *corev1.SecretList {
-	secretList := corev1.SecretList{}
-	for _, secretName := range secretNames {
-		secret := corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: mockNamespaceName,
-			},
-		}
-		secretList.Items = append(secretList.Items, secret)
-	}
-	return &secretList
 }
 
 func GetVersions(log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, versionFilter string) ([]*version.Version, error) {

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -338,21 +338,13 @@ func CopyImages(ctx context.Context, log logrus.FieldLogger, dryRun bool, images
 		return 0, len(imageList), nil
 	}
 
-	var failedImages []string
-
 	for index, image := range imageList {
 		if err := copyImage(ctx, log.WithField("image", fmt.Sprintf("%d/%d", index+1, len(imageList))), image, userAgent); err != nil {
-			log.Errorf("Failed to copy image: %v", err)
-			failedImages = append(failedImages, fmt.Sprintf("  - %s", image.Source))
+			return index, len(imageList), fmt.Errorf("failed copying image %s: %w", image.Source, err)
 		}
 	}
 
-	successCount := len(imageList) - len(failedImages)
-	if len(failedImages) > 0 {
-		return successCount, len(imageList), fmt.Errorf("failed images:\n%s", strings.Join(failedImages, "\n"))
-	}
-
-	return successCount, len(imageList), nil
+	return len(imageList), len(imageList), nil
 }
 
 func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDest, userAgent string) error {
@@ -370,7 +362,7 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 
 	numTries := 0
 	backoff := wait.Backoff{
-		Steps:    3,
+		Steps:    10,
 		Duration: 500 * time.Millisecond,
 		Factor:   1.0,
 		Jitter:   0.1,
@@ -900,8 +892,6 @@ func getVersionsFromKubermaticConfiguration(config *kubermaticv1.KubermaticConfi
 		versions = append(versions, &version.Version{
 			Version: v.Semver(),
 		})
-
-		return versions
 	}
 
 	return versions


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve the experience `mirror-images` by ensuring the process continues processing all images without blocking, even if some images fail. Collect and list all failed images at the end of the operation for better visibility and debugging. This approach provides a comprehensive summary of failures while maintaining process continuity.

![Screenshot from 2025-03-21 15-53-43](https://github.com/user-attachments/assets/fd37c167-1c47-44a9-9735-f0e4f3e262ea)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure `mirror-images` processes all images without blocking, logging failed images at the end for better visibility and debugging.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
