### PR TITLE
(fix): add revision labels to OpenStack CSI addon

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -77,6 +77,9 @@ const (
 	csiAddonName                 = "csi"
 	pvMigrationAnnotation        = "pv.kubernetes.io/migrated-to"
 	defaultStorageClassAddonName = "default-storage-class"
+
+	kindDeployment             = "Deployment"
+	openstackCsiDeploymentName = "openstack-cinder-csi-controllerplugin"
 )
 
 // KubeconfigProvider provides functionality to get a clusters admin kubeconfig.
@@ -992,8 +995,8 @@ func (r *Reconciler) addCSIRevisionLabels(
 	parsedUnstructuredObj *metav1unstructured.Unstructured,
 ) (*metav1unstructured.Unstructured, error) {
 	if cluster == nil || cluster.Spec.Cloud.Openstack == nil ||
-		parsedUnstructuredObj == nil || parsedUnstructuredObj.GetKind() != "Deployment" ||
-		parsedUnstructuredObj.GetName() != "openstack-cinder-csi-controllerplugin" {
+		parsedUnstructuredObj == nil || parsedUnstructuredObj.GetKind() != kindDeployment ||
+		parsedUnstructuredObj.GetName() != openstackCsiDeploymentName {
 		// Currently, we add revision labels to the OpenStack CSI Drivers to restart CSI deployment pods
 		// whenever cloud-config-csi secret, which contains Application Credentials for Openstack, is updated.
 		return parsedUnstructuredObj, nil

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -431,7 +431,7 @@ func TestController_ensureAddonLabelOnManifests(t *testing.T) {
 			Name: "test",
 		},
 	}
-	labeledManifests, err := controller.ensureAddonLabelOnManifests(a, []runtime.RawExtension{manifest})
+	labeledManifests, err := controller.ensureAddonLabelOnManifests(context.Background(), nil, a, []runtime.RawExtension{manifest})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -241,7 +241,7 @@ func (r *Reconciler) ensureAddons(ctx context.Context, log *zap.SugaredLogger, c
 		}
 
 		ensuredAddonsMap.Insert(addon.Name)
-		creators = append(creators, r.addonReconciler(ctx, cluster, addons.Items[i]))
+		creators = append(creators, r.addonReconciler(cluster, addons.Items[i]))
 	}
 
 	if err := reconciling.ReconcileAddons(ctx, creators, cluster.Status.NamespaceName, r); err != nil {
@@ -264,7 +264,7 @@ func (r *Reconciler) ensureAddons(ctx context.Context, log *zap.SugaredLogger, c
 	return nil
 }
 
-func (r *Reconciler) addonReconciler(_ context.Context, cluster *kubermaticv1.Cluster, addon kubermaticv1.Addon) reconciling.NamedAddonReconcilerFactory {
+func (r *Reconciler) addonReconciler(cluster *kubermaticv1.Cluster, addon kubermaticv1.Addon) reconciling.NamedAddonReconcilerFactory {
 	return func() (name string, create reconciling.AddonReconciler) {
 		return addon.Name, func(existing *kubermaticv1.Addon) (*kubermaticv1.Addon, error) {
 			existing.Labels = addon.Labels

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -264,7 +264,7 @@ func (r *Reconciler) ensureAddons(ctx context.Context, log *zap.SugaredLogger, c
 	return nil
 }
 
-func (r *Reconciler) addonReconciler(ctx context.Context, cluster *kubermaticv1.Cluster, addon kubermaticv1.Addon) reconciling.NamedAddonReconcilerFactory {
+func (r *Reconciler) addonReconciler(_ context.Context, cluster *kubermaticv1.Cluster, addon kubermaticv1.Addon) reconciling.NamedAddonReconcilerFactory {
 	return func() (name string, create reconciling.AddonReconciler) {
 		return addon.Name, func(existing *kubermaticv1.Addon) (*kubermaticv1.Addon, error) {
 			existing.Labels = addon.Labels

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -112,7 +112,7 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		return &reconcile.Result{RequeueAfter: clusterIPUnknownRetryTimeout}, nil
 	}
 
-	// check that all secrets are available // New way of handling secrets
+	// check that all secrets are available
 	if err := r.ensureSecrets(ctx, cluster, data); err != nil {
 		return nil, err
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -507,7 +507,7 @@ func (r *Reconciler) GetSecretReconcilers(ctx context.Context, data *resources.T
 	namespace := data.Cluster().Status.NamespaceName
 
 	creators := []reconciling.NamedSecretReconcilerFactory{
-		cloudconfig.SecretReconciler(data, resources.CloudConfigSecretName),
+		cloudconfig.SecretReconciler(data, resources.CloudConfigSeedSecretName),
 		certificates.RootCAReconciler(data),
 		certificates.FrontProxyCAReconciler(),
 		resources.ImagePullSecretReconciler(r.dockerPullConfigJSON),

--- a/pkg/resources/reconciling/modifier/related_revisions.go
+++ b/pkg/resources/reconciling/modifier/related_revisions.go
@@ -46,6 +46,12 @@ func RelatedRevisionsLabels(ctx context.Context, client ctrlruntimeclient.Client
 	}
 }
 
+// AddRevisionLabelsToObject is a helper function that adds revisions of the resources that the given object depends on, to the given object labels.
+// The revision labels are used to trigger a restart of the object when the dependent resources are updated.
+func AddRevisionLabelsToObject(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+	return addRevisionLabelsToObject(ctx, client, obj)
+}
+
 func addRevisionLabelsToObject(ctx context.Context, client ctrlruntimeclient.Client, obj ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 	switch asserted := obj.(type) {
 	case *appsv1.Deployment:


### PR DESCRIPTION


**What this PR does / why we need it**:

Adds revision label support to OpenStack CSI controller deployment to trigger pod restarts when cloud-config-csi secret is updated. This ensures CSI pods are restarted when the cloud-config-csi  secret containing OpenStack Application Credentials is updated.

This PR
- Adds new CSI revision label handling for OpenStack Cinder CSI controller plugin
- Fixes typo in requeue comment


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14216 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds revision label support to OpenStack CSI controller deployment to trigger pod restarts when cloud-config-csi secret is updated.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
