### PR TITLE
Bump Go build image version to latest 1.24

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -74,7 +74,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -119,7 +119,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -164,7 +164,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -209,7 +209,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -254,7 +254,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -299,7 +299,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -344,7 +344,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -389,7 +389,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -434,7 +434,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -479,7 +479,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -524,7 +524,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -569,7 +569,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -614,7 +614,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -659,7 +659,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -325,7 +325,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           command:
             - "./hack/ci/run-encryption-at-rest-tests.sh"
           env:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump Go build image version to latest 1.24. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
