### PR TITLE
use $KUBERMATIC_EXTERNAL_URL while fetching kubeconfig

### DIFF
--- a/hack/run-seed-controller-manager.sh
+++ b/hack/run-seed-controller-manager.sh
@@ -44,7 +44,7 @@ fi
 
 if [ -z "${KUBECONFIG:-}" ]; then
   KUBECONFIG=dev.kubeconfig
-  vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > $KUBECONFIG
+  vault kv get -field=kubeconfig dev/seed-clusters/$KUBERMATIC_EXTERNAL_URL > $KUBECONFIG
 fi
 
 if [ -z "${DOCKERCONFIGJSON:-}" ]; then


### PR DESCRIPTION


**What this PR does / why we need it**:
This PR updates the script `hack/run-seed-controller-manager.sh` and allows the script to fetch kubeconfig based on `KUBERMATIC_EXTERNAL_URL` variable. 
Otherwise, the script always tries to use the kubeconfig of the dev domain, which yields issues if KUBERMATIC_EXTERNAL_URL points to somewhere else.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
