### PR TITLE
feat: disable default kubevirt instance types and preferences

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -165,6 +165,11 @@ spec:
                 podSelector: {}
                 policyTypes:
                   - Ingress
+          # DisableDefaultInstanceTypes prevents KKP from automatically creating default instance types.
+          # (standard-2, standard-4, standard-8) in KubeVirt environments.
+          disableDefaultInstanceTypes: false
+          # DisableKubermaticPreferences prevents KKP from setting default KubeVirt preferences.
+          disableDefaultPreferences: false
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
           dnsConfig:

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -168,6 +168,11 @@ spec:
                 podSelector: {}
                 policyTypes:
                   - Ingress
+          # DisableDefaultInstanceTypes prevents KKP from automatically creating default instance types.
+          # (standard-2, standard-4, standard-8) in KubeVirt environments.
+          disableDefaultInstanceTypes: false
+          # DisableKubermaticPreferences prevents KKP from setting default KubeVirt preferences.
+          disableDefaultPreferences: false
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
           dnsConfig:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -902,6 +902,14 @@ spec:
                                     - spec
                                   type: object
                                 type: array
+                              disableDefaultInstanceTypes:
+                                description: |-
+                                  DisableDefaultInstanceTypes prevents KKP from automatically creating default instance types.
+                                  (standard-2, standard-4, standard-8) in KubeVirt environments.
+                                type: boolean
+                              disableDefaultPreferences:
+                                description: DisableKubermaticPreferences prevents KKP from setting default KubeVirt preferences.
+                                type: boolean
                               dnsConfig:
                                 description: |-
                                   DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -151,14 +151,18 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		return cluster, err
 	}
 
-	err = reconcileInstancetypes(ctx, kubevirtNamespace, client)
-	if err != nil {
-		return cluster, err
+	if k.dc != nil && !k.dc.DisableDefaultInstanceTypes {
+		err = reconcileInstancetypes(ctx, kubevirtNamespace, client)
+		if err != nil {
+			return cluster, err
+		}
 	}
 
-	err = reconcilePreferences(ctx, kubevirtNamespace, client)
-	if err != nil {
-		return cluster, err
+	if k.dc != nil && !k.dc.DisableDefaultPreferences {
+		err = reconcilePreferences(ctx, kubevirtNamespace, client)
+		if err != nil {
+			return cluster, err
+		}
 	}
 
 	enableDefaultNetworkPolices := true

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -897,6 +897,11 @@ type DatacenterSpecKubevirt struct {
 	// example, if the storage class has the region `eu` and zone was `central`, the subnet must be in the same region and zone.
 	// otherwise KKP will reject the creation of the machine deployment and eventually the cluster.
 	MatchSubnetAndStorageLocation *bool `json:"matchSubnetAndStorageLocation,omitempty"`
+	// DisableDefaultInstanceTypes prevents KKP from automatically creating default instance types.
+	// (standard-2, standard-4, standard-8) in KubeVirt environments.
+	DisableDefaultInstanceTypes bool `json:"disableDefaultInstanceTypes,omitempty"`
+	// DisableKubermaticPreferences prevents KKP from setting default KubeVirt preferences.
+	DisableDefaultPreferences bool `json:"disableDefaultPreferences,omitempty"`
 }
 
 // ProviderNetwork describes the infra cluster network fabric that is being used.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces two fields in the kubevirt datacenter spec to disable the automatic creation of default kubevirt instance types and preferences

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14415

/kind feature

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add ability to disable automatic installation of default kubevirt instance types and preferences
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
