### PR TITLE
Download kube-test binaries on demand

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -594,3 +594,28 @@ provider_disabled() {
   echodate "\$$disableEnv is set, tests will be disabled. Apply the label $labelName to this PR to forcefully enable them."
   return 0
 }
+
+# This is an alias for curl, but will in the CI system rewrite the
+# request to allow it to pass through an in-cluster caching proxy.
+# The proxy is not a regular proxy (due to TLS limitations), but a
+# simply plain-HTTP reverse proxy, so a request to GitHub would
+# go plain HTTP between this script and the proxy, and HTTPS between
+# the proxy and GitHub.
+download_archive() {
+  local url="$1"
+  shift
+
+  domain="$(echo "$url" | sed -E 's#^https?://([^/]+)/.*#\1#')"
+  proxiedDomains="github.com,codeberg.org,dl.k8s.io"
+
+  if [[ -z "${PROW_JOB_ID:-}" ]] || [[ -z "${DOWNLOAD_CACHE_HOST:-}" ]] || ! echo "$proxiedDomains" | grep -w -q "$domain"; then
+    # do nothing special when running outside of the CI environment
+    # or when using a domain we do not proxy internally
+    curl "$url" "$@"
+  else
+    # determine target domain
+    echodate "Note: Proxying request to $domain through download proxy." >&2
+    url="$(echo "$url" | sed -E "s#https?://$domain/#http://$DOWNLOAD_CACHE_HOST/#")"
+    curl --header "Host: $domain" "$url" "$@"
+  fi
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Many years ago we decided to use a single container image for all our build jobs, in all our projects. This image would contain each and every little tool and dependency we need to build KKP, KubeOne etc.

This concept has worked out surprisingly well, but it does show its age. The upside of shipping a consistent set of tools is that no tools get left behind: if you want a new Go version, you also must update your goreleaser, golangci-lint, yq etc. The downsides are well known though:

* It's difficult for external contributors to know where to install what tool from.
* Large breaking changes like the golangci-lint v1->v2 migration reduce acceptance among devs to make the jump and update.

My main concern with not having everything in a common image is that nothing is cached anymore. Every job would need to re-download every tool it needs, which increases our reliance on external services being up and makes jobs simply slower than necessary. We just saw what happened when Docker Hub introduced download limits, who knows when GitHub will do the same all of a sudden.

My solution is to meet in the middle. To allow downloading tools, but to please ask every project to include a small snippet to, when run in CI, proxy the request through an in-cluster caching proxy.

This PR trials this new cache by using it to download the kube test binaries during conformance tests. Getting these finally out of our build images will save hundreds of megabytes in image size, but more importantly make the build image independent of KKP release cycles.

My goal is that eventually, over time we thin out our build image and move downloading the necessary tools into each project's Makefile (or similar). I assume some tools will stay in the build image, like kind or buildah, because they are either really large or difficult to install by just downloading a zip file.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
