### PR TITLE
Fix KubeVirt CSI Driver Operator to respect `OverwriteRegistry` in air-gapped setups

### DIFF
--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -68,9 +68,15 @@ func MutateCreate(newCluster *kubermaticv1.Cluster, config *kubermaticv1.Kuberma
 		}
 	}
 
-	if newCluster.Spec.Cloud.Kubevirt != nil && len(datacenter.Node.RegistryMirrors) > 0 {
-		newCluster.Spec.Cloud.Kubevirt.CSIDriverOperator = &kubermaticv1.KubeVirtCSIDriverOperator{
-			OverwriteRegistry: datacenter.Node.RegistryMirrors[0],
+	// Ensure the KubeVirt CSI Driver Operator uses the configured overwrite registry
+	// to enforce consistent image pulling from the specified registry in offline setups.
+	if newCluster.Spec.Cloud.Kubevirt != nil && config.Spec.UserCluster.OverwriteRegistry != "" {
+		if newCluster.Spec.Cloud.Kubevirt.CSIDriverOperator == nil {
+			newCluster.Spec.Cloud.Kubevirt.CSIDriverOperator = &kubermaticv1.KubeVirtCSIDriverOperator{
+				OverwriteRegistry: config.Spec.UserCluster.OverwriteRegistry,
+			}
+		} else if newCluster.Spec.Cloud.Kubevirt.CSIDriverOperator.OverwriteRegistry == "" {
+			newCluster.Spec.Cloud.Kubevirt.CSIDriverOperator.OverwriteRegistry = config.Spec.UserCluster.OverwriteRegistry
 		}
 	}
 

--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -68,6 +68,12 @@ func MutateCreate(newCluster *kubermaticv1.Cluster, config *kubermaticv1.Kuberma
 		}
 	}
 
+	if newCluster.Spec.Cloud.Kubevirt != nil && len(datacenter.Node.RegistryMirrors) > 0 {
+		newCluster.Spec.Cloud.Kubevirt.CSIDriverOperator = &kubermaticv1.KubeVirtCSIDriverOperator{
+			OverwriteRegistry: datacenter.Node.RegistryMirrors[0],
+		}
+	}
+
 	if newCluster.Spec.ClusterNetwork.KonnectivityEnabled == nil { //nolint:staticcheck
 		newCluster.Spec.ClusterNetwork.KonnectivityEnabled = ptr.To(true) //nolint:staticcheck
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In offline/airgapped kubevirt setups, the `kubevirt-csi-driver-operator` (deployed as an addon) risks pulling container images (since it reconciles [daemonsets](https://github.com/kubermatic/kubevirt-csi-driver-operator/blob/master/controllers/tenant/daemonset.go#L275-L286))  from external registries instead of the user-configured overwrite registry (specified in kubermatic configuration).

This PR ensures that this `kubevirt-csi-driver-operator` (addon) always respects the overwriteRegistry configured by the user in kubermatic configuration. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix KubeVirt CSI Driver Operator to respect `OverwriteRegistry` in air-gapped setups, preventing external image pulls.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
