### PR TITLE
Update scripts to remove containerize feature from codegen and related scripts

### DIFF
--- a/hack/update-cert-manager-crds.sh
+++ b/hack/update-cert-manager-crds.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-containerize ./hack/update-cert-manager-crds.sh
-
 cd charts/cert-manager/
 
 version=$(yq '.appVersion' Chart.yaml)

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/update-codegen.sh
-
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"
 

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/update-docs.sh
-
 (
   cd docs
   go run ../codegen/godoc/main.go

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/update-fixtures.sh
-
 echodate "Updating fixtures..."
 make test-update &> /dev/null
 echodate "Updated fixtures, starting tests..."

--- a/hack/update-gatekeeper-crds.sh
+++ b/hack/update-gatekeeper-crds.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-containerize ./hack/update-gatekeeper-crds.sh
-
 gatekeeperVersion="v3.12.0"
 
 tmpFile=gatekeeper.tar.gz
@@ -29,7 +27,12 @@ curl -fLo "$tmpFile" "https://github.com/open-policy-agent/gatekeeper/archive/re
 crdDir=pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/
 rm -f $crdDir/*
 
-tar xzf "$tmpFile" --wildcards -C "$crdDir" --strip-components=5 '*/charts/gatekeeper/crds/*'
+tar_flags="xzf"
+if tar --help 2>&1 | grep -q -- '--wildcards'; then
+  tar_flags="xzf --wildcards"
+fi
+
+tar $tar_flags "$tmpFile" -C "$crdDir" --strip-components=5 '*/charts/gatekeeper/crds/*'
 rm "$tmpFile"
 
 cd "$crdDir"

--- a/hack/update-grafana-dashboards.sh
+++ b/hack/update-grafana-dashboards.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-containerize ./hack/update-grafana-dashboards.sh
-
 for dashboard in charts/monitoring/grafana/dashboards/*/*.json; do
   echodate "$dashboard"
   format_dashboard "$dashboard"

--- a/hack/update-prometheus-rules.sh
+++ b/hack/update-prometheus-rules.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-containerize ./hack/update-prometheus-rules.sh
-
 promtool=promtool
 if ! [ -x "$(command -v $promtool)" ]; then
   version=2.43.1

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-if [ "$#" -lt 2 ] || [ "$1" == "--help" ]; then
+if [ "$#" -lt 1 ] || [ "$1" == "--help" ]; then
   cat << EOF
 Usage: $(basename $0) (version)
 where:
@@ -29,14 +29,6 @@ EOF
   exit 0
 fi
 
-containerize ./hack/update-velero-crds.sh $1
-
-# positional args refer to the args of containerize() function, not the script. So, we skip one
-# echo $*
-# ./hack/update-velero-crds.sh v1.10.1
-if is_containerized; then
-  version="$2"
-fi
 velero=velero
 
 if ! [ -x "$(command -v $velero)" ]; then
@@ -53,6 +45,7 @@ crd_dir="pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static"
 cd "$crd_dir"
 
 version=$($velero version --client-only | grep Version | cut -d' ' -f2)
+echo "version is: $version"
 crds=$($velero install --crds-only --dry-run -o json | jq -c '.items[]')
 
 while IFS= read -r crd; do

--- a/hack/update-velero-crds.sh
+++ b/hack/update-velero-crds.sh
@@ -45,7 +45,6 @@ crd_dir="pkg/ee/cluster-backup/user-cluster/velero-controller/resources/static"
 cd "$crd_dir"
 
 version=$($velero version --client-only | grep Version | cut -d' ' -f2)
-echo "version is: $version"
 crds=$($velero install --crds-only --dry-run -o json | jq -c '.items[]')
 
 while IFS= read -r crd; do

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic-labs/boilerplate:v0.2.0 containerize hack/verify-boilerplate.sh
-
 echodate "Checking Kubermatic CE licenses..."
 boilerplate \
   -boilerplates hack/boilerplate/ce \

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/verify-licenses.sh
-
 go mod vendor
 
 echodate "Checking licenses..."

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,8 +19,6 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-3 containerize ./hack/verify-spelling.sh
-
 echodate "Running codespell..."
 
 skip=(


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates hack scripts to remove containerize feature from kkp. Containerize in our scripts adds additional overhead and it has already served its purpose when not all code generators were capable of non-GOPATH operations.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
