### PR TITLE
[monitoring/grafana] fix: Make argocd happy about default resource block

### DIFF
--- a/charts/monitoring/grafana/templates/deployment.yaml
+++ b/charts/monitoring/grafana/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           {{- end }}
 
           echo "Datasource provisioning completed successfully."
-
+        resources: {}
         volumeMounts:
         - mountPath: /etc/grafana/provisioning/datasources
           name: grafana-datasources


### PR DESCRIPTION
**What this PR does / why we need it**:
Grafana init container `datasource-assembler` does not have a required spec entry for `resources`. At least empty entry is required as it will get automatically added to resource definition and then ArgoCD keeps showing the diff.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes NA

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
