### PR TITLE
verify that no accidental Go upgrades happen in release branches

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -67,12 +67,6 @@ registry.
 The purpose of this is to mirror all images used in a KKP setup
 to prewarm a local Docker registry, for example in offline setups.
 
-## run-ccm-migration-e2e-test-in-kind.sh
-
-This script sets up a local KKP installation in kind, deploys a
-couple of test Presets and Users and then runs the e2e tests for the
-external ccm-migration.
-
 ## run-conformance-tests.sh
 
 Compiles the conformance tests and then runs them in a local Docker

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -204,7 +204,7 @@ Go cache again.
 
 ## verify-go-version.sh
 
-This that when we're in a PR targetting a release branch, the minimum
+This that when we're in a PR targeting a release branch, the minimum
 Go version used to build KKP is not bumped to a different minor version.
 
 ## verify.sh

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -55,15 +55,28 @@ This script compiles the KKP binaries and then builds and pushes all
 container images by using `hack/release-images.sh`. It is only
 useful as part of another script to setup KKP for testing.
 
+## run-addons-integration-test.sh
+
+TBD
+
 ## run-cilium-e2e-test.sh
 
 This script is used as a postsubmit job and updates the dev master
 cluster after every commit to main.
 
+## run-cluster-backup-e2e-tests.sh
+
+TBD
+
 ## run-conformance-tests.sh
 
 After having set up a local KKP installation, this script is then
 used to run the conformance-tester for a given cloud provider.
+
+## run-default-application-e2e-test.sh
+
+This script is used as a postsubmit job and updates the dev master
+cluster after every commit to main.
 
 ## run-dualstack-e2e-test.sh
 
@@ -74,6 +87,10 @@ TBD
 This script sets up a local KKP installation in kind and then
 runs the conformance-tester to create userclusters and check their
 Kubernetes conformance.
+
+## run-encryption-at-rest-tests.sh
+
+TBD
 
 ## run-etcd-launcher-tests.sh
 
@@ -129,6 +146,10 @@ This serves as the precursor for all other tests.
 This script should be sourced, not called, so callers get the variables
 it sets.
 
+## setup-kubermatic-cluster-backup-in-kind.sh
+
+TBD
+
 ## setup-kubermatic-in-kind.sh
 
 This script creates a local kind cluster, compiles the KKP binaries,
@@ -181,6 +202,11 @@ Runs as a postsubmit and refreshes the gocache by downloading the
 previous version, compiling everything and then tar'ing up the
 Go cache again.
 
+## verify-go-version.sh
+
+This that when we're in a PR targetting a release branch, the minimum
+Go version used to build KKP is not bumped to a different minor version.
+
 ## verify.sh
 
 This script is used as a presubmit to check that Helm chart versions
@@ -192,8 +218,3 @@ vars, this script won't run properly.
 This ensures that the Prometheus rules deployed into userclusters
 are valid Prometheus rules.
 
-## run-default-application-e2e-test.sh
-
-This script triggers and monitors Prow jobs for end-to-end (E2E) testing of applications from the default application catalog.
-Each Prow job verifies the successful installation of an ApplicationInstallation object, checks its conditions for a healthy state,
-ensures a Helm release has been deployed, and confirms that the application's pods are running correctly.

--- a/hack/ci/verify-go-version.sh
+++ b/hack/ci/verify-go-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2025 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/ci/verify-go-version.sh
+++ b/hack/ci/verify-go-version.sh
@@ -38,20 +38,34 @@ go_minor_version() {
   grep -E '^go 1' "$1" | sed -E 's/^go (1\.[0-9]+).*$/\1/'
 }
 
-releaseURL="https://github.com/$REPO_OWNER/$REPO_NAME/raw/refs/heads/$TARGET_BRANCH/go.mod"
-wget -O release.go.mod --no-verbose "$releaseURL"
+go_remote_minor_version() {
+  local branch="$1"
+  local modulePath="$2"
 
-currentVersion="$(go_minor_version go.mod)"
-releaseVersion="$(go_minor_version release.go.mod)"
-rm release.go.mod
+  local url="https://github.com/$REPO_OWNER/$REPO_NAME/raw/refs/heads/$branch/${modulePath}go.mod"
+  wget -O tmp.go.mod --quiet "$url"
 
-echo "$TARGET_BRANCH's Go release: $releaseVersion"
-echo "This PR's Go release......: $currentVersion"
+  go_minor_version tmp.go.mod
+  rm tmp.go.mod
+}
+
+newVersions="main module: $(go_minor_version go.mod)"
+branchVersions="main module: $(go_remote_minor_version "$TARGET_BRANCH" "")"
+
+if [ -d sdk ]; then
+  newVersions="$newVersions, SDK module: $(go_minor_version sdk/go.mod)"
+  branchVersions="$branchVersions, SDK module: $(go_remote_minor_version "$TARGET_BRANCH" "sdk/")"
+fi
+
+echo "Go releases:"
+frmt="  %-15s : %s\n"
+printf "$frmt" "$TARGET_BRANCH" "$branchVersions"
+printf "$frmt" "This PR" "$newVersions"
 echo
 
-if [[ "$currentVersion" != "$releaseVersion" ]]; then
-  echo "Go upgrades are not allowed in release branches."
+if [[ "$branchVersions" != "$newVersions" ]]; then
+  echo "Error: Go upgrades are not allowed in release branches."
   exit 1
 fi
 
-echo "go.mod is valid."
+echo "Go modules are valid."

--- a/hack/ci/verify-go-version.sh
+++ b/hack/ci/verify-go-version.sh
@@ -38,18 +38,18 @@ go_minor_version() {
   grep -E '^go 1' "$1" | sed -E 's/^go (1\.[0-9]+).*$/\1/'
 }
 
-currentURL="https://github.com/$REPO_OWNER/$REPO_NAME/raw/refs/heads/$TARGET_BRANCH/go.mod"
-wget -O current.go.mod --no-verbose "$currentURL"
+releaseURL="https://github.com/$REPO_OWNER/$REPO_NAME/raw/refs/heads/$TARGET_BRANCH/go.mod"
+wget -O release.go.mod --no-verbose "$releaseURL"
 
-requested="$(go_minor_version go.mod)"
-current="$(go_minor_version current.go.mod)"
-rm current.go.mod
+currentVersion="$(go_minor_version go.mod)"
+releaseVersion="$(go_minor_version release.go.mod)"
+rm release.go.mod
 
-echo "$TARGET_BRANCH's Go release: $current"
-echo "This PR's Go release......: $requested"
+echo "$TARGET_BRANCH's Go release: $releaseVersion"
+echo "This PR's Go release......: $currentVersion"
 echo
 
-if [[ "$requested" != "$current" ]]; then
+if [[ "$currentVersion" != "$releaseVersion" ]]; then
   echo "Go upgrades are not allowed in release branches."
   exit 1
 fi

--- a/hack/ci/verify-go-version.sh
+++ b/hack/ci/verify-go-version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This that when we're in a PR targetting a release branch, the minimum
+### Go version used to build KKP is not bumped to a different minor version.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+TARGET_BRANCH="${PULL_BASE_REF:-}"
+
+if [ -z "$TARGET_BRANCH" ]; then
+  echo "This check can only work in CI when \$PULL_BASE_REF is set."
+  exit 1
+fi
+
+if ! [[ "$TARGET_BRANCH" =~ ^release/ ]]; then
+  echo "This PR is not targetting a release branch, skipping Go version check."
+  exit 0
+fi
+
+go_minor_version() {
+  grep -E '^go 1' "$1" | sed -E 's/^go (1\.[0-9]+).*$/\1/'
+}
+
+currentURL="https://github.com/$REPO_OWNER/$REPO_NAME/raw/refs/heads/$TARGET_BRANCH/go.mod"
+wget -O current.go.mod --no-verbose "$currentURL"
+
+requested="$(go_minor_version go.mod)"
+current="$(go_minor_version current.go.mod)"
+rm current.go.mod
+
+echo "$TARGET_BRANCH's Go release: $current"
+echo "This PR's Go release......: $requested"
+echo
+
+if [[ "$requested" != "$current" ]]; then
+  echo "Go upgrades are not allowed in release branches."
+  exit 1
+fi
+
+echo "go.mod is valid."

--- a/hack/ci/verify-go-version.sh
+++ b/hack/ci/verify-go-version.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-### This that when we're in a PR targetting a release branch, the minimum
+### This that when we're in a PR targeting a release branch, the minimum
 ### Go version used to build KKP is not bumped to a different minor version.
 
 set -euo pipefail
@@ -30,7 +30,7 @@ if [ -z "$TARGET_BRANCH" ]; then
 fi
 
 if ! [[ "$TARGET_BRANCH" =~ ^release/ ]]; then
-  echo "This PR is not targetting a release branch, skipping Go version check."
+  echo "This PR is not targeting a release branch, skipping Go version check."
   exit 0
 fi
 

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -53,7 +53,7 @@ try() {
     EXIT_CODE=1
   fi
 
-  SUMMARY="$SUMMARY\n$(printf "%-35s %s" "$title" "$status")"
+  SUMMARY="$SUMMARY\n$(printf "%-40s %s" "$title" "$status")"
 
   git reset --hard --quiet
   git clean --force
@@ -82,8 +82,8 @@ echo
 echo "SUMMARY"
 echo "======="
 echo
-echo "Check                               Result"
-echo -n "------------------------------------------"
+echo "Check                                    Result"
+echo -n "-----------------------------------------------"
 echo -e "$SUMMARY"
 
 exit $EXIT_CODE

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -24,13 +24,14 @@ cd $(dirname $0)/../..
 source hack/lib.sh
 
 EXIT_CODE=0
+SUMMARY=
 
 try() {
   local title="$1"
   shift
 
   heading "$title"
-  echo -e "$@\n"
+  echo
 
   start_time=$(date +%s)
 
@@ -42,12 +43,17 @@ try() {
   elapsed_time=$(($(date +%s) - $start_time))
   TEST_NAME="$title" write_junit $exitCode "$elapsed_time"
 
+  local status
   if [[ $exitCode -eq 0 ]]; then
     echo -e "\n[${elapsed_time}s] SUCCESS :)"
+    status=OK
   else
     echo -e "\n[${elapsed_time}s] FAILED."
+    status=FAIL
     EXIT_CODE=1
   fi
+
+  SUMMARY="$SUMMARY\n$(printf "%-35s %s" "$title" "$status")"
 
   git reset --hard --quiet
   git clean --force
@@ -65,10 +71,19 @@ try "Verify Grafana dashboards" ./hack/verify-grafana-dashboards.sh
 try "Verify Prometheus rules" ./hack/verify-prometheus-rules.sh
 try "Verify User Cluster Prometheus rules" ./hack/ci/verify-user-cluster-prometheus-configs.sh
 try "Display Versioning Information" ./hack/versions-gen.sh
+try "Verify Go Version" ./hack/ci/verify-go-version.sh
 
 # -l        list files whose formatting differs from shfmt's
 # -d        error with a diff when the formatting differs
 # -i uint   indent: 0 for tabs (default), >0 for number of spaces
 try "shfmt" shfmt -l -sr -i 2 -d hack
+
+echo
+echo "SUMMARY"
+echo "======="
+echo
+echo "Check                               Result"
+echo -n "------------------------------------------"
+echo -e "$SUMMARY"
 
 exit $EXIT_CODE


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently we ran into issues with the dashboard (https://github.com/kubermatic/dashboard/pull/7308) because we accidentally bumped the minimum required Go version in a KKP release branch.

I think it would be a good idea to prevent Go minor version bumps in releases branches, so this PR adds a new check to the verify job for that. Since this is a mandatory job, a break in this promise would require an /override by an admin (sadly I don't think we can grant this to SIG release).

This PR also adopts a goodie from the kcp world: a summary at the end of the job, making it easier to quickly see which checks in particular failed. This is a cheap knock-off version of doing it correctly (outputting junit xml stuff and whatnot).

**What type of PR is this?**
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
