### PR TITLE
Fixed value for the flag use-ingress-class

### DIFF
--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -205,7 +205,7 @@ func getFlags(name string, kubelb *kubermaticv1.KubeLBDatacenterSettings, cluste
 			flags = append(flags, "-enable-secret-synchronizer")
 		}
 		if kubelb.DisableIngressClass {
-			flags = append(flags, "-use-ingress-class", "false")
+			flags = append(flags, "-use-ingress-class=false")
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates how boolean value for `use-ingress-class` flag is written. Specifically, boolean literals such as true and false are now written in lowercase and without separation (e.g., not 'True', 'FALSE', or with spaces).
Another example [here](https://github.com/kubermatic/kubermatic/blob/main/pkg/resources/apiserver/deployment.go#L361-L362).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14296

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug for KubeLB where disabling the ingress class for a user cluster was not working.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
