### PR TITLE
Bump Go build image version to 1.23.7

### DIFF
--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -582,7 +582,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -159,7 +159,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -117,7 +117,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -204,7 +204,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -247,7 +247,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -286,7 +286,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -206,7 +206,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/release-utility-images.sh"
           env:

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.6 AS builder
+FROM docker.io/golang:1.23.7 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.6 AS builder
+FROM docker.io/golang:1.23.7 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.6 AS builder
+FROM docker.io/golang:1.23.7 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-3
+FROM quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
 LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/hack/images/integration-tests/Dockerfile"
 LABEL org.opencontainers.image.vendor="Kubermatic"
 LABEL org.opencontainers.image.authors="support@kubermatic.com"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-9 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-9 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-9 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/update-kubermatic-ca-bundle.sh
+++ b/hack/update-kubermatic-ca-bundle.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.23.6 containerize ./hack/update-kubermatic-ca-bundle.sh
+CONTAINERIZE_IMAGE=golang:1.23.7 containerize ./hack/update-kubermatic-ca-bundle.sh
 
 echodate "Updating CA bundle..."
 curl -Lo charts/kubermatic-operator/static/ca-bundle.pem https://curl.se/ca/cacert.pem

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-9 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-9 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump the Go version to v1.23.7

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
