### PR TITLE
Upgrade process fix for kube-state-metrics

### DIFF
--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -33,6 +33,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -605,19 +606,15 @@ func upgradeKubeStateMetricsDeployment(
 	// 1: find the old deployment
 	logger.Info("Backing up old kube-state-metrics deployment…")
 
-	deploymentsList := &unstructured.UnstructuredList{}
-	deploymentsList.SetGroupVersionKind(schema.GroupVersionKind{
+	deployment := &unstructured.Unstructured{}
+	deployment.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "apps",
-		Kind:    "DeploymentList",
+		Kind:    "Deployment",
 		Version: "v1",
 	})
+	key := types.NamespacedName{Name: KubeStateMetricsReleaseName, Namespace: KubeStateMetricsNamespace}
 
-	ksbMatcher := ctrlruntimeclient.MatchingLabels{
-		"app":                          KubeStateMetricsReleaseName,
-		"app.kubernetes.io/managed-by": "Helm",
-		"release":                      release.Name,
-	}
-	if err := kubeClient.List(ctx, deploymentsList, ctrlruntimeclient.InNamespace(KubeStateMetricsNamespace), ksbMatcher); err != nil {
+	if err := kubeClient.Get(ctx, key, deployment); err != nil {
 		return fmt.Errorf("Error querying API for the existing Deployment object, aborting upgrade process.")
 	}
 
@@ -625,17 +622,16 @@ func upgradeKubeStateMetricsDeployment(
 	backupTS := time.Now().Format("2006-01-02T150405")
 	filename := fmt.Sprintf("backup_%s_%s.yaml", KubeStateMetricsReleaseName, backupTS)
 	logger.Infof("Attempting to store the deployments in file: %s", filename)
-	if err := util.DumpResources(ctx, filename, deploymentsList.Items); err != nil {
-		return fmt.Errorf("failed to back up the deployments, it is not removed: %w", err)
+	if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*deployment}); err != nil {
+		return fmt.Errorf("failed to back up the deployment, it is not removed: %w", err)
 	}
 
 	// 3: delete the deployment
-	logger.Info("Deleting the deployments from the cluster")
-	for _, obj := range deploymentsList.Items {
-		if err := kubeClient.Delete(ctx, &obj); err != nil {
-			return fmt.Errorf("failed to remove the deployment: %w\n\nuse backup file to check the changes and restore if needed", err)
-		}
+	logger.Info("Deleting the deployment from the cluster")
+	if err := kubeClient.Delete(ctx, deployment); err != nil {
+		return fmt.Errorf("failed to remove the deployment: %w\n\nuse backup file to check the changes and restore if needed", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains the upgrade issue for `kube-state-metrics` upstream chart introduced with #14174 


**Which issue(s) this PR fixes**:

Part of #8465 

**What type of PR is this?**
/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
kube-state-metrics chart is now using the upstream helm chart with app version 2.15.0.
```

**Documentation**:
```documentation
TBD
```
