### PR TITLE
feat(cluster-backup): add tags for backup objects

### DIFF
--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/cluster_backup.go
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/cluster_backup.go
@@ -52,7 +52,7 @@ const (
 	version       = "v1.14.0"
 	pluginVersion = "v1.10.0"
 
-	backupOrigin = "kkp-backend"
+	backupOrigin = "kkp-controllers"
 
 	// Adds AWS tags to backup objects created through the BSL configured via KKP.
 	// For more details, refer to:
@@ -168,5 +168,5 @@ func CustomizationConfigMapReconciler(rewriter registry.ImageRewriter) reconcili
 }
 
 func getTags(backupOrigin, projectID, clusterID string) string {
-	return fmt.Sprintf("backup-origin:%s&project-id:%s&cluster-id:%s", backupOrigin, projectID, clusterID)
+	return fmt.Sprintf("backup-origin=%s&project-id=%s&cluster-id=%s", backupOrigin, projectID, clusterID)
 }

--- a/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/cluster_backup.go
+++ b/pkg/ee/cluster-backup/user-cluster/velero-controller/resources/cluster_backup.go
@@ -51,6 +51,13 @@ const (
 
 	version       = "v1.14.0"
 	pluginVersion = "v1.10.0"
+
+	backupOrigin = "kkp-backend"
+
+	// Adds AWS tags to backup objects created through the BSL configured via KKP.
+	// For more details, refer to:
+	// https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/aaf7d434f5f4e3c0f728f1d840d106e37e51ffd7/backupstoragelocation.md?plain=1#L119
+	BSLTags = "tagging"
 )
 
 // NamespaceReconciler creates the namespace for velero related resources on the user cluster.
@@ -121,6 +128,12 @@ func BSLReconciler(cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBack
 			bsl.Spec.Credential = nil
 			// add bucket prefix using projectID/clusterID to avoid collision.
 			bsl.Spec.ObjectStorage.Prefix = fmt.Sprintf("%s/%s", projectID, cluster.Name)
+
+			if bsl.Spec.Config == nil {
+				bsl.Spec.Config = make(map[string]string)
+			}
+			bsl.Spec.Config[BSLTags] = getTags(backupOrigin, projectID, cluster.Name)
+
 			return bsl, nil
 		}
 	}
@@ -152,4 +165,8 @@ func CustomizationConfigMapReconciler(rewriter registry.ImageRewriter) reconcili
 			return cm, nil
 		}
 	}
+}
+
+func getTags(backupOrigin, projectID, clusterID string) string {
+	return fmt.Sprintf("backup-origin:%s&project-id:%s&cluster-id:%s", backupOrigin, projectID, clusterID)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a feature that adds tagging support for backup objects in Kubermatic's cluster-backup component. This helps with better tracking, filtering, or organizing backup resources. That means when Kubermatic takes backups of cluster resources, it can now attach metadata tags to those objects.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14198 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for tagging cluster backup objects in Kubermatic for improved management and traceability. It can help to identify, categorise, and track backup resources more effectively across multiple clusters and tenants.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
