### PR TITLE
Add Cert-manager version v1.16.5 in the default applications catalog

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml
@@ -48,6 +48,13 @@ spec:
           chartVersion: v1.16.3
           url: https://charts.jetstack.io
     version: v1.16.3
+  - template:
+      source:
+        helm:
+          chartName: cert-manager
+          chartVersion: v1.16.5
+          url: https://charts.jetstack.io
+    version: v1.16.5
   defaultValuesBlock: |
     installCRDs: true
   documentationURL: https://cert-manager.io/


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add Cert-manager version v1.16.5 in the default applications catalog which addresses few CVEs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Cert-manager version v1.16.5 in the default applications catalog
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
