### PR TITLE
Fix Dex migration documentation link

### DIFF
--- a/pkg/install/stack/kubermatic-master/dex.go
+++ b/pkg/install/stack/kubermatic-master/dex.go
@@ -47,7 +47,7 @@ func deployDex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntime
 	useNewDexChart, _ := opt.HelmValues.GetBool(yamled.Path{"useNewDexChart"})
 	if !useNewDexChart {
 		logger.Warn("Consider migrating to the new Dex Helm chart by setting useNewDexChart.")
-		logger.Warn("Please see the migration guide at https://docs.kubermatic.com/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/#dex-240")
+		logger.Warn("Please see the migration guide at https://docs.kubermatic.com/kubermatic/v2.27/installation/upgrading/upgrade-from-2.26-to-2.27/#dex-v242")
 		logger.Warn("for more information.")
 
 		chartName = LegacyDexChartName


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to fix the migration link displayed in the kubermatic-installer warn message for Dex migration. 
```
WARN[0004]    Consider migrating to the new Dex Helm chart by setting useNewDexChart.
WARN[0004]    Please see the migration guide at https://docs.kubermatic.com/kubermatic/main/installation/upgrading/upgrade-from-2.25-to-2.26/#dex-240
WARN[0004]    for more information.
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
