### PR TITLE
add option to install kube ovn cni for local kind command

### DIFF
--- a/charts/local-kube-ovn/Chart.yaml
+++ b/charts/local-kube-ovn/Chart.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: kube-ovn
+description: Helm chart for Kube-OVN
+type: application
+version: v1.13.11
+appVersion: "1.13.11"
+
+kubeVersion: ">= 1.29.0-0"
+maintainers:
+  - name: The Kubermatic Kubernetes Platform contributors
+    email: support@kubermatic.com
+dependencies:
+  - repository: https://kubeovn.github.io/kube-ovn
+    name: kube-ovn
+    version: 1.13.11

--- a/charts/local-kube-ovn/Chart.yaml
+++ b/charts/local-kube-ovn/Chart.yaml
@@ -16,8 +16,8 @@ apiVersion: v2
 name: kube-ovn
 description: Helm chart for Kube-OVN
 type: application
-version: v1.13.11
-appVersion: "1.13.11"
+version: v1.15.9
+appVersion: "1.15.9"
 
 kubeVersion: ">= 1.29.0-0"
 maintainers:
@@ -26,4 +26,4 @@ maintainers:
 dependencies:
   - repository: https://kubeovn.github.io/kube-ovn
     name: kube-ovn
-    version: 1.13.11
+    version: 1.15.9

--- a/charts/local-kube-ovn/values.yaml
+++ b/charts/local-kube-ovn/values.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kube-ovn:
+  MASTER_NODES_LABEL: "kubernetes.io/hostname=kkp-cluster-control-plane"
+  ipv4:
+    POD_CIDR: "10.244.0.0/16"
+    POD_GATEWAY: "10.244.0.1"
+    SVC_CIDR: "10.96.0.0/12"

--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -74,9 +74,10 @@ var (
 type LocalOptions struct {
 	Options
 
-	HelmBinary  string
-	HelmTimeout time.Duration
-	Endpoint    string
+	HelmBinary     string
+	HelmTimeout    time.Duration
+	Endpoint       string
+	KubeOVNEnabled bool
 }
 
 func LocalCommand(logger *logrus.Logger) *cobra.Command {
@@ -100,7 +101,6 @@ func LocalCommand(logger *logrus.Logger) *cobra.Command {
 	}
 	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
 	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "full path to the Helm 3 binary to use")
-	cmd.PersistentFlags().StringVar(&opt.Endpoint, "endpoint", "", "endpoint address for KKP installation (e.g. 10.0.0.5.nip.io), if this flag is left empty, the installer does best effort in auto-configuring from available network interfaces")
 
 	cmd.AddCommand(localKindCommand(logger, opt))
 	// TODO: expose when ready
@@ -144,16 +144,21 @@ func localKindCommand(logger *logrus.Logger, opt LocalOptions) *cobra.Command {
 				logger.Fatalf("failed to find 'helm' binary: %v", err)
 			}
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return localKindFunc(logger, opt)(cmd, args)
-		},
+		RunE: localKindFunc(logger, &opt),
 	}
+	cmd.PersistentFlags().StringVar(&opt.Endpoint, "endpoint", "", "endpoint address for KKP installation (e.g. 10.0.0.5.nip.io), if this flag is left empty, the installer does best effort in auto-configuring from available network interfaces")
+	cmd.PersistentFlags().BoolVar(&opt.KubeOVNEnabled, "kube-ovn-enabled", false, "enables usage of kube-ovn instead of kindnet as the cni plugin")
 	return cmd
 }
 
-func localKind(logger *logrus.Logger, dir string) (ctrlruntimeclient.Client, context.CancelFunc) {
+func localKind(logger *logrus.Logger, dir string, opt *LocalOptions) (ctrlruntimeclient.Client, context.CancelFunc) {
 	kindConfig := filepath.Join(dir, "kind-config.yaml")
-	if err := os.WriteFile(kindConfig, []byte(kindConfigContent), 0600); err != nil {
+	configContent := kindConfigContent
+	if opt.KubeOVNEnabled {
+		configContent += kindConfigKubeOVNContent
+		logger.Info("Disabling kindnet to deploy kube-ovn cni plugin")
+	}
+	if err := os.WriteFile(kindConfig, []byte(configContent), 0600); err != nil {
 		logger.Fatalf("failed to create 'kind' config: %v", err)
 	}
 
@@ -264,6 +269,17 @@ func installKubevirt(logger *logrus.Logger, helmClient helm.Client, opt LocalOpt
 	)
 	if err != nil {
 		logger.Fatalf("Failed to install KubeVirt Helm client: %v", err)
+	}
+}
+
+func installKubeOVN(logger *logrus.Logger, helmClient helm.Client, opt LocalOptions) {
+	logger.Info("Installing KubeOVN...")
+	if err := helmClient.BuildChartDependencies(filepath.Join(opt.ChartsDirectory, "local-kube-ovn"), nil); err != nil {
+		logger.Fatalf("Failed to fetch KubeOVN Helm chart: %v", err)
+	}
+	err := helmClient.InstallChart("kube-system", "kube-ovn", filepath.Join(opt.ChartsDirectory, "local-kube-ovn"), "", nil, []string{"--wait"})
+	if err != nil {
+		logger.Fatalf("Failed to install KubeOVN Helm release: %v", err)
 	}
 }
 
@@ -455,13 +471,13 @@ func installKubermatic(logger *logrus.Logger, dir string, kubeClient ctrlruntime
 	internalKubeconfig := filepath.Join(dir, "kube-config-internal.yaml")
 	kindSeedSecret := initKindSeedSecret(kubeClient, logger, kubeconfig, internalKubeconfig)
 	ensureResource(kubeClient, logger, &kindSeedSecret)
-	kindPreset := initKindPreset(logger, internalKubeconfig)
+	kindPreset := initKindPreset(logger, internalKubeconfig, opts.KubeOVNEnabled)
 	ensureResource(kubeClient, logger, &kindPreset)
 	ensureResource(kubeClient, logger, &kindLocalSeed)
 	return kkpEndpoint
 }
 
-func localKindFunc(logger *logrus.Logger, opt LocalOptions) cobraFuncE {
+func localKindFunc(logger *logrus.Logger, opt *LocalOptions) cobraFuncE {
 	return handleErrors(logger, func(cmd *cobra.Command, args []string) error {
 		exampleDir := "./examples"
 
@@ -474,7 +490,7 @@ func localKindFunc(logger *logrus.Logger, opt LocalOptions) cobraFuncE {
 			logger.Fatal("Failed to find examples directory, please ensure it and the charts directory from the KKP download archive remain together with the kubermatic-installer.")
 		}
 
-		kubeClient, cancel := localKind(logger, exampleDir)
+		kubeClient, cancel := localKind(logger, exampleDir, opt)
 		defer cancel()
 
 		kubeconfig := filepath.Join(exampleDir, "kube-config.yaml")
@@ -482,8 +498,11 @@ func localKindFunc(logger *logrus.Logger, opt LocalOptions) cobraFuncE {
 		if err != nil {
 			logger.Fatalf("Failed to create helm client: %v", err)
 		}
-		installKubevirt(logger, helmClient, opt)
-		endpoint := installKubermatic(logger, exampleDir, kubeClient, helmClient, opt)
+		if opt.KubeOVNEnabled {
+			installKubeOVN(logger, helmClient, *opt)
+		}
+		installKubevirt(logger, helmClient, *opt)
+		endpoint := installKubermatic(logger, exampleDir, kubeClient, helmClient, *opt)
 		logger.Infoln()
 		logger.Infof("KKP installed successfully, login at http://%v", endpoint)
 		logger.Infof("  Default login:    %v", kkpDefaultLogin)
@@ -547,12 +566,15 @@ func initKindSeedSecret(kubeClient ctrlruntimeclient.Client, logger *logrus.Logg
 	return kindKubeconfigSeedSecret
 }
 
-func initKindPreset(logger *logrus.Logger, internalKubeconfigPath string) kubermaticv1.Preset {
+func initKindPreset(logger *logrus.Logger, internalKubeconfigPath string, kubeOVNEnabled bool) kubermaticv1.Preset {
 	k, err := os.ReadFile(internalKubeconfigPath)
 	if err != nil {
 		logger.Fatalf("Failed to initialize preset: %v", err)
 	}
 	kindLocalPreset.Spec.Kubevirt.Kubeconfig = base64.StdEncoding.EncodeToString(k)
+	if kubeOVNEnabled {
+		kindLocalPreset.Spec.Kubevirt.VPCName = "ovn-cluster"
+	}
 	return kindLocalPreset
 }
 

--- a/cmd/kubermatic-installer/local_kind_resources.go
+++ b/cmd/kubermatic-installer/local_kind_resources.go
@@ -44,6 +44,13 @@ nodes:
    - containerPort: 32394
      hostPort: 443`
 
+var kindConfigKubeOVNContent = `
+networking:
+  disableDefaultCNI: true
+  kubeProxyMode: "iptables"
+  serviceSubnet: "10.96.0.0/12"
+  podSubnet: "10.244.0.0/16"`
+
 var kindKubermaticNamespace = corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "kubermatic",


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr introduces the option to deploy the kind cluster with kube-ovn as the cni plugin instead of kindnet when using the command `kubermatic-installer local kind`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
By using the flag `kube-ovn-enabled` when running the command `kubermatic-installer local kind` kube-ovn will be deployed as the cni instead of kindnet. Also the kkp preset will be configured with the default vpc.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
