### PR TITLE
Update to Go 1.24, golangci-lint 2.x

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,6 @@ linters:
     - nosprintfhostport
     - predeclared
     - promlinter
-    - revive
     - staticcheck
     - unconvert
     - unused
@@ -112,11 +111,6 @@ linters:
         - pkg: github.com/vmware-tanzu/velero/pkg/apis/velero/v1
           alias: velerov1
       no-unaliased: true
-    revive:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
-      rules:
-        - name: duplicated-imports
-          severity: warning
     staticcheck:
       checks:
         - all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,7 +139,7 @@ linters:
       - path: (.+)\.go$
         text: cyclomatic complexity [0-9]+ of func `\(\*Azure\)\.CleanUpCloudProvider` is high
       - path: (.+)\.go$
-        text: cyclomatic complexity [0-9]+ of func `\(\*Reconciler\)\.reconcile` is high
+        text: cyclomatic complexity [0-9]+ of func `\(\*[rR]econciler\)\.reconcile` is high
       - path: (.+)\.go$
         text: cyclomatic complexity [0-9]+ of func `initTestEndpoint` is high
       - path: (.+)\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 run:
   # concurrency=1 lowers memory usage a bit
   concurrency: 1
   modules-download-mode: readonly
-  timeout: 30m
   build-tags:
     - ce
     - cloud
@@ -30,6 +30,7 @@ run:
     - logout
 
 linters:
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -45,8 +46,6 @@ linters:
     - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - gosimple
     - govet
     - importas
     - ineffassign
@@ -59,96 +58,123 @@ linters:
     - promlinter
     - revive
     - staticcheck
-    - tenv
     - unconvert
     - unused
     - usestdlibvars
     - wastedassign
     - whitespace
-  disable-all: true
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: https://go.dev/doc/go1.16#ioutil
+            - pkg: github.com/ghodss/yaml
+              desc: use sigs.k8s.io/yaml instead
+    goconst:
+      min-occurrences: 5
+    govet:
+      enable:
+        - nilness # find tautologies / impossible conditions
+    importas:
+      alias:
+        # KKP
+        - pkg: k8c.io/kubermatic/sdk/v2/api/v1
+          alias: apiv1
+        - pkg: k8c.io/kubermatic/sdk/v2/api/v2
+          alias: apiv2
+        - pkg: k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1
+          alias: appskubermaticv1
+        - pkg: k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1
+          alias: kubermaticv1
+        - pkg: k8c.io/kubermatic/v2/pkg/util/errors
+          alias: utilerrors
+        # Kubernetes
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        # Controller Runtime
+        - pkg: sigs.k8s.io/controller-runtime/pkg/client
+          alias: ctrlruntimeclient
+        # Misc
+        - pkg: k8c.io/machine-controller/pkg/apis/cluster/v1alpha1
+          alias: clusterv1alpha1
+        - pkg: github.com/Masterminds/semver/v3
+          alias: semverlib
+        - pkg: github.com/vmware-tanzu/velero/pkg/apis/velero/v1
+          alias: velerov1
+      no-unaliased: true
+    revive:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      rules:
+        - name: duplicated-imports
+          severity: warning
+    staticcheck:
+      checks:
+        - all
+        # disable "error strings should not be capitalized":
+        # but often errors start with k8s kinds and it's annoying to rephrase every error
+        - '-ST1005'
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling
+      - common-false-positives
+      - legacy
+    # NOTE: Do not use commas in the exclude patterns, or else the regex will be
+    # split and you will be sad: https://github.com/golangci/golangci-lint/issues/665
+    rules:
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `main` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `DefaultConfiguration` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `\(\*Azure\)\.CleanUpCloudProvider` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `\(\*Reconciler\)\.reconcile` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `initTestEndpoint` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `\(\*Provider\)\.InitializeCloudProvider` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `\(\*Reconciler\)\.ensureResourcesAreDeployed` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `TestKonnectivity` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `validateOpenStackCloudSpec` is high
+      - path: (.+)\.go$
+        text: cyclomatic complexity [0-9]+ of func `\(\*ModifiersBuilder\)\.Build` is high
+      # gocritic
+      - path: (.+)\.go$
+        text: singleCaseSwitch # in most cases this is the beginning of a lookup table and should be kept an obvious table
+      - linters:
+          - goconst
+        path: (.+)_test\.go
+    paths:
+      - zz_generated.*.go
+      # This package was forked from upstream (in #9826)
+      # and we want to keep it as close to upstream as possible.
+      - pkg/provider/cloud/eks/authenticator
 
-# NOTE: Do not use commas in the exclude patterns, or else the regex will be
-# split and you will be sad: https://github.com/golangci/golangci-lint/issues/665
 issues:
-  exclude-files:
-    - zz_generated.*.go
-  exclude-dirs:
-    # This package was forked from upstream (in #9826)
-    # and we want to keep it as close to upstream as possible.
-    - pkg/provider/cloud/eks/authenticator
-
   # defaults to 3, which often needlessly hides issues and forces
   # to re-run the linter across the entire repo many times
-  max-same-issues: 50
-  exclude:
-  # gocyclo
-  - cyclomatic complexity [0-9]+ of func `main` is high
-  - cyclomatic complexity [0-9]+ of func `DefaultConfiguration` is high
-  - cyclomatic complexity [0-9]+ of func `\(\*Azure\)\.CleanUpCloudProvider` is high
-  - cyclomatic complexity [0-9]+ of func `\(\*Reconciler\)\.reconcile` is high
-  - cyclomatic complexity [0-9]+ of func `initTestEndpoint` is high
-  - cyclomatic complexity [0-9]+ of func `\(\*Provider\)\.InitializeCloudProvider` is high
-  - cyclomatic complexity [0-9]+ of func `\(\*Reconciler\)\.ensureResourcesAreDeployed` is high
-  - cyclomatic complexity [0-9]+ of func `TestKonnectivity` is high
-  - cyclomatic complexity [0-9]+ of func `validateOpenStackCloudSpec` is high
-  - cyclomatic complexity [0-9]+ of func `\(\*ModifiersBuilder\)\.Build` is high
-  # gocritic
-  - singleCaseSwitch # in most cases this is the beginning of a lookup table and should be kept an obvious table
+  max-same-issues: 0
 
-linters-settings:
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
-      - name: duplicated-imports
-        severity: warning
-
-  depguard:
-    rules:
-      main:
-        deny:
-          - { pkg: io/ioutil, desc: https://go.dev/doc/go1.16#ioutil }
-          - { pkg: github.com/ghodss/yaml, desc: use sigs.k8s.io/yaml instead }
-
-  govet:
-    enable:
-      - nilness # find tautologies / impossible conditions
-
-  goconst:
-    min-occurrences: 5
-    ignore-tests: true
-
-  importas:
-    no-unaliased: true
-    alias:
-      # KKP
-      - pkg: k8c.io/kubermatic/sdk/v2/api/v1
-        alias: apiv1
-      - pkg: k8c.io/kubermatic/sdk/v2/api/v2
-        alias: apiv2
-      - pkg: k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1
-        alias: appskubermaticv1
-      - pkg: k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1
-        alias: kubermaticv1
-      - pkg: k8c.io/kubermatic/v2/pkg/util/errors
-        alias: utilerrors
-      # Kubernetes
-      - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
-        alias: $1$2
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-        alias: apiextensionsv1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: k8s.io/apimachinery/pkg/util/errors
-        alias: kerrors
-      # Controller Runtime
-      - pkg: sigs.k8s.io/controller-runtime/pkg/client
-        alias: ctrlruntimeclient
-      # Misc
-      - pkg: k8c.io/machine-controller/pkg/apis/cluster/v1alpha1
-        alias: clusterv1alpha1
-      - pkg: github.com/Masterminds/semver/v3
-        alias: semverlib
-      - pkg: github.com/vmware-tanzu/velero/pkg/apis/velero/v1
-        alias: velerov1
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    paths:
+      - zz_generated.*.go
+      # This package was forked from upstream (in #9826)
+      # and we want to keep it as close to upstream as possible.
+      - pkg/provider/cloud/eks/authenticator

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -582,7 +582,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -159,7 +159,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -117,7 +117,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -204,7 +204,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -247,7 +247,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -286,7 +286,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -206,7 +206,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-3
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/release-utility-images.sh"
           env:

--- a/cmd/alertmanager-authorization-server/main.go
+++ b/cmd/alertmanager-authorization-server/main.go
@@ -167,8 +167,8 @@ func (s *authorizationServer) Check(ctx context.Context, req *authv3.CheckReques
 	}, nil
 }
 
-func (a *authorizationServer) authorize(ctx context.Context, userEmail, clusterID string) (authorized bool, reason string, err error) {
-	isAdmin, err := a.isAdminUser(ctx, userEmail)
+func (s *authorizationServer) authorize(ctx context.Context, userEmail, clusterID string) (authorized bool, reason string, err error) {
+	isAdmin, err := s.isAdminUser(ctx, userEmail)
 	if err != nil {
 		return false, "", fmt.Errorf("checking if user is admin: %w", err)
 	}
@@ -177,7 +177,7 @@ func (a *authorizationServer) authorize(ctx context.Context, userEmail, clusterI
 	}
 
 	cluster := &kubermaticv1.Cluster{}
-	if err := a.client.Get(ctx, types.NamespacedName{Name: clusterID}, cluster); err != nil {
+	if err := s.client.Get(ctx, types.NamespacedName{Name: clusterID}, cluster); err != nil {
 		return false, "", fmt.Errorf("getting cluster: %w", err)
 	}
 
@@ -187,7 +187,7 @@ func (a *authorizationServer) authorize(ctx context.Context, userEmail, clusterI
 	}
 
 	allMembers := &kubermaticv1.UserProjectBindingList{}
-	if err := a.client.List(ctx, allMembers); err != nil {
+	if err := s.client.List(ctx, allMembers); err != nil {
 		return false, "", fmt.Errorf("listing userProjectBinding: %w", err)
 	}
 
@@ -199,7 +199,7 @@ func (a *authorizationServer) authorize(ctx context.Context, userEmail, clusterI
 
 	// authorize through group project bindings
 	allGroupBindings := &kubermaticv1.GroupProjectBindingList{}
-	if err := a.client.List(ctx, allGroupBindings, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID}); err != nil {
+	if err := s.client.List(ctx, allGroupBindings, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: projectID}); err != nil {
 		return false, "", fmt.Errorf("listing groupProjectBinding: %w", err)
 	}
 
@@ -210,7 +210,7 @@ func (a *authorizationServer) authorize(ctx context.Context, userEmail, clusterI
 		}
 
 		allUsers := &kubermaticv1.UserList{}
-		if err := a.client.List(ctx, allUsers); err != nil {
+		if err := s.client.List(ctx, allUsers); err != nil {
 			return false, "", fmt.Errorf("listing users: %w", err)
 		}
 

--- a/cmd/conformance-tester/pkg/runner/result.go
+++ b/cmd/conformance-tester/pkg/runner/result.go
@@ -235,20 +235,20 @@ func (sr *ScenarioResult) MatchesScenario(scenario scenarios.Scenario) bool {
 		scenario.ClusterVersion() == sr.KubernetesVersion
 }
 
-func (r *ScenarioResult) PrintJUnitDetails() {
-	if r.report == nil {
+func (sr *ScenarioResult) PrintJUnitDetails() {
+	if sr.report == nil {
 		return
 	}
 
 	const separator = "============================================================="
 
 	fmt.Println(separator)
-	fmt.Printf("Test results for: %s\n", r.report.Name)
+	fmt.Printf("Test results for: %s\n", sr.report.Name)
 
 	// Only print details errors in case we have a testcase which failed.
 	// Printing everything which has an error will print the errors from retried tests as for each attempt a TestCase entry exists.
-	if r.report.Failures > 0 || r.report.Errors > 0 {
-		for _, t := range r.report.TestCases {
+	if sr.report.Failures > 0 || sr.report.Errors > 0 {
+		for _, t := range sr.report.TestCases {
 			if t.FailureMessage == nil {
 				continue
 			}
@@ -259,8 +259,8 @@ func (r *ScenarioResult) PrintJUnitDetails() {
 	}
 
 	fmt.Println("----------------------------")
-	fmt.Printf("Passed: %d\n", r.report.Tests-r.report.Failures)
-	fmt.Printf("Failed: %d\n", r.report.Failures)
+	fmt.Printf("Passed: %d\n", sr.report.Tests-sr.report.Failures)
+	fmt.Printf("Failed: %d\n", sr.report.Failures)
 	fmt.Println(separator)
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/anexia.go
+++ b/cmd/conformance-tester/pkg/scenarios/anexia.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	nodeCpu      = 2
+	nodeCPU      = 2
 	nodeDiskSize = 60
 	nodeMemory   = 2048
 )
@@ -40,7 +40,7 @@ type anexiaScenario struct {
 }
 
 func (s *anexiaScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](
+	return sets.New(
 		providerconfig.OperatingSystemFlatcar,
 	)
 }
@@ -71,7 +71,7 @@ func (s *anexiaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 
 func (s *anexiaScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewAnexiaConfig().
-		WithCPUs(nodeCpu).
+		WithCPUs(nodeCPU).
 		WithMemory(nodeMemory).
 		AddDisk(nodeDiskSize, "ENT6").
 		WithTemplateID(secrets.Anexia.TemplateID).

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	kubevirtImageHttpServerSvc = "http://image-repo.kube-system.svc/images"
+	kubevirtImageHTTPServerSvc = "http://image-repo.kube-system.svc/images"
 	kubevirtCPUs               = 2
 	kubevirtMemory             = "4Gi"
 	kubevirtDiskSize           = "25Gi"
@@ -43,7 +43,7 @@ type kubevirtScenario struct {
 }
 
 func (s *kubevirtScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](
+	return sets.New(
 		providerconfig.OperatingSystemUbuntu,
 		providerconfig.OperatingSystemRHEL,
 		providerconfig.OperatingSystemFlatcar,
@@ -104,7 +104,7 @@ func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secret
 func (s *kubevirtScenario) getOSImage() (string, error) {
 	switch s.operatingSystem {
 	case providerconfig.OperatingSystemUbuntu:
-		return kubevirtImageHttpServerSvc + "/ubuntu-22.04.img", nil
+		return kubevirtImageHTTPServerSvc + "/ubuntu-22.04.img", nil
 	default:
 		return "", fmt.Errorf("unsupported OS %q selected", s.operatingSystem)
 	}

--- a/cmd/conformance-tester/pkg/tests/telemetry.go
+++ b/cmd/conformance-tester/pkg/tests/telemetry.go
@@ -107,7 +107,7 @@ func getLatestTelemetryPod(ctx context.Context, client ctrlruntimeclient.Client,
 	)
 
 	for i, pod := range podList.Items {
-		if pod.Status.Phase == corev1.PodSucceeded && pod.CreationTimestamp.Time.After(latest) {
+		if pod.Status.Phase == corev1.PodSucceeded && pod.CreationTimestamp.After(latest) {
 			latestPod = &podList.Items[i]
 			latest = pod.CreationTimestamp.Time
 		}

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -374,7 +374,7 @@ func initialMemberList(ctx context.Context, log *zap.SugaredLogger, client ctrlr
 				members = append(members, fmt.Sprintf("etcd-%d=http://etcd-%d.etcd.%s.svc.cluster.local:2380", i, i, namespace))
 			}
 
-			if _, ok := pod.ObjectMeta.Annotations[resources.EtcdTLSEnabledAnnotation]; ok {
+			if _, ok := pod.Annotations[resources.EtcdTLSEnabledAnnotation]; ok {
 				members = append(
 					members,
 					fmt.Sprintf("etcd-%d=https://etcd-%d.etcd.%s.svc.cluster.local:2381", i, i, namespace),

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.7 AS builder
+FROM docker.io/golang:1.24.2 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/kubermatic-installer/cmd_mirror_binaries.go
+++ b/cmd/kubermatic-installer/cmd_mirror_binaries.go
@@ -112,7 +112,7 @@ func getKubermaticConfigurationFromYaml(options *MirrorBinariesOptions) (*kuberm
 	return kubermaticConfig, nil
 }
 
-func downloadFromUrl(ctx context.Context, url, fileDownloadPath string) error {
+func downloadFromURL(ctx context.Context, url, fileDownloadPath string) error {
 	// Create a request with the provided context
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -185,10 +185,10 @@ func getChecksumOfFile(path string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func verifyChecksum(ctx context.Context, checksumUrl string, binaryFilePath string) error {
-	expectedChecksum, err := getChecksumFromURL(ctx, checksumUrl)
+func verifyChecksum(ctx context.Context, checksumURL string, binaryFilePath string) error {
+	expectedChecksum, err := getChecksumFromURL(ctx, checksumURL)
 	if err != nil {
-		return fmt.Errorf("error getting checksum from url %s: %w", checksumUrl, err)
+		return fmt.Errorf("error getting checksum from url %s: %w", checksumURL, err)
 	}
 	actualChecksum, err := getChecksumOfFile(binaryFilePath)
 	if err != nil {
@@ -232,7 +232,7 @@ func downloadCRITools(ctx context.Context, logger *logrus.Logger, version semver
 	criToolsFilePath := filepath.Join(criToolsDir, criToolsFileName)
 
 	// Download tarball
-	if err := downloadFromUrl(ctx, criToolsURL, criToolsFilePath); err != nil {
+	if err := downloadFromURL(ctx, criToolsURL, criToolsFilePath); err != nil {
 		return fmt.Errorf("failed to download CRI tools tarball (%s): %w", criToolsRelease, err)
 	}
 
@@ -280,7 +280,7 @@ func downloadAndVerifyBinary(ctx context.Context, binary, baseURL, targetDir str
 	binaryURL := fmt.Sprintf("%s/%s", baseURL, binary)
 	binaryPath := filepath.Join(targetDir, binary)
 
-	if err := downloadFromUrl(ctx, binaryURL, binaryPath); err != nil {
+	if err := downloadFromURL(ctx, binaryURL, binaryPath); err != nil {
 		return fmt.Errorf("failed to download %s: %w", binary, err)
 	}
 
@@ -319,7 +319,7 @@ func downloadCNIPlugins(ctx context.Context, logger *logrus.Logger, binPath, hos
 	cniPluginsFilePath := filepath.Join(cniPluginsDir, cniPluginsFileName)
 
 	// Download CNI plugins tarball
-	if err := downloadFromUrl(ctx, cniPluginsURL, cniPluginsFilePath); err != nil {
+	if err := downloadFromURL(ctx, cniPluginsURL, cniPluginsFilePath); err != nil {
 		return fmt.Errorf("failed to download CNI plugins tarball (%s): %w", cniPluginsVersion, err)
 	}
 
@@ -412,7 +412,7 @@ func ensureCleanDir(dir string) error {
 
 // downloadAndVerifyChecksum downloads the checksum from the specified URL and verifies the file's integrity.
 func downloadAndVerifyChecksum(ctx context.Context, checksumURL, checksumPath, filePath string) error {
-	if err := downloadFromUrl(ctx, checksumURL, checksumPath); err != nil {
+	if err := downloadFromURL(ctx, checksumURL, checksumPath); err != nil {
 		return fmt.Errorf("failed to download checksum: %w", err)
 	}
 

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -344,7 +344,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 
 				chartImage := fmt.Sprintf("%s/%s:%s",
 					defaulting.DefaultSystemApplicationsHelmRepository,
-					sysChart.ApplicationVersion.Template.Source.Helm.ChartName,
+					sysChart.Template.Source.Helm.ChartName,
 					sysChart.Version,
 				)
 

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.7 AS builder
+FROM docker.io/golang:1.24.2 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/main.go
+++ b/cmd/network-interface-manager/main.go
@@ -165,7 +165,7 @@ func checkIfAddrExists(link *netlink.Dummy, ifAddr string) error {
 	}
 	for _, addr := range addrs {
 		err = errors.New("address not present")
-		if addr.IPNet.IP.String() == ifAddr {
+		if addr.IP.String() == ifAddr {
 			err = nil
 			break
 		}

--- a/cmd/nodeport-proxy/lb-updater/main.go
+++ b/cmd/nodeport-proxy/lb-updater/main.go
@@ -243,10 +243,9 @@ func (u *LBUpdater) syncLB(ctx context.Context, s string) error {
 	buf.WriteString("======================\n")
 	buf.WriteString("Updated LB Ports:\n")
 	for _, p := range lb.Spec.Ports {
-		buf.WriteString(fmt.Sprintf("Name: %s\n", p.Name))
-		buf.WriteString(fmt.Sprintf("Port: %d\n", p.Port))
-		buf.WriteString(fmt.Sprintf("NodePort: %d\n", p.NodePort))
-		buf.WriteString("\n")
+		fmt.Fprintf(buf, "Name: %s\n", p.Name)
+		fmt.Fprintf(buf, "Port: %d\n", p.Port)
+		fmt.Fprintf(buf, "NodePort: %d\n\n", p.NodePort)
 	}
 	buf.WriteString("======================\n")
 	u.log.Debug(buf.String())

--- a/cmd/nodeport-proxy/lb-updater/main.go
+++ b/cmd/nodeport-proxy/lb-updater/main.go
@@ -140,7 +140,7 @@ type LBUpdater struct {
 }
 
 func (u *LBUpdater) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	err := u.syncLB(ctx, request.NamespacedName.String())
+	err := u.syncLB(ctx, request.String())
 	if err != nil {
 		u.log.Errorw("Error syncing LoadBalancer", zap.Error(err))
 	}

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.7 AS builder
+FROM docker.io/golang:1.24.2 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
+FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
 LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/hack/images/integration-tests/Dockerfile"
 LABEL org.opencontainers.image.vendor="Kubermatic"
 LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
-ENV KUBE_VERSION=1.31.0
+ENV KUBE_VERSION=1.32.0
 
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \

--- a/hack/images/integration-tests/settings.sh
+++ b/hack/images/integration-tests/settings.sh
@@ -1,1 +1,1 @@
-TAG=k8s-1.31.0-rev0
+TAG=k8s-1.32.0-rev0

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/update-kubermatic-ca-bundle.sh
+++ b/hack/update-kubermatic-ca-bundle.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.23.7 containerize ./hack/update-kubermatic-ca-bundle.sh
-
 echodate "Updating CA bundle..."
 curl -Lo charts/kubermatic-operator/static/ca-bundle.pem https://curl.se/ca/cacert.pem
 echodate "Done."

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -708,15 +708,15 @@ func TestDownloadChart(t *testing.T) {
 	chartArchiveV1Name := path.Base(chartArchiveV1Path)
 	chartArchiveV2Name := path.Base(chartArchiveV2Path)
 
-	httpRegistryUrl := test.StartHttpRegistryWithCleanup(t, chartGlobPath)
-	httpRegistryWithAuthUrl := test.StartHttpRegistryWithAuthAndCleanup(t, chartGlobPath)
+	httpRegistryURL := test.StartHTTPRegistryWithCleanup(t, chartGlobPath)
+	httpRegistryWithAuthURL := test.StartHTTPRegistryWithAuthAndCleanup(t, chartGlobPath)
 
-	ociRegistryUrl := test.StartOciRegistry(t, chartGlobPath)
-	ociregistryWithAuthUrl, registryConfigFile := test.StartOciRegistryWithAuth(t, chartGlobPath)
+	ociRegistryURL := test.StartOciRegistry(t, chartGlobPath)
+	ociregistryWithAuthURL, registryConfigFile := test.StartOciRegistryWithAuth(t, chartGlobPath)
 
 	testCases := []struct {
 		name                string
-		repoUrl             string
+		repoURL             string
 		chartName           string
 		chartVersion        string
 		auth                AuthSettings
@@ -726,7 +726,7 @@ func TestDownloadChart(t *testing.T) {
 	}{
 		{
 			name:                "Download from HTTP repository should be successful",
-			repoUrl:             httpRegistryUrl,
+			repoURL:             httpRegistryURL,
 			chartName:           "examplechart",
 			chartVersion:        "0.1.0",
 			auth:                AuthSettings{},
@@ -736,7 +736,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:                "Download from HTTP repository with empty version should get the latest version",
-			repoUrl:             httpRegistryUrl,
+			repoURL:             httpRegistryURL,
 			chartName:           "examplechart",
 			chartVersion:        "",
 			auth:                AuthSettings{},
@@ -746,7 +746,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:                "Download from HTTP repository with auth should be successful",
-			repoUrl:             httpRegistryWithAuthUrl,
+			repoURL:             httpRegistryWithAuthURL,
 			chartName:           "examplechart",
 			chartVersion:        "0.1.0",
 			auth:                AuthSettings{Username: "username", Password: "password"},
@@ -756,7 +756,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:              "Download from HTTP repository should fail when chart does not exist",
-			repoUrl:           httpRegistryUrl,
+			repoURL:           httpRegistryURL,
 			chartName:         "chartthatdoesnotexist",
 			chartVersion:      "0.1.0",
 			auth:              AuthSettings{},
@@ -765,7 +765,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:              "Download from HTTP repository should fail when version is not a semversion",
-			repoUrl:           httpRegistryUrl,
+			repoURL:           httpRegistryURL,
 			chartName:         "examplechart",
 			chartVersion:      "notSemver",
 			auth:              AuthSettings{},
@@ -775,7 +775,7 @@ func TestDownloadChart(t *testing.T) {
 
 		{
 			name:                "Download from OCI repository should be successful",
-			repoUrl:             ociRegistryUrl,
+			repoURL:             ociRegistryURL,
 			chartName:           "examplechart",
 			chartVersion:        "0.1.0",
 			auth:                AuthSettings{PlainHTTP: true},
@@ -785,7 +785,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:                "Download from OCI repository with empty version should get the latest version",
-			repoUrl:             ociRegistryUrl,
+			repoURL:             ociRegistryURL,
 			chartName:           "examplechart",
 			chartVersion:        "",
 			auth:                AuthSettings{PlainHTTP: true},
@@ -795,7 +795,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:                "Download from OCI repository with auth should be successful",
-			repoUrl:             ociregistryWithAuthUrl,
+			repoURL:             ociregistryWithAuthURL,
 			chartName:           "examplechart",
 			chartVersion:        "0.1.0",
 			auth:                AuthSettings{RegistryConfigFile: registryConfigFile, PlainHTTP: true},
@@ -805,7 +805,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:              "Download from OCI repository should fail when chart does not exist",
-			repoUrl:           ociRegistryUrl,
+			repoURL:           ociRegistryURL,
 			chartName:         "chartthatdoesnotexist",
 			chartVersion:      "0.1.0",
 			auth:              AuthSettings{PlainHTTP: true},
@@ -814,7 +814,7 @@ func TestDownloadChart(t *testing.T) {
 		},
 		{
 			name:              "Download from OCI repository should fail when version is not a semversion",
-			repoUrl:           ociRegistryUrl,
+			repoURL:           ociRegistryURL,
 			chartName:         "examplechart",
 			chartVersion:      "notSemver",
 			auth:              AuthSettings{PlainHTTP: true},
@@ -836,7 +836,7 @@ func TestDownloadChart(t *testing.T) {
 					t.Fatalf("can not init helm Client: %s", err)
 				}
 
-				chartLoc, err := helmClient.DownloadChart(tc.repoUrl, tc.chartName, tc.chartVersion, downloadDest, tc.auth)
+				chartLoc, err := helmClient.DownloadChart(tc.repoURL, tc.chartName, tc.chartVersion, downloadDest, tc.auth)
 
 				if (err != nil) != tc.wantErr {
 					t.Fatalf("DownloadChart() error = %v, wantErr %v", err, tc.wantErr)
@@ -876,15 +876,15 @@ func TestBuildDependencies(t *testing.T) {
 	test.PackageChart(t, "testdata/examplechart", chartArchiveDir)
 	test.PackageChart(t, "testdata/examplechart2", chartArchiveDir)
 
-	httpRegistryUrl := test.StartHttpRegistryWithCleanup(t, chartGlobPath)
-	httpRegistryWithAuthUrl := test.StartHttpRegistryWithAuthAndCleanup(t, chartGlobPath)
+	httpRegistryURL := test.StartHTTPRegistryWithCleanup(t, chartGlobPath)
+	httpRegistryWithAuthURL := test.StartHTTPRegistryWithAuthAndCleanup(t, chartGlobPath)
 
-	httpsRegistryUrl, httpsRegistryPKI := test.StartHttpsRegistryWithCleanup(t, chartGlobPath)
+	httpsRegistryURL, httpsRegistryPKI := test.StartHTTPSRegistryWithCleanup(t, chartGlobPath)
 
-	ociPlainRegistryUrl := test.StartOciRegistry(t, chartGlobPath)
-	ociPlainRegistryWithAuthUrl, plainRegistryConfigFile := test.StartOciRegistryWithAuth(t, chartGlobPath)
+	ociPlainRegistryURL := test.StartOciRegistry(t, chartGlobPath)
+	ociPlainRegistryWithAuthURL, plainRegistryConfigFile := test.StartOciRegistryWithAuth(t, chartGlobPath)
 
-	ociSecureRegistryUrl, ociSecurePKI := test.StartSecureOciRegistry(t, chartGlobPath)
+	ociSecureRegistryURL, ociSecurePKI := test.StartSecureOciRegistry(t, chartGlobPath)
 
 	const fileDepChartName = "filedepchart"
 	const fileDepChartVersion = "2.3.4"
@@ -904,28 +904,28 @@ func TestBuildDependencies(t *testing.T) {
 		},
 		{
 			name:         "http dependencies with Chat.lock file",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryURL}},
 			hasLockFile:  true,
 			auth:         AuthSettings{},
 			wantErr:      false,
 		},
 		{
 			name:         "http dependencies without Chat.lock file",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{},
 			wantErr:      false,
 		},
 		{
 			name:         "oci dependencies with Chat.lock file",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryURL}},
 			hasLockFile:  true,
 			auth:         AuthSettings{PlainHTTP: true},
 			wantErr:      false,
 		},
 		{
 			name:         "oci dependencies without Chat.lock file",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{PlainHTTP: true},
 			wantErr:      false,
@@ -946,70 +946,70 @@ func TestBuildDependencies(t *testing.T) {
 		},
 		{
 			name:         "http and oci dependencies with Chat.lock file",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryUrl}, {Name: "examplechart2", Version: "0.1.0", Repository: ociPlainRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryURL}, {Name: "examplechart2", Version: "0.1.0", Repository: ociPlainRegistryURL}},
 			hasLockFile:  true,
 			auth:         AuthSettings{PlainHTTP: true},
 			wantErr:      false,
 		},
 		{
 			name:         "http and oci dependencies without Chat.lock file",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryUrl}, {Name: "examplechart2", Version: "0.1.0", Repository: ociPlainRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryURL}, {Name: "examplechart2", Version: "0.1.0", Repository: ociPlainRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{PlainHTTP: true},
 			wantErr:      false,
 		},
 		{
 			name:         "http dependencies with Chat.lock file and auth",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryWithAuthUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryWithAuthURL}},
 			hasLockFile:  true,
 			auth:         AuthSettings{Username: "username", Password: "password"},
 			wantErr:      false,
 		},
 		{
 			name:         "http dependencies without Chat.lock file and auth",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryWithAuthUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpRegistryWithAuthURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{Username: "username", Password: "password"},
 			wantErr:      false,
 		},
 		{
 			name:         "oci dependencies with Chat.lock file and auth",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryWithAuthUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryWithAuthURL}},
 			hasLockFile:  true,
 			auth:         AuthSettings{PlainHTTP: true, RegistryConfigFile: plainRegistryConfigFile},
 			wantErr:      false,
 		},
 		{
 			name:         "oci dependencies without Chat.lock file and auth",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryWithAuthUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociPlainRegistryWithAuthURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{PlainHTTP: true, RegistryConfigFile: plainRegistryConfigFile},
 			wantErr:      false,
 		},
 		{
 			name:         "http dependency with empty version should fail",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: httpRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: httpRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{},
 			wantErr:      true,
 		},
 		{
 			name:         "oci dependency with empty version should fail",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: ociPlainRegistryWithAuthUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: ociPlainRegistryWithAuthURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{PlainHTTP: true},
 			wantErr:      true,
 		},
 		{
 			name:         "http dependency with non semver should fail",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: httpRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: httpRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{},
 			wantErr:      true,
 		},
 		{
 			name:         "oci dependency with non semver should fail",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: ociPlainRegistryWithAuthUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "", Repository: ociPlainRegistryWithAuthURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{PlainHTTP: true},
 			wantErr:      true,
@@ -1017,28 +1017,28 @@ func TestBuildDependencies(t *testing.T) {
 
 		{
 			name:         "secure oci registry with a valid certificate",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{CAFile: ociSecurePKI.CAFile},
 			wantErr:      false,
 		},
 		{
 			name:         "secure oci registry without a valid certificate",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{},
 			wantErr:      true,
 		},
 		{
 			name:         "secure oci registry without a valid certificate, but ignoring it",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{Insecure: true},
 			wantErr:      false,
 		},
 		{
 			name:         "secure oci registry failing to try plain HTTP",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: ociSecureRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{CAFile: ociSecurePKI.CAFile, PlainHTTP: true},
 			wantErr:      true,
@@ -1046,21 +1046,21 @@ func TestBuildDependencies(t *testing.T) {
 
 		{
 			name:         "HTTPS registry with a valid certificate",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpsRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpsRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{CAFile: httpsRegistryPKI.CAFile},
 			wantErr:      false,
 		},
 		{
 			name:         "HTTPS registry without a valid certificate",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpsRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpsRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{},
 			wantErr:      true,
 		},
 		{
 			name:         "HTTPS registry without a valid certificate, but ignoring it",
-			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpsRegistryUrl}},
+			dependencies: []*chart.Dependency{{Name: "examplechart", Version: "0.1.0", Repository: httpsRegistryURL}},
 			hasLockFile:  false,
 			auth:         AuthSettings{Insecure: true},
 			wantErr:      false,

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -59,7 +59,7 @@ func TestNewDeploySettings(t *testing.T) {
 		wait      bool
 		timeout   time.Duration
 		atomic    bool
-		enableDns bool
+		enableDNS bool
 		want      *DeployOpts
 		wantErr   bool
 	}{
@@ -68,7 +68,7 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      false,
 			timeout:   0,
 			atomic:    false,
-			enableDns: false,
+			enableDNS: false,
 			want: &DeployOpts{
 				wait:      false,
 				timeout:   0,
@@ -82,7 +82,7 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      true,
 			timeout:   10 * time.Second,
 			atomic:    false,
-			enableDns: false,
+			enableDNS: false,
 			want: &DeployOpts{
 				wait:      true,
 				timeout:   10 * time.Second,
@@ -96,7 +96,7 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      true,
 			timeout:   10 * time.Second,
 			atomic:    true,
-			enableDns: false,
+			enableDNS: false,
 			want: &DeployOpts{
 				wait:      true,
 				timeout:   10 * time.Second,
@@ -110,7 +110,7 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      true,
 			timeout:   10 * time.Second,
 			atomic:    true,
-			enableDns: true,
+			enableDNS: true,
 			want: &DeployOpts{
 				wait:      true,
 				timeout:   10 * time.Second,
@@ -124,7 +124,7 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      false,
 			timeout:   0,
 			atomic:    false,
-			enableDns: true,
+			enableDNS: true,
 			want: &DeployOpts{
 				wait:      false,
 				timeout:   0,
@@ -138,7 +138,7 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      true,
 			timeout:   0,
 			atomic:    false,
-			enableDns: false,
+			enableDNS: false,
 			want:      nil,
 			wantErr:   true,
 		},
@@ -147,14 +147,14 @@ func TestNewDeploySettings(t *testing.T) {
 			wait:      false,
 			timeout:   10 * time.Second,
 			atomic:    true,
-			enableDns: false,
+			enableDNS: false,
 			want:      nil,
 			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewDeployOpts(tt.wait, tt.timeout, tt.atomic, tt.enableDns)
+			got, err := NewDeployOpts(tt.wait, tt.timeout, tt.atomic, tt.enableDNS)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewDeployOpts() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/applications/providers/source/git_test.go
+++ b/pkg/applications/providers/source/git_test.go
@@ -55,11 +55,11 @@ func TestDownloadGitSource(t *testing.T) {
 	fatalOnErr(err, "failed to create temporary directory for git server", t)
 
 	repoInfo := createGitRepository(t, gitServerDir)
-	privateKey, publicKey := generateSSHkey(t)
+	privateKey, publicKey := generateSSHKey(t)
 
 	sshRemote := "ssh://git@" + newGitSSHServer(gitServerDir, publicKey, t) + repoInfo.Name
-	httpRemote := newGitHttpServer(gitServerDir, "", "", t) + repoInfo.Name
-	httpWithAuthRemote := newGitHttpServer(gitServerDir, "user", "pass", t) + repoInfo.Name
+	httpRemote := newGitHTTPServer(gitServerDir, "", "", t) + repoInfo.Name
+	httpWithAuthRemote := newGitHTTPServer(gitServerDir, "user", "pass", t) + repoInfo.Name
 
 	secretName := "git-cred"
 	passwordCredentials := appskubermaticv1.GitCredentials{
@@ -426,8 +426,8 @@ func checkOnlyOneCommit(repository *git.Repository, t *testing.T) {
 	}
 }
 
-// generateSSHkey a private and public ssh key and returned it in that order.
-func generateSSHkey(t *testing.T) (string, string) {
+// generateSSHKey a private and public ssh key and returned it in that order.
+func generateSSHKey(t *testing.T) (string, string) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	fatalOnErr(err, "failed to genetate client private key", t)
 
@@ -440,7 +440,7 @@ func generateSSHkey(t *testing.T) (string, string) {
 	return privateKeyPEM, pubKey
 }
 
-func newGitHttpServer(repoPath string, user string, password string, t *testing.T) string {
+func newGitHTTPServer(repoPath string, user string, password string, t *testing.T) string {
 	service := gitkit.New(gitkit.Config{
 		Dir:        repoPath,
 		AutoCreate: false,

--- a/pkg/applications/providers/template/helm_integration_test.go
+++ b/pkg/applications/providers/template/helm_integration_test.go
@@ -82,7 +82,7 @@ func TestHelmProvider(t *testing.T) {
 	chartDir := t.TempDir()
 	chartGlobPath := path.Join(chartDir, "*.tgz")
 	test.PackageChart(t, "../../helmclient/testdata/examplechart2", chartDir)
-	registryUrl, regCredFile := test.StartOciRegistryWithAuth(t, chartGlobPath)
+	registryURL, regCredFile := test.StartOciRegistryWithAuth(t, chartGlobPath)
 
 	tests := []struct {
 		name     string
@@ -184,7 +184,7 @@ func TestHelmProvider(t *testing.T) {
 		{
 			name: "application installation should be successful when dependency requires credentials that are provided",
 			testFunc: func(t *testing.T) {
-				chartFullPath := createChartWithDependency(t, registryUrl)
+				chartFullPath := createChartWithDependency(t, registryURL)
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "", nil, helm)
@@ -214,7 +214,7 @@ func TestHelmProvider(t *testing.T) {
 		{
 			name: "application installation should fail when dependency requires credentials that are not provided",
 			testFunc: func(t *testing.T) {
-				chartFullPath := createChartWithDependency(t, registryUrl)
+				chartFullPath := createChartWithDependency(t, registryURL)
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				test.EnsureClusterWithCleanup(t, ctx, client)
 				app := createApplicationInstallation(testNs, nil, "", nil, helm)
@@ -314,7 +314,7 @@ func TestHelmProvider(t *testing.T) {
 			},
 		},
 		{
-			name: "when an application is created with no values and enableDns=true, it should install app with default values and dns should be resolved",
+			name: "when an application is created with no values and enableDNS=true, it should install app with default values and dns should be resolved",
 			testFunc: func(t *testing.T) {
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: false, Timeout: metav1.Duration{Duration: 0}, Atomic: false, EnableDNS: true}}
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
@@ -351,7 +351,7 @@ func TestHelmProvider(t *testing.T) {
 	}
 }
 
-func installOrUpgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, testNs *corev1.Namespace, app *appskubermaticv1.ApplicationInstallation, chartLoc string, expectedData map[string]string, expectedVersionLabel string, expectedVersion int, enableDns bool) {
+func installOrUpgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, testNS *corev1.Namespace, app *appskubermaticv1.ApplicationInstallation, chartLoc string, expectedData map[string]string, expectedVersionLabel string, expectedVersion int, enableDNS bool) {
 	template := HelmTemplate{
 		Ctx:             context.Background(),
 		Kubeconfig:      kubeconfigPath,
@@ -368,7 +368,7 @@ func installOrUpgradeTest(t *testing.T, ctx context.Context, client ctrlruntimec
 	}
 	statusUpdater(&app.Status)
 
-	test.CheckConfigMap(t, ctx, client, testNs, expectedData, expectedVersionLabel, enableDns)
+	test.CheckConfigMap(t, ctx, client, testNS, expectedData, expectedVersionLabel, enableDNS)
 	assertStatusIsUpdated(t, app, statusUpdater, expectedVersion)
 }
 func createApplicationInstallation(testNs *corev1.Namespace, rawValues []byte, rawValuesBlock string, deployOpts *appskubermaticv1.DeployOptions, source Source) *appskubermaticv1.ApplicationInstallation {
@@ -487,7 +487,7 @@ func createCredentialSecret(t *testing.T, ctx context.Context, client ctrlruntim
 
 // createChartWithDependency takes testdata/examplechart as base and adds examplechart2 as a dependency. The full path to the chart directory is returned.
 // The dependency is stored on the helm registry accessible by registryUrl.
-func createChartWithDependency(t *testing.T, registryUrl string) string {
+func createChartWithDependency(t *testing.T, registryURL string) string {
 	// copy exampleChart  and add examplechart2 as dependency
 	chartFullPath := path.Join(t.TempDir(), "chartWithDependencies")
 	if err := test.CopyDir("../../helmclient/testdata/examplechart", chartFullPath); err != nil {
@@ -498,7 +498,7 @@ func createChartWithDependency(t *testing.T, registryUrl string) string {
 	if err != nil {
 		t.Fatalf("failed to load chart: %s", err)
 	}
-	chartToInstall.Metadata.Dependencies = []*chart.Dependency{{Name: "examplechart2", Version: "0.1.0", Repository: registryUrl}}
+	chartToInstall.Metadata.Dependencies = []*chart.Dependency{{Name: "examplechart2", Version: "0.1.0", Repository: registryURL}}
 	// Save the chart file.
 	out, err := yaml.Marshal(chartToInstall.Metadata)
 	if err != nil {

--- a/pkg/applications/providers/template/helm_test.go
+++ b/pkg/applications/providers/template/helm_test.go
@@ -222,9 +222,9 @@ func TestGetDeployOps(t *testing.T) {
 	}
 }
 
-func newDeployOpts(t *testing.T, wait bool, timeout time.Duration, atomic bool, enableDns bool) *helmclient.DeployOpts {
+func newDeployOpts(t *testing.T, wait bool, timeout time.Duration, atomic bool, enableDNS bool) *helmclient.DeployOpts {
 	t.Helper()
-	deployOps, err := helmclient.NewDeployOpts(wait, timeout, atomic, enableDns)
+	deployOps, err := helmclient.NewDeployOpts(wait, timeout, atomic, enableDNS)
 	if err != nil {
 		t.Fatalf("failed to build deployOpts: %s", err)
 	}

--- a/pkg/applications/test/helm.go
+++ b/pkg/applications/test/helm.go
@@ -126,17 +126,17 @@ func PackageChart(t *testing.T, chartDir string, destDir string) (string, int64)
 	return archivePath, expectedChartInfo.Size()
 }
 
-// StartHttpRegistryWithCleanup starts a Helm http registry and uploads charts archives matching
+// StartHTTPRegistryWithCleanup starts a Helm http registry and uploads charts archives matching
 // glob and returns the registry URL.
-func StartHttpRegistryWithCleanup(t *testing.T, glob string) string {
+func StartHTTPRegistryWithCleanup(t *testing.T, glob string) string {
 	u, _ := startRegistryWithCleanup(t, glob, false)
 	return u
 }
 
-// StartHttpsRegistryWithCleanup is the same as StartHttpRegistryWithCleanup, but starts a TLS
+// StartHTTPSRegistryWithCleanup is the same as StartHttpRegistryWithCleanup, but starts a TLS
 // server instead. Any package calling this must provide a "testdata" directory with the Helm
 // test PKI.
-func StartHttpsRegistryWithCleanup(t *testing.T, glob string) (string, *PKI) {
+func StartHTTPSRegistryWithCleanup(t *testing.T, glob string) (string, *PKI) {
 	return startRegistryWithCleanup(t, glob, true)
 }
 
@@ -160,18 +160,18 @@ func startRegistryWithCleanup(t *testing.T, glob string, secure bool) (string, *
 	return srv.URL(), pki
 }
 
-// StartHttpRegistryWithAuthAndCleanup starts a Helm http registry with basic auth enabled and
+// StartHTTPRegistryWithAuthAndCleanup starts a Helm http registry with basic auth enabled and
 // uploads charts archives matching glob and returns the registry URL.
 // the basic auth is hardcoded to Username: "username", Password: "password".
-func StartHttpRegistryWithAuthAndCleanup(t *testing.T, glob string) string {
+func StartHTTPRegistryWithAuthAndCleanup(t *testing.T, glob string) string {
 	u, _ := startRegistryWithAuthAndCleanup(t, glob, false)
 	return u
 }
 
-// StartHttpsRegistryWithAuthAndCleanup is the same as StartHttpRegistryWithAuthAndCleanup, but
+// StartHTTPSRegistryWithAuthAndCleanup is the same as StartHttpRegistryWithAuthAndCleanup, but
 // starts a TLS server instead. Any package calling this must provide a "testdata" directory with
 // the Helm test PKI.
-func StartHttpsRegistryWithAuthAndCleanup(t *testing.T, glob string) (string, *PKI) {
+func StartHTTPSRegistryWithAuthAndCleanup(t *testing.T, glob string) (string, *PKI) {
 	return startRegistryWithAuthAndCleanup(t, glob, true)
 }
 
@@ -243,9 +243,9 @@ func StartSecureOciRegistry(t *testing.T, glob string) (string, *PKI) {
 // returns the registry URL and registryConfigFile.
 // registryConfigFile contains the credentials of the registry.
 func StartOciRegistryWithAuth(t *testing.T, glob string) (string, string) {
-	ociRegistryUrl, registryConfigFile, _ := newOciRegistry(t, glob, true, false)
+	ociRegistryURL, registryConfigFile, _ := newOciRegistry(t, glob, true, false)
 
-	return ociRegistryUrl, registryConfigFile
+	return ociRegistryURL, registryConfigFile
 }
 
 // StartOciRegistryWithAuth start an oci registry with authentication, uploads charts archives matching glob,
@@ -330,7 +330,7 @@ func newOciRegistry(t *testing.T, glob string, enableAuth bool, secure bool) (st
 	config.Storage = map[string]configuration.Parameters{"inmemory": map[string]interface{}{}}
 
 	fullHost := net.JoinHostPort(registryHostname, strconv.Itoa(port))
-	ociRegistryUrl := fmt.Sprintf("oci://%s/helm-charts", fullHost)
+	ociRegistryURL := fmt.Sprintf("oci://%s/helm-charts", fullHost)
 
 	ctx := context.Background()
 
@@ -361,7 +361,7 @@ func newOciRegistry(t *testing.T, glob string, enableAuth bool, secure bool) (st
 	}
 
 	// ensure registry is listening
-	waitForRegistry(t, ctx, &httpClient, ociRegistryUrl, secure)
+	waitForRegistry(t, ctx, &httpClient, ociRegistryURL, secure)
 
 	// preload registry
 	if glob != "" {
@@ -402,14 +402,14 @@ func newOciRegistry(t *testing.T, glob string, enableAuth bool, secure bool) (st
 			t.Fatalf("failed to upload chart, invalid blob: %s", err)
 		}
 		for i := range files {
-			err = chartUploader.UploadTo(files[i], ociRegistryUrl)
+			err = chartUploader.UploadTo(files[i], ociRegistryURL)
 			if err != nil {
 				t.Fatalf("can not push chart '%s' to oci registry: %s", files[i], err)
 			}
 		}
 	}
 
-	return ociRegistryUrl, registryConfigFile, pki
+	return ociRegistryURL, registryConfigFile, pki
 }
 
 func waitForRegistry(t *testing.T, ctx context.Context, httpClient *http.Client, url string, secure bool) {

--- a/pkg/applications/test/kubernetes.go
+++ b/pkg/applications/test/kubernetes.go
@@ -187,7 +187,7 @@ func StartTestEnvWithCleanup(t *testing.T, crdPath string) (context.Context, ctr
 }
 
 // CheckConfigMap asserts that configMap deployed by helm chart has been created/ updated with the desired data and labels.
-func CheckConfigMap(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, expectedData map[string]string, expectedVersionLabel string, enableDns bool) {
+func CheckConfigMap(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, expectedData map[string]string, expectedVersionLabel string, enableDNS bool) {
 	t.Helper()
 
 	cm := &corev1.ConfigMap{}
@@ -195,7 +195,7 @@ func CheckConfigMap(t *testing.T, ctx context.Context, client ctrlruntimeclient.
 	if !utils.WaitFor(ctx, time.Second*1, time.Second*10, func() bool {
 		errorGetCm = client.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: ConfigmapName}, cm)
 		// if config map has not been  updated
-		if errorGetCm != nil || !diff.SemanticallyEqual(expectedData, cm.Data) || cm.Labels[VersionLabelKey] != expectedVersionLabel || !isExpectedDnsValue(cm.Labels[EnableDNSLabelKey], enableDns) {
+		if errorGetCm != nil || !diff.SemanticallyEqual(expectedData, cm.Data) || cm.Labels[VersionLabelKey] != expectedVersionLabel || !isExpectedDNSValue(cm.Labels[EnableDNSLabelKey], enableDNS) {
 			return false
 		}
 		return true
@@ -212,8 +212,8 @@ func CheckConfigMap(t *testing.T, ctx context.Context, client ctrlruntimeclient.
 		if cm.Labels[VersionLabelKey] != expectedVersionLabel {
 			t.Errorf("ConfigMap versionLabel has invalid value. expected '%s', got '%s'", expectedVersionLabel, cm.Labels[VersionLabelKey])
 		}
-		if !isExpectedDnsValue(cm.Labels[EnableDNSLabelKey], enableDns) {
-			if enableDns {
+		if !isExpectedDNSValue(cm.Labels[EnableDNSLabelKey], enableDNS) {
+			if enableDNS {
 				t.Errorf("ConfigMap label '%s' should not be empty as enableDns is enabled", EnableDNSLabelKey)
 			}
 			t.Errorf("ConfigMap label '%s' should be empty as enableDns is disabled", EnableDNSLabelKey)
@@ -221,8 +221,8 @@ func CheckConfigMap(t *testing.T, ctx context.Context, client ctrlruntimeclient.
 	}
 }
 
-func isExpectedDnsValue(value string, enableDns bool) bool {
-	if enableDns {
+func isExpectedDNSValue(value string, enableDNS bool) bool {
+	if enableDNS {
 		// is enableDns the value should be equal to the ip of the hostname but to make test more resilient we just check is not empty.
 		return len(value) > 0
 	}

--- a/pkg/clusterdeletion/volumes.go
+++ b/pkg/clusterdeletion/volumes.go
@@ -143,7 +143,7 @@ func (d *Deletion) cleanupPVCUsingPods(ctx context.Context, log *zap.SugaredLogg
 
 func podUsesPV(p *corev1.Pod) bool {
 	for _, volume := range p.Spec.Volumes {
-		if volume.VolumeSource.PersistentVolumeClaim != nil {
+		if volume.PersistentVolumeClaim != nil {
 			return true
 		}
 	}

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -36,7 +36,7 @@ const (
 	ciliumImageRegistry = "quay.io/cilium/"
 )
 
-func toOciUrl(s string) string {
+func toOCIURL(s string) string {
 	if strings.Contains(s, "://") {
 		return s
 	}
@@ -75,7 +75,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.0",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -88,7 +88,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.3",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -101,7 +101,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.4",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -114,7 +114,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.6",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -127,7 +127,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.7",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -140,7 +140,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.8",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -153,7 +153,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.14",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -166,7 +166,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.14.1",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -179,7 +179,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.14.2",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -192,7 +192,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.14.3",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -205,7 +205,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.14.9",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -218,7 +218,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.14.16",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -231,7 +231,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.15.3",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -244,7 +244,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.15.10",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -257,7 +257,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.16.6",
-								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
+								URL:          toOCIURL(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -194,10 +194,10 @@ func (c *clusterBackupCollector) getS3Client(ctx context.Context, destination *k
 		return nil, fmt.Errorf("failed to retrieve credentials secret: %w", err)
 	}
 
-	accessKey := string(creds.Data[etcdbackup.AccessKeyIdEnvVarKey])
+	accessKey := string(creds.Data[etcdbackup.AccessKeyIDEnvVarKey])
 	secretKey := string(creds.Data[etcdbackup.SecretAccessKeyEnvVarKey])
 	if accessKey == "" || secretKey == "" {
-		return nil, fmt.Errorf("backup credentials do not contain %q or %q keys", etcdbackup.AccessKeyIdEnvVarKey, etcdbackup.SecretAccessKeyEnvVarKey)
+		return nil, fmt.Errorf("backup credentials do not contain %q or %q keys", etcdbackup.AccessKeyIDEnvVarKey, etcdbackup.SecretAccessKeyEnvVarKey)
 	}
 
 	return s3.NewClient(destination.Endpoint, accessKey, secretKey, c.caBundle.CertPool())

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -112,10 +112,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	result, err := r.reconcile(ctx, log.With("provider", cluster.Spec.CloudSpec.ProviderName), cluster)
 	if err != nil {
 		switch {
-		case isHttpError(err, http.StatusNotFound):
+		case isHTTPError(err, http.StatusNotFound):
 			r.recorder.Event(cluster, corev1.EventTypeWarning, "ResourceNotFound", err.Error())
 			err = nil
-		case isHttpError(err, http.StatusForbidden):
+		case isHTTPError(err, http.StatusForbidden):
 			r.recorder.Event(cluster, corev1.EventTypeWarning, "AuthorizationFailed", err.Error())
 			err = nil
 		default:
@@ -156,7 +156,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		}
 		condition, err := gke.GetClusterStatus(ctx, secretKeySelector, cloud.GKE)
 		if err != nil {
-			if isHttpError(err, http.StatusNotFound) {
+			if isHTTPError(err, http.StatusNotFound) {
 				condition := &kubermaticv1.ExternalClusterCondition{
 					Phase:   kubermaticv1.ExternalClusterPhaseError,
 					Message: err.Error(),
@@ -206,7 +206,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		}
 		condition, err := eks.GetClusterStatus(ctx, secretKeySelector, cloud.EKS)
 		if err != nil {
-			if isHttpError(err, http.StatusNotFound) {
+			if isHTTPError(err, http.StatusNotFound) {
 				condition := &kubermaticv1.ExternalClusterCondition{
 					Phase:   kubermaticv1.ExternalClusterPhaseError,
 					Message: err.Error(),
@@ -253,7 +253,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		}
 		condition, err := aks.GetClusterStatus(ctx, secretKeySelector, cloud.AKS)
 		if err != nil {
-			if isHttpError(err, http.StatusNotFound) {
+			if isHTTPError(err, http.StatusNotFound) {
 				condition := &kubermaticv1.ExternalClusterCondition{
 					Phase:   kubermaticv1.ExternalClusterPhaseError,
 					Message: err.Error(),
@@ -447,7 +447,7 @@ func kubeconfigSecretReconcilerFactory(cluster *kubermaticv1.ExternalCluster, se
 	}
 }
 
-func isHttpError(err error, status int) bool {
+func isHTTPError(err error, status int) bool {
 	var httpError utilerrors.HTTPError
 	if errors.As(err, &httpError) {
 		if httpError.StatusCode() == status {

--- a/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
+++ b/pkg/controller/master-controller-manager/external-cluster/cluster_controller.go
@@ -89,7 +89,7 @@ func Add(ctx context.Context, mgr manager.Manager, log *zap.SugaredLogger) error
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	paused, err := kuberneteshelper.ExternalClusterPausedChecker(ctx, request.Name, r.Client)
+	paused, err := kuberneteshelper.ExternalClusterPausedChecker(ctx, request.Name, r)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to check external cluster pause status: %w", err)
 	}
@@ -136,11 +136,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	}
 
 	cloud := cluster.Spec.CloudSpec
-	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, r.Client)
+	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, r)
 
 	if cloud.ProviderName == kubermaticv1.ExternalClusterBringYourOwnProvider {
 		if cluster.Spec.KubeconfigReference != nil {
-			if err := kuberneteshelper.TryAddFinalizer(ctx, r.Client, cluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer); err != nil {
+			if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, kubermaticv1.ExternalClusterKubeconfigCleanupFinalizer); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to add kubeconfig secret finalizer: %w", err)
 			}
 		}
@@ -150,7 +150,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	if cloud.GKE != nil {
 		log.Debug("Reconciling GKE cluster")
 		if cloud.GKE.CredentialsReference != nil {
-			if err := kuberneteshelper.TryAddFinalizer(ctx, r.Client, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
+			if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to add credential secret finalizer: %w", err)
 			}
 		}
@@ -200,7 +200,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	if cloud.EKS != nil {
 		log.Debug("Reconciling EKS cluster")
 		if cloud.EKS.CredentialsReference != nil {
-			if err := kuberneteshelper.TryAddFinalizer(ctx, r.Client, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
+			if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to add credential secret finalizer: %w", err)
 			}
 		}
@@ -247,7 +247,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	if cloud.AKS != nil {
 		log.Debug("Reconciling AKS cluster")
 		if cloud.AKS.CredentialsReference != nil {
-			if err := kuberneteshelper.TryAddFinalizer(ctx, r.Client, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
+			if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, kubermaticv1.CredentialsSecretsCleanupFinalizer); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to add credential secret finalizer: %w", err)
 			}
 		}
@@ -360,7 +360,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, condition kubermaticv1.Ex
 
 func (r *Reconciler) ensureGKEKubeconfig(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
 	cloud := cluster.Spec.CloudSpec
-	cred, err := resources.GetGKECredentials(ctx, r.Client, cluster)
+	cred, err := resources.GetGKECredentials(ctx, r, cluster)
 	if err != nil {
 		return err
 	}
@@ -374,7 +374,7 @@ func (r *Reconciler) ensureGKEKubeconfig(ctx context.Context, cluster *kubermati
 
 func (r *Reconciler) ensureEKSKubeconfig(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
 	cloud := cluster.Spec.CloudSpec
-	cred, err := resources.GetEKSCredentials(ctx, r.Client, cluster)
+	cred, err := resources.GetEKSCredentials(ctx, r, cluster)
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func (r *Reconciler) ensureEKSKubeconfig(ctx context.Context, cluster *kubermati
 
 func (r *Reconciler) ensureAKSKubeconfig(ctx context.Context, cluster *kubermaticv1.ExternalCluster) error {
 	cloud := cluster.Spec.CloudSpec
-	cred, err := resources.GetAKSCredentials(ctx, r.Client, cluster)
+	cred, err := resources.GetAKSCredentials(ctx, r, cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -1012,14 +1012,14 @@ func (r *reconciler) generateKubeOneActionJob(ctx context.Context, log *zap.Suga
 		},
 	)
 
-	switch {
-	case action == ImportAction:
+	switch action {
+	case ImportAction:
 		kubeoneJobName = KubeOneImportJob
 		kubeoneCMName = KubeOneImportConfigMap
-	case action == UpgradeControlPlaneAction:
+	case UpgradeControlPlaneAction:
 		kubeoneJobName = KubeOneUpgradeJob
 		kubeoneCMName = KubeOneUpgradeConfigMap
-	case action == MigrateContainerRuntimeAction:
+	case MigrateContainerRuntimeAction:
 		kubeoneJobName = KubeOneMigrateJob
 		kubeoneCMName = KubeOneMigrateConfigMap
 	}
@@ -1408,14 +1408,14 @@ func generateConfigMap(namespace, action string) *corev1.ConfigMap {
 	var name, scriptToRun string
 	scriptToRun = resources.KubeOneScript
 
-	switch {
-	case action == ImportAction:
+	switch action {
+	case ImportAction:
 		name = KubeOneImportConfigMap
 		scriptToRun += "kubeone kubeconfig --manifest kubeonemanifest/manifest 2> /dev/null"
-	case action == UpgradeControlPlaneAction:
+	case UpgradeControlPlaneAction:
 		name = KubeOneUpgradeConfigMap
 		scriptToRun += "kubeone apply --manifest kubeonemanifest/manifest -y --log-format json"
-	case action == MigrateContainerRuntimeAction:
+	case MigrateContainerRuntimeAction:
 		name = KubeOneMigrateConfigMap
 		scriptToRun += "kubeone migrate to-containerd --manifest kubeonemanifest/manifest --log-format json"
 	}
@@ -1548,18 +1548,18 @@ func getPodLogs(ctx context.Context, pod *corev1.Pod) (string, error) {
 
 func determineExitCode(exitCode int32) kubermaticv1.ExternalClusterPhase {
 	var phaseError kubermaticv1.ExternalClusterPhase
-	switch {
-	case exitCode == fail.RuntimeErrorExitCode:
+	switch exitCode {
+	case fail.RuntimeErrorExitCode:
 		phaseError = kubermaticv1.ExternalClusterPhaseRuntimeError
-	case exitCode == fail.EtcdErrorExitCode:
+	case fail.EtcdErrorExitCode:
 		phaseError = kubermaticv1.ExternalClusterPhaseEtcdError
-	case exitCode == fail.KubeClientErrorExitCode:
+	case fail.KubeClientErrorExitCode:
 		phaseError = kubermaticv1.ExternalClusterPhaseKubeClientError
-	case exitCode == fail.SSHErrorExitCode:
+	case fail.SSHErrorExitCode:
 		phaseError = kubermaticv1.ExternalClusterPhaseSSHError
-	case exitCode == fail.ConnectionErrorExitCode:
+	case fail.ConnectionErrorExitCode:
 		phaseError = kubermaticv1.ExternalClusterPhaseConnectionError
-	case exitCode == fail.ConfigErrorExitCode:
+	case fail.ConfigErrorExitCode:
 		phaseError = kubermaticv1.ExternalClusterPhaseConfigError
 	default:
 		phaseError = kubermaticv1.ExternalClusterPhaseError

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -178,7 +178,7 @@ func withEventFilter() predicate.Predicate {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	paused, err := kuberneteshelper.ExternalClusterPausedChecker(ctx, request.Name, r.Client)
+	paused, err := kuberneteshelper.ExternalClusterPausedChecker(ctx, request.Name, r)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to check kubeone external cluster pause status: %w", err)
 	}
@@ -245,7 +245,7 @@ func (r *reconciler) reconcile(ctx context.Context, externalClusterName string, 
 	finalizersToAddList := finalizersToAdd.UnsortedList()
 
 	if len(finalizersToAddList) > 0 {
-		if err := kuberneteshelper.TryAddFinalizer(ctx, r.Client, externalCluster, finalizersToAddList...); err != nil {
+		if err := kuberneteshelper.TryAddFinalizer(ctx, r, externalCluster, finalizersToAddList...); err != nil {
 			return fmt.Errorf("failed to add kubeone namespace finalizer: %w", err)
 		}
 	}
@@ -448,7 +448,7 @@ func (r *reconciler) importAction(
 		}
 	} else if externalCluster.Spec.KubeconfigReference != nil && externalCluster.Status.Condition.Phase == kubermaticv1.ExternalClusterPhaseRunning {
 		// checking if cluster is accessible using client
-		clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r.Client)
+		clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r)
 		if err != nil {
 			return err
 		}
@@ -606,7 +606,7 @@ func (r *reconciler) upgradeAction(
 	manifestRef := externalCluster.Spec.CloudSpec.KubeOne.ManifestReference
 	kubeOneNamespaceName := externalCluster.GetKubeOneNamespaceName()
 
-	clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r.Client)
+	clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r)
 	if err != nil {
 		return err
 	}
@@ -782,7 +782,7 @@ func (r *reconciler) migrateAction(
 ) error {
 	manifestRef := externalCluster.Spec.CloudSpec.KubeOne.ManifestReference
 
-	clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r.Client)
+	clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/master-controller-manager/project-synchronizer/resources.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/resources.go
@@ -24,11 +24,11 @@ import (
 func projectReconcilerFactory(project *kubermaticv1.Project) reconciling.NamedProjectReconcilerFactory {
 	return func() (string, reconciling.ProjectReconciler) {
 		return project.Name, func(p *kubermaticv1.Project) (*kubermaticv1.Project, error) {
-			if p.ObjectMeta.Labels == nil {
-				p.ObjectMeta.Labels = map[string]string{}
+			if p.Labels == nil {
+				p.Labels = map[string]string{}
 			}
-			for k, v := range project.ObjectMeta.Labels {
-				p.ObjectMeta.Labels[k] = v
+			for k, v := range project.Labels {
+				p.Labels[k] = v
 			}
 			p.Spec = project.Spec
 			return p, nil

--- a/pkg/controller/master-controller-manager/rbac/sync_project_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project_test.go
@@ -103,8 +103,8 @@ func TestEnsureProjectInitialized(t *testing.T) {
 			err = masterClient.List(ctx, &projectList)
 			assert.NoError(t, err)
 
-			projectList.Items[0].ObjectMeta.ResourceVersion = ""
-			test.expectedProject.ObjectMeta.ResourceVersion = ""
+			projectList.Items[0].ResourceVersion = ""
+			test.expectedProject.ResourceVersion = ""
 
 			assert.Len(t, projectList.Items, 1)
 			assert.Equal(t, projectList.Items[0], *test.expectedProject)

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -59,7 +59,7 @@ type Reconciler struct {
 // an error if any API operation failed, otherwise will return an empty
 // dummy Result struct.
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("seed", request.NamespacedName.String())
+	log := r.log.With("seed", request.String())
 	log.Debug("reconciling seed")
 
 	return reconcile.Result{}, r.reconcile(ctx, request.Name, log)
@@ -324,7 +324,7 @@ func (r *Reconciler) reconcileMasterDeployments(ctx context.Context, seed *kuber
 		masterDeploymentReconciler(seed, secret, registry.GetImageRewriterFunc(config.Spec.UserCluster.OverwriteRegistry)),
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, creators, seed.Namespace, r.Client); err != nil {
+	if err := reconciling.ReconcileDeployments(ctx, creators, seed.Namespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments in the namespace %s: %w", seed.Namespace, err)
 	}
 
@@ -336,7 +336,7 @@ func (r *Reconciler) reconcileMasterServices(ctx context.Context, seed *kubermat
 		masterServiceReconciler(seed, secret),
 	}
 
-	if err := reconciling.ReconcileServices(ctx, creators, seed.Namespace, r.Client); err != nil {
+	if err := reconciling.ReconcileServices(ctx, creators, seed.Namespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile Services in the namespace %s: %w", seed.Namespace, err)
 	}
 
@@ -358,7 +358,7 @@ func (r *Reconciler) reconcileMasterGrafanaProvisioning(ctx context.Context, see
 		r.masterGrafanaConfigmapReconciler(seeds),
 	}
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, MasterGrafanaNamespace, r.Client); err != nil {
+	if err := reconciling.ReconcileConfigMaps(ctx, creators, MasterGrafanaNamespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in the namespace %s: %w", MasterGrafanaNamespace, err)
 	}
 

--- a/pkg/controller/master-controller-manager/user-project-binding/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller.go
@@ -71,7 +71,7 @@ func Add(ctx context.Context, mgr manager.Manager, log *zap.SugaredLogger) error
 	_, err := builder.ControllerManagedBy(mgr).
 		Named(controllerName).
 		For(&kubermaticv1.UserProjectBinding{}).
-		Watches(&kubermaticv1.User{}, enqueueUserProjectBindingsForUser(r.Client, r.log)).
+		Watches(&kubermaticv1.User{}, enqueueUserProjectBindingsForUser(r, r.log)).
 		Build(r)
 
 	return err

--- a/pkg/controller/master-controller-manager/user-project-binding/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller_test.go
@@ -130,8 +130,8 @@ func TestEnsureNotProjectOwnerForBinding(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			updatedProject.ObjectMeta.ResourceVersion = ""
-			test.expectedProject.ObjectMeta.ResourceVersion = ""
+			updatedProject.ResourceVersion = ""
+			test.expectedProject.ResourceVersion = ""
 
 			if !diff.SemanticallyEqual(test.expectedProject, updatedProject) {
 				t.Fatalf("Objects differ:\n%v", diff.ObjectDiff(test.expectedProject, updatedProject))
@@ -205,8 +205,8 @@ func TestEnsureProjectOwnerForBinding(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			updatedProject.ObjectMeta.ResourceVersion = ""
-			test.expectedProject.ObjectMeta.ResourceVersion = ""
+			updatedProject.ResourceVersion = ""
+			test.expectedProject.ResourceVersion = ""
 
 			if !diff.SemanticallyEqual(test.expectedProject, updatedProject) {
 				t.Fatalf("Objects differ:\n%v", diff.ObjectDiff(test.expectedProject, updatedProject))

--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -368,7 +368,7 @@ func TestSync(t *testing.T) {
 			}
 
 			gotClusters := map[string]*envoyclusterv3.Cluster{}
-			s, _ := c.cache.GetSnapshot(c.EnvoyNodeName)
+			s, _ := c.cache.GetSnapshot(c.options.EnvoyNodeName)
 
 			for name, res := range s.GetResources(envoyresourcev3.ClusterType) {
 				gotClusters[name] = res.(*envoyclusterv3.Cluster)
@@ -593,8 +593,8 @@ func TestNewEndpointHandler(t *testing.T) {
 				Build()
 
 			handler := (&Reconciler{
-				Options: Options{ExposeAnnotationKey: nodeportproxy.DefaultExposeAnnotationKey},
-				Client:  client,
+				options: Options{ExposeAnnotationKey: nodeportproxy.DefaultExposeAnnotationKey},
+				client:  client,
 				log:     log,
 			}).newEndpointHandler()
 

--- a/pkg/controller/nodeport-proxy/envoymanager/resources.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/resources.go
@@ -664,10 +664,8 @@ func (sb *snapshotBuilder) getEndpoints(s *corev1.Service, port *corev1.ServiceP
 
 			var targetPort int32
 
-			if port.Name == "" {
-				// port.Name is optional if there is only one port
-				targetPort = epPort.Port
-			} else if port.Name == epPort.Name {
+			// port.Name is optional if there is only one port
+			if port.Name == "" || port.Name == epPort.Name {
 				targetPort = epPort.Port
 			}
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -598,7 +598,7 @@ func (r *Reconciler) reconcileCiliumNetworkPolicies(ctx context.Context, cfg *ku
 
 	netpol := &ciliumv2.CiliumClusterwideNetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: networkpolicy.CiliumSeedApiserverAllow}}
 	if _, err := controllerutil.CreateOrUpdate(ctx, client, netpol, func() error {
-		netpol.Spec = networkpolicy.SeedApiServerRule()
+		netpol.Spec = networkpolicy.SeedApiserverRule()
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to reconcile CiliumClusterwideNetworkPolicies: %w", err)

--- a/pkg/controller/operator/seed/resources/networkpolicy/cilium.go
+++ b/pkg/controller/operator/seed/resources/networkpolicy/cilium.go
@@ -35,7 +35,7 @@ const (
 	CiliumSeedApiserverAllow = "cilium-seed-apiserver-allow"
 )
 
-func SeedApiServerRule() *api.Rule {
+func SeedApiserverRule() *api.Rule {
 	egressRule := []api.EgressRule{
 		{
 			EgressCommonRule: api.EgressCommonRule{

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
 	"k8c.io/kubermatic/v2/pkg/util/kubectl"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -230,6 +231,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	ctx := context.Background()
 
 	controller := &Reconciler{
+		Client:             fake.NewClientBuilder().Build(),
 		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(ctx, log, testAddon, cluster, addonObj)
@@ -289,6 +291,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
 
 	controller := &Reconciler{
+		Client:             fake.NewClientBuilder().Build(),
 		overwriteRegistry:  "bar.io",
 		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
@@ -333,6 +336,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
 
 	controller := &Reconciler{
+		Client:             fake.NewClientBuilder().Build(),
 		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(context.Background(), log, testAddon, cluster, addonObj)
@@ -382,6 +386,7 @@ func TestController_getAddonManifests(t *testing.T) {
 	}
 
 	controller := &Reconciler{
+		Client:             fake.NewClientBuilder().Build(),
 		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(context.Background(), log, testAddon, cluster, addonObj)
@@ -408,6 +413,7 @@ func TestController_getAddonManifests(t *testing.T) {
 
 func TestController_ensureAddonLabelOnManifests(t *testing.T) {
 	controller := &Reconciler{
+		Client:             fake.NewClientBuilder().Build(),
 		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 
@@ -470,6 +476,7 @@ func TestHugeManifest(t *testing.T) {
 	}
 
 	r := &Reconciler{
+		Client:             fake.NewClientBuilder().Build(),
 		kubeconfigProvider: &fakeKubeconfigProvider{},
 		addons:             allAddons,
 	}

--- a/pkg/controller/seed-controller-manager/addon/migrations/csi-vsphere.go
+++ b/pkg/controller/seed-controller-manager/addon/migrations/csi-vsphere.go
@@ -51,14 +51,11 @@ func (m *csiVsphereMigration) PreApply(ctx context.Context, log *zap.SugaredLogg
 		return fmt.Errorf("failed to get CSIDriver: %w", err)
 	}
 
-	recreate := false
-	if len(driver.Spec.VolumeLifecycleModes) > 1 || (len(driver.Spec.VolumeLifecycleModes) == 1 && driver.Spec.VolumeLifecycleModes[0] != storagev1.VolumeLifecyclePersistent) {
-		recreate = true
-	}
-
-	if driver.Spec.PodInfoOnMount == nil || *driver.Spec.PodInfoOnMount {
-		recreate = true
-	}
+	recreate := false ||
+		len(driver.Spec.VolumeLifecycleModes) > 1 ||
+		(len(driver.Spec.VolumeLifecycleModes) == 1 && driver.Spec.VolumeLifecycleModes[0] != storagev1.VolumeLifecyclePersistent) ||
+		driver.Spec.PodInfoOnMount == nil ||
+		*driver.Spec.PodInfoOnMount
 
 	if recreate {
 		log.Info("Deleting vSphere CSIDriver to allow upgrade")

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
@@ -109,7 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -270,6 +270,6 @@ func (r *Reconciler) clusterUpdater(ctx context.Context, name string, modify fun
 
 func (r *Reconciler) makeGlobalSecretKeySelectorValue(ctx context.Context) provider.SecretKeySelectorValueFunc {
 	return func(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error) {
-		return provider.SecretKeySelectorValueFuncFactory(ctx, r.Client)(configVar, key)
+		return provider.SecretKeySelectorValueFuncFactory(ctx, r)(configVar, key)
 	}
 }

--- a/pkg/controller/seed-controller-manager/cluster-credentials-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-credentials-controller/controller.go
@@ -144,7 +144,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -201,10 +201,7 @@ func (r *Reconciler) reconcile(ctx context.Context, logger *zap.SugaredLogger, c
 	if err := r.parseCNIValuesAnnotation(cluster, initialValues); err != nil {
 		return &reconcile.Result{}, err
 	}
-	removeAnnotation := false
-	if len(initialValues) > 0 {
-		removeAnnotation = true
-	}
+	removeAnnotation := len(initialValues) > 0
 
 	// If initial values were not loaded from the annotation, use the default values from the ApplicationDefinition
 	if len(initialValues) == 0 {

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -130,7 +130,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("cluster", request.NamespacedName.Name)
+	log := r.log.With("cluster", request.Name)
 	log.Debug("Processing")
 
 	cluster := &kubermaticv1.Cluster{}
@@ -149,7 +149,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here, so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -254,13 +254,13 @@ func (r *Reconciler) ensureLegacyCNIAddonIsRemoved(ctx context.Context, cluster 
 			},
 		}
 		// trigger addon uninstall
-		err := r.Client.Delete(ctx, cniAddon)
+		err := r.Delete(ctx, cniAddon)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return 0, fmt.Errorf("failed to delete CNI addon %s: %w", cniAddon.GetName(), err)
 		}
 
 		// check addon has been uninstalled
-		err = r.Client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(cniAddon), cniAddon)
+		err = r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(cniAddon), cniAddon)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return 0, fmt.Errorf("failed to check CNI addon %s has been uninstalled: %w", cniAddon.GetName(), err)
@@ -291,7 +291,7 @@ func (r *Reconciler) removeCNIValuesAnnotation(ctx context.Context, cluster *kub
 
 func (r *Reconciler) parseAppDefDefaultValues(ctx context.Context, cluster *kubermaticv1.Cluster) (map[string]any, error) {
 	appDef := &appskubermaticv1.ApplicationDefinition{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: cluster.Spec.CNIPlugin.Type.String()}, appDef); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: cluster.Spec.CNIPlugin.Type.String()}, appDef); err != nil {
 		return nil, ctrlruntimeclient.IgnoreNotFound(err)
 	}
 

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
@@ -315,7 +315,7 @@ func TestReconcile(t *testing.T) {
 
 			// fetch potentially updated cluster object
 			newCluster := &kubermaticv1.Cluster{}
-			if err := r.Client.Get(ctx, nName, newCluster); err != nil {
+			if err := r.Get(ctx, nName, newCluster); err != nil {
 				t.Fatalf("Cluster object in seed cluster could not be found anymore: %v", err)
 			}
 

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller_test.go
@@ -143,9 +143,9 @@ func genConstraint(name, namespace, kind string, label, deleted bool) *kubermati
 	constraint := generator.GenConstraint(name, namespace, kind)
 	if label {
 		if constraint.Labels != nil {
-			constraint.Labels[Key] = constraint.Name
+			constraint.Labels[key] = constraint.Name
 		} else {
-			constraint.Labels = map[string]string{Key: constraint.Name}
+			constraint.Labels = map[string]string{key: constraint.Name}
 		}
 	}
 	if deleted {

--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -147,6 +147,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	//nolint:staticcheck
 	ignoreDefaultApplications := false
 
 	// If the cluster has the initial application installations request annotation, we don't want to install the default applications as they will be

--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -95,7 +95,7 @@ func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName st
 		// Watch for clusters
 		For(&kubermaticv1.Cluster{}).
 		// Watch changes for ApplicationDefinitions that have been enforced.
-		Watches(&appskubermaticv1.ApplicationDefinition{}, enqueueClusters(reconciler.Client, log), builder.WithPredicates(withEventFilter())).
+		Watches(&appskubermaticv1.ApplicationDefinition{}, enqueueClusters(reconciler, log), builder.WithPredicates(withEventFilter())).
 		Build(reconciler)
 
 	return err
@@ -119,7 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -216,7 +216,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	}
 
 	if len(errors) == 0 && !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionDefaultApplicationInstallationsControllerCreatedSuccessfully, corev1.ConditionTrue) {
-		if err := util.UpdateClusterStatus(ctx, r.Client, cluster, func(c *kubermaticv1.Cluster) {
+		if err := util.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
 			util.SetClusterCondition(
 				cluster,
 				r.versions,

--- a/pkg/controller/seed-controller-manager/default-application-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller_test.go
@@ -534,7 +534,7 @@ func TestReconcile(t *testing.T) {
 
 			// fetch potentially updated cluster object
 			newCluster := &kubermaticv1.Cluster{}
-			if err := r.Client.Get(ctx, nName, newCluster); err != nil {
+			if err := r.Get(ctx, nName, newCluster); err != nil {
 				t.Fatalf("Cluster object in seed cluster could not be found anymore: %v", err)
 			}
 

--- a/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// replicate the predicate from above to make sure that reconcile loops triggered by apiserver and secret
 	// do not run unexpected reconciles.
-	if !(cluster.IsEncryptionEnabled() || cluster.IsEncryptionActive()) {
+	if !cluster.IsEncryptionEnabled() && !cluster.IsEncryptionActive() {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
@@ -140,7 +140,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := controllerutil.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -228,7 +228,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 
 	switch cluster.Status.Encryption.Phase {
 	case kubermaticv1.ClusterEncryptionPhasePending:
-		isUpdated, err := isApiserverUpdated(ctx, r.Client, cluster)
+		isUpdated, err := isApiserverUpdated(ctx, r, cluster)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
@@ -238,12 +238,12 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 			return &reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
-		keyHint, resourceList, err := getActiveConfiguration(ctx, r.Client, cluster)
+		keyHint, resourceList, err := getActiveConfiguration(ctx, r, cluster)
 		if err != nil {
 			return &reconcile.Result{}, err
 		}
 
-		if err := controllerutil.UpdateClusterStatus(ctx, r.Client, cluster, func(c *kubermaticv1.Cluster) {
+		if err := controllerutil.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
 			if c.Status.Encryption.ActiveKey != keyHint || !isEqualSlice(c.Status.Encryption.EncryptedResources, resourceList) {
 				// the active key as per the parsed EncryptionConfiguration has changed; we need to re-run encryption
 				c.Status.Encryption.Phase = kubermaticv1.ClusterEncryptionPhaseEncryptionNeeded
@@ -259,7 +259,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return &reconcile.Result{}, nil
 
 	case kubermaticv1.ClusterEncryptionPhaseEncryptionNeeded:
-		return r.encryptData(ctx, r.Client, log, cluster)
+		return r.encryptData(ctx, r, log, cluster)
 
 	case kubermaticv1.ClusterEncryptionPhaseActive:
 		// get a key hint as defined in the ClusterSpec to compare to the current status.
@@ -276,7 +276,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 			}
 
 			log.Debugf("configured key %q != %q, moving cluster to EncryptionPhase 'Pending'", configuredKey, cluster.Status.Encryption.ActiveKey)
-			if err := controllerutil.UpdateClusterStatus(ctx, r.Client, cluster, func(c *kubermaticv1.Cluster) {
+			if err := controllerutil.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
 				c.Status.Encryption.Phase = kubermaticv1.ClusterEncryptionPhasePending
 			}); err != nil {
 				return &reconcile.Result{}, err
@@ -286,7 +286,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		// encryption is set to "identity", thus secrets are unencrypted, and encryption is longer wished.
 		// This means we can fully reset the encryption status
 		if cluster.Status.Encryption.ActiveKey == encryptionresources.IdentityKey && !cluster.IsEncryptionEnabled() {
-			if err := controllerutil.UpdateClusterStatus(ctx, r.Client, cluster, func(c *kubermaticv1.Cluster) {
+			if err := controllerutil.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
 				c.Status.Encryption = nil
 				controllerutil.SetClusterCondition(
 					cluster,
@@ -319,7 +319,7 @@ func (r *Reconciler) validateSecretRef(ctx context.Context, cluster *kubermaticv
 
 	for _, key := range cluster.Spec.EncryptionConfiguration.Secretbox.Keys {
 		if key.SecretRef != nil {
-			v, err := getSecretKeyValue(ctx, r.Client, key.SecretRef, fmt.Sprintf("cluster-%s", cluster.Name))
+			v, err := getSecretKeyValue(ctx, r, key.SecretRef, fmt.Sprintf("cluster-%s", cluster.Name))
 			if err != nil {
 				return &reconcile.Result{}, err
 			} else {
@@ -335,7 +335,7 @@ func (r *Reconciler) validateSecretRef(ctx context.Context, cluster *kubermaticv
 
 func (r *Reconciler) setInitializedCondition(ctx context.Context, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	// set the encryption initialized condition (should only happen once on every cluster)
-	if err := controllerutil.UpdateClusterStatus(ctx, r.Client, cluster, func(c *kubermaticv1.Cluster) {
+	if err := controllerutil.UpdateClusterStatus(ctx, r, cluster, func(c *kubermaticv1.Cluster) {
 		if cluster.Status.Encryption == nil {
 			cluster.Status.Encryption = &kubermaticv1.ClusterEncryptionStatus{
 				Phase:              kubermaticv1.ClusterEncryptionPhasePending,

--- a/pkg/controller/seed-controller-manager/encryption-at-rest-controller/encryption.go
+++ b/pkg/controller/seed-controller-manager/encryption-at-rest-controller/encryption.go
@@ -55,7 +55,7 @@ func (r *Reconciler) encryptData(ctx context.Context, client ctrlruntimeclient.C
 
 	if err := r.List(ctx, &jobList, ctrlruntimeclient.MatchingLabels{
 		encryptionresources.ClusterLabelKey:        cluster.Name,
-		encryptionresources.SecretRevisionLabelKey: secret.ObjectMeta.ResourceVersion,
+		encryptionresources.SecretRevisionLabelKey: secret.ResourceVersion,
 	}); err != nil {
 		return &reconcile.Result{}, err
 	}

--- a/pkg/controller/seed-controller-manager/encryption-at-rest-controller/utils.go
+++ b/pkg/controller/seed-controller-manager/encryption-at-rest-controller/utils.go
@@ -52,7 +52,7 @@ func isApiserverUpdated(ctx context.Context, client ctrlruntimeclient.Client, cl
 	hash := sha1.New()
 	hash.Write(spec)
 
-	if val, ok := secret.ObjectMeta.Labels[encryptionresources.ApiserverEncryptionHashLabelKey]; !ok || val != hex.EncodeToString(hash.Sum(nil)) {
+	if val, ok := secret.Labels[encryptionresources.ApiserverEncryptionHashLabelKey]; !ok || val != hex.EncodeToString(hash.Sum(nil)) {
 		// the secret on the cluster (or in the cache) doesn't seem updated yet
 		return false, nil
 	}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -197,7 +197,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -385,7 +385,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		// compute the pending (i.e. latest past) and the next (i.e. earliest future) backup time,
 		// based on the most recent scheduled backup or, as a fallback, the backupConfig's creation time
 
-		nextBackupTime := backupConfig.ObjectMeta.CreationTimestamp.Time
+		nextBackupTime := backupConfig.CreationTimestamp.Time
 
 		if len(backupConfig.Status.CurrentBackups) > 0 {
 			latestBackup := &backupConfig.Status.CurrentBackups[len(backupConfig.Status.CurrentBackups)-1]
@@ -807,7 +807,7 @@ func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cl
 	secretName := etcdbackup.GetEtcdBackupSecretName(cluster)
 
 	getCA := func() (*triple.KeyPair, error) {
-		return resources.GetClusterRootCA(ctx, cluster.Status.NamespaceName, r.Client)
+		return resources.GetClusterRootCA(ctx, cluster.Status.NamespaceName, r)
 	}
 
 	creators := []reconciling.NamedSecretReconcilerFactory{
@@ -821,7 +821,7 @@ func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cl
 		),
 	}
 
-	return reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r.Client, modifier.Ownership(cluster, "", r.scheme))
+	return reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r, modifier.Ownership(cluster, "", r.scheme))
 }
 
 func caBundleConfigMapName(cluster *kubermaticv1.Cluster) string {
@@ -835,7 +835,7 @@ func (r *Reconciler) ensureConfigMaps(ctx context.Context, cluster *kubermaticv1
 		certificates.CABundleConfigMapReconciler(name, r.caBundle),
 	}
 
-	return reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespaceSystem, r.Client, modifier.Ownership(cluster, "", r.scheme))
+	return reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespaceSystem, r, modifier.Ownership(cluster, "", r.scheme))
 }
 
 func parseCronSchedule(scheduleString string) (cron.Schedule, error) {

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -1660,7 +1660,7 @@ func TestMultipleBackupDestination(t *testing.T) {
 				return c
 			}(),
 			expectedJobEnvVars: []corev1.EnvVar{
-				etcdbackup.GenSecretEnvVar(etcdbackup.AccessKeyIdEnvVarKey, etcdbackup.AccessKeyIdEnvVarKey, genDefaultBackupDestination()),
+				etcdbackup.GenSecretEnvVar(etcdbackup.AccessKeyIDEnvVarKey, etcdbackup.AccessKeyIDEnvVarKey, genDefaultBackupDestination()),
 				etcdbackup.GenSecretEnvVar(etcdbackup.SecretAccessKeyEnvVarKey, etcdbackup.SecretAccessKeyEnvVarKey, genDefaultBackupDestination()),
 				{
 					Name:  etcdbackup.BucketNameEnvVarKey,

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -63,9 +63,10 @@ const (
 
 // Reconciler stores necessary components that are required to restore etcd backups.
 type Reconciler struct {
+	ctrlruntimeclient.Client
+
 	log        *zap.SugaredLogger
 	workerName string
-	ctrlruntimeclient.Client
 	recorder   record.EventRecorder
 	versions   kubermatic.Versions
 	seedGetter provider.SeedGetter
@@ -85,8 +86,9 @@ func Add(
 	client := mgr.GetClient()
 
 	reconciler := &Reconciler{
+		Client: client,
+
 		log:        log,
-		Client:     client,
 		workerName: workerName,
 		recorder:   mgr.GetEventRecorderFor(ControllerName),
 		versions:   versions,
@@ -202,7 +204,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 	}
 
 	// check that the backup to restore from exists and is accessible
-	s3Client, bucketName, err := resources.GetEtcdRestoreS3Client(ctx, restore, true, r.Client, cluster, destination)
+	s3Client, bucketName, err := resources.GetEtcdRestoreS3Client(ctx, restore, true, r, cluster, destination)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain S3 client: %w", err)
 	}
@@ -225,7 +227,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, rest
 			cluster.Annotations = map[string]string{}
 		}
 		cluster.Annotations[ActiveRestoreAnnotationName] = thisRestore
-		if err := r.Client.Update(ctx, cluster); err != nil {
+		if err := r.Update(ctx, cluster); err != nil {
 			if apierrors.IsConflict(err) {
 				return &reconcile.Result{RequeueAfter: 1 * time.Minute}, nil
 			}

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -107,7 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
@@ -341,7 +341,7 @@ func TestReconcile(t *testing.T) {
 
 			// fetch potentially updated cluster object
 			newCluster := &kubermaticv1.Cluster{}
-			if err := r.Client.Get(ctx, nName, newCluster); err != nil {
+			if err := r.Get(ctx, nName, newCluster); err != nil {
 				t.Fatalf("Cluster object in seed cluster could not be found anymore: %v", err)
 			}
 

--- a/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller.go
@@ -103,7 +103,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller_test.go
@@ -292,7 +292,7 @@ func TestReconcile(t *testing.T) {
 
 			// fetch potentially updated cluster object
 			newCluster := &kubermaticv1.Cluster{}
-			if err := r.Client.Get(ctx, nName, newCluster); err != nil {
+			if err := r.Get(ctx, nName, newCluster); err != nil {
 				t.Fatalf("Cluster object in seed cluster could not be found anymore: %v", err)
 			}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/address.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/address.go
@@ -45,7 +45,7 @@ func (r *Reconciler) syncAddress(ctx context.Context, log *zap.SugaredLogger, cl
 	b := address.NewModifiersBuilder(log)
 	modifiers, err := b.
 		Cluster(cluster).
-		Client(r.Client).
+		Client(r).
 		ExternalURL(r.externalURL).
 		Seed(seed).
 		Build(ctx)

--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -288,7 +288,7 @@ func (r *Reconciler) applicationControllerHealthCheck(ctx context.Context, clust
 func (r *Reconciler) statefulSetHealthCheck(ctx context.Context, c *kubermaticv1.Cluster) (bool, error) {
 	// check the etcd
 	statefulSet := &appsv1.StatefulSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.EtcdStatefulSetName}, statefulSet)
+	err := r.Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.EtcdStatefulSetName}, statefulSet)
 
 	if err != nil {
 		// if the StatefulSet for etcd doesn't exist yet, there's nothing to worry about

--- a/pkg/controller/seed-controller-manager/kubernetes/launching.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/launching.go
@@ -50,7 +50,7 @@ func (r *Reconciler) clusterIsReachable(ctx context.Context, c *kubermaticv1.Clu
 
 func (r *Reconciler) etcdUseStrictTLS(ctx context.Context, c *kubermaticv1.Cluster) (bool, error) {
 	statefulSet := &appsv1.StatefulSet{}
-	err := r.Client.Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.EtcdStatefulSetName}, statefulSet)
+	err := r.Get(ctx, types.NamespacedName{Namespace: c.Status.NamespaceName, Name: resources.EtcdStatefulSetName}, statefulSet)
 
 	if err != nil {
 		// if the StatefulSet for etcd doesn't exist yet, a new one can be deployed with strict TLS peers
@@ -64,7 +64,7 @@ func (r *Reconciler) etcdUseStrictTLS(ctx context.Context, c *kubermaticv1.Clust
 	pods := &corev1.PodList{}
 	labelSet := etcd.GetBasePodLabels(c)
 
-	err = r.Client.List(ctx, pods, &ctrlruntimeclient.ListOptions{
+	err = r.List(ctx, pods, &ctrlruntimeclient.ListOptions{
 		Namespace:     c.Status.NamespaceName,
 		LabelSelector: labels.SelectorFromSet(labelSet),
 	})

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -755,7 +755,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			return fmt.Errorf("failed to fetch Kubernetes API service IP list: %w", err)
 		}
 
-		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.SeedApiServerAllowReconciler(apiIPs))
+		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.SeedApiserverAllowReconciler(apiIPs))
 
 		if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 			return fmt.Errorf("failed to ensure Network Policies: %w", err)

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -231,7 +231,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
 	}
 
-	supportsFailureDomainZoneAntiAffinity, err := resources.SupportsFailureDomainZoneAntiAffinity(ctx, r.Client)
+	supportsFailureDomainZoneAntiAffinity, err := resources.SupportsFailureDomainZoneAntiAffinity(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +601,7 @@ func (r *Reconciler) GetSecretReconcilers(ctx context.Context, data *resources.T
 func (r *Reconciler) ensureSecrets(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	namedSecretReconcilerFactories := r.GetSecretReconcilers(ctx, data)
 
-	if err := reconciling.ReconcileSecrets(ctx, namedSecretReconcilerFactories, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, namedSecretReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the Secret exists: %w", err)
 	}
 
@@ -629,7 +629,7 @@ func (r *Reconciler) ensureServiceAccounts(ctx context.Context, c *kubermaticv1.
 		namedServiceAccountReconcilerFactories = append(namedServiceAccountReconcilerFactories, nodeportproxy.ServiceAccountReconciler)
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, namedServiceAccountReconcilerFactories, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(ctx, namedServiceAccountReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure ServiceAccounts: %w", err)
 	}
 
@@ -637,7 +637,7 @@ func (r *Reconciler) ensureServiceAccounts(ctx context.Context, c *kubermaticv1.
 		etcd.KubeSystemServiceAccountReconciler(c),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, namedKubeSystemServiceAccountReconcilerFactories, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(ctx, namedKubeSystemServiceAccountReconcilerFactories, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to ensure ServiceAccounts in %s namespace: %w", metav1.NamespaceSystem, err)
 	}
 
@@ -653,7 +653,7 @@ func (r *Reconciler) ensureRoles(ctx context.Context, c *kubermaticv1.Cluster) e
 		namedRoleReconcilerFactories = append(namedRoleReconcilerFactories, nodeportproxy.RoleReconciler)
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, namedRoleReconcilerFactories, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileRoles(ctx, namedRoleReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure Roles: %w", err)
 	}
 
@@ -672,7 +672,7 @@ func (r *Reconciler) ensureRoleBindings(ctx context.Context, c *kubermaticv1.Clu
 		namedRoleBindingReconcilerFactories = append(namedRoleBindingReconcilerFactories, nodeportproxy.RoleBindingReconciler)
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, namedRoleBindingReconcilerFactories, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileRoleBindings(ctx, namedRoleBindingReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure RoleBindings: %w", err)
 	}
 	return nil
@@ -688,7 +688,7 @@ func (r *Reconciler) ensureClusterRoles(ctx context.Context, c *kubermaticv1.Clu
 		namedClusterRoleReconcilerFactories = append(namedClusterRoleReconcilerFactories, csi.ClusterRolesReconcilers(c)...)
 	}
 
-	if err := reconciling.ReconcileClusterRoles(ctx, namedClusterRoleReconcilerFactories, "", r.Client); err != nil {
+	if err := reconciling.ReconcileClusterRoles(ctx, namedClusterRoleReconcilerFactories, "", r); err != nil {
 		return fmt.Errorf("failed to ensure Cluster Roles: %w", err)
 	}
 
@@ -700,7 +700,7 @@ func (r *Reconciler) ensureClusterRoleBindings(ctx context.Context, namespace *c
 		usercluster.ClusterRoleBinding(namespace),
 		userclusterwebhook.ClusterRoleBinding(namespace),
 	}
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, namedClusterRoleBindingsReconcilerFactories, "", r.Client); err != nil {
+	if err := reconciling.ReconcileClusterRoleBindings(ctx, namedClusterRoleBindingsReconcilerFactories, "", r); err != nil {
 		return fmt.Errorf("failed to ensure Cluster Role Bindings: %w", err)
 	}
 
@@ -757,7 +757,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 
 		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.SeedApiServerAllowReconciler(apiIPs))
 
-		if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, c.Status.NamespaceName, r.Client); err != nil {
+		if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 			return fmt.Errorf("failed to ensure Network Policies: %w", err)
 		}
 	}
@@ -791,7 +791,7 @@ func GetConfigMapReconcilers(data *resources.TemplateData) []reconciling.NamedCo
 func (r *Reconciler) ensureConfigMaps(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetConfigMapReconcilers(data)
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileConfigMaps(ctx, creators, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the ConfigMap exists: %w", err)
 	}
 
@@ -836,7 +836,7 @@ func GetPodDisruptionBudgetReconcilers(data *resources.TemplateData) []reconcili
 func (r *Reconciler) ensurePodDisruptionBudgets(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetPodDisruptionBudgetReconcilers(data)
 
-	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the PodDisruptionBudget exists: %w", err)
 	}
 
@@ -853,7 +853,7 @@ func GetCronJobReconcilers(data *resources.TemplateData) []reconciling.NamedCron
 func (r *Reconciler) ensureCronJobs(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetCronJobReconcilers(data)
 
-	if err := reconciling.ReconcileCronJobs(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileCronJobs(ctx, creators, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the CronJobs exists: %w", err)
 	}
 
@@ -883,12 +883,12 @@ func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, c *kuberm
 		)
 	}
 
-	creators, err := resources.GetVerticalPodAutoscalersForAll(ctx, r.Client, controlPlaneDeploymentNames, []string{resources.EtcdStatefulSetName}, c.Status.NamespaceName, r.features.VPA)
+	creators, err := resources.GetVerticalPodAutoscalersForAll(ctx, r, controlPlaneDeploymentNames, []string{resources.EtcdStatefulSetName}, c.Status.NamespaceName, r.features.VPA)
 	if err != nil {
 		return fmt.Errorf("failed to create the functions to handle VPA resources: %w", err)
 	}
 
-	return kkpreconciling.ReconcileVerticalPodAutoscalers(ctx, creators, c.Status.NamespaceName, r.Client)
+	return kkpreconciling.ReconcileVerticalPodAutoscalers(ctx, creators, c.Status.NamespaceName, r)
 }
 
 func (r *Reconciler) ensureStatefulSets(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
@@ -904,30 +904,30 @@ func (r *Reconciler) ensureStatefulSets(ctx context.Context, c *kubermaticv1.Clu
 		modifier.ControlplaneComponent(c),
 	}
 
-	return reconciling.ReconcileStatefulSets(ctx, creators, c.Status.NamespaceName, r.Client, modifiers...)
+	return reconciling.ReconcileStatefulSets(ctx, creators, c.Status.NamespaceName, r, modifiers...)
 }
 
 func (r *Reconciler) ensureEtcdBackupConfigs(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData,
 	seed *kubermaticv1.Seed) error {
 	if seed.IsDefaultEtcdAutomaticBackupEnabled() {
 		creators := GetEtcdBackupConfigReconcilers(data, seed)
-		return kkpreconciling.ReconcileEtcdBackupConfigs(ctx, creators, c.Status.NamespaceName, r.Client)
+		return kkpreconciling.ReconcileEtcdBackupConfigs(ctx, creators, c.Status.NamespaceName, r)
 	}
 	// If default etcd automatic backups are not enabled, remove them if any
 	ebc := &kubermaticv1.EtcdBackupConfig{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: resources.EtcdDefaultBackupConfigName, Namespace: c.Status.NamespaceName}, ebc)
+	err := r.Get(ctx, types.NamespacedName{Name: resources.EtcdDefaultBackupConfigName, Namespace: c.Status.NamespaceName}, ebc)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	return r.Client.Delete(ctx, ebc)
+	return r.Delete(ctx, ebc)
 }
 
 func (r *Reconciler) ensureOldOPAIntegrationIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range gatekeeper.GetResourcesToRemoveOnDelete(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure old OPA integration version resources are removed/not present: %w", err)
 		}
 	}
@@ -937,7 +937,7 @@ func (r *Reconciler) ensureOldOPAIntegrationIsRemoved(ctx context.Context, data 
 
 func (r *Reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range kubernetesdashboard.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure kubernetes-dashboard resources are removed/not present: %w", err)
 		}
@@ -947,7 +947,7 @@ func (r *Reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Co
 
 func (r *Reconciler) ensureCSIDriverResourcesAreRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range csi.ResourcesForDeletion(data.Cluster()) {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure CSI driver resources are removed/not present: %w", err)
 		}
@@ -957,17 +957,17 @@ func (r *Reconciler) ensureCSIDriverResourcesAreRemoved(ctx context.Context, dat
 
 func (r *Reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range openvpn.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure OpenVPN resources are removed/not present: %w", err)
 		}
 	}
 	for _, resource := range metricsserver.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure metrics-server resources are removed/not present: %w", err)
 		}
 	}
 	for _, resource := range dns.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure dns-resolver resources are removed/not present: %w", err)
 		}
 	}
@@ -977,7 +977,7 @@ func (r *Reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context, data *reso
 			Namespace: data.Cluster().Status.NamespaceName,
 		},
 	}
-	if err := r.Client.Delete(ctx, dnatControllerSecret); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.Delete(ctx, dnatControllerSecret); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to ensure DNAT controller resources are removed/not present: %w", err)
 	}
 	return nil
@@ -985,7 +985,7 @@ func (r *Reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context, data *reso
 
 func (r *Reconciler) ensureKonnectivitySetupIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range konnectivity.ResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure Konnectivity resources are removed/not present: %w", err)
 		}
 	}
@@ -995,7 +995,7 @@ func (r *Reconciler) ensureKonnectivitySetupIsRemoved(ctx context.Context, data 
 // ensureKonnectivityNetworkPolicyIsRemoved removes the NetworkPolicy put in place for
 // konnectivity-server -> external API server endpoint communication.
 func (r *Reconciler) ensureKonnectivityNetworkPolicyIsRemoved(ctx context.Context, data *resources.TemplateData) error {
-	if err := r.Client.Delete(ctx, &networkingv1.NetworkPolicy{
+	if err := r.Delete(ctx, &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resources.NetworkPolicyClusterExternalAddrAllow,
 			Namespace: data.Cluster().Status.NamespaceName,
@@ -1009,7 +1009,7 @@ func (r *Reconciler) ensureKonnectivityNetworkPolicyIsRemoved(ctx context.Contex
 
 func (r *Reconciler) ensureEncryptionConfigurationIsRemoved(ctx context.Context, data *resources.TemplateData) error {
 	for _, resource := range apiserver.EncryptionResourcesForDeletion(data.Cluster().Status.NamespaceName) {
-		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure encryption-at-rest resources are removed/not present: %w", err)
 		}
 	}
@@ -1047,7 +1047,7 @@ func (r *Reconciler) fetchKubernetesServiceIPList(ctx context.Context, resolverC
 
 	// fetch endpoint slices for the "kubernetes" Service.
 	endpointSlices := &discoveryv1.EndpointSliceList{}
-	if err := r.Client.List(ctx, endpointSlices,
+	if err := r.List(ctx, endpointSlices,
 		ctrlruntimeclient.InNamespace(corev1.NamespaceDefault),
 		ctrlruntimeclient.MatchingLabels{"kubernetes.io/service-name": "kubernetes"},
 	); err != nil {
@@ -1087,7 +1087,7 @@ func (r *Reconciler) listAPIServerAlternateNames(ctx context.Context, cluster *k
 	// That's okay because even if they did, the CCM might not have assigned a LoadBalancer yet.
 
 	service := &corev1.Service{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.ApiserverServiceName}, service); ctrlruntimeclient.IgnoreNotFound(err) != nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.ApiserverServiceName}, service); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 		return nil, fmt.Errorf("failed to get API server service: %w", err)
 	}
 
@@ -1104,7 +1104,7 @@ func (r *Reconciler) listAPIServerAlternateNames(ctx context.Context, cluster *k
 
 	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
 		service := &corev1.Service{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.FrontLoadBalancerServiceName}, service); ctrlruntimeclient.IgnoreNotFound(err) != nil {
+		if err := r.Get(ctx, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.FrontLoadBalancerServiceName}, service); ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			return nil, fmt.Errorf("failed to get front-loadbalancer service: %w", err)
 		}
 
@@ -1156,7 +1156,7 @@ func (r *Reconciler) ensureAuditWebhook(ctx context.Context, c *kubermaticv1.Clu
 	if data.DC().Spec.EnforcedAuditWebhookSettings != nil {
 		// if webhook backend is enabled on the DC then create the auditwebhookconfig secret in the user cluster ns.
 		creators := []reconciling.NamedSecretReconcilerFactory{r.auditWebhookSecretReconciler(ctx, data)}
-		if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+		if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -145,7 +145,7 @@ func (r *alertmanagerReconciler) Reconcile(ctx context.Context, request reconcil
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -391,7 +391,7 @@ func (r *alertmanagerController) getAlertmanagerConfigForCluster(ctx context.Con
 	}
 
 	if alertmanager.Spec.ConfigSecret.Name == "" {
-		if _, err := controllerruntime.CreateOrUpdate(ctx, r.Client, alertmanager, func() error {
+		if _, err := controllerruntime.CreateOrUpdate(ctx, r, alertmanager, func() error {
 			alertmanager.Spec.ConfigSecret.Name = resources.DefaultAlertmanagerConfigSecretName
 			return nil
 		}); err != nil {
@@ -414,7 +414,7 @@ func (r *alertmanagerController) getAlertmanagerConfigForCluster(ctx context.Con
 	}
 
 	if secret.Data == nil || len(secret.Data[resources.AlertmanagerConfigSecretKey]) == 0 {
-		if _, err := controllerruntime.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if _, err := controllerruntime.CreateOrUpdate(ctx, r, secret, func() error {
 			secret.Data = map[string][]byte{
 				resources.AlertmanagerConfigSecretKey: configuration,
 			}
@@ -479,7 +479,7 @@ func (r *alertmanagerController) ensureAlertManagerConfigStatus(ctx context.Cont
 
 	// Update alertmanager config status in Alertmanager CR
 	if oldAlertmanager.Status.ConfigStatus != alertmanager.Status.ConfigStatus {
-		if err := r.Client.Status().Patch(ctx, alertmanager, ctrlruntimeclient.MergeFrom(oldAlertmanager)); err != nil {
+		if err := r.Status().Patch(ctx, alertmanager, ctrlruntimeclient.MergeFrom(oldAlertmanager)); err != nil {
 			return fmt.Errorf("error patching alertmanager config status: %w", err)
 		}
 	}

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -119,7 +119,7 @@ func (r *datasourceGrafanaReconciler) Reconcile(ctx context.Context, request rec
 	// Add a wrapping here so we can emit an event on error
 	result, err := controllerutil.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -224,7 +224,7 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 
 	data := resources.NewTemplateDataBuilder().
 		WithContext(ctx).
-		WithClient(r.Client).
+		WithClient(r).
 		WithCluster(cluster).
 		WithOverwriteRegistry(r.overwriteRegistry).
 		Build()
@@ -360,7 +360,7 @@ func (r *datasourceGrafanaController) ensureDeployments(ctx context.Context, c *
 	creators := []reconciling.NamedDeploymentReconcilerFactory{
 		GatewayDeploymentReconciler(data, settings),
 	}
-	if err := reconciling.ReconcileDeployments(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileDeployments(ctx, creators, c.Status.NamespaceName, r); err != nil {
 		return err
 	}
 	return nil
@@ -370,7 +370,7 @@ func (r *datasourceGrafanaController) ensureConfigMaps(ctx context.Context, c *k
 	creators := []reconciling.NamedConfigMapReconcilerFactory{
 		GatewayConfigMapReconciler(c, r.mlaNamespace, settings),
 	}
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileConfigMaps(ctx, creators, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the ConfigMap exists: %w", err)
 	}
 	return nil
@@ -381,7 +381,7 @@ func (r *datasourceGrafanaController) ensureSecrets(ctx context.Context, c *kube
 		GatewayCAReconciler(),
 		GatewayCertificateReconciler(c, data.GetMLAGatewayCA),
 	}
-	if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the Secrets exist: %w", err)
 	}
 	return nil
@@ -392,7 +392,7 @@ func (r *datasourceGrafanaController) ensureServices(ctx context.Context, c *kub
 		GatewayInternalServiceReconciler(),
 		GatewayExternalServiceReconciler(c),
 	}
-	return reconciling.ReconcileServices(ctx, creators, c.Status.NamespaceName, r.Client)
+	return reconciling.ReconcileServices(ctx, creators, c.Status.NamespaceName, r)
 }
 
 func (r *datasourceGrafanaController) CleanUp(ctx context.Context) error {
@@ -437,7 +437,7 @@ func (r *datasourceGrafanaController) handleDeletion(ctx context.Context, cluste
 	}
 	if cluster.DeletionTimestamp.IsZero() && cluster.Status.NamespaceName != "" {
 		for _, resource := range ResourcesOnDeletion(cluster.Status.NamespaceName) {
-			err := r.Client.Delete(ctx, resource)
+			err := r.Delete(ctx, resource)
 			// Update Health status even in case of error
 			// If any resources could not be deleted (configmap, secret,.. not only deployment)
 			// The status will be kubermaticv1.HealthStatusDown until everything is cleaned up.
@@ -455,7 +455,7 @@ func (r *datasourceGrafanaController) handleDeletion(ctx context.Context, cluste
 }
 
 func (r *datasourceGrafanaController) mlaGatewayHealth(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	mlaGatewayHealth, err := resources.HealthyDeployment(ctx, r.Client, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: gatewayName}, 1)
+	mlaGatewayHealth, err := resources.HealthyDeployment(ctx, r, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: gatewayName}, 1)
 	if err != nil {
 		return fmt.Errorf("failed to get dep health %s: %w", resources.MLAMonitoringAgentDeploymentName, err)
 	}

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -173,7 +173,7 @@ func (r *ruleGroupReconciler) Reconcile(ctx context.Context, request reconcile.R
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -196,7 +196,7 @@ func (r *ruleGroupSyncController) syncClusterNS(
 			log.Debugw("cluster have mla disabled, skipping", "cluster", cluster.Name)
 			continue
 		}
-		if err := action(r.Client, ruleGroup, &cluster); err != nil {
+		if err := action(r, ruleGroup, &cluster); err != nil {
 			return fmt.Errorf("failed to sync rulegroup for cluster %s: %w", cluster.Name, err)
 		}
 	}

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -93,8 +93,8 @@ func newUserGrafanaReconciler(
 			MaxConcurrentReconciles: numWorkers,
 		}).
 		For(&kubermaticv1.User{}, builder.WithPredicates(serviceAccountPredicate)).
-		Watches(&kubermaticv1.UserProjectBinding{}, handler.EnqueueRequestsFromMapFunc(enqueueUserForUserProjectBinding(reconciler.Client))).
-		Watches(&kubermaticv1.GroupProjectBinding{}, handler.EnqueueRequestsFromMapFunc(enqueueUserForGroupProjectBinding(reconciler.Client))).
+		Watches(&kubermaticv1.UserProjectBinding{}, handler.EnqueueRequestsFromMapFunc(enqueueUserForUserProjectBinding(reconciler))).
+		Watches(&kubermaticv1.GroupProjectBinding{}, handler.EnqueueRequestsFromMapFunc(enqueueUserForGroupProjectBinding(reconciler))).
 		Build(reconciler)
 
 	return err
@@ -317,7 +317,7 @@ func (r *userGrafanaController) ensureGrafanaUser(ctx context.Context, user *kub
 		projectMap[project.Name] = project.DeepCopy()
 	}
 	if !user.Spec.IsAdmin {
-		projectRoles, err := getProjectRolesForUser(ctx, r.Client, user)
+		projectRoles, err := getProjectRolesForUser(ctx, r, user)
 		if err != nil {
 			return fmt.Errorf("error getting project roles for user %q: %w", user.Name, err)
 		}

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -102,8 +102,7 @@ func Add(
 	log = log.Named(ControllerName)
 
 	reconciler := &Reconciler{
-		Client: mgr.GetClient(),
-
+		Client:                  mgr.GetClient(),
 		userClusterConnProvider: userClusterConnProvider,
 		workerName:              workerName,
 		log:                     log,
@@ -179,7 +178,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := controllerutil.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,
@@ -214,7 +213,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	log.Debug("Reconciling cluster now")
 
-	data, err := r.getClusterTemplateData(ctx, r.Client, cluster)
+	data, err := r.getClusterTemplateData(ctx, r, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/seed-controller-manager/monitoring/resources.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources.go
@@ -73,7 +73,7 @@ func (r *Reconciler) ensureRoles(ctx context.Context, cluster *kubermaticv1.Clus
 		prometheus.RoleReconciler(),
 	}
 
-	return reconciling.ReconcileRoles(ctx, getters, cluster.Status.NamespaceName, r.Client)
+	return reconciling.ReconcileRoles(ctx, getters, cluster.Status.NamespaceName, r)
 }
 
 func (r *Reconciler) ensureRoleBindings(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -81,7 +81,7 @@ func (r *Reconciler) ensureRoleBindings(ctx context.Context, cluster *kubermatic
 		prometheus.RoleBindingReconciler(cluster.Status.NamespaceName),
 	}
 
-	return reconciling.ReconcileRoleBindings(ctx, getters, cluster.Status.NamespaceName, r.Client)
+	return reconciling.ReconcileRoleBindings(ctx, getters, cluster.Status.NamespaceName, r)
 }
 
 // GetDeploymentReconcilers returns all DeploymentReconcilers that are currently in use.
@@ -101,7 +101,7 @@ func (r *Reconciler) ensureDeployments(ctx context.Context, cluster *kubermaticv
 		modifier.ControlplaneComponent(cluster),
 	}
 
-	return reconciling.ReconcileDeployments(ctx, creators, cluster.Status.NamespaceName, r.Client, modifiers...)
+	return reconciling.ReconcileDeployments(ctx, creators, cluster.Status.NamespaceName, r, modifiers...)
 }
 
 // GetSecretReconcilerOperations returns all SecretReconcilers that are currently in use.
@@ -120,7 +120,7 @@ func GetSecretReconcilerOperations(data *resources.TemplateData) []reconciling.N
 func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	namedSecretReconcilerFactories := GetSecretReconcilerOperations(data)
 
-	if err := reconciling.ReconcileSecrets(ctx, namedSecretReconcilerFactories, cluster.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, namedSecretReconcilerFactories, cluster.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the Secret exists: %w", err)
 	}
 
@@ -137,7 +137,7 @@ func GetConfigMapReconcilers(data *resources.TemplateData) []reconciling.NamedCo
 func (r *Reconciler) ensureConfigMaps(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetConfigMapReconcilers(data)
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, cluster.Status.NamespaceName, r.Client); err != nil {
+	if err := reconciling.ReconcileConfigMaps(ctx, creators, cluster.Status.NamespaceName, r); err != nil {
 		return fmt.Errorf("failed to ensure that the ConfigMap exists: %w", err)
 	}
 
@@ -159,7 +159,7 @@ func (r *Reconciler) ensureStatefulSets(ctx context.Context, cluster *kubermatic
 		modifier.ControlplaneComponent(cluster),
 	}
 
-	return reconciling.ReconcileStatefulSets(ctx, creators, cluster.Status.NamespaceName, r.Client, modifiers...)
+	return reconciling.ReconcileStatefulSets(ctx, creators, cluster.Status.NamespaceName, r, modifiers...)
 }
 
 func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, cluster *kubermaticv1.Cluster) error {
@@ -172,7 +172,7 @@ func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, cluster *
 
 	creators, err := resources.GetVerticalPodAutoscalersForAll(
 		ctx,
-		r.Client,
+		r,
 		deploymentNames,
 		statefulSetNames,
 		cluster.Status.NamespaceName,
@@ -180,7 +180,7 @@ func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, cluster *
 	if err != nil {
 		return fmt.Errorf("failed to create the functions to handle VPA resources: %w", err)
 	}
-	return kkpreconciling.ReconcileVerticalPodAutoscalers(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return kkpreconciling.ReconcileVerticalPodAutoscalers(ctx, creators, cluster.Status.NamespaceName, r)
 }
 
 // GetServiceReconcilers returns all service creators that are currently in use.
@@ -193,7 +193,7 @@ func GetServiceReconcilers(data *resources.TemplateData) []reconciling.NamedServ
 func (r *Reconciler) ensureServices(ctx context.Context, cluster *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	creators := GetServiceReconcilers(data)
 
-	return reconciling.ReconcileServices(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.ReconcileServices(ctx, creators, cluster.Status.NamespaceName, r)
 }
 
 // GetServiceReconcilers returns all service creators that are currently in use.
@@ -206,5 +206,5 @@ func GetServiceAccountReconcilers() []reconciling.NamedServiceAccountReconcilerF
 func (r *Reconciler) ensureServiceAccounts(ctx context.Context, cluster *kubermaticv1.Cluster, _ *resources.TemplateData) error {
 	creators := GetServiceAccountReconcilers()
 
-	return reconciling.ReconcileServiceAccounts(ctx, creators, cluster.Status.NamespaceName, r.Client)
+	return reconciling.ReconcileServiceAccounts(ctx, creators, cluster.Status.NamespaceName, r)
 }

--- a/pkg/controller/seed-controller-manager/monitoring/resources_test.go
+++ b/pkg/controller/seed-controller-manager/monitoring/resources_test.go
@@ -105,7 +105,7 @@ func TestCreateConfigMap(t *testing.T) {
 			}
 			controller := newTestReconciler(t, objects)
 
-			data, err := controller.getClusterTemplateData(ctx, controller.Client, test.cluster)
+			data, err := controller.getClusterTemplateData(ctx, controller, test.cluster)
 			if err != nil {
 				t.Fatal(err)
 				return
@@ -117,7 +117,7 @@ func TestCreateConfigMap(t *testing.T) {
 
 			keyName := types.NamespacedName{Namespace: test.cluster.Status.NamespaceName, Name: resources.PrometheusConfigConfigMapName}
 			gotConfigMap := &corev1.ConfigMap{}
-			if err := controller.Client.Get(ctx, keyName, gotConfigMap); err != nil {
+			if err := controller.Get(ctx, keyName, gotConfigMap); err != nil {
 				t.Fatalf("failed to get the ConfigMap from the dynamic client: %v", err)
 			}
 

--- a/pkg/controller/seed-controller-manager/operating-system-manager-migrator/controller.go
+++ b/pkg/controller/seed-controller-manager/operating-system-manager-migrator/controller.go
@@ -78,12 +78,12 @@ func Add(
 	}
 
 	reconciler := &Reconciler{
+		Client:                        mgr.GetClient(),
 		log:                           log.Named(ControllerName),
 		workerNameLabelSelector:       workerSelector,
 		workerName:                    workerName,
 		recorder:                      mgr.GetEventRecorderFor(ControllerName),
 		userClusterConnectionProvider: userClusterConnectionProvider,
-		Client:                        mgr.GetClient(),
 		versions:                      versions,
 	}
 
@@ -116,7 +116,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := util.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/sync_reconciler.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/sync_reconciler.go
@@ -93,7 +93,7 @@ func addSyncReconciler(
 }
 
 func (r *syncReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("operatingsystemprofile", request.NamespacedName.String())
+	log := r.log.With("operatingsystemprofile", request.String())
 	log.Debug("Reconciling")
 
 	cosp := &unstructured.Unstructured{}

--- a/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
+++ b/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
@@ -47,10 +47,11 @@ const (
 )
 
 type Reconciler struct {
+	ctrlruntimeclient.Client
+
 	log        *zap.SugaredLogger
 	workerName string
-	ctrlruntimeclient.Client
-	recorder record.EventRecorder
+	recorder   record.EventRecorder
 }
 
 // add the controller.
@@ -62,9 +63,9 @@ func Add(
 ) error {
 	log = log.Named(ControllerName)
 	reconciler := &Reconciler{
+		Client:     mgr.GetClient(),
 		log:        log,
 		workerName: workerName,
-		Client:     mgr.GetClient(),
 		recorder:   mgr.GetEventRecorderFor(ControllerName),
 	}
 

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -309,7 +309,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return fmt.Errorf("failed to load KubermaticConfiguration: %w", err)
 	}
 
-	newVersion, err := getNextApiServerVersion(ctx, config, cluster)
+	newVersion, err := getNextApiserverVersion(ctx, config, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to determine update path: %w", err)
 	}
@@ -481,7 +481,7 @@ func hasOwnerRefToAny(obj ctrlruntimeclient.Object, ownerKind string, ownerNames
 	return false
 }
 
-func getNextApiServerVersion(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, cluster *kubermaticv1.Cluster) (*semver.Semver, error) {
+func getNextApiserverVersion(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, cluster *kubermaticv1.Cluster) (*semver.Semver, error) {
 	updateConditions := clusterversion.GetVersionConditions(&cluster.Spec)
 	updateManager := version.NewFromConfiguration(config)
 	currentVersion := cluster.Status.Versions.Apiserver.Semver()

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -70,8 +70,7 @@ type Reconciler struct {
 // Add creates a new update controller.
 func Add(mgr manager.Manager, numWorkers int, workerName string, configGetter provider.KubermaticConfigurationGetter, log *zap.SugaredLogger, versions kubermatic.Versions) error {
 	reconciler := &Reconciler{
-		Client: mgr.GetClient(),
-
+		Client:       mgr.GetClient(),
 		workerName:   workerName,
 		configGetter: configGetter,
 		recorder:     mgr.GetEventRecorderFor(ControllerName),
@@ -119,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	result, err := controllerutil.ClusterReconcileWrapper(
 		ctx,
-		r.Client,
+		r,
 		r.workerName,
 		cluster,
 		r.versions,

--- a/pkg/controller/seed-controller-manager/update-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller_test.go
@@ -821,7 +821,7 @@ func TestReconcile(t *testing.T) {
 				}
 
 				newCluster := &kubermaticv1.Cluster{}
-				err := rec.Client.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(cluster), newCluster)
+				err := rec.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(cluster), newCluster)
 				if err != nil {
 					t.Fatalf("Failed to find cluster: %v", err)
 				}

--- a/pkg/controller/seed-controller-manager/update-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller_test.go
@@ -315,7 +315,7 @@ func TestGetNextApiServerVersion(t *testing.T) {
 				},
 			}
 
-			nextVersion, err := getNextApiServerVersion(context.Background(), config, cluster)
+			nextVersion, err := getNextApiserverVersion(context.Background(), config, cluster)
 			if err != nil {
 				if !tt.expectedErr {
 					t.Fatalf("Expected next version %s, but got error: %v", tt.expected.String(), err)

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -45,7 +45,7 @@ const (
 	spec                 = "spec"
 	parametersField      = "parameters"
 	matchField           = "match"
-	rawJsonField         = "rawJSON"
+	rawJSONField         = "rawJSON"
 	enforcementAction    = "enforcementAction"
 )
 
@@ -151,17 +151,17 @@ func constraintReconcilerFactory(constraint *kubermaticv1.Constraint) reconcilin
 				}
 
 				// To keep backwards compatibility for Constraints that still use rawJSON. Support for this should be removed for 2.19
-				if rawJson, ok := params[rawJsonField]; ok {
-					var rawJsonParams map[string]interface{}
-					rawJson, ok := rawJson.(string)
+				if rawJSON, ok := params[rawJSONField]; ok {
+					var rawJSONParams map[string]interface{}
+					rawJSON, ok := rawJSON.(string)
 					if !ok {
 						return nil, fmt.Errorf("error converting raw json parameters")
 					}
-					err := json.Unmarshal([]byte(rawJson), &rawJsonParams)
+					err := json.Unmarshal([]byte(rawJSON), &rawJSONParams)
 					if err != nil {
 						return nil, fmt.Errorf("error unmarshalling raw json parameters: %w", err)
 					}
-					params = rawJsonParams
+					params = rawJSONParams
 				}
 
 				if err := unstructured.SetNestedField(u.Object, params, spec, parametersField); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -55,7 +55,7 @@ func AgentDaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.
 			labels := map[string]string{"app.kubernetes.io/name": AgentDaemonSetName}
 
 			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-			ds.Spec.Template.ObjectMeta.Labels = labels
+			ds.Spec.Template.Labels = labels
 
 			// The agent should only run on Flatcar nodes
 			ds.Spec.Template.Spec.NodeSelector = map[string]string{nodelabelerapi.DistributionLabelKey: nodelabelerapi.FlatcarLabelValue}

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -56,7 +56,7 @@ func OperatorDeploymentReconciler(imageRewriter registry.ImageRewriter, updateWi
 			labels := map[string]string{"app.kubernetes.io/name": OperatorDeploymentName}
 
 			dep.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-			dep.Spec.Template.ObjectMeta.Labels = labels
+			dep.Spec.Template.Labels = labels
 			dep.Spec.Template.Spec.ServiceAccountName = operatorServiceAccountName
 
 			env := []corev1.EnvVar{

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -348,7 +348,7 @@ func (r *reconciler) mlaReconcileData(ctx context.Context) (monitoring, logging 
 }
 
 func (r *reconciler) setupNetworkingData(cluster *kubermaticv1.Cluster, data *reconcileData) (err error) {
-	data.k8sServiceApiIP, err = resources.InClusterApiserverIP(cluster)
+	data.k8sServiceAPIIP, err = resources.InClusterApiserverIP(cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get Cluster Apiserver IP: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -309,7 +309,7 @@ func (r *reconciler) ensureAPIServices(ctx context.Context, data reconcileData) 
 		metricsserver.APIServiceReconciler(caCert),
 	}
 
-	if err := kkpreconciling.ReconcileAPIServices(ctx, creators, metav1.NamespaceNone, r.Client); err != nil {
+	if err := kkpreconciling.ReconcileAPIServices(ctx, creators, metav1.NamespaceNone, r); err != nil {
 		return fmt.Errorf("failed to reconcile APIServices: %w", err)
 	}
 
@@ -331,7 +331,7 @@ func (r *reconciler) reconcileServiceAccounts(ctx context.Context, data reconcil
 		creators = append(creators, usersshkeys.ServiceAccountReconciler())
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", metav1.NamespaceSystem, err)
 	}
 
@@ -340,7 +340,7 @@ func (r *reconciler) reconcileServiceAccounts(ctx context.Context, data reconcil
 		creators = []reconciling.NamedServiceAccountReconcilerFactory{
 			kubernetesdashboard.ServiceAccountReconciler(),
 		}
-		if err := reconciling.ReconcileServiceAccounts(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
+		if err := reconciling.ReconcileServiceAccounts(ctx, creators, kubernetesdashboard.Namespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", kubernetesdashboard.Namespace, err)
 		}
 	}
@@ -348,7 +348,7 @@ func (r *reconciler) reconcileServiceAccounts(ctx context.Context, data reconcil
 	cloudInitSAReconciler := []reconciling.NamedServiceAccountReconcilerFactory{
 		cloudinitsettings.ServiceAccountReconciler(),
 	}
-	if err := reconciling.ReconcileServiceAccounts(ctx, cloudInitSAReconciler, resources.CloudInitSettingsNamespace, r.Client); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(ctx, cloudInitSAReconciler, resources.CloudInitSettingsNamespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile cloud-init-getter in the namespace %s: %w", resources.CloudInitSettingsNamespace, err)
 	}
 
@@ -357,7 +357,7 @@ func (r *reconciler) reconcileServiceAccounts(ctx context.Context, data reconcil
 		creators = []reconciling.NamedServiceAccountReconcilerFactory{
 			gatekeeper.ServiceAccountReconciler(),
 		}
-		if err := reconciling.ReconcileServiceAccounts(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileServiceAccounts(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -367,7 +367,7 @@ func (r *reconciler) reconcileServiceAccounts(ctx context.Context, data reconcil
 			konnectivity.ServiceAccountReconciler(),
 			metricsserver.ServiceAccountReconciler(), // required only if metrics-server is running in user cluster
 		}
-		if err := reconciling.ReconcileServiceAccounts(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+		if err := reconciling.ReconcileServiceAccounts(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 			return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", metav1.NamespaceSystem, err)
 		}
 	}
@@ -385,7 +385,7 @@ func (r *reconciler) reconcileServiceAccounts(ctx context.Context, data reconcil
 	}
 
 	if len(creators) != 0 {
-		if err := reconciling.ReconcileServiceAccounts(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileServiceAccounts(ctx, creators, resources.UserClusterMLANamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", resources.UserClusterMLANamespace, err)
 		}
 	}
@@ -403,7 +403,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 		creators = append(creators, usersshkeys.RoleReconciler())
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", metav1.NamespaceSystem, err)
 	}
 
@@ -414,7 +414,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 		operatingsystemmanager.KubePublicRoleReconciler(),
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespacePublic, r.Client); err != nil {
+	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespacePublic, r); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", metav1.NamespacePublic, err)
 	}
 
@@ -424,7 +424,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 		operatingsystemmanager.DefaultRoleReconciler(),
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceDefault, r.Client); err != nil {
+	if err := reconciling.ReconcileRoles(ctx, creators, metav1.NamespaceDefault, r); err != nil {
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", metav1.NamespaceDefault, err)
 	}
 
@@ -434,7 +434,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 			kubernetesdashboard.RoleReconciler(),
 		}
 
-		if err := reconciling.ReconcileRoles(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
+		if err := reconciling.ReconcileRoles(ctx, creators, kubernetesdashboard.Namespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", kubernetesdashboard.Namespace, err)
 		}
 	}
@@ -444,7 +444,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 		operatingsystemmanager.CloudInitSettingsRoleReconciler(),
 	}
 
-	if err := reconciling.ReconcileRoles(ctx, cloudInitRoleReconciler, resources.CloudInitSettingsNamespace, r.Client); err != nil {
+	if err := reconciling.ReconcileRoles(ctx, cloudInitRoleReconciler, resources.CloudInitSettingsNamespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile cloud-init-getter role in the namespace %s: %w", resources.CloudInitSettingsNamespace, err)
 	}
 
@@ -453,7 +453,7 @@ func (r *reconciler) reconcileRoles(ctx context.Context, data reconcileData) err
 		creators = []reconciling.NamedRoleReconcilerFactory{
 			gatekeeper.RoleReconciler(),
 		}
-		if err := reconciling.ReconcileRoles(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileRoles(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -475,7 +475,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		creators = append(creators, usersshkeys.RoleBindingReconciler())
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in kube-system Namespace: %w", err)
 	}
 
@@ -486,7 +486,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		operatingsystemmanager.KubePublicRoleBindingReconciler(),
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespacePublic, r.Client); err != nil {
+	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespacePublic, r); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in kube-public Namespace: %w", err)
 	}
 
@@ -496,7 +496,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		operatingsystemmanager.DefaultRoleBindingReconciler(),
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceDefault, r.Client); err != nil {
+	if err := reconciling.ReconcileRoleBindings(ctx, creators, metav1.NamespaceDefault, r); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in default Namespace: %w", err)
 	}
 
@@ -505,7 +505,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		creators = []reconciling.NamedRoleBindingReconcilerFactory{
 			kubernetesdashboard.RoleBindingReconciler(),
 		}
-		if err := reconciling.ReconcileRoleBindings(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
+		if err := reconciling.ReconcileRoleBindings(ctx, creators, kubernetesdashboard.Namespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile RoleBindings in the namespace: %s: %w", kubernetesdashboard.Namespace, err)
 		}
 	}
@@ -515,7 +515,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		operatingsystemmanager.CloudInitSettingsRoleBindingReconciler(),
 	}
 
-	if err := reconciling.ReconcileRoleBindings(ctx, cloudInitRoleBindingReconciler, resources.CloudInitSettingsNamespace, r.Client); err != nil {
+	if err := reconciling.ReconcileRoleBindings(ctx, cloudInitRoleBindingReconciler, resources.CloudInitSettingsNamespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile cloud-init-getter RoleBindings in the namespace: %s: %w", resources.CloudInitSettingsNamespace, err)
 	}
 
@@ -524,7 +524,7 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 		creators = []reconciling.NamedRoleBindingReconcilerFactory{
 			gatekeeper.RoleBindingReconciler(),
 		}
-		if err := reconciling.ReconcileRoleBindings(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileRoleBindings(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile RoleBindings in namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -559,7 +559,7 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileDa
 		creators = append(creators, mlamonitoringagent.ClusterRoleReconciler())
 	}
 
-	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoles: %w", err)
 	}
 	return nil
@@ -605,7 +605,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context, data reco
 		creators = append(creators, konnectivity.ClusterRoleBindingReconciler())
 	}
 
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r); err != nil {
 		return fmt.Errorf("failed to reconcile ClusterRoleBindings: %w", err)
 	}
 	return nil
@@ -642,7 +642,7 @@ func (r *reconciler) reconcileCRDs(ctx context.Context, data reconcileData) erro
 		}
 	}
 
-	if err := kkpreconciling.ReconcileCustomResourceDefinitions(ctx, creators, "", r.Client); err != nil {
+	if err := kkpreconciling.ReconcileCustomResourceDefinitions(ctx, creators, "", r); err != nil {
 		return fmt.Errorf("failed to reconcile CustomResourceDefinitions: %w", err)
 	}
 
@@ -663,7 +663,7 @@ func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context,
 		creators = append(creators, gatekeeper.MutatingWebhookConfigurationReconciler(r.opaWebhookTimeout))
 	}
 
-	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, creators, "", r); err != nil {
 		return fmt.Errorf("failed to reconcile MutatingWebhookConfigurations: %w", err)
 	}
 	return nil
@@ -692,7 +692,7 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 		creators = append(creators, csisnapshotter.ValidatingSnapshotWebhookConfigurationReconciler(data.caCert.Cert, metav1.NamespaceSystem, resources.CSISnapshotValidationWebhookConfigurationName))
 	}
 
-	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r); err != nil {
 		return fmt.Errorf("failed to reconcile ValidatingWebhookConfigurations: %w", err)
 	}
 	return nil
@@ -710,7 +710,7 @@ func (r *reconciler) reconcileServices(ctx context.Context, data reconcileData) 
 		creatorsKubeSystem = append(creatorsKubeSystem, metricsserver.ExternalNameServiceReconciler(r.namespace))
 	}
 
-	if err := reconciling.ReconcileServices(ctx, creatorsKubeSystem, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileServices(ctx, creatorsKubeSystem, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile Services in kube-system namespace: %w", err)
 	}
 
@@ -719,7 +719,7 @@ func (r *reconciler) reconcileServices(ctx context.Context, data reconcileData) 
 		creators := []reconciling.NamedServiceReconcilerFactory{
 			kubernetesdashboard.ServiceReconciler(data.ipFamily),
 		}
-		if err := reconciling.ReconcileServices(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
+		if err := reconciling.ReconcileServices(ctx, creators, kubernetesdashboard.Namespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Services in namespace %s: %w", kubernetesdashboard.Namespace, err)
 		}
 	}
@@ -729,7 +729,7 @@ func (r *reconciler) reconcileServices(ctx context.Context, data reconcileData) 
 		creators := []reconciling.NamedServiceReconcilerFactory{
 			gatekeeper.ServiceReconciler(),
 		}
-		if err := reconciling.ReconcileServices(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileServices(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Services in namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -744,13 +744,13 @@ func (r *reconciler) reconcileEndpoints(ctx context.Context, data reconcileData)
 	epReconcilers := []reconciling.NamedEndpointsReconcilerFactory{
 		kubernetesresources.EndpointsReconciler(data.k8sServiceEndpointAddress, data.k8sServiceEndpointPort),
 	}
-	if err := reconciling.ReconcileEndpoints(ctx, epReconcilers, metav1.NamespaceDefault, r.Client); err != nil {
+	if err := reconciling.ReconcileEndpoints(ctx, epReconcilers, metav1.NamespaceDefault, r); err != nil {
 		return fmt.Errorf("failed to reconcile Endpoints: %w", err)
 	}
 	epSliceReconcilers := []reconciling.NamedEndpointSliceReconcilerFactory{
 		kubernetesresources.EndpointSliceReconciler(data.k8sServiceEndpointAddress, data.k8sServiceEndpointPort),
 	}
-	if err := reconciling.ReconcileEndpointSlices(ctx, epSliceReconcilers, metav1.NamespaceDefault, r.Client); err != nil {
+	if err := reconciling.ReconcileEndpointSlices(ctx, epSliceReconcilers, metav1.NamespaceDefault, r); err != nil {
 		return fmt.Errorf("failed to reconcile EndpointSlices: %w", err)
 	}
 	return nil
@@ -761,7 +761,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 		machinecontroller.ClusterInfoConfigMapReconciler(r.clusterURL.String(), data.caCert.Cert),
 	}
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespacePublic, r.Client); err != nil {
+	if err := reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespacePublic, r); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in kube-public namespace: %w", err)
 	}
 
@@ -815,7 +815,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 		}
 	}
 
-	if err := reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileConfigMaps(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in kube-system namespace: %w", err)
 	}
 
@@ -834,7 +834,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 				HAClusterIdentifier: r.clusterName,
 			}),
 		}
-		if err := reconciling.ReconcileConfigMaps(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileConfigMaps(ctx, creators, resources.UserClusterMLANamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile ConfigMap in namespace %s: %w", resources.UserClusterMLANamespace, err)
 		}
 	}
@@ -880,7 +880,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		creators = append(creators, usersshkeys.SecretReconciler(data.userSSHKeys))
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile Secrets in kube-system Namespace: %w", err)
 	}
 
@@ -891,7 +891,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 			kubernetesdashboard.CsrfTokenSecretReconciler(),
 		}
 
-		if err := reconciling.ReconcileSecrets(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
+		if err := reconciling.ReconcileSecrets(ctx, creators, kubernetesdashboard.Namespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %w", kubernetesdashboard.Namespace, err)
 		}
 	}
@@ -901,7 +901,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		creators = []reconciling.NamedSecretReconcilerFactory{
 			gatekeeper.SecretReconciler(),
 		}
-		if err := reconciling.ReconcileSecrets(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileSecrets(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -910,7 +910,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		creators = []reconciling.NamedSecretReconcilerFactory{
 			mlamonitoringagent.ClientCertificateReconciler(data.mlaGatewayCACert),
 		}
-		if err := reconciling.ReconcileSecrets(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileSecrets(ctx, creators, resources.UserClusterMLANamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %w", resources.UserClusterMLANamespace, err)
 		}
 	}
@@ -924,7 +924,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 			}),
 			mlaloggingagent.ClientCertificateReconciler(data.mlaGatewayCACert),
 		}
-		if err := reconciling.ReconcileSecrets(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileSecrets(ctx, creators, resources.UserClusterMLANamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Secrets in namespace %s: %w", resources.UserClusterMLANamespace, err)
 		}
 	}
@@ -933,7 +933,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		cloudinitsettings.SecretReconciler(),
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, resources.CloudInitSettingsNamespace, r.Client); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, creators, resources.CloudInitSettingsNamespace, r); err != nil {
 		return fmt.Errorf("failed to reconcile Secrets in namespace %s: %w", resources.CloudInitSettingsNamespace, err)
 	}
 
@@ -959,7 +959,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context, data reconcileData)
 		dsReconcilers = append(dsReconcilers, envoyagent.DaemonSetReconciler(r.tunnelingAgentIP, r.versions, configHash, r.imageRewriter))
 	}
 
-	if err := reconciling.ReconcileDaemonSets(ctx, dsReconcilers, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileDaemonSets(ctx, dsReconcilers, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile the DaemonSet: %w", err)
 	}
 
@@ -967,7 +967,7 @@ func (r *reconciler) reconcileDaemonSet(ctx context.Context, data reconcileData)
 		dsReconcilers = []reconciling.NamedDaemonSetReconcilerFactory{
 			mlaloggingagent.DaemonSetReconciler(data.loggingRequirements, r.imageRewriter),
 		}
-		if err := reconciling.ReconcileDaemonSets(ctx, dsReconcilers, resources.UserClusterMLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileDaemonSets(ctx, dsReconcilers, resources.UserClusterMLANamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile the DaemonSet: %w", err)
 		}
 	}
@@ -990,7 +990,7 @@ func (r *reconciler) reconcileNamespaces(ctx context.Context, data reconcileData
 		creators = append(creators, mla.NamespaceReconciler)
 	}
 
-	if err := reconciling.ReconcileNamespaces(ctx, creators, "", r.Client); err != nil {
+	if err := reconciling.ReconcileNamespaces(ctx, creators, "", r); err != nil {
 		return fmt.Errorf("failed to reconcile namespaces: %w", err)
 	}
 
@@ -1019,7 +1019,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		creators := []reconciling.NamedDeploymentReconcilerFactory{
 			kubernetesdashboard.DeploymentReconciler(r.imageRewriter),
 		}
-		if err := reconciling.ReconcileDeployments(ctx, creators, kubernetesdashboard.Namespace, r.Client); err != nil {
+		if err := reconciling.ReconcileDeployments(ctx, creators, kubernetesdashboard.Namespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %w", kubernetesdashboard.Namespace, err)
 		}
 	}
@@ -1028,7 +1028,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		coredns.DeploymentReconciler(r.clusterSemVer, data.cluster, r.imageRewriter),
 	}
 
-	if err := reconciling.ReconcileDeployments(ctx, kubeSystemReconcilers, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileDeployments(ctx, kubeSystemReconcilers, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile Deployments in namespace %s: %w", metav1.NamespaceSystem, err)
 	}
 
@@ -1039,7 +1039,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 			gatekeeper.AuditDeploymentReconciler(r.imageRewriter, data.gatekeeperAuditRequirements),
 		}
 
-		if err := reconciling.ReconcileDeployments(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileDeployments(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -1048,7 +1048,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		creators := []reconciling.NamedDeploymentReconcilerFactory{
 			mlamonitoringagent.DeploymentReconciler(data.monitoringRequirements, data.monitoringReplicas, r.imageRewriter),
 		}
-		if err := reconciling.ReconcileDeployments(ctx, creators, resources.UserClusterMLANamespace, r.Client); err != nil {
+		if err := reconciling.ReconcileDeployments(ctx, creators, resources.UserClusterMLANamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %w", resources.UserClusterMLANamespace, err)
 		}
 	}
@@ -1060,7 +1060,7 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 			konnectivity.DeploymentReconciler(data.clusterVersion, r.konnectivityServerHost, r.konnectivityServerPort, r.konnectivityKeepaliveTime, r.imageRewriter, konnectivityResources),
 			metricsserver.DeploymentReconciler(r.imageRewriter), // deploy metrics-server in user cluster
 		}
-		if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+		if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 			return fmt.Errorf("failed to reconcile Deployments in namespace %s: %w", metav1.NamespaceSystem, err)
 		}
 	}
@@ -1083,7 +1083,7 @@ func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcil
 		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, metricsserver.NetworkPolicyReconciler(), konnectivity.NetworkPolicyReconciler())
 	}
 
-	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %w", err)
 	}
 
@@ -1099,7 +1099,7 @@ func (r *reconciler) reconcilePodDisruptionBudgets(ctx context.Context) error {
 		creators = []reconciling.NamedPodDisruptionBudgetReconcilerFactory{
 			gatekeeper.PodDisruptionBudgetReconciler(),
 		}
-		if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, resources.GatekeeperNamespace, r.Client); err != nil {
+		if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, resources.GatekeeperNamespace, r); err != nil {
 			return fmt.Errorf("failed to reconcile PodDisruptionBudgets in namespace %s: %w", resources.GatekeeperNamespace, err)
 		}
 	}
@@ -1109,7 +1109,7 @@ func (r *reconciler) reconcilePodDisruptionBudgets(ctx context.Context) error {
 			metricsserver.PodDisruptionBudgetReconciler(),
 		)
 	}
-	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, metav1.NamespaceSystem, r.Client); err != nil {
+	if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, metav1.NamespaceSystem, r); err != nil {
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %w", err)
 	}
 	return nil
@@ -1148,7 +1148,7 @@ func (r *reconciler) ensureOPAIntegrationIsRemoved(ctx context.Context) error {
 	}
 
 	for _, resource := range resources {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if errC := r.cleanUpOPAHealthStatus(ctx, err); errC != nil {
 			return fmt.Errorf("failed to update OPA health status in cluster: %w", errC)
 		}
@@ -1161,7 +1161,7 @@ func (r *reconciler) ensureOPAIntegrationIsRemoved(ctx context.Context) error {
 }
 
 func (r *reconciler) ensureOPAExperimentalMutationWebhookIsRemoved(ctx context.Context) error {
-	if err := r.Client.Delete(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{
+	if err := r.Delete(ctx, &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resources.GatekeeperMutatingWebhookConfigurationName,
 		}}); err != nil && !apierrors.IsNotFound(err) {
@@ -1234,7 +1234,7 @@ func (r *reconciler) healthCheck(ctx context.Context) error {
 
 func (r *reconciler) getGatekeeperHealth(ctx context.Context) (ctlrHealth kubermaticv1.HealthStatus, auditHealth kubermaticv1.HealthStatus, err error) {
 	ctlrHealth, err = resources.HealthyDeployment(ctx,
-		r.Client,
+		r,
 		types.NamespacedName{Namespace: resources.GatekeeperNamespace, Name: resources.GatekeeperControllerDeploymentName},
 		1)
 	if err != nil {
@@ -1243,7 +1243,7 @@ func (r *reconciler) getGatekeeperHealth(ctx context.Context) (ctlrHealth kuberm
 	}
 
 	auditHealth, err = resources.HealthyDeployment(ctx,
-		r.Client,
+		r,
 		types.NamespacedName{Namespace: resources.GatekeeperNamespace, Name: resources.GatekeeperAuditDeploymentName},
 		1)
 	if err != nil {
@@ -1255,7 +1255,7 @@ func (r *reconciler) getGatekeeperHealth(ctx context.Context) (ctlrHealth kuberm
 
 func (r *reconciler) getMLAMonitoringHealth(ctx context.Context) (health kubermaticv1.HealthStatus, err error) {
 	health, err = resources.HealthyDeployment(ctx,
-		r.Client,
+		r,
 		types.NamespacedName{Namespace: resources.UserClusterMLANamespace, Name: resources.MLAMonitoringAgentDeploymentName},
 		1)
 	if err != nil {
@@ -1268,7 +1268,7 @@ func (r *reconciler) getMLAMonitoringHealth(ctx context.Context) (health kuberma
 
 func (r *reconciler) getMLALoggingHealth(ctx context.Context) (kubermaticv1.HealthStatus, error) {
 	loggingHealth, err := resources.HealthyDaemonSet(ctx,
-		r.Client,
+		r,
 		types.NamespacedName{Namespace: resources.UserClusterMLANamespace, Name: resources.MLALoggingAgentDaemonSetName},
 		1)
 	if err != nil {
@@ -1279,7 +1279,7 @@ func (r *reconciler) getMLALoggingHealth(ctx context.Context) (kubermaticv1.Heal
 
 func (r *reconciler) ensureLoggingAgentIsRemoved(ctx context.Context) error {
 	for _, resource := range mlaloggingagent.ResourcesOnDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if errC := r.cleanUpMLAHealthStatus(ctx, true, false, err); errC != nil {
 			return fmt.Errorf("failed to update mla logging health status in cluster: %w", errC)
 		}
@@ -1292,7 +1292,7 @@ func (r *reconciler) ensureLoggingAgentIsRemoved(ctx context.Context) error {
 
 func (r *reconciler) ensureLegacyPromtailIsRemoved(ctx context.Context) error {
 	for _, resource := range mlaloggingagent.LegacyResourcesOnDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure promtail is removed/not present: %w", err)
 		}
@@ -1302,7 +1302,7 @@ func (r *reconciler) ensureLegacyPromtailIsRemoved(ctx context.Context) error {
 
 func (r *reconciler) ensureUserClusterMonitoringAgentIsRemoved(ctx context.Context) error {
 	for _, resource := range mlamonitoringagent.ResourcesOnDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if errC := r.cleanUpMLAHealthStatus(ctx, false, true, err); errC != nil {
 			return fmt.Errorf("failed to update mla monitoring health status in cluster: %w", errC)
 		}
@@ -1315,7 +1315,7 @@ func (r *reconciler) ensureUserClusterMonitoringAgentIsRemoved(ctx context.Conte
 
 func (r *reconciler) ensureLegacyPrometheusIsRemoved(ctx context.Context) error {
 	for _, resource := range mlamonitoringagent.LegacyResourcesOnDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure user cluster monitoring agent is removed/not present: %w", err)
 		}
@@ -1325,7 +1325,7 @@ func (r *reconciler) ensureLegacyPrometheusIsRemoved(ctx context.Context) error 
 
 func (r *reconciler) ensureMLAIsRemoved(ctx context.Context) error {
 	for _, resource := range mla.ResourcesOnDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if errC := r.cleanUpMLAHealthStatus(ctx, true, true, err); errC != nil {
 			return fmt.Errorf("failed to update mla health status in cluster: %w", errC)
 		}
@@ -1338,7 +1338,7 @@ func (r *reconciler) ensureMLAIsRemoved(ctx context.Context) error {
 
 func (r *reconciler) ensureCSIDriverResourcesAreRemoved(ctx context.Context) error {
 	for _, resource := range cloudcontroller.ResourcesForDeletion(metav1.NamespaceSystem) {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure CSI driver resources are removed/not present: %w", err)
 		}
@@ -1348,7 +1348,7 @@ func (r *reconciler) ensureCSIDriverResourcesAreRemoved(ctx context.Context) err
 
 func (r *reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context) error {
 	for _, resource := range openvpn.ResourcesForDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure OpenVPN resources are removed/not present: %w", err)
 		}
@@ -1358,13 +1358,13 @@ func (r *reconciler) ensureOpenVPNSetupIsRemoved(ctx context.Context) error {
 
 func (r *reconciler) ensureKonnectivitySetupIsRemoved(ctx context.Context) error {
 	for _, resource := range konnectivity.ResourcesForDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure Konnectivity resources are removed/not present: %w", err)
 		}
 	}
 	for _, resource := range metricsserver.UserClusterResourcesForDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure metrics-server resources are removed/not present: %w", err)
 		}
@@ -1374,7 +1374,7 @@ func (r *reconciler) ensureKonnectivitySetupIsRemoved(ctx context.Context) error
 
 func (r *reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Context) error {
 	for _, resource := range kubernetesdashboard.ResourcesForDeletion() {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure Kubernetes Dashboard resources are removed/not present: %w", err)
 		}
@@ -1404,7 +1404,7 @@ func (r *reconciler) getUserClusterMonitoringAgentCustomScrapeConfigs(ctx contex
 
 func (r *reconciler) getEnvoyAgentConfigHash(ctx context.Context) (string, error) {
 	cm := corev1.ConfigMap{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: resources.EnvoyAgentConfigMapName, Namespace: metav1.NamespaceSystem}, &cm)
+	err := r.Get(ctx, types.NamespacedName{Name: resources.EnvoyAgentConfigMapName, Namespace: metav1.NamespaceSystem}, &cm)
 	if err != nil {
 		return "", fmt.Errorf("failed to get envoy-agent configmap: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -1071,12 +1071,12 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 func (r *reconciler) reconcileNetworkPolicies(ctx context.Context, data reconcileData) error {
 	namedNetworkPolicyReconcilerFactories := []reconciling.NamedNetworkPolicyReconcilerFactory{
 		kubesystem.DefaultNetworkPolicyReconciler(),
-		coredns.KubeDNSNetworkPolicyReconciler(data.k8sServiceEndpointAddress, int(data.k8sServiceEndpointPort), data.k8sServiceApiIP.String()),
+		coredns.KubeDNSNetworkPolicyReconciler(data.k8sServiceEndpointAddress, int(data.k8sServiceEndpointPort), data.k8sServiceAPIIP.String()),
 	}
 
 	if r.userSSHKeyAgent {
 		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories,
-			usersshkeys.NetworkPolicyReconciler(data.k8sServiceEndpointAddress, int(data.k8sServiceEndpointPort), data.k8sServiceApiIP.String()))
+			usersshkeys.NetworkPolicyReconciler(data.k8sServiceEndpointAddress, int(data.k8sServiceEndpointPort), data.k8sServiceAPIIP.String()))
 	}
 
 	if r.isKonnectivityEnabled {
@@ -1134,7 +1134,7 @@ type reconcileData struct {
 	gatekeeperAuditRequirements *corev1.ResourceRequirements
 	monitoringReplicas          *int32
 	ipFamily                    kubermaticv1.IPFamily
-	k8sServiceApiIP             *net.IP
+	k8sServiceAPIIP             *net.IP
 	k8sServiceEndpointAddress   string
 	k8sServiceEndpointPort      int32
 	reconcileK8sSvcEndpoints    bool

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -92,9 +92,9 @@ func DeploymentReconciler(kubernetesVersion *semverlib.Version, cluster *kuberma
 				}
 			}
 
-			if dep.Spec.Template.ObjectMeta.Labels == nil {
+			if dep.Spec.Template.Labels == nil {
 				// has to be the same as the selector
-				dep.Spec.Template.ObjectMeta.Labels = dep.Spec.Selector.MatchLabels
+				dep.Spec.Template.Labels = dep.Spec.Selector.MatchLabels
 			}
 
 			iptr := intstr.FromInt(1)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/networkpolicy.go
@@ -30,14 +30,14 @@ import (
 )
 
 // KubeDNSNetworkPolicyReconciler NetworkPolicy allows ingress traffic to coredns on port 53 TCP/UDP and egress to anywhere on port 53 TCP/UDP.
-func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceApi string) reconciling.NamedNetworkPolicyReconcilerFactory {
+func KubeDNSNetworkPolicyReconciler(k8sAPIIP string, k8sAPIPort int, k8sServiceAPI string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		dnsPort := intstr.FromInt(53)
 		apiServicePort := intstr.FromInt(443)
-		apiPort := intstr.FromInt(k8sApiPort)
+		apiPort := intstr.FromInt(k8sAPIPort)
 		metricsPort := intstr.FromInt(9153)
-		protoUdp := corev1.ProtocolUDP
-		protoTcp := corev1.ProtocolTCP
+		protoUDP := corev1.ProtocolUDP
+		protoTCP := corev1.ProtocolTCP
 
 		return "kube-dns", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -58,11 +58,11 @@ func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceA
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoUdp,
+								Protocol: &protoUDP,
 								Port:     &dnsPort,
 							},
 						},
@@ -77,11 +77,11 @@ func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceA
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoUdp,
+								Protocol: &protoUDP,
 								Port:     &dnsPort,
 							},
 						},
@@ -99,7 +99,7 @@ func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceA
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &metricsPort,
 							},
 						},
@@ -111,13 +111,13 @@ func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceA
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", k8sApiIP),
+									CIDR: fmt.Sprintf("%s/32", k8sAPIIP),
 								},
 							},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &apiPort,
 							},
 						},
@@ -126,13 +126,13 @@ func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceA
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", k8sServiceApi),
+									CIDR: fmt.Sprintf("%s/32", k8sServiceAPI),
 								},
 							},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &apiServicePort,
 							},
 						},
@@ -148,11 +148,11 @@ func KubeDNSNetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceA
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoUdp,
+								Protocol: &protoUDP,
 								Port:     &dnsPort,
 							},
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/clusterrolebinding.go
@@ -27,7 +27,7 @@ import (
 func ClusterRoleBindingReconciler() reconciling.NamedClusterRoleBindingReconcilerFactory {
 	return func() (string, reconciling.ClusterRoleBindingReconciler) {
 		return resources.KonnectivityClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			crb.ObjectMeta.Labels = resources.BaseAppLabels(resources.KonnectivityDeploymentName, nil)
+			crb.Labels = resources.BaseAppLabels(resources.KonnectivityDeploymentName, nil)
 
 			crb.RoleRef = rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -62,7 +62,7 @@ func DeploymentReconciler(
 		return resources.KonnectivityDeploymentName, func(ds *appsv1.Deployment) (*appsv1.Deployment, error) {
 			labels := resources.BaseAppLabels(resources.KonnectivityDeploymentName, nil)
 			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-			ds.Spec.Template.ObjectMeta.Labels = labels
+			ds.Spec.Template.Labels = labels
 
 			replicas := int32(2)
 			ds.Spec.Replicas = &replicas

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubesystem/networkpolicy.go
@@ -34,8 +34,8 @@ const NodeLocalDNSCacheAddress = "169.254.20.10"
 func DefaultNetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		dnsPort := intstr.FromInt(53)
-		protoUdp := corev1.ProtocolUDP
-		protoTcp := corev1.ProtocolTCP
+		protoUDP := corev1.ProtocolUDP
+		protoTCP := corev1.ProtocolTCP
 
 		return "default-deny", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			// dns access to node local dns cache
@@ -50,11 +50,11 @@ func DefaultNetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFa
 					{
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoUdp,
+								Protocol: &protoUDP,
 								Port:     &dnsPort,
 							},
 						},
@@ -69,11 +69,11 @@ func DefaultNetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFa
 					{
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoUdp,
+								Protocol: &protoUDP,
 								Port:     &dnsPort,
 							},
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -85,7 +85,7 @@ func DeploymentReconciler(imageRewriter registry.ImageRewriter) reconciling.Name
 					MaxSurge:       &sptr,
 				},
 			}
-			dep.Spec.Template.ObjectMeta.Labels = resources.BaseAppLabels(resources.MetricsServerDeploymentName, nil)
+			dep.Spec.Template.Labels = resources.BaseAppLabels(resources.MetricsServerDeploymentName, nil)
 
 			volumes := getVolumes()
 			dep.Spec.Template.Spec.Volumes = volumes

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
@@ -33,7 +33,7 @@ func NetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 		return "metrics-server", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			metricsPort := intstr.FromInt(9153)
 			httpsPort := intstr.FromInt(servingPort)
-			protoTcp := corev1.ProtocolTCP
+			protoTCP := corev1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
@@ -58,7 +58,7 @@ func NetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Port:     &metricsPort,
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 							},
 						},
 					},
@@ -73,7 +73,7 @@ func NetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Port:     &httpsPort,
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 							},
 						},
 					},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
@@ -82,7 +82,7 @@ func DaemonSetReconciler(overrides *corev1.ResourceRequirements, imageRewriter r
 				MatchLabels: controllerLabels,
 			}
 
-			ds.Spec.Template.ObjectMeta.Labels = controllerLabels
+			ds.Spec.Template.Labels = controllerLabels
 			ds.Spec.Template.Spec.ServiceAccountName = resources.MLALoggingAgentServiceAccountName
 			ds.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 				RunAsUser:  ptr.To[int64](0),

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -60,8 +60,8 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 			if ds.Spec.Selector == nil {
 				ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
 			}
-			if ds.Spec.Template.ObjectMeta.Labels == nil {
-				ds.Spec.Template.ObjectMeta.Labels = labels
+			if ds.Spec.Template.Labels == nil {
+				ds.Spec.Template.Labels = labels
 			}
 
 			ds.Spec.Template.Spec.ServiceAccountName = resources.NodeLocalDNSServiceAccountName

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
@@ -54,7 +54,7 @@ func DaemonSetReconciler(versions kubermatic.Versions, imageRewriter registry.Im
 
 			labels := map[string]string{"app": "user-ssh-keys-agent"}
 			ds.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-			ds.Spec.Template.ObjectMeta.Labels = labels
+			ds.Spec.Template.Labels = labels
 
 			ds.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/networkpolicy.go
@@ -29,11 +29,11 @@ import (
 )
 
 // NetworkPolicyReconciler NetworkPolicy allows egress traffic of user ssh keys agent to the world.
-func NetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceApi string) reconciling.NamedNetworkPolicyReconcilerFactory {
+func NetworkPolicyReconciler(k8sAPIIP string, k8sAPIPort int, k8sServiceAPI string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		apiServicePort := intstr.FromInt(443)
-		apiPort := intstr.FromInt(k8sApiPort)
-		protoTcp := corev1.ProtocolTCP
+		apiPort := intstr.FromInt(k8sAPIPort)
+		protoTCP := corev1.ProtocolTCP
 
 		return "user-ssh-key-agent", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -50,14 +50,14 @@ func NetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceApi stri
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", k8sApiIP),
+									CIDR: fmt.Sprintf("%s/32", k8sAPIIP),
 								},
 							},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Port:     &apiPort,
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 							},
 						},
 					},
@@ -65,14 +65,14 @@ func NetworkPolicyReconciler(k8sApiIP string, k8sApiPort int, k8sServiceApi stri
 						To: []networkingv1.NetworkPolicyPeer{
 							{
 								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", k8sServiceApi),
+									CIDR: fmt.Sprintf("%s/32", k8sServiceAPI),
 								},
 							},
 						},
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
 								Port:     &apiServicePort,
-								Protocol: &protoTcp,
+								Protocol: &protoTCP,
 							},
 						},
 					},

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -99,7 +99,7 @@ func Add(
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	r.log.Debug("Processing")
 
-	secret, err := r.fetchUserSSHKeySecret(ctx, request.NamespacedName.Namespace)
+	secret, err := r.fetchUserSSHKeySecret(ctx, request.Namespace)
 	if err != nil || secret == nil {
 		return reconcile.Result{}, fmt.Errorf("failed to fetch user ssh keys: %w", err)
 	}

--- a/pkg/ee/cluster-backup/master/storage-location-controller/controller.go
+++ b/pkg/ee/cluster-backup/master/storage-location-controller/controller.go
@@ -59,15 +59,14 @@ const (
 )
 
 type reconciler struct {
-	ctrlruntimeclient.Client
-
+	client   ctrlruntimeclient.Client
 	recorder record.EventRecorder
 	log      *zap.SugaredLogger
 }
 
 func Add(mgr manager.Manager, numWorkers int, log *zap.SugaredLogger) error {
 	reconciler := &reconciler{
-		Client:   mgr.GetClient(),
+		client:   mgr.GetClient(),
 		recorder: mgr.GetEventRecorderFor(ControllerName),
 		log:      log,
 	}
@@ -88,7 +87,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Reconciling")
 
 	cbsl := &kubermaticv1.ClusterBackupStorageLocation{}
-	if err := r.Client.Get(ctx, request.NamespacedName, cbsl); err != nil {
+	if err := r.client.Get(ctx, request.NamespacedName, cbsl); err != nil {
 		return reconcile.Result{}, nil
 	}
 	if cbsl.DeletionTimestamp != nil {
@@ -122,7 +121,7 @@ func (r *reconciler) reconcile(ctx context.Context, cbsl *kubermaticv1.ClusterBa
 		return fmt.Errorf("failed to get the credentials secret: %w", err)
 	}
 
-	if err := kuberneteshelper.TryAddFinalizer(ctx, r.Client, cbsl, CleanupFinalizer); err != nil {
+	if err := kuberneteshelper.TryAddFinalizer(ctx, r.client, cbsl, CleanupFinalizer); err != nil {
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
@@ -153,7 +152,7 @@ func (r *reconciler) updateCBSLStatus(ctx context.Context, cbsl *kubermaticv1.Cl
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Client.Get(ctx, key, cbsl); err != nil {
+		if err := r.client.Get(ctx, key, cbsl); err != nil {
 			return err
 		}
 
@@ -163,7 +162,7 @@ func (r *reconciler) updateCBSLStatus(ctx context.Context, cbsl *kubermaticv1.Cl
 		now := metav1.Now()
 		updatedCBSL.Status.LastValidationTime = &now
 		// we patch anyway even if there is no changes because we want to update the LastValidationTime.
-		return r.Client.Status().Patch(ctx, updatedCBSL, ctrlruntimeclient.MergeFrom(cbsl))
+		return r.client.Status().Patch(ctx, updatedCBSL, ctrlruntimeclient.MergeFrom(cbsl))
 	})
 }
 
@@ -171,14 +170,14 @@ func (r *reconciler) cleanup(ctx context.Context, cbsl *kubermaticv1.ClusterBack
 	creds, err := r.getCredentials(ctx, cbsl)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return kuberneteshelper.TryRemoveFinalizer(ctx, r.Client, cbsl, CleanupFinalizer)
+			return kuberneteshelper.TryRemoveFinalizer(ctx, r.client, cbsl, CleanupFinalizer)
 		}
 		return fmt.Errorf("failed to get the credentials secret: %w", err)
 	}
-	if err := r.Client.Delete(ctx, creds); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.client.Delete(ctx, creds); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete credentials secret: %w", err)
 	}
-	return kuberneteshelper.TryRemoveFinalizer(ctx, r.Client, cbsl, CleanupFinalizer)
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r.client, cbsl, CleanupFinalizer)
 }
 
 func (r *reconciler) getCredentials(ctx context.Context, cbsl *kubermaticv1.ClusterBackupStorageLocation) (*corev1.Secret, error) {
@@ -188,7 +187,7 @@ func (r *reconciler) getCredentials(ctx context.Context, cbsl *kubermaticv1.Clus
 		Namespace: cbsl.Namespace,
 	}
 
-	if err := r.Client.Get(ctx, key, creds); err != nil {
+	if err := r.client.Get(ctx, key, creds); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ee/cluster-backup/master/sync-controller/resources.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/resources.go
@@ -32,11 +32,11 @@ import (
 func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) reconciling.NamedClusterBackupStorageLocationReconcilerFactory {
 	return func() (string, reconciling.ClusterBackupStorageLocationReconciler) {
 		return cbsl.Name, func(existing *kubermaticv1.ClusterBackupStorageLocation) (*kubermaticv1.ClusterBackupStorageLocation, error) {
-			if existing.ObjectMeta.Labels == nil {
-				existing.ObjectMeta.Labels = map[string]string{}
+			if existing.Labels == nil {
+				existing.Labels = map[string]string{}
 			}
-			for k, v := range cbsl.ObjectMeta.Labels {
-				existing.ObjectMeta.Labels[k] = v
+			for k, v := range cbsl.Labels {
+				existing.Labels[k] = v
 			}
 			existing.Spec = cbsl.Spec
 			return existing, nil

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/controller.go
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/controller.go
@@ -385,7 +385,7 @@ func (r *reconciler) removeManagedObject(ctx context.Context, resource ctrlrunti
 	}
 
 	if isManagedBackupResource(resource) {
-		if err := r.userClient.Delete(ctx, resource); err != nil && !(apierrors.IsNotFound(err) || meta.IsNoMatchError(err)) {
+		if err := r.userClient.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
 			return fmt.Errorf("failed to delete user-cluster resource: %w", err)
 		}
 	}

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/secret.go
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/secret.go
@@ -39,13 +39,13 @@ import (
 func SecretReconciler(credentials *corev1.Secret) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return CloudCredentialsSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
-			awsAccessKeyId := credentials.Data[aws.AccessKeyIDKeyName]
+			awsAccessKeyID := credentials.Data[aws.AccessKeyIDKeyName]
 			awsSecretAccessKey := credentials.Data[aws.SecretAccessKeyName]
-			if awsAccessKeyId == nil || awsSecretAccessKey == nil {
+			if awsAccessKeyID == nil || awsSecretAccessKey == nil {
 				return nil, fmt.Errorf("backup destination credentials secret is not set correctly: [%s] and [%s] can't be empty", aws.AccessKeyIDKeyName, aws.SecretAccessKeyName)
 			}
 
-			cloudCredsFile, err := getVeleroCloudCredentials(awsAccessKeyId, awsSecretAccessKey)
+			cloudCredsFile, err := getVeleroCloudCredentials(awsAccessKeyID, awsSecretAccessKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate Velero cloud-credentials file: %w", err)
 			}
@@ -58,18 +58,18 @@ func SecretReconciler(credentials *corev1.Secret) reconciling.NamedSecretReconci
 }
 
 var credentialsTemplate string = `[default]
-aws_access_key_id = {{ .awsAccessKeyId }}
+aws_access_key_id = {{ .awsAccessKeyID }}
 aws_secret_access_key = {{ .awsSecretAccessKey }}
 `
 
-func getVeleroCloudCredentials(awsAccessKeyId, awsSecretAccessKey []byte) ([]byte, error) {
+func getVeleroCloudCredentials(awsAccessKeyID, awsSecretAccessKey []byte) ([]byte, error) {
 	t, err := template.New("cloud-credentials").Parse(credentialsTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse credentials file template: %w", err)
 	}
 	var buff bytes.Buffer
 	if err := t.Execute(&buff, map[string]interface{}{
-		"awsAccessKeyId":     string(awsAccessKeyId),
+		"awsAccessKeyID":     string(awsAccessKeyID),
 		"awsSecretAccessKey": string(awsSecretAccessKey),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to execute credentials file template: %w", err)

--- a/pkg/ee/kubelb/cleanup.go
+++ b/pkg/ee/kubelb/cleanup.go
@@ -55,7 +55,7 @@ func (r *reconciler) handleKubeLBCleanup(ctx context.Context, cluster *kubermati
 
 func (r *reconciler) ensureKubeLBSeedClusterResourcesAreRemoved(ctx context.Context, namespace string) error {
 	for _, resource := range kubelbseedresources.ResourcesForDeletion(namespace) {
-		err := r.Client.Delete(ctx, resource)
+		err := r.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure kubeLB resources are removed/not present on seed cluster: %w", err)
 		}

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -121,14 +121,14 @@ func (r *reconciler) reconcile(ctx context.Context, resourceQuota *kubermaticv1.
 		return nil
 	}
 
-	projectIdReq, err := labels.NewRequirement(kubermaticv1.ProjectIDLabelKey, selection.Equals, []string{resourceQuota.Spec.Subject.Name})
+	projectIDReq, err := labels.NewRequirement(kubermaticv1.ProjectIDLabelKey, selection.Equals, []string{resourceQuota.Spec.Subject.Name})
 	if err != nil {
 		return fmt.Errorf("error creating project id req: %w", err)
 	}
 
 	clusterList := &kubermaticv1.ClusterList{}
 	if err := r.seedClient.List(ctx, clusterList,
-		&ctrlruntimeclient.ListOptions{LabelSelector: labels.NewSelector().Add(*projectIdReq)}); err != nil {
+		&ctrlruntimeclient.ListOptions{LabelSelector: labels.NewSelector().Add(*projectIDReq)}); err != nil {
 		return fmt.Errorf("failed listing clusters: %w", err)
 	}
 
@@ -205,13 +205,13 @@ func enqueueResourceQuota(client ctrlruntimeclient.Client, log *zap.SugaredLogge
 		var requests []reconcile.Request
 
 		clusterLabels := a.GetLabels()
-		projectId, ok := clusterLabels[kubermaticv1.ProjectIDLabelKey]
+		projectID, ok := clusterLabels[kubermaticv1.ProjectIDLabelKey]
 		if !ok {
 			log.Debugw("cluster does not have `project-id` label, skipping", "cluster", a.GetName())
 			return requests
 		}
 
-		subjectNameReq, err := labels.NewRequirement(kubermaticv1.ResourceQuotaSubjectNameLabelKey, selection.Equals, []string{projectId})
+		subjectNameReq, err := labels.NewRequirement(kubermaticv1.ResourceQuotaSubjectNameLabelKey, selection.Equals, []string{projectID})
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("error creating subject name req: %w", err))
 			return requests

--- a/pkg/ee/resource-quota/seed-controller/controller_test.go
+++ b/pkg/ee/resource-quota/seed-controller/controller_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 const rqName = "resourceQuota"
-const projectId = "project1"
+const projectID = "project1"
 
 func TestReconcile(t *testing.T) {
 	testCases := []struct {
@@ -58,8 +58,8 @@ func TestReconcile(t *testing.T) {
 			seedClient: fake.
 				NewClientBuilder().
 				WithObjects(genResourceQuota(rqName),
-					genCluster("c1", projectId, "2", "5G", "10G"),
-					genCluster("c2", projectId, "5", "2G", "8G"),
+					genCluster("c1", projectID, "2", "5G", "10G"),
+					genCluster("c2", projectID, "5", "2G", "8G"),
 					genCluster("notSameProjectCluster", "impostor", "3", "3G", "3G")).
 				Build(),
 			expectedUsage: *genResourceDetails("7", "7G", "18G"),
@@ -99,7 +99,7 @@ func genResourceQuota(name string) *kubermaticv1.ResourceQuota {
 	rq.Name = name
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{
-			Name: projectId,
+			Name: projectID,
 			Kind: kubermaticv1.ProjectSubjectKind,
 		},
 	}
@@ -111,10 +111,10 @@ func genResourceDetails(cpu, mem, storage string) *kubermaticv1.ResourceDetails 
 	return kubermaticv1.NewResourceDetails(resource.MustParse(cpu), resource.MustParse(mem), resource.MustParse(storage))
 }
 
-func genCluster(name, projectId, cpu, mem, storage string) *kubermaticv1.Cluster {
+func genCluster(name, projectID, cpu, mem, storage string) *kubermaticv1.Cluster {
 	cluster := &kubermaticv1.Cluster{}
 	cluster.Name = name
-	cluster.Labels = map[string]string{kubermaticv1.ProjectIDLabelKey: projectId}
+	cluster.Labels = map[string]string{kubermaticv1.ProjectIDLabelKey: projectID}
 	cluster.Status.ResourceUsage = genResourceDetails(cpu, mem, storage)
 
 	return cluster

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -22,7 +22,7 @@
    END OF TERMS AND CONDITIONS
 */
 
-package resource_usage_controller
+package resourceusagecontroller
 
 import (
 	"context"

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -123,7 +123,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 			return fmt.Errorf("error getting machine resource usage for machine %q: %w", machine.Name, err)
 		}
 
-		resourceUsage.CPU.Add(*resourceDetails.Cpu())
+		resourceUsage.CPU.Add(*resourceDetails.CPU())
 		resourceUsage.Memory.Add(*resourceDetails.Memory())
 		resourceUsage.Storage.Add(*resourceDetails.Storage())
 	}

--- a/pkg/ee/resource-usage-controller/controller_test.go
+++ b/pkg/ee/resource-usage-controller/controller_test.go
@@ -22,7 +22,7 @@
    END OF TERMS AND CONDITIONS
 */
 
-package resource_usage_controller
+package resourceusagecontroller
 
 import (
 	"context"

--- a/pkg/ee/validation/machine/fake.go
+++ b/pkg/ee/validation/machine/fake.go
@@ -38,7 +38,7 @@ func getFakeQuotaRequest(config *providerconfig.Config) (*ResourceDetails, error
 	if err := json.Unmarshal(config.CloudProviderSpec.Raw, spec); err != nil {
 		return nil, fmt.Errorf("error unmarshalling fake raw config: %w", err)
 	}
-	cpu, err := resource.ParseQuantity(spec.Cpu)
+	cpu, err := resource.ParseQuantity(spec.CPU)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing quantity: %w", err)
 	}
@@ -57,7 +57,7 @@ func getFakeQuotaRequest(config *providerconfig.Config) (*ResourceDetails, error
 }
 
 type FakeProviderSpec struct {
-	Cpu     string `json:"cpu"`
+	CPU     string `json:"cpu"`
 	Memory  string `json:"memory"`
 	Storage string `json:"storage"`
 }

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -70,16 +70,16 @@ func ValidateQuota(ctx context.Context,
 
 	// add requested resources to current usage and compare
 	combinedUsage := NewResourceDetails(currentCPU, currentMem, currentStorage)
-	combinedUsage.Cpu().Add(*machineResourceUsage.Cpu())
+	combinedUsage.CPU().Add(*machineResourceUsage.CPU())
 	combinedUsage.Memory().Add(*machineResourceUsage.Memory())
 	combinedUsage.Storage().Add(*machineResourceUsage.Storage())
 
 	quota := resourceQuota.Spec.Quota
-	if quota.CPU != nil && quota.CPU.Cmp(*combinedUsage.Cpu()) < 0 {
+	if quota.CPU != nil && quota.CPU.Cmp(*combinedUsage.CPU()) < 0 {
 		log.Debugw("requested CPU would exceed current quota", "request",
-			machineResourceUsage.Cpu(), "quota", quota.CPU, "used", currentCPU.String())
+			machineResourceUsage.CPU(), "quota", quota.CPU, "used", currentCPU.String())
 		return fmt.Errorf("requested CPU %q would exceed current quota (quota/used %q/%q)",
-			machineResourceUsage.Cpu(), quota.CPU, currentCPU.String())
+			machineResourceUsage.CPU(), quota.CPU, currentCPU.String())
 	}
 
 	if quota.Memory != nil && quota.Memory.Cmp(*combinedUsage.Memory()) < 0 {
@@ -133,7 +133,7 @@ func NewResourceDetailsFromCapacity(capacity *provider.NodeCapacity) (*ResourceD
 	}, nil
 }
 
-func (r *ResourceDetails) Cpu() *resource.Quantity {
+func (r *ResourceDetails) CPU() *resource.Quantity {
 	return &r.cpu
 }
 

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -381,7 +381,7 @@ func showDNSSettings(ctx context.Context, logger *logrus.Entry, kubeClient ctrlr
 			if ip == "" {
 				ip = ingress.IP
 			}
-			if isPublicIp(ingress.IP) {
+			if isPublicIP(ingress.IP) {
 				ip = ingress.IP
 			}
 		}

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -42,7 +42,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+func (*MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
 	var errs []error
 
 	// validation can only happen if KKP was already installed, otherwise the resource types

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -387,8 +387,8 @@ func randomString() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// isPublicIp validates whether ip provided is public.
-func isPublicIp(ipAddress string) bool {
+// isPublicIP validates whether ip provided is public.
+func isPublicIP(ipAddress string) bool {
 	ipAddr := net.ParseIP(ipAddress)
 	return ipAddr != nil && !ipAddr.IsPrivate()
 }

--- a/pkg/install/stack/kubermatic-master/validation_test.go
+++ b/pkg/install/stack/kubermatic-master/validation_test.go
@@ -130,7 +130,7 @@ func Test_isPublicIp(t *testing.T) {
 	}
 
 	for ip, want := range testCases {
-		if got := isPublicIp(ip); got != want {
+		if got := isPublicIP(ip); got != want {
 			t.Errorf("isPublicIp(%s) = %v , want: %v", ip, got, want)
 		}
 	}

--- a/pkg/install/stack/kubermatic-seed/validation.go
+++ b/pkg/install/stack/kubermatic-seed/validation.go
@@ -36,7 +36,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (m *SeedStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+func (*SeedStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
 	failures := []error{}
 
 	if err := ValidateMinioCompatibility(ctx, opt); err != nil {

--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -88,19 +88,19 @@ const (
 	PromtailNamespace   = LoggingNamespace
 )
 
-type Monitoring struct{}
+type MonitoringStack struct{}
 
 func NewStack() stack.Stack {
-	return &Monitoring{}
+	return &MonitoringStack{}
 }
 
-var _ stack.Stack = &Monitoring{}
+var _ stack.Stack = &MonitoringStack{}
 
-func (*Monitoring) Name() string {
+func (*MonitoringStack) Name() string {
 	return "KKP Seed MLA Stack"
 }
 
-func (s *Monitoring) Deploy(ctx context.Context, opt stack.DeployOptions) error {
+func (s *MonitoringStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
 	if err := deployNodeExporter(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
 		return fmt.Errorf("failed to deploy Node Exporter: %w", err)
 	}

--- a/pkg/install/stack/seed-mla/validation.go
+++ b/pkg/install/stack/seed-mla/validation.go
@@ -29,13 +29,13 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
-func (m *Monitoring) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+func (*MonitoringStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
 	failures := []error{}
 
 	return failures
 }
 
-func (*Monitoring) ValidateConfiguration(config *kubermaticv1.KubermaticConfiguration, helmValues *yamled.Document, opt stack.DeployOptions, logger logrus.FieldLogger) (*kubermaticv1.KubermaticConfiguration, *yamled.Document, []error) {
+func (*MonitoringStack) ValidateConfiguration(config *kubermaticv1.KubermaticConfiguration, helmValues *yamled.Document, opt stack.DeployOptions, logger logrus.FieldLogger) (*kubermaticv1.KubermaticConfiguration, *yamled.Document, []error) {
 	helmFailures := validateHelmValues(helmValues, opt)
 	for idx, e := range helmFailures {
 		helmFailures[idx] = prefixError("Helm values: ", e)

--- a/pkg/install/stack/usercluster-mla/stack.go
+++ b/pkg/install/stack/usercluster-mla/stack.go
@@ -78,19 +78,19 @@ const (
 	MLAIAPNamespace   = UserClusterMLANamespace
 )
 
-type UserClusterMLA struct{}
+type UserClusterMLAStack struct{}
 
 func NewStack() stack.Stack {
-	return &UserClusterMLA{}
+	return &UserClusterMLAStack{}
 }
 
-var _ stack.Stack = &UserClusterMLA{}
+var _ stack.Stack = &UserClusterMLAStack{}
 
-func (*UserClusterMLA) Name() string {
+func (*UserClusterMLAStack) Name() string {
 	return "KKP User Cluster MLA"
 }
 
-func (s *UserClusterMLA) Deploy(ctx context.Context, opt stack.DeployOptions) error {
+func (s *UserClusterMLAStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
 	if err := deployMLASecrets(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
 		return fmt.Errorf("failed to deploy MLA Secrets: %w", err)
 	}

--- a/pkg/install/stack/usercluster-mla/validation.go
+++ b/pkg/install/stack/usercluster-mla/validation.go
@@ -37,7 +37,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (m *UserClusterMLA) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+func (*UserClusterMLAStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
 	failures := []error{}
 
 	if err := ValidateMinioCompatibility(ctx, opt); err != nil {
@@ -136,7 +136,7 @@ func ValidateMinioCompatibility(ctx context.Context, opt stack.DeployOptions) er
 	return nil
 }
 
-func (*UserClusterMLA) ValidateConfiguration(config *kubermaticv1.KubermaticConfiguration, helmValues *yamled.Document, opt stack.DeployOptions, logger logrus.FieldLogger) (*kubermaticv1.KubermaticConfiguration, *yamled.Document, []error) {
+func (*UserClusterMLAStack) ValidateConfiguration(config *kubermaticv1.KubermaticConfiguration, helmValues *yamled.Document, opt stack.DeployOptions, logger logrus.FieldLogger) (*kubermaticv1.KubermaticConfiguration, *yamled.Document, []error) {
 	helmFailures := validateHelmValues(helmValues, opt)
 	for idx, e := range helmFailures {
 		helmFailures[idx] = prefixError("Helm values: ", e)

--- a/pkg/install/util/backup.go
+++ b/pkg/install/util/backup.go
@@ -62,7 +62,7 @@ func DumpResources(ctx context.Context, filename string, objects []unstructured.
 	encoder := yaml.NewEncoder(f)
 	encoder.SetIndent(2)
 
-	if _, err := f.WriteString(fmt.Sprintf("# This backup was created %s.\n", time.Now().Format(time.UnixDate))); err != nil {
+	if _, err := fmt.Fprintf(f, "# This backup was created %s.\n", time.Now().Format(time.UnixDate)); err != nil {
 		return fmt.Errorf("failed to write date: %w", err)
 	}
 

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -464,7 +464,7 @@ func GetNodeGroupReadyCount(nodes *corev1.NodeList, providerNodeLabel, providerN
 }
 
 func GetVersion(client *kubernetes.Clientset) (*ksemver.Semver, error) {
-	version, err := client.DiscoveryClient.ServerVersion()
+	version, err := client.ServerVersion()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machine/provider/helpers.go
+++ b/pkg/machine/provider/helpers.go
@@ -61,14 +61,14 @@ func mergeTags(existing []providerconfig.ConfigVarString, newTags []string) []pr
 
 func IsConfigVarStringEmpty(val providerconfig.ConfigVarString) bool {
 	// Check if SecretKeyRef is empty.
-	if val.SecretKeyRef.ObjectReference.Namespace != "" ||
-		val.SecretKeyRef.ObjectReference.Name != "" ||
+	if val.SecretKeyRef.Namespace != "" ||
+		val.SecretKeyRef.Name != "" ||
 		val.SecretKeyRef.Key != "" {
 		return false
 	}
 	// Check if ConfigMapKeyRef is empty.
-	if val.ConfigMapKeyRef.ObjectReference.Namespace != "" ||
-		val.ConfigMapKeyRef.ObjectReference.Name != "" ||
+	if val.ConfigMapKeyRef.Namespace != "" ||
+		val.ConfigMapKeyRef.Name != "" ||
 		val.ConfigMapKeyRef.Key != "" {
 		return false
 	}

--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -117,10 +117,10 @@ func MutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, config *kubermat
 }
 
 func addCCMCSIMigrationAnnotations(cluster *kubermaticv1.Cluster) {
-	if cluster.ObjectMeta.Annotations == nil {
-		cluster.ObjectMeta.Annotations = map[string]string{}
+	if cluster.Annotations == nil {
+		cluster.Annotations = map[string]string{}
 	}
 
-	cluster.ObjectMeta.Annotations[kubermaticv1.CCMMigrationNeededAnnotation] = ""
-	cluster.ObjectMeta.Annotations[kubermaticv1.CSIMigrationNeededAnnotation] = ""
+	cluster.Annotations[kubermaticv1.CCMMigrationNeededAnnotation] = ""
+	cluster.Annotations[kubermaticv1.CSIMigrationNeededAnnotation] = ""
 }

--- a/pkg/provider/cloud/aws/security_group_test.go
+++ b/pkg/provider/cloud/aws/security_group_test.go
@@ -96,7 +96,7 @@ func assertSecurityGroup(t *testing.T, cluster *kubermaticv1.Cluster, group *ec2
 				expectedPerm.UserIdGroupPairs[i].UserId = nil
 			}
 
-			if compareIpPermissions(perm, expectedPerm) {
+			if compareIPPermissions(perm, expectedPerm) {
 				found = true
 				break
 			}
@@ -112,7 +112,7 @@ func assertSecurityGroup(t *testing.T, cluster *kubermaticv1.Cluster, group *ec2
 	}
 }
 
-func compareIpPermissions(perm1 ec2types.IpPermission, perm2 ec2types.IpPermission) bool {
+func compareIPPermissions(perm1 ec2types.IpPermission, perm2 ec2types.IpPermission) bool {
 	if ptr.Deref[int32](perm1.FromPort, -1) != ptr.Deref[int32](perm2.FromPort, -1) {
 		return false
 	}

--- a/pkg/provider/cloud/azure/availability_set.go
+++ b/pkg/provider/cloud/azure/availability_set.go
@@ -65,9 +65,10 @@ func reconcileAvailabilitySet(ctx context.Context, clients *ClientSet, location 
 	// - SKU name
 	// - fault domain count
 	// - update domain count
-	if !((availabilitySet.SKU != nil && availabilitySet.SKU.Name != nil && *availabilitySet.SKU.Name == *target.SKU.Name) && availabilitySet.Properties != nil &&
-		(availabilitySet.Properties.PlatformFaultDomainCount != nil && *availabilitySet.Properties.PlatformFaultDomainCount == *target.Properties.PlatformFaultDomainCount) &&
-		(availabilitySet.Properties.PlatformUpdateDomainCount != nil && *availabilitySet.Properties.PlatformUpdateDomainCount == *target.Properties.PlatformUpdateDomainCount)) {
+	if availabilitySet.SKU == nil || availabilitySet.SKU.Name == nil || *availabilitySet.SKU.Name != *target.SKU.Name ||
+		availabilitySet.Properties == nil ||
+		availabilitySet.Properties.PlatformFaultDomainCount == nil || *availabilitySet.Properties.PlatformFaultDomainCount != *target.Properties.PlatformFaultDomainCount ||
+		availabilitySet.Properties.PlatformUpdateDomainCount == nil || *availabilitySet.Properties.PlatformUpdateDomainCount != *target.Properties.PlatformUpdateDomainCount {
 		if err := ensureAvailabilitySet(ctx, clients.AvailabilitySets, cluster.Spec.Cloud, target); err != nil {
 			return nil, fmt.Errorf("failed to ensure AvailabilitySet exists: %w", err)
 		}

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -70,8 +70,7 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 	//
 	// Attributes we check:
 	// - defined security rules
-	if !(securityGroup.Properties != nil && securityGroup.Properties.SecurityRules != nil &&
-		compareSecurityRules(securityGroup.Properties.SecurityRules, target.Properties.SecurityRules)) {
+	if securityGroup.Properties == nil || securityGroup.Properties.SecurityRules == nil || !compareSecurityRules(securityGroup.Properties.SecurityRules, target.Properties.SecurityRules) {
 		if err := ensureSecurityGroup(ctx, clients, cluster.Spec.Cloud, target); err != nil {
 			return cluster, err
 		}

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -89,10 +89,10 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 	//
 	// Attributes we check:
 	// - Subnet CIDR
-	if !(subnet.Properties != nil &&
-		reflect.DeepEqual(subnet.Properties.AddressPrefix, target.Properties.AddressPrefix) &&
-		reflect.DeepEqual(subnet.Properties.AddressPrefixes, target.Properties.AddressPrefixes) &&
-		reflect.DeepEqual(subnet.Properties.RouteTable, target.Properties.RouteTable)) {
+	if subnet.Properties == nil ||
+		!reflect.DeepEqual(subnet.Properties.AddressPrefix, target.Properties.AddressPrefix) ||
+		!reflect.DeepEqual(subnet.Properties.AddressPrefixes, target.Properties.AddressPrefixes) ||
+		!reflect.DeepEqual(subnet.Properties.RouteTable, target.Properties.RouteTable) {
 		if err := ensureSubnet(ctx, clients, cluster.Spec.Cloud, target); err != nil {
 			return nil, err
 		}

--- a/pkg/provider/cloud/azure/vnet.go
+++ b/pkg/provider/cloud/azure/vnet.go
@@ -75,8 +75,7 @@ func reconcileVNet(ctx context.Context, clients *ClientSet, location string, clu
 	//
 	// Attributes we check:
 	// - Address space CIDR
-	if !(vnet.Properties != nil && vnet.Properties.AddressSpace != nil &&
-		reflect.DeepEqual(vnet.Properties.AddressSpace.AddressPrefixes, target.Properties.AddressSpace.AddressPrefixes)) {
+	if vnet.Properties == nil || vnet.Properties.AddressSpace == nil || !reflect.DeepEqual(vnet.Properties.AddressSpace.AddressPrefixes, target.Properties.AddressSpace.AddressPrefixes) {
 		if err := ensureVNet(ctx, clients, cluster.Spec.Cloud, target); err != nil {
 			return nil, err
 		}

--- a/pkg/provider/cloud/kubevirt/network_policy.go
+++ b/pkg/provider/cloud/kubevirt/network_policy.go
@@ -32,15 +32,15 @@ import (
 
 // clusterIsolationNetworkPolicyReconciler creates a network policy that restrict Egress traffic. By default it allows access to
 // each other pod in the same namespace, Internet, Kubermatic nodeport proxy and DNS servers.
-func clusterIsolationNetworkPolicyReconciler(clusterIp string, nameservers []string) reconciling.NamedNetworkPolicyReconcilerFactory {
-	apiServerCIDR := clusterIp + "/32"
+func clusterIsolationNetworkPolicyReconciler(clusterIP string, nameservers []string) reconciling.NamedNetworkPolicyReconcilerFactory {
+	apiServerCIDR := clusterIP + "/32"
 	dnsPort := intstr.FromInt(53)
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
 
 	// This address might only be set after the control plane has initialized.
 	var apiServerRule networkingv1.NetworkPolicyEgressRule
-	if clusterIp != "" {
+	if clusterIP != "" {
 		apiServerRule = networkingv1.NetworkPolicyEgressRule{
 			To: []networkingv1.NetworkPolicyPeer{
 				{

--- a/pkg/provider/cloud/kubevirt/storage_class.go
+++ b/pkg/provider/cloud/kubevirt/storage_class.go
@@ -39,7 +39,7 @@ func ListStorageClasses(ctx context.Context, client ctrlruntimeclient.Client, an
 	res := apiv2.StorageClassList{}
 	for _, sc := range storageClassList.Items {
 		if annotationFilter == nil || annotationFilter(sc.Annotations) {
-			res = append(res, apiv2.StorageClass{Name: sc.ObjectMeta.Name})
+			res = append(res, apiv2.StorageClass{Name: sc.Name})
 		}
 	}
 	return res, nil

--- a/pkg/provider/cloud/nutanix/client.go
+++ b/pkg/provider/cloud/nutanix/client.go
@@ -259,10 +259,10 @@ func ParseNutanixError(err error) (*ErrorResponse, error) {
 	// Nutanix errors are prefixed with various strings, sometimes "error: ",
 	// sometimes "status: 404 Not Found, error-response: "; we therefore trim
 	// everything up to the first opening bracket
-	errJsonString := strings.TrimLeftFunc(err.Error(), func(r rune) bool { return r != '{' })
+	errJSONString := strings.TrimLeftFunc(err.Error(), func(r rune) bool { return r != '{' })
 
 	var resp ErrorResponse
-	if parseErr := json.Unmarshal([]byte(errJsonString), &resp); parseErr != nil {
+	if parseErr := json.Unmarshal([]byte(errJSONString), &resp); parseErr != nil {
 		return nil, fmt.Errorf("failed to parse '%w': %w", err, parseErr)
 	}
 

--- a/pkg/provider/cloud/vsphere/folder.go
+++ b/pkg/provider/cloud/vsphere/folder.go
@@ -124,7 +124,7 @@ func GetVMFolders(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, u
 		if !strings.HasPrefix(folderRef.InventoryPath, rootPath+"/") && folderRef.InventoryPath != rootPath {
 			continue
 		}
-		folder := Folder{Path: folderRef.Common.InventoryPath}
+		folder := Folder{Path: folderRef.InventoryPath}
 		folders = append(folders, folder)
 	}
 

--- a/pkg/provider/kubernetes/seed_test.go
+++ b/pkg/provider/kubernetes/seed_test.go
@@ -61,9 +61,9 @@ func TestSeedGetterFactoriesetsDefaults(t *testing.T) {
 	if nodeSettings == nil {
 		t.Fatal("expected the datacenter's node setting to be set, but it's nil")
 	}
-	if nodeSettings.ProxySettings.HTTPProxy.String() != "seed-proxy" {
+	if nodeSettings.HTTPProxy.String() != "seed-proxy" {
 		t.Errorf("expected the datacenters http proxy setting to get set but was %v",
-			nodeSettings.ProxySettings.HTTPProxy)
+			nodeSettings.HTTPProxy)
 	}
 }
 
@@ -103,9 +103,9 @@ func TestSeedsGetterFactoriesetsDefaults(t *testing.T) {
 	if nodeSettings == nil {
 		t.Fatal("expected the datacenter's node setting to be set, but it's nil")
 	}
-	if nodeSettings.ProxySettings.HTTPProxy.String() != "seed-proxy" {
+	if nodeSettings.HTTPProxy.String() != "seed-proxy" {
 		t.Errorf("expected the datacenters http proxy setting to get set but was %v",
-			nodeSettings.ProxySettings.HTTPProxy)
+			nodeSettings.HTTPProxy)
 	}
 }
 

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -211,7 +211,7 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 	}
 
 	// Port
-	var port int32 = service.Spec.Ports[0].TargetPort.IntVal
+	var port = service.Spec.Ports[0].TargetPort.IntVal
 	if m.cluster.Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
 		port = service.Spec.Ports[0].NodePort
 	}

--- a/pkg/resources/apiserver/encryption.go
+++ b/pkg/resources/apiserver/encryption.go
@@ -56,7 +56,7 @@ func EncryptionConfigurationSecretReconciler(data encryptionData) reconciling.Na
 			secret.Name = resources.EncryptionConfigurationSecretName
 
 			// return empty secret if no config and no condition is set.
-			if !(data.Cluster().IsEncryptionEnabled() || data.Cluster().IsEncryptionActive()) {
+			if !data.Cluster().IsEncryptionEnabled() && !data.Cluster().IsEncryptionActive() {
 				return secret, nil
 			}
 

--- a/pkg/resources/apiserver/encryption.go
+++ b/pkg/resources/apiserver/encryption.go
@@ -178,8 +178,8 @@ func EncryptionConfigurationSecretReconciler(data encryptionData) reconciling.Na
 
 			secret.Data = secretData
 
-			if secret.ObjectMeta.Labels == nil {
-				secret.ObjectMeta.Labels = map[string]string{}
+			if secret.Labels == nil {
+				secret.Labels = map[string]string{}
 			}
 
 			spec, err := json.Marshal(data.Cluster().Spec.EncryptionConfiguration)
@@ -190,7 +190,7 @@ func EncryptionConfigurationSecretReconciler(data encryptionData) reconciling.Na
 			hash := sha1.New()
 			hash.Write(spec)
 
-			secret.ObjectMeta.Labels[encryptionresources.ApiserverEncryptionHashLabelKey] = hex.EncodeToString(hash.Sum(nil))
+			secret.Labels[encryptionresources.ApiserverEncryptionHashLabelKey] = hex.EncodeToString(hash.Sum(nil))
 
 			return secret, nil
 		}

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -29,6 +29,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 // DenyAllPolicyReconciler returns a func to create/update the apiserver
@@ -92,8 +93,6 @@ func DNSAllowReconciler(c *kubermaticv1.Cluster, data *resources.TemplateData) r
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return resources.NetworkPolicyDNSAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			dnsPort := intstr.FromInt(53)
-			protoUdp := corev1.ProtocolUDP
-			protoTcp := corev1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
@@ -108,11 +107,11 @@ func DNSAllowReconciler(c *kubermaticv1.Cluster, data *resources.TemplateData) r
 					{
 						Ports: []networkingv1.NetworkPolicyPort{
 							{
-								Protocol: &protoUdp,
+								Protocol: ptr.To(corev1.ProtocolUDP),
 								Port:     &dnsPort,
 							},
 							{
-								Protocol: &protoTcp,
+								Protocol: ptr.To(corev1.ProtocolTCP),
 								Port:     &dnsPort,
 							},
 						},
@@ -364,7 +363,7 @@ func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) rec
 	}
 }
 
-func SeedApiServerAllowReconciler(endpoints []net.IP) reconciling.NamedNetworkPolicyReconcilerFactory {
+func SeedApiserverAllowReconciler(endpoints []net.IP) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return resources.NetworkPolicySeedApiserverAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -73,7 +73,7 @@ func EctdAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicy
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										resources.AppLabelKey: "etcd",
-										"cluster":             c.ObjectMeta.Name,
+										"cluster":             c.Name,
 									},
 								},
 							},
@@ -144,7 +144,7 @@ func OpenVPNServerAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetw
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										resources.AppLabelKey: "openvpn-server",
-										"cluster":             c.ObjectMeta.Name,
+										"cluster":             c.Name,
 									},
 								},
 							},

--- a/pkg/resources/cloudconfig/ini/writer.go
+++ b/pkg/resources/cloudconfig/ini/writer.go
@@ -90,12 +90,12 @@ func (s *section) AddBoolKey(key string, value bool) {
 }
 
 func (s *section) render(out io.Writer) error {
-	if _, err := out.Write([]byte(fmt.Sprintf("[%s]\n", s.name))); err != nil {
+	if _, err := fmt.Fprintf(out, "[%s]\n", s.name); err != nil {
 		return err
 	}
 
 	for _, pair := range s.pairs {
-		if _, err := out.Write([]byte(pair.String() + "\n")); err != nil {
+		if _, err := fmt.Fprintf(out, "%s\n", pair.String()); err != nil {
 			return err
 		}
 	}

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -286,7 +286,7 @@ func getFlags(data *resources.TemplateData, version *semverlib.Version) ([]strin
 	flags = append(flags, "--authorization-kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig")
 
 	// Apply leader election settings
-	if lds := cluster.Spec.ComponentsOverride.ControllerManager.LeaderElectionSettings.LeaseDurationSeconds; lds != nil {
+	if lds := cluster.Spec.ComponentsOverride.ControllerManager.LeaseDurationSeconds; lds != nil {
 		flags = append(flags, "--leader-elect-lease-duration", fmt.Sprintf("%ds", *lds))
 	}
 	if rds := cluster.Spec.ComponentsOverride.ControllerManager.LeaderElectionSettings.DeepCopy().RenewDeadlineSeconds; rds != nil {

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -108,6 +108,7 @@ func NewTemplateDataBuilder() *TemplateDataBuilder {
 }
 
 func (td *TemplateDataBuilder) WithContext(ctx context.Context) *TemplateDataBuilder {
+	//nolint:fatcontext // tracked via https://github.com/kubermatic/kubermatic/issues/13563
 	td.data.ctx = ctx
 	return td
 }

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -749,9 +749,9 @@ func (d *TemplateData) KubermaticConfiguration() *kubermaticv1.KubermaticConfigu
 	return d.config
 }
 
-func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
-	cluster := data.Cluster()
-	dc := data.DC()
+func (d *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
+	cluster := d.Cluster()
+	dc := d.DC()
 
 	refTo := func(key string) *corev1.EnvVarSource {
 		return &corev1.EnvVarSource{
@@ -801,7 +801,7 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "DO_TOKEN", ValueFrom: refTo(DigitaloceanToken)})
 	}
 	if cluster.Spec.Cloud.VSphere != nil {
-		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(data.ctx, data.client)
+		secretKeySelector := provider.SecretKeySelectorValueFuncFactory(d.ctx, d.client)
 		spec := cluster.Spec.Cloud.VSphere
 		vars = append(vars, corev1.EnvVar{Name: "VSPHERE_ADDRESS", Value: dc.Spec.VSphere.Endpoint})
 		if val, _ := secretKeySelector(spec.CredentialsReference, VsphereInfraManagementUserUsername); val != "" {
@@ -865,7 +865,7 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 			vars = append(vars, corev1.EnvVar{Name: "VCD_ALLOW_UNVERIFIED_SSL", Value: "true"})
 		}
 	}
-	vars = append(vars, GetHTTPProxyEnvVarsFromSeed(data.Seed(), cluster.Status.Address.InternalName)...)
+	vars = append(vars, GetHTTPProxyEnvVarsFromSeed(d.Seed(), cluster.Status.Address.InternalName)...)
 
 	vars = SanitizeEnvVars(vars)
 	if cluster.Spec.Cloud.Kubevirt != nil && dc.Spec.Kubevirt != nil && dc.Spec.Kubevirt.NamespacedMode != nil && dc.Spec.Kubevirt.NamespacedMode.Enabled {

--- a/pkg/resources/encryption/job.go
+++ b/pkg/resources/encryption/job.go
@@ -61,7 +61,7 @@ func EncryptionJobCreator(data encryptionData, cluster *kubermaticv1.Cluster, se
 			Labels: map[string]string{
 				resources.AppLabelKey:  AppLabelValue,
 				ClusterLabelKey:        cluster.Name,
-				SecretRevisionLabelKey: secret.ObjectMeta.ResourceVersion,
+				SecretRevisionLabelKey: secret.ResourceVersion,
 			},
 		},
 		Spec: batchv1.JobSpec{

--- a/pkg/resources/etcd/backup/jobs.go
+++ b/pkg/resources/etcd/backup/jobs.go
@@ -38,7 +38,7 @@ const (
 	// will write the backup to.
 	SharedVolumeName = "etcd-backup"
 	// clusterEnvVarKey defines the environment variable key for the cluster name.
-	AccessKeyIdEnvVarKey = "ACCESS_KEY_ID"
+	AccessKeyIDEnvVarKey = "ACCESS_KEY_ID"
 	// SecretAccessKeyEnvVarKey defines the environment variable key for the backup credentials secret access key.
 	SecretAccessKeyEnvVarKey = "SECRET_ACCESS_KEY"
 	// bucketNameEnvVarKey defines the environment variable key for the backup bucket name.
@@ -80,7 +80,7 @@ func BackupJob(data etcdBackupData, config *kubermaticv1.EtcdBackupConfig, statu
 
 	// If destination is set, we need to set the credentials and backup bucket details to match the destination
 	if data.EtcdBackupDestination() != nil {
-		storeContainer.Env = setEnvVar(storeContainer.Env, GenSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, data.EtcdBackupDestination()))
+		storeContainer.Env = setEnvVar(storeContainer.Env, GenSecretEnvVar(AccessKeyIDEnvVarKey, AccessKeyIDEnvVarKey, data.EtcdBackupDestination()))
 		storeContainer.Env = setEnvVar(storeContainer.Env, GenSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, data.EtcdBackupDestination()))
 		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
 			Name:  BucketNameEnvVarKey,
@@ -217,7 +217,7 @@ func BackupDeleteJob(data etcdBackupData, config *kubermaticv1.EtcdBackupConfig,
 
 	// If destination is set, we need to set the credentials and backup bucket details to match the destination
 	if data.EtcdBackupDestination() != nil {
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, GenSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, data.EtcdBackupDestination()))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, GenSecretEnvVar(AccessKeyIDEnvVarKey, AccessKeyIDEnvVarKey, data.EtcdBackupDestination()))
 		deleteContainer.Env = setEnvVar(deleteContainer.Env, GenSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, data.EtcdBackupDestination()))
 		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
 			Name:  BucketNameEnvVarKey,

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -301,7 +301,7 @@ func getFlags(data operatingSystemManagerData, cs *clusterSpec) []string {
 }
 
 const (
-	flagHttpProxy = "-node-http-proxy"
+	flagHTTPProxy = "-node-http-proxy"
 	flagNoProxy   = "-node-no-proxy"
 )
 
@@ -316,7 +316,7 @@ func appendProxyFlags(flags []string, nodeSettings *kubermaticv1.NodeSettings, c
 	flagsMap := make(map[string]string)
 	if nodeSettings != nil {
 		if httpProxy := nodeSettings.HTTPProxy; !httpProxy.Empty() {
-			flagsMap[flagHttpProxy] = nodeSettings.HTTPProxy.String()
+			flagsMap[flagHTTPProxy] = nodeSettings.HTTPProxy.String()
 		}
 		if noProxy := nodeSettings.NoProxy; !noProxy.Empty() {
 			flagsMap[flagNoProxy] = nodeSettings.NoProxy.String()
@@ -327,7 +327,7 @@ func appendProxyFlags(flags []string, nodeSettings *kubermaticv1.NodeSettings, c
 		osm := cluster.Spec.ComponentsOverride.OperatingSystemManager
 		if osm != nil {
 			if httpProxy := osm.Proxy.HTTPProxy; httpProxy != nil && !httpProxy.Empty() {
-				flagsMap[flagHttpProxy] = httpProxy.String()
+				flagsMap[flagHTTPProxy] = httpProxy.String()
 			}
 
 			if noProxy := osm.Proxy.NoProxy; noProxy != nil && !noProxy.Empty() {

--- a/pkg/resources/operatingsystemmanager/deployment_test.go
+++ b/pkg/resources/operatingsystemmanager/deployment_test.go
@@ -69,7 +69,7 @@ func TestAppendProxyFlags(t *testing.T) {
 				},
 			},
 			cluster: nil,
-			want:    []string{"-flag1", "value1", flagHttpProxy, sampleProxy},
+			want:    []string{"-flag1", "value1", flagHTTPProxy, sampleProxy},
 		},
 		{
 			name:  "empty flags with valid node settings should add proxy flags",
@@ -80,7 +80,7 @@ func TestAppendProxyFlags(t *testing.T) {
 				},
 			},
 			cluster: &kubermaticv1.Cluster{},
-			want:    []string{flagHttpProxy, sampleProxy},
+			want:    []string{flagHTTPProxy, sampleProxy},
 		},
 		{
 			name:  "cluster settings should override nodeSettings",
@@ -104,7 +104,7 @@ func TestAppendProxyFlags(t *testing.T) {
 			},
 			want: []string{
 				"-flag1", "value1",
-				flagHttpProxy, sampleProxyAnother,
+				flagHTTPProxy, sampleProxyAnother,
 				flagNoProxy, noProxy,
 			},
 		},
@@ -132,7 +132,7 @@ func TestAppendProxyFlags(t *testing.T) {
 			cluster: &kubermaticv1.Cluster{},
 			want: []string{
 				"-flag1", "value1",
-				flagHttpProxy, sampleProxy,
+				flagHTTPProxy, sampleProxy,
 				flagNoProxy, noProxy,
 			},
 		},
@@ -154,7 +154,7 @@ func TestAppendProxyFlags(t *testing.T) {
 			},
 			want: []string{
 				"-flag1", "value1",
-				flagHttpProxy, sampleProxy,
+				flagHTTPProxy, sampleProxy,
 				flagNoProxy, noProxy,
 			},
 		},

--- a/pkg/resources/reconciling/modifier/related_revisions.go
+++ b/pkg/resources/reconciling/modifier/related_revisions.go
@@ -145,14 +145,14 @@ func getRelatedRevisionLabels(
 	}
 
 	for _, v := range volumes {
-		if v.VolumeSource.Secret != nil {
-			if err := loadSecret(v.VolumeSource.Secret.SecretName, false); err != nil {
+		if v.Secret != nil {
+			if err := loadSecret(v.Secret.SecretName, false); err != nil {
 				return nil, err
 			}
 		}
 
-		if v.VolumeSource.ConfigMap != nil {
-			if err := loadConfigMap(v.VolumeSource.ConfigMap.Name, false); err != nil {
+		if v.ConfigMap != nil {
+			if err := loadConfigMap(v.ConfigMap.Name, false); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -72,7 +72,7 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 			}
 
 			// Apply leader election settings
-			if lds := data.Cluster().Spec.ComponentsOverride.Scheduler.LeaderElectionSettings.LeaseDurationSeconds; lds != nil {
+			if lds := data.Cluster().Spec.ComponentsOverride.Scheduler.LeaseDurationSeconds; lds != nil {
 				flags = append(flags, "--leader-elect-lease-duration", fmt.Sprintf("%ds", *lds))
 			}
 			if rds := data.Cluster().Spec.ComponentsOverride.Scheduler.LeaderElectionSettings.DeepCopy().RenewDeadlineSeconds; rds != nil {

--- a/pkg/test/clusterexposer/controller/controller.go
+++ b/pkg/test/clusterexposer/controller/controller.go
@@ -135,7 +135,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	outerService := getServiceFromServiceList(outerServices, request.NamespacedName)
 	if outerService == nil {
 		var err error
-		outerService, err = r.createOuterService(ctx, request.NamespacedName.String())
+		outerService, err = r.createOuterService(ctx, request.String())
 		if err != nil {
 			return fmt.Errorf("failed to create service in outer cluster: %w", err)
 		}

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -710,7 +710,7 @@ func deleteEtcdPVC(ctx context.Context, client ctrlruntimeclient.Client, cluster
 	// created of the PVC resource.
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
 		if err := client.Get(ctx, types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, &pvc); err == nil {
-			if oldPvc.ObjectMeta.CreationTimestamp.Before(&pvc.ObjectMeta.CreationTimestamp) {
+			if oldPvc.CreationTimestamp.Before(&pvc.CreationTimestamp) {
 				return true, nil
 			}
 		}

--- a/pkg/test/e2e/nodeport-proxy/services.go
+++ b/pkg/test/e2e/nodeport-proxy/services.go
@@ -105,7 +105,7 @@ func (j *ServiceJig) newNamespaceTemplate() *corev1.Namespace {
 		},
 	}
 	if j.Namespace == "" {
-		ns.ObjectMeta.GenerateName = "np-proxy-test-"
+		ns.GenerateName = "np-proxy-test-"
 	}
 	return ns
 }

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -167,7 +167,7 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 	}
 
 	// KubeLB can only be enabled on the cluster if it's either enforced or enabled at the datacenter level.
-	if spec.IsKubeLBEnabled() && (dc.Spec.KubeLB == nil || !(dc.Spec.KubeLB.Enabled || dc.Spec.KubeLB.Enforced)) {
+	if spec.IsKubeLBEnabled() && (dc.Spec.KubeLB == nil || (!dc.Spec.KubeLB.Enabled && !dc.Spec.KubeLB.Enforced)) {
 		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("kubeLB"), "KubeLB is not enabled on this datacenter"))
 	}
 

--- a/pkg/validation/clustertemplate.go
+++ b/pkg/validation/clustertemplate.go
@@ -45,8 +45,8 @@ func ValidateClusterTemplate(ctx context.Context, template *kubermaticv1.Cluster
 
 	// ensure that a ClusterTemplate has a project reference
 	if scope == kubermaticv1.ProjectClusterTemplateScope {
-		projectId, ok := template.Labels[kubermaticv1.ClusterTemplateProjectLabelKey]
-		if !ok || projectId == "" {
+		projectID, ok := template.Labels[kubermaticv1.ClusterTemplateProjectLabelKey]
+		if !ok || projectID == "" {
 			allErrs = append(allErrs, field.Required(
 				parentFieldPath.Child("metadata", "labels", kubermaticv1.ClusterTemplateProjectLabelKey),
 				fmt.Sprintf("label '%s' is required", kubermaticv1.ClusterTemplateProjectLabelKey),

--- a/pkg/webhook/addon/mutation/mutation_test.go
+++ b/pkg/webhook/addon/mutation/mutation_test.go
@@ -265,12 +265,12 @@ func TestHandle(t *testing.T) {
 				},
 			}
 			res := handler.Handle(context.Background(), tt.req)
-			if res.AdmissionResponse.Result != nil && res.AdmissionResponse.Result.Code == http.StatusInternalServerError {
+			if res.Result != nil && res.Result.Code == http.StatusInternalServerError {
 				if tt.wantError {
 					return
 				}
 
-				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+				t.Fatalf("Request failed: %v", res.Result.Message)
 			}
 
 			a := map[string]jsonpatch.JsonPatchOperation{}

--- a/pkg/webhook/application/applicationdefinition/mutation/mutation_test.go
+++ b/pkg/webhook/application/applicationdefinition/mutation/mutation_test.go
@@ -129,8 +129,8 @@ func TestHandle(t *testing.T) {
 				decoder: admission.NewDecoder(testScheme),
 			}
 			res := handler.Handle(context.Background(), tt.req)
-			if res.AdmissionResponse.Result != nil && (res.AdmissionResponse.Result.Code == http.StatusInternalServerError || res.AdmissionResponse.Result.Code == http.StatusBadRequest) {
-				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+			if res.Result != nil && (res.Result.Code == http.StatusInternalServerError || res.Result.Code == http.StatusBadRequest) {
+				t.Fatalf("Request failed: %v", res.Result.Message)
 			}
 
 			a := map[string]jsonpatch.JsonPatchOperation{}

--- a/pkg/webhook/application/applicationinstallation/mutation/mutation_test.go
+++ b/pkg/webhook/application/applicationinstallation/mutation/mutation_test.go
@@ -263,8 +263,8 @@ func TestHandle(t *testing.T) {
 				client:  fakeClient,
 			}
 			res := handler.Handle(context.Background(), tt.req)
-			if res.AdmissionResponse.Result != nil && (res.AdmissionResponse.Result.Code == http.StatusInternalServerError || res.AdmissionResponse.Result.Code == http.StatusBadRequest) {
-				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+			if res.Result != nil && (res.Result.Code == http.StatusInternalServerError || res.Result.Code == http.StatusBadRequest) {
+				t.Fatalf("Request failed: %v", res.Result.Message)
 			}
 
 			a := map[string]jsonpatch.JsonPatchOperation{}

--- a/pkg/webhook/mlaadminsetting/mutation/mutation_test.go
+++ b/pkg/webhook/mlaadminsetting/mutation/mutation_test.go
@@ -244,12 +244,12 @@ func TestHandle(t *testing.T) {
 				},
 			}
 			res := handler.Handle(context.Background(), tt.req)
-			if res.AdmissionResponse.Result != nil && res.AdmissionResponse.Result.Code == http.StatusInternalServerError {
+			if res.Result != nil && res.Result.Code == http.StatusInternalServerError {
 				if tt.wantError {
 					return
 				}
 
-				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+				t.Fatalf("Request failed: %v", res.Result.Message)
 			}
 
 			a := map[string]jsonpatch.JsonPatchOperation{}

--- a/pkg/webhook/usersshkey/mutation/mutation_test.go
+++ b/pkg/webhook/usersshkey/mutation/mutation_test.go
@@ -80,8 +80,8 @@ func TestHandle(t *testing.T) {
 				decoder: admission.NewDecoder(testScheme),
 			}
 			res := handler.Handle(context.Background(), tt.req)
-			if res.AdmissionResponse.Result != nil && res.AdmissionResponse.Result.Code == http.StatusInternalServerError {
-				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+			if res.Result != nil && res.Result.Code == http.StatusInternalServerError {
+				t.Fatalf("Request failed: %v", res.Result.Message)
 			}
 
 			a := map[string]jsonpatch.JsonPatchOperation{}

--- a/sdk/.golangci.yml
+++ b/sdk/.golangci.yml
@@ -18,28 +18,26 @@
 # root's .golangci.yml and once with the SDK's config file.
 #
 
+version: "2"
 run:
-  timeout: 10m
   modules-download-mode: readonly
-
 linters:
+  default: none
   enable:
     - depguard
     - tagliatelle
-  disable-all: true
-
-linters-settings:
-  tagliatelle:
-    case:
+  settings:
+    depguard:
       rules:
-        json: goCamel
-        yaml: goCamel
-  depguard:
-    rules:
-      noControllerRuntime:
-        deny:
-          - { pkg: sigs.k8s.io/controller-runtime, desc: no dependency on controller-runtime allowed }
-
-issues:
-  exclude-files:
-    - zz_generated.*.go
+        noControllerRuntime:
+          deny:
+            - pkg: sigs.k8s.io/controller-runtime
+              desc: no dependency on controller-runtime allowed
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+          yaml: goCamel
+  exclusions:
+    paths:
+      - zz_generated.*.go

--- a/sdk/api/v2/types.go
+++ b/sdk/api/v2/types.go
@@ -317,7 +317,7 @@ type EKSKubernetesNetworkConfigResponse struct {
 	// IP family is always ipv4, unless you have a 1.21 or later cluster running
 	// version 1.10.1 or later of the Amazon VPC CNI add-on and specified ipv6 when
 	// you created the cluster.
-	IpFamily string `json:"ipFamily,omitempty"`
+	IpFamily string `json:"ipFamily,omitempty"` //nolint:staticcheck
 
 	// The CIDR block that Kubernetes pod and service IP addresses are assigned
 	// from. Kubernetes assigns addresses from an IPv4 CIDR block assigned to a
@@ -360,7 +360,7 @@ type AKSClusterStatus struct {
 
 type VpcConfigRequest struct {
 	// The VPC associated with your cluster.
-	VpcId *string `json:"vpcId,omitempty"` //nolint:tagliatelle
+	VpcId *string `json:"vpcId,omitempty"` //nolint:tagliatelle,staticcheck
 
 	// Specify one or more security groups for the cross-account elastic network
 	// interfaces that Amazon EKS creates to use to allow communication between

--- a/sdk/apis/apps.kubermatic/v1/application_definition.go
+++ b/sdk/apis/apps.kubermatic/v1/application_definition.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -300,7 +300,7 @@ type ApplicationDefinitionList struct {
 // Will return nil if none of the fields are set.
 func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
 	if ad.DefaultValues != nil && len(ad.DefaultValues.Raw) > 0 && ad.DefaultValuesBlock != "" {
-		return nil, fmt.Errorf("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
+		return nil, errors.New("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously, please delete one of them")
 	}
 	if ad.DefaultValues != nil && len(ad.DefaultValues.Raw) > 0 {
 		return ad.DefaultValues.Raw, nil
@@ -316,7 +316,7 @@ func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
 func (ai *ApplicationDefinitionSpec) GetParsedDefaultValues() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 	if !isEmptyRawExtension(ai.DefaultValues) && ai.DefaultValuesBlock != "" {
-		return nil, fmt.Errorf("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
+		return nil, errors.New("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously, please delete one of them")
 	}
 	if !isEmptyRawExtension(ai.DefaultValues) {
 		err := json.Unmarshal(ai.DefaultValues.Raw, &values)

--- a/sdk/apis/apps.kubermatic/v1/application_definition.go
+++ b/sdk/apis/apps.kubermatic/v1/application_definition.go
@@ -313,15 +313,15 @@ func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
 
 // GetParsedDefaultValues parses the values either from the DefaultValues or DefaultValuesBlock field.
 // Will return an error if both fields are set.
-func (ai *ApplicationDefinitionSpec) GetParsedDefaultValues() (map[string]interface{}, error) {
+func (ad *ApplicationDefinitionSpec) GetParsedDefaultValues() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
-	if !isEmptyRawExtension(ai.DefaultValues) && ai.DefaultValuesBlock != "" {
+	if !isEmptyRawExtension(ad.DefaultValues) && ad.DefaultValuesBlock != "" {
 		return nil, errors.New("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously, please delete one of them")
 	}
-	if !isEmptyRawExtension(ai.DefaultValues) {
-		err := json.Unmarshal(ai.DefaultValues.Raw, &values)
+	if !isEmptyRawExtension(ad.DefaultValues) {
+		err := json.Unmarshal(ad.DefaultValues.Raw, &values)
 		return values, err
 	}
-	err := yaml.Unmarshal([]byte(ai.DefaultValuesBlock), &values)
+	err := yaml.Unmarshal([]byte(ad.DefaultValuesBlock), &values)
 	return values, err
 }

--- a/sdk/apis/apps.kubermatic/v1/application_installation.go
+++ b/sdk/apis/apps.kubermatic/v1/application_installation.go
@@ -18,7 +18,7 @@ package v1
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -321,7 +321,7 @@ func (appInstallation *ApplicationInstallation) SetReadyCondition(installErr err
 func (ai *ApplicationInstallationSpec) GetParsedValues() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 	if len(ai.Values.Raw) > 0 && string(ai.Values.Raw) != "{}" && ai.ValuesBlock != "" {
-		return nil, fmt.Errorf("the fields Values and ValuesBlock cannot be used simultaneously. Please delete one of them.")
+		return nil, errors.New("the fields Values and ValuesBlock cannot be used simultaneously, please delete one of them")
 	}
 	if len(ai.Values.Raw) > 0 && string(ai.Values.Raw) != "{}" {
 		err := json.Unmarshal(ai.Values.Raw, &values)

--- a/sdk/apis/equality/semantic.go
+++ b/sdk/apis/equality/semantic.go
@@ -43,6 +43,6 @@ var Semantic = conversion.EqualitiesOrDie(
 		return false
 	},
 	func(a, b time.Time) bool {
-		return a.UTC() == b.UTC()
+		return a.Equal(b)
 	},
 )

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -1608,70 +1608,70 @@ func NewBytes(b64 string) Bytes {
 	return Bytes(bs)
 }
 
-func (cluster *Cluster) GetSecretName() string {
+func (c *Cluster) GetSecretName() string {
 	// new clusters might not have a name yet (if the user used GenerateName),
 	// so we must be careful when constructing the Secret name
-	clusterName := cluster.Name
+	clusterName := c.Name
 	if clusterName == "" {
 		clusterName = rand.String(5)
 
-		if cluster.GenerateName != "" {
-			clusterName = fmt.Sprintf("%s-%s", strings.TrimSuffix(cluster.GenerateName, "-"), clusterName)
+		if c.GenerateName != "" {
+			clusterName = fmt.Sprintf("%s-%s", strings.TrimSuffix(c.GenerateName, "-"), clusterName)
 		}
 	}
 
-	if cluster.Spec.Cloud.AWS != nil {
+	if c.Spec.Cloud.AWS != nil {
 		return fmt.Sprintf("%s-aws-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Azure != nil {
+	if c.Spec.Cloud.Azure != nil {
 		return fmt.Sprintf("%s-azure-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Baremetal != nil {
+	if c.Spec.Cloud.Baremetal != nil {
 		return fmt.Sprintf("%s-baremetal-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Digitalocean != nil {
+	if c.Spec.Cloud.Digitalocean != nil {
 		return fmt.Sprintf("%s-digitalocean-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.GCP != nil {
+	if c.Spec.Cloud.GCP != nil {
 		return fmt.Sprintf("%s-gcp-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Hetzner != nil {
+	if c.Spec.Cloud.Hetzner != nil {
 		return fmt.Sprintf("%s-hetzner-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Openstack != nil {
+	if c.Spec.Cloud.Openstack != nil {
 		return fmt.Sprintf("%s-openstack-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Packet != nil {
+	if c.Spec.Cloud.Packet != nil {
 		return fmt.Sprintf("%s-packet-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Kubevirt != nil {
+	if c.Spec.Cloud.Kubevirt != nil {
 		return fmt.Sprintf("%s-kubevirt-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.VSphere != nil {
+	if c.Spec.Cloud.VSphere != nil {
 		return fmt.Sprintf("%s-vsphere-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Alibaba != nil {
+	if c.Spec.Cloud.Alibaba != nil {
 		return fmt.Sprintf("%s-alibaba-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Anexia != nil {
+	if c.Spec.Cloud.Anexia != nil {
 		return fmt.Sprintf("%s-anexia-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.Nutanix != nil {
+	if c.Spec.Cloud.Nutanix != nil {
 		return fmt.Sprintf("%s-nutanix-%s", CredentialPrefix, clusterName)
 	}
-	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
+	if c.Spec.Cloud.VMwareCloudDirector != nil {
 		return fmt.Sprintf("%s-vmware-cloud-director-%s", CredentialPrefix, clusterName)
 	}
 	return ""
 }
 
 // IsEncryptionConfigurationEnabled returns whether encryption-at-rest is configured on this cluster.
-func (cluster *Cluster) IsEncryptionEnabled() bool {
-	return cluster.Spec.Features[ClusterFeatureEncryptionAtRest] && cluster.Spec.EncryptionConfiguration != nil && cluster.Spec.EncryptionConfiguration.Enabled
+func (c *Cluster) IsEncryptionEnabled() bool {
+	return c.Spec.Features[ClusterFeatureEncryptionAtRest] && c.Spec.EncryptionConfiguration != nil && c.Spec.EncryptionConfiguration.Enabled
 }
 
 // IsEncryptionActive returns whether encryption-at-rest is active on this cluster. This can still be
 // the case when encryption configuration has been disabled, as encrypted resources require a decryption.
-func (cluster *Cluster) IsEncryptionActive() bool {
-	return cluster.Status.HasConditionValue(ClusterConditionEncryptionInitialized, corev1.ConditionTrue)
+func (c *Cluster) IsEncryptionActive() bool {
+	return c.Status.HasConditionValue(ClusterConditionEncryptionInitialized, corev1.ConditionTrue)
 }

--- a/sdk/apis/kubermatic/v1/preset.go
+++ b/sdk/apis/kubermatic/v1/preset.go
@@ -254,13 +254,15 @@ type VMwareCloudDirector struct {
 }
 
 func (s VMwareCloudDirector) IsValid() bool {
-	return ((len(s.Username) > 0 &&
-		len(s.Password) > 0) ||
-		len(s.APIToken) > 0) &&
+	hasAnyNet := len(s.OVDCNetwork) > 0 || len(s.OVDCNetworks) > 0
+	hasBothNets := len(s.OVDCNetwork) > 0 && len(s.OVDCNetworks) > 0
+	hasCredentials := len(s.Username) > 0 && len(s.Password) > 0
+
+	return true &&
+		(hasCredentials || len(s.APIToken) > 0) &&
 		len(s.VDC) > 0 &&
 		len(s.Organization) > 0 &&
-		(len(s.OVDCNetwork) > 0 || len(s.OVDCNetworks) > 0) &&
-		!(len(s.OVDCNetwork) > 0 && len(s.OVDCNetworks) > 0)
+		hasAnyNet && !hasBothNets
 }
 
 type Baremetal struct {

--- a/sdk/semver/semver.go
+++ b/sdk/semver/semver.go
@@ -144,6 +144,6 @@ func (s Semver) DeepCopy() Semver {
 	return *NewSemverOrDie(s.String())
 }
 
-func (in *Semver) DeepCopyInto(out *Semver) {
-	*out = in.DeepCopy()
+func (s *Semver) DeepCopyInto(out *Semver) {
+	*out = s.DeepCopy()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates KKP to Go 1.24, and because our build image ships with the most recent tools available, this also upgrades us to golangci-lint 2.x.

The newly merged staticcheck stuff in golangci-lint is causing a lot of errors, but I found them all to be valid and so I chose to adjust them instead of disabling the individual checks in staticcheck. Primarily because I want _new_ code to adhere to all of them, and we cannot easily make a distinction in golangci-lint between old and new code.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.24.2.
```

**Documentation**:
```documentation
NONE
```
