### PR TITLE
add new field to allow vcpu configuration for kubevirt virtual machines

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -185,6 +185,9 @@ spec:
           # 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
           # policy selected with DNSPolicy.
           dnsPolicy: ""
+          # Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
+          # Defaults to false.
+          enableDedicatedCpus: false
           # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
           # Defaults to true.
           enableDefaultNetworkPolicies: true

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -188,6 +188,9 @@ spec:
           # 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
           # policy selected with DNSPolicy.
           dnsPolicy: ""
+          # Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
+          # Defaults to false.
+          enableDedicatedCpus: false
           # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
           # Defaults to true.
           enableDefaultNetworkPolicies: true

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -955,6 +955,11 @@ spec:
                                   - Default
                                   - None
                                 type: string
+                              enableDedicatedCpus:
+                                description: |-
+                                  Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
+                                  Defaults to false.
+                                type: boolean
                               enableDefaultNetworkPolicies:
                                 description: |-
                                   Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -823,6 +823,10 @@ type DatacenterSpecKubevirt struct {
 	// Defaults to true.
 	EnableDefaultNetworkPolicies *bool `json:"enableDefaultNetworkPolicies,omitempty"`
 
+	// Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
+	// Defaults to false.
+	EnableDedicatedCPUs bool `json:"enableDedicatedCpus,omitempty"`
+
 	// Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
 	// in the dedicated infra KubeVirt cluster. They are added to the defaults.
 	CustomNetworkPolicies []CustomNetworkPolicy `json:"customNetworkPolicies,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a new field to seed crd to control whether kubevirt machine cpus are configured by resource requests and limits or domain spec. Later one is required to use kubevirt cpu allocation ratio feature.
The logic for the new field will be added by another pull request in the dashboard repository because the creation of machine deployments is controlled by kkp api.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Is related to #14245.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new field `spec.datacenters.<example-dc>.spec.kubevirt.enableDedicatedCpus` was added to seed crd to control whether kubevirt machine cpus are configured by `spec.template.spec.domain.resources` with requests and limits or `spec.template.spec.domain.cpu` . Later one is required to use kubevirt cpu allocation ratio feature.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
