### PR TITLE
[release/v2.25] allow to use the update-docs script for release branches (#14288)

### DIFF
--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -29,35 +29,49 @@ line() {
 TARGET_DIR=docs_sync
 REVISION=$(git rev-parse --short HEAD)
 
-# create the addon resource overview (addonresources.json)
-go run codegen/addon-resources/main.go
+# figure out what release we're updating the docs for (main branch or a fixed release branch?)
+GIT_BRANCH="${PULL_BASE_REF:-main}"
+
+export KKP_RELEASE="$GIT_BRANCH"
+if [[ "$GIT_BRANCH" =~ release/v[0-9]+.* ]]; then
+  # turn "release/v2.21" into "v2.21"
+  KKP_RELEASE="${GIT_BRANCH#release/}"
+fi
+
+echodate "Updating documentation for KKP."
+echodate "GIt branch: $GIT_BRANCH"
+echodate "KKP version directory: $KKP_RELEASE"
+echo
 
 # configure Git
 git config --global user.email "dev@kubermatic.com"
-git config --global user.name "Prow CI Robot"
+git config --global user.name "Kubermatic Bot"
 git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
 ensure_github_host_pubkey
+
+# create the addon resource overview (addonresources.json)
+go run codegen/addon-resources/main.go
 
 # create a fresh clone
 git clone git@github.com:kubermatic/docs.git $TARGET_DIR
 cd $TARGET_DIR
 
 # copy interesting files over
-mkdir -p data/kubermatic/main
-mkdir -p content/kubermatic/main/data
+mkdir -p "data/kubermatic/$KKP_RELEASE"
+mkdir -p "content/kubermatic/$KKP_RELEASE/data"
 
 for resource in seed kubermaticConfiguration applicationDefinition applicationInstallation; do
   for edition in ce ee; do
-    cp ../docs/zz_generated.$resource.$edition.yaml content/kubermatic/main/data/$resource.$edition.yaml
+    cp ../docs/zz_generated.$resource.$edition.yaml "content/kubermatic/$KKP_RELEASE/data/$resource.$edition.yaml"
   done
 
   # for backwards compatibility with the scripting in the docs repository
-  cp ../docs/zz_generated.$resource.ce.yaml content/kubermatic/main/data/$resource.yaml
+  cp ../docs/zz_generated.$resource.ce.yaml "content/kubermatic/$KKP_RELEASE/data/$resource.yaml"
 done
 
-cp ../docs/zz_generated.addondata.go.txt content/kubermatic/main/data/addondata.go
-cp ../docs/zz_generated.prometheusdata.go.txt content/kubermatic/main/data/prometheusdata.go
-cp ../addonresources.json content/kubermatic/main/data/addonresources.json
+cp ../docs/zz_generated.addondata.go.txt "content/kubermatic/$KKP_RELEASE/data/addondata.go"
+cp ../docs/zz_generated.prometheusdata.go.txt "content/kubermatic/$KKP_RELEASE/data/prometheusdata.go"
+cp ../addonresources.json "content/kubermatic/$KKP_RELEASE/data/addonresources.json"
 
 # re-create Prometheus runbook
 make runbook
@@ -66,7 +80,7 @@ make runbook
 hack/render-crds.sh
 
 # update components page
-components_file=content/kubermatic/main/architecture/compatibility/kkp-components-versioning/_index.en.md
+components_file=content/kubermatic/$KKP_RELEASE/architecture/compatibility/kkp-components-versioning/_index.en.md
 cat > ${components_file} << EOT
 +++
 title = "KKP Components"
@@ -98,6 +112,6 @@ done
 git add .
 
 if ! git diff --cached --stat --exit-code; then
-  git commit -m "Syncing with kubermatic/kubermatic@$REVISION"
+  git commit -m "Syncing with KKP $KKP_RELEASE ($REVISION)"
   git push
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #14288.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
