### PR TITLE
[release/v2.26] Add nginx secure version 1.11.5

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml
@@ -41,6 +41,13 @@ spec:
           chartVersion: 4.9.1
           url: https://kubernetes.github.io/ingress-nginx
     version: 1.9.6
+  - template:
+      source:
+        helm:
+          chartName: ingress-nginx
+          chartVersion: 4.11.5
+          url: https://kubernetes.github.io/ingress-nginx
+    version: 1.11.5
   defaultValues: {}
   documentationURL: https://kubernetes.github.io/ingress-nginx/
   sourceURL: https://github.com/kubernetes/ingress-nginx


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add nginx secure version 1.11.5 fixing the CVEs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the default application's nginx ingress controller to use the save and patched version of v1.11.5.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
