### PR TITLE
[release/v2.26] Bump default k8s version and patch releases

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -454,7 +454,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.30.11
+    default: v1.30.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -565,9 +565,11 @@ spec:
       - v1.30.5
       - v1.30.9
       - v1.30.11
+      - v1.30.12
       - v1.31.1
       - v1.31.5
       - v1.31.7
+      - v1.31.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -454,7 +454,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.30.11
+    default: v1.30.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -565,9 +565,11 @@ spec:
       - v1.30.5
       - v1.30.9
       - v1.30.11
+      - v1.30.12
       - v1.31.1
       - v1.31.5
       - v1.31.7
+      - v1.31.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.30.11"),
+		Default: semver.NewSemverOrDie("v1.30.12"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -243,10 +243,12 @@ var (
 			newSemver("v1.30.5"),
 			newSemver("v1.30.9"),
 			newSemver("v1.30.11"),
+			newSemver("v1.30.12"),
 			// Kubernetes 1.31
 			newSemver("v1.31.1"),
 			newSemver("v1.31.5"),
 			newSemver("v1.31.7"),
+			newSemver("v1.31.8"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.27 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/14385

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add 1.31.8/1.30.12 to the list of supported Kubernetes releases.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
