### PR TITLE
Fix the auto-deletion of SG not created by KKP in Openstack

### DIFF
--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -338,14 +338,6 @@ func reconcileExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClie
 }
 
 func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	// first ensure we have our cleanup finalizer
-	cluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
-		kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to add security group finalizer: %w", err)
-	}
-
 	securityGroup := cluster.Spec.Cloud.Openstack.SecurityGroups
 
 	// automatically create and fill-in the default security group if none was specified
@@ -365,7 +357,7 @@ func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *goph
 		NodePorts()
 
 	// for each security group, ensure that it exists
-	err = validateSecurityGroupExists(netClient, securityGroup)
+	err := validateSecurityGroupExists(netClient, securityGroup)
 
 	if err != nil {
 		if isNotFoundErr(err) {
@@ -383,6 +375,15 @@ func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *goph
 			if err != nil {
 				return nil, fmt.Errorf("failed to create security group: %w", err)
 			}
+
+			cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+				kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
+			})
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to add security group finalizer: %w", err)
+			}
+
 		} else {
 			return cluster, fmt.Errorf("failed to check security group: %w", err)
 		}

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -383,7 +383,6 @@ func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *goph
 			if err != nil {
 				return nil, fmt.Errorf("failed to add security group finalizer: %w", err)
 			}
-
 		} else {
 			return cluster, fmt.Errorf("failed to check security group: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR optimizes the `reconcileSecurityGroups` function by ensuring the SecurityGroupCleanupFinalizer is added only once when a new security group is created.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14049

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed auto-deletion of non-created OpenStack security group during cluster cleanup.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
