### PR TITLE
fix: service account deletion issue

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -84,7 +84,7 @@ func newUserGrafanaReconciler(
 	serviceAccountPredicate := predicate.NewPredicateFuncs(func(object ctrlruntimeclient.Object) bool {
 		// We don't trigger reconciliation for service account.
 		user := object.(*kubermaticv1.User)
-		return !kubermaticv1helper.IsProjectServiceAccount(user.Spec.Email)
+		return !kubermaticv1helper.IsProjectServiceAccount(user.Name)
 	})
 
 	_, err := builder.ControllerManagedBy(mgr).
@@ -155,6 +155,10 @@ func (r *userGrafanaReconciler) Reconcile(ctx context.Context, request reconcile
 	user := &kubermaticv1.User{}
 	if err := r.Get(ctx, request.NamespacedName, user); err != nil {
 		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	if kubermaticv1helper.IsProjectServiceAccount(user.Name) {
+		return reconcile.Result{}, nil
 	}
 
 	grafanaClient, err := r.userGrafanaController.clientProvider(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:

Service accounts were incorrectly reconciled once (adding a finalizer) despite a predicate to exclude them.  The [`serviceAccountPredicate`](https://github.com/kubermatic/kubermatic/blob/main/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go#L84-L88) only filter direct `User` events, not reconciles triggered by [`UserProjectBinding`](https://github.com/kubermatic/kubermatic/blob/main/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go#L104-L125) / [`GroupProjectBinding`](https://github.com/kubermatic/kubermatic/blob/main/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go#L127-L149) changes. These Map functions enqueded all matching `User` objects, including service accounts.

This PR resolves this issue where service accounts were unintentionally reconciled (adding a finalizer) due to `UserProjectBinding`/`GroupProjectBinding` events bypassing the existing `User` predicate. 

We are now skipping the service account in `UserProjectBinding`/`GroupProjectBinding` events. 
Service accounts are never reconciled (no finalizer added), resolving deletion deadlocks.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14130

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the service account deletion process
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
