### PR TITLE
Fix display name for Cluster Autoscaler

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cluster-autoscaler-app.yaml
@@ -23,8 +23,8 @@ kind: ApplicationDefinition
 metadata:
   name: cluster-autoscaler
 spec:
-  description: Cluster autoscaler -  a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes.
-  displayName: Cluster autoscaler
+  description: Cluster Autoscaler -  a component that automatically adjusts the size of a Kubernetes Cluster so that all pods have a place to run and there are no unneeded nodes.
+  displayName: Cluster Autoscaler
   defaultNamespace:
     name: kube-system
     create: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the casing for display name of cluster-autoscaler. It's only used in UI so this doesn't warrant any release note etc.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
