### PR TITLE
Fix Binding location to be in Seed in cluster namespaces

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -85,7 +85,9 @@ declare -A locationMap=(
   ["verticalpodautoscalercheckpoints.autoscaling.k8s.io"]="seed"
 
   ["policytemplates.kubermatic.k8c.io"]="master,seed"
-  ["policybindings.kubermatic.k8c.io"]="usercluster"
+  # PolicyBindings will be deployed on master clusters although they are used on seed cluster namespaces.
+  # This is because the KKP API (running on master) sets up caching rules for PolicyBindings.
+  ["policybindings.kubermatic.k8c.io"]="master,seed"
 )
 
 failure=false

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_policybindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_policybindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    kubermatic.k8c.io/location: usercluster
+    kubermatic.k8c.io/location: master,seed
   name: policybindings.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io


### PR DESCRIPTION
**What this PR does / why we need it**:
PolicyBinding should live in seed in each cluster namespace. The webhooks pr changed this location incorrectly. We should scope it back to Seed and let the policy controllers work with it from seed cluster namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #14326

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
Note: previously it was `["policybindings.kubermatic.k8c.io"]="seed"` but there were issues after the SDK changes, so it was discussed to have master too although, as stated in the comment, PolicyBinding will be used in Seed. That's why I have put it as `["policybindings.kubermatic.k8c.io"]="master,seed"` instead of seed only.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
