### PR TITLE
Add support for global viewer role for a user

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -169,7 +169,6 @@ spec:
               required:
                 - admin
                 - email
-                - isGlobalViewer
                 - name
               type: object
             status:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -125,6 +125,12 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                isGlobalViewer:
+                  default: false
+                  description: |-
+                    IsGlobalViewer defines whether this user is a global viewer with read-only access across the KKP dashboard.
+                    GlobalViewer can for example see all projects and clusters in the KKP dashboard.
+                  type: boolean
                 name:
                   description: Name is the full name of this user.
                   type: string
@@ -163,6 +169,7 @@ spec:
               required:
                 - admin
                 - email
+                - isGlobalViewer
                 - name
               type: object
             status:

--- a/pkg/validation/user.go
+++ b/pkg/validation/user.go
@@ -59,6 +59,16 @@ func ValidateUser(u *kubermaticv1.User) field.ErrorList {
 		}
 	}
 
+	// Ensure that `isAdmin` and `globalViewer` are not both true at the same time.
+	// These roles are mutually exclusive — a user can't be both an admin and a global viewer.
+	if isAdminAndGlobalViewer(u.Spec.IsAdmin, u.Spec.IsGlobalViewer) {
+		allErrs = append(allErrs, field.Invalid(
+			field.NewPath("spec"),
+			u.Spec,
+			"`isAdmin` and `globalViewer` cannot both be true",
+		))
+	}
+
 	return allErrs
 }
 
@@ -137,4 +147,11 @@ func ValidateUserDelete(ctx context.Context,
 	}
 
 	return nil
+}
+
+func isAdminAndGlobalViewer(isAdmin, isGlobalViewer bool) bool {
+	if isAdmin && isGlobalViewer {
+		return true
+	}
+	return false
 }

--- a/pkg/validation/user.go
+++ b/pkg/validation/user.go
@@ -61,7 +61,7 @@ func ValidateUser(u *kubermaticv1.User) field.ErrorList {
 
 	// Ensure that `isAdmin` and `globalViewer` are not both true at the same time.
 	// These roles are mutually exclusive — a user can't be both an admin and a global viewer.
-	if isAdminAndGlobalViewer(u.Spec.IsAdmin, u.Spec.IsGlobalViewer) {
+	if isAdminAndGlobalViewer(u.Spec) {
 		allErrs = append(allErrs, field.Invalid(
 			field.NewPath("spec"),
 			u.Spec,
@@ -149,8 +149,8 @@ func ValidateUserDelete(ctx context.Context,
 	return nil
 }
 
-func isAdminAndGlobalViewer(isAdmin, isGlobalViewer bool) bool {
-	if isAdmin && isGlobalViewer {
+func isAdminAndGlobalViewer(userSpec kubermaticv1.UserSpec) bool {
+	if userSpec.IsAdmin && userSpec.IsGlobalViewer {
 		return true
 	}
 	return false

--- a/sdk/apis/kubermatic/v1/user.go
+++ b/sdk/apis/kubermatic/v1/user.go
@@ -79,6 +79,10 @@ type UserSpec struct {
 	// Admins can for example see all projects and clusters in the KKP dashboard.
 	// +kubebuilder:default=false
 	IsAdmin bool `json:"admin"`
+	// IsGlobalViewer defines whether this user is a global viewer with read-only access across the KKP dashboard.
+	// GlobalViewer can for example see all projects and clusters in the KKP dashboard.
+	// +kubebuilder:default=false
+	IsGlobalViewer bool `json:"isGlobalViewer"`
 	// Groups holds the information to which groups the user belongs to. Set automatically when logging in to the
 	// KKP API, and used by the KKP API.
 	Groups []string `json:"groups,omitempty"`

--- a/sdk/apis/kubermatic/v1/user.go
+++ b/sdk/apis/kubermatic/v1/user.go
@@ -82,7 +82,8 @@ type UserSpec struct {
 	// IsGlobalViewer defines whether this user is a global viewer with read-only access across the KKP dashboard.
 	// GlobalViewer can for example see all projects and clusters in the KKP dashboard.
 	// +kubebuilder:default=false
-	IsGlobalViewer bool `json:"isGlobalViewer"`
+	// +optional
+	IsGlobalViewer bool `json:"isGlobalViewer,omitempty"`
 	// Groups holds the information to which groups the user belongs to. Set automatically when logging in to the
 	// KKP API, and used by the KKP API.
 	Groups []string `json:"groups,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces support for a new user role: GlobalViewer.
This role allows platform-level users to access all projects in read-only mode without being explicitly added to each project.
Rather than managing UserProjectBinding CRs, the role is resolved dynamically via middleware by injecting the appropriate viewers-<projectID> groups during request processing.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14242 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
- Reuses the isAdmin-style middleware approach for implementation.
- Avoids static binding pollution by not creating UserProjectBindings for global viewers.
- Ensures mutual exclusivity: `isAdmin` and `isGlobalViewer` cannot both be true (enforced via webhook validation).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for GlobalViewer role. Users marked with isGlobalViewer: true now gain read-only access to all projects without being explicitly added to them. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
