### PR TITLE
Update the default ipv6 services range

### DIFF
--- a/pkg/defaulting/cluster_test.go
+++ b/pkg/defaulting/cluster_test.go
@@ -68,7 +68,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 						CIDRBlocks: []string{"172.25.0.0/16", "fd01::/48"},
 					},
 					Services: kubermaticv1.NetworkRanges{
-						CIDRBlocks: []string{"10.240.16.0/20", "fd02::/120"},
+						CIDRBlocks: []string{"10.240.16.0/20", "fd02::/108"},
 					},
 					ProxyMode: "ipvs",
 					IPVS: &kubermaticv1.IPVSConfiguration{
@@ -97,7 +97,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 						CIDRBlocks: []string{"174.27.0.0/16", "fd05::/48"},
 					},
 					Services: kubermaticv1.NetworkRanges{
-						CIDRBlocks: []string{"10.240.16.0/20", "fd02::/120"},
+						CIDRBlocks: []string{"10.240.16.0/20", "fd02::/108"},
 					},
 					ProxyMode: "ipvs",
 					IPVS: &kubermaticv1.IPVSConfiguration{
@@ -130,7 +130,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 						CIDRBlocks: []string{"172.26.0.0/16", "fd01::/48"},
 					},
 					Services: kubermaticv1.NetworkRanges{
-						CIDRBlocks: []string{"10.241.0.0/20", "fd02::/120"},
+						CIDRBlocks: []string{"10.241.0.0/20", "fd02::/108"},
 					},
 					ProxyMode: "ipvs",
 					IPVS: &kubermaticv1.IPVSConfiguration{

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1036,7 +1036,7 @@ const (
 	// DefaultClusterServicesCIDRIPv4KubeVirt is the default network range from which IPv4 service VIPs are allocated for KubeVirt clusters.
 	DefaultClusterServicesCIDRIPv4KubeVirt = "10.241.0.0/20"
 	// DefaultClusterServicesCIDRIPv6 is the default network range from which IPv6 service VIPs are allocated.
-	DefaultClusterServicesCIDRIPv6 = "fd02::/120"
+	DefaultClusterServicesCIDRIPv6 = "fd02::/108"
 
 	// DefaultNodeCIDRMaskSizeIPv4 is the default mask size used to address the nodes within provided IPv4 Pods CIDR.
 	DefaultNodeCIDRMaskSizeIPv4 = 24

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -389,7 +389,7 @@ func TestNewClusters(t *testing.T) {
 				WithPatch(func(c *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
 					c.ClusterNetwork.IPFamily = kubermaticv1.IPFamilyDualStack
 					c.ClusterNetwork.Pods.CIDRBlocks = []string{"172.25.0.0/16", "fd01::/48"}
-					c.ClusterNetwork.Services.CIDRBlocks = []string{"10.240.16.0/20", "fd02::/120"}
+					c.ClusterNetwork.Services.CIDRBlocks = []string{"10.240.16.0/20", "fd02::/108"}
 					return c
 				})
 

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -468,7 +468,7 @@ func TestHandle(t *testing.T) {
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 					IPFamily:                 kubermaticv1.IPFamilyDualStack,
 					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16", "fd01::/48"}},
-					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/120"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/108"}},
 					DNSDomain:                "cluster.local",
 					ProxyMode:                resources.IPVSProxyMode,
 					NodeLocalDNSCacheEnabled: ptr.To(true),
@@ -500,7 +500,7 @@ func TestHandle(t *testing.T) {
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 					IPFamily:                 kubermaticv1.IPFamilyDualStack,
 					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16", "fd01::/48"}},
-					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/120"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/108"}},
 					DNSDomain:                "cluster.local",
 					ProxyMode:                resources.IPVSProxyMode,
 					NodeLocalDNSCacheEnabled: ptr.To(true),

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -476,7 +476,7 @@ func TestHandle(t *testing.T) {
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 					IPFamily:                 kubermaticv1.IPFamilyDualStack,
 					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16", "fd01::/48"}},
-					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/120"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/108"}},
 					DNSDomain:                "cluster.local",
 					ProxyMode:                resources.IPVSProxyMode,
 					NodeLocalDNSCacheEnabled: ptr.To(true),
@@ -509,7 +509,7 @@ func TestHandle(t *testing.T) {
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 					IPFamily:                 kubermaticv1.IPFamilyDualStack,
 					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16", "fd01::/48"}},
-					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/120"}},
+					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20", "fd02::/108"}},
 					DNSDomain:                "cluster.local",
 					ProxyMode:                resources.IPVSProxyMode,
 					NodeLocalDNSCacheEnabled: ptr.To(true),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the default IPv6 services range to be equal to or larger than the default IPv4 services range.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13982

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update the default ipv6 services range to `fd02::/108`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
