### PR TITLE
fix: overwriting etcd backup images

### DIFF
--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -296,7 +296,7 @@ func (r *Reconciler) reconcile(
 	return totalReconcile, nil
 }
 
-func getBackupStoreContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
+func getBackupStoreContainer(cfg *kubermaticv1.KubermaticConfiguration) (*corev1.Container, error) {
 	// a customized container is configured
 	if cfg.Spec.SeedController.BackupStoreContainer != "" {
 		return kuberneteshelper.ContainerFromString(cfg.Spec.SeedController.BackupStoreContainer)
@@ -305,7 +305,7 @@ func getBackupStoreContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *ku
 	return kuberneteshelper.ContainerFromString(defaulting.DefaultBackupStoreContainer)
 }
 
-func getBackupDeleteContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
+func getBackupDeleteContainer(cfg *kubermaticv1.KubermaticConfiguration) (*corev1.Container, error) {
 	// a customized container is configured
 	if cfg.Spec.SeedController.BackupDeleteContainer != "" {
 		return kuberneteshelper.ContainerFromString(cfg.Spec.SeedController.BackupDeleteContainer)
@@ -892,12 +892,12 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		return nil, fmt.Errorf("credentials not set for backup destination %q", backupConfig.Spec.Destination)
 	}
 
-	storeContainer, err := getBackupStoreContainer(config, seed)
+	storeContainer, err := getBackupStoreContainer(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get etcd backup store container: %w", err)
 	}
 
-	deleteContainer, err := getBackupDeleteContainer(config, seed)
+	deleteContainer, err := getBackupDeleteContainer(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get etcd backup delete container: %w", err)
 	}

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -602,8 +602,8 @@ func TestStartPendingBackupJobs(t *testing.T) {
 				WithCluster(cluster).
 				WithVersions(kubermatic.GetFakeVersions()).
 				WithEtcdLauncherImage(defaulting.DefaultEtcdLauncherImage).
-				WithEtcdBackupStoreContainer(genStoreContainer()).
-				WithEtcdBackupDeleteContainer(genDeleteContainer()).
+				WithEtcdBackupStoreContainer(genStoreContainer(), false).
+				WithEtcdBackupDeleteContainer(genDeleteContainer(), false).
 				WithEtcdBackupDestination(genDefaultBackupDestination()).
 				Build()
 
@@ -949,8 +949,8 @@ func TestStartPendingBackupDeleteJobs(t *testing.T) {
 				WithCluster(cluster).
 				WithVersions(kubermatic.GetFakeVersions()).
 				WithEtcdLauncherImage(defaulting.DefaultEtcdLauncherImage).
-				WithEtcdBackupStoreContainer(genStoreContainer()).
-				WithEtcdBackupDeleteContainer(genDeleteContainer()).
+				WithEtcdBackupStoreContainer(genStoreContainer(), false).
+				WithEtcdBackupDeleteContainer(genDeleteContainer(), false).
 				WithEtcdBackupDestination(genDefaultBackupDestination()).
 				Build()
 
@@ -1236,8 +1236,8 @@ func TestUpdateRunningBackupDeleteJobs(t *testing.T) {
 				WithCluster(cluster).
 				WithVersions(kubermatic.GetFakeVersions()).
 				WithEtcdLauncherImage(defaulting.DefaultEtcdLauncherImage).
-				WithEtcdBackupStoreContainer(genStoreContainer()).
-				WithEtcdBackupDeleteContainer(genDeleteContainer()).
+				WithEtcdBackupStoreContainer(genStoreContainer(), false).
+				WithEtcdBackupDeleteContainer(genDeleteContainer(), false).
 				WithEtcdBackupDestination(genDefaultBackupDestination()).
 				Build()
 
@@ -1558,8 +1558,8 @@ func TestDeleteFinishedBackupJobs(t *testing.T) {
 				WithCluster(cluster).
 				WithVersions(kubermatic.GetFakeVersions()).
 				WithEtcdLauncherImage(defaulting.DefaultEtcdLauncherImage).
-				WithEtcdBackupStoreContainer(genStoreContainer()).
-				WithEtcdBackupDeleteContainer(genDeleteContainer()).
+				WithEtcdBackupStoreContainer(genStoreContainer(), false).
+				WithEtcdBackupDeleteContainer(genDeleteContainer(), false).
 				WithEtcdBackupDestination(genDefaultBackupDestination()).
 				Build()
 

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -199,13 +199,17 @@ func (td *TemplateDataBuilder) WithEtcdLauncherImage(image string) *TemplateData
 }
 
 func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Container) *TemplateDataBuilder {
-	container.Image = registry.Must(td.data.RewriteImage(container.Image))
+	if td.data.KubermaticConfiguration().Spec.SeedController.BackupStoreContainer == "" {
+		container.Image = registry.Must(td.data.RewriteImage(container.Image))
+	}
 	td.data.etcdBackupStoreContainer = container
 	return td
 }
 
 func (td *TemplateDataBuilder) WithEtcdBackupDeleteContainer(container *corev1.Container) *TemplateDataBuilder {
-	container.Image = registry.Must(td.data.RewriteImage(container.Image))
+	if td.data.KubermaticConfiguration().Spec.SeedController.BackupDeleteContainer == "" {
+		container.Image = registry.Must(td.data.RewriteImage(container.Image))
+	}
 	td.data.etcdBackupDeleteContainer = container
 	return td
 }

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -199,11 +199,13 @@ func (td *TemplateDataBuilder) WithEtcdLauncherImage(image string) *TemplateData
 }
 
 func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Container) *TemplateDataBuilder {
+	container.Image = registry.Must(td.data.RewriteImage(container.Image))
 	td.data.etcdBackupStoreContainer = container
 	return td
 }
 
 func (td *TemplateDataBuilder) WithEtcdBackupDeleteContainer(container *corev1.Container) *TemplateDataBuilder {
+	container.Image = registry.Must(td.data.RewriteImage(container.Image))
 	td.data.etcdBackupDeleteContainer = container
 	return td
 }

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -199,7 +199,7 @@ func (td *TemplateDataBuilder) WithEtcdLauncherImage(image string) *TemplateData
 }
 
 func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Container) *TemplateDataBuilder {
-	if td.data.KubermaticConfiguration().Spec.SeedController.BackupStoreContainer == "" {
+	if td.data.KubermaticConfiguration() != nil && td.data.KubermaticConfiguration().Spec.SeedController.BackupStoreContainer == "" {
 		container.Image = registry.Must(td.data.RewriteImage(container.Image))
 	}
 	td.data.etcdBackupStoreContainer = container
@@ -207,7 +207,7 @@ func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Co
 }
 
 func (td *TemplateDataBuilder) WithEtcdBackupDeleteContainer(container *corev1.Container) *TemplateDataBuilder {
-	if td.data.KubermaticConfiguration().Spec.SeedController.BackupDeleteContainer == "" {
+	if td.data.KubermaticConfiguration() != nil && td.data.KubermaticConfiguration().Spec.SeedController.BackupDeleteContainer == "" {
 		container.Image = registry.Must(td.data.RewriteImage(container.Image))
 	}
 	td.data.etcdBackupDeleteContainer = container

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -198,16 +198,16 @@ func (td *TemplateDataBuilder) WithEtcdLauncherImage(image string) *TemplateData
 	return td
 }
 
-func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Container) *TemplateDataBuilder {
-	if td.data.KubermaticConfiguration() != nil && td.data.KubermaticConfiguration().Spec.SeedController.BackupStoreContainer == "" {
+func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Container, isCustom bool) *TemplateDataBuilder {
+	if !isCustom {
 		container.Image = registry.Must(td.data.RewriteImage(container.Image))
 	}
 	td.data.etcdBackupStoreContainer = container
 	return td
 }
 
-func (td *TemplateDataBuilder) WithEtcdBackupDeleteContainer(container *corev1.Container) *TemplateDataBuilder {
-	if td.data.KubermaticConfiguration() != nil && td.data.KubermaticConfiguration().Spec.SeedController.BackupDeleteContainer == "" {
+func (td *TemplateDataBuilder) WithEtcdBackupDeleteContainer(container *corev1.Container, isCustom bool) *TemplateDataBuilder {
+	if !isCustom {
 		container.Image = registry.Must(td.data.RewriteImage(container.Image))
 	}
 	td.data.etcdBackupDeleteContainer = container


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issue where etcd backup container images were not being overwritten in air-gapped environments. It ensures that all image references respect the configured private registry settings. With this change, users can now reliably override image paths for air-gapped setups.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14351

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure that etcd backup images are pulled from the overwrite Registry in air-gapped environments
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
