### PR TITLE
Rename the default environment variable used in Audit Logging

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -147,7 +147,7 @@ spec:
                             Additional environment variables can be set and passed to the AuditSidecarConfiguration field
                             to allow passing variables to the fluent-bit configuration.
                             Only, `Value` field is supported for the environment variables; `ValueFrom` field is not supported.
-                            By default, `CLUSTER_NAME` is set as an environment variable in the audit-logging sidecar.
+                            By default, `CLUSTER_ID` is set as an environment variable in the audit-logging sidecar.
                           items:
                             description: EnvVar represents an environment variable present in a Container.
                             properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -141,7 +141,7 @@ spec:
                             Additional environment variables can be set and passed to the AuditSidecarConfiguration field
                             to allow passing variables to the fluent-bit configuration.
                             Only, `Value` field is supported for the environment variables; `ValueFrom` field is not supported.
-                            By default, `CLUSTER_NAME` is set as an environment variable in the audit-logging sidecar.
+                            By default, `CLUSTER_ID` is set as an environment variable in the audit-logging sidecar.
                           items:
                             description: EnvVar represents an environment variable present in a Container.
                             properties:

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -58,9 +58,9 @@ import (
 const (
 	CloudProviderExternalFlag = "external"
 
-	// AuditLoggingSidecarEnvClusterName is the name of the environment variable that contains the cluster name
+	// AuditLoggingSidecarEnvClusterID is the name of the environment variable that contains the cluster ID
 	// that is used to identify the cluster for the audit logging sidecar.
-	AuditLoggingSidecarEnvClusterName = "CLUSTER_NAME"
+	AuditLoggingSidecarEnvClusterID = "CLUSTER_ID"
 )
 
 var auditLoggingConfigParserRegex = regexp.MustCompile(`\$\{([a-zA-Z0-9_]+)\}`)
@@ -986,8 +986,8 @@ func (d *TemplateData) GetAuditLoggingSidecarEnvs() []corev1.EnvVar {
 		}
 	}
 
-	envMap[AuditLoggingSidecarEnvClusterName] = corev1.EnvVar{
-		Name:  AuditLoggingSidecarEnvClusterName,
+	envMap[AuditLoggingSidecarEnvClusterID] = corev1.EnvVar{
+		Name:  AuditLoggingSidecarEnvClusterID,
 		Value: c.Name,
 	}
 

--- a/pkg/resources/data_audit_test.go
+++ b/pkg/resources/data_audit_test.go
@@ -107,7 +107,7 @@ func TestParseFluentBitRecords(t *testing.T) {
 									{
 										"Name":   "record_modifier",
 										"Match":  "*",
-										"Record": "cluster ${CLUSTER_NAME}",
+										"Record": "cluster ${CLUSTER_ID}",
 										"Extra":  "value with ${CUSTOM_VAR}",
 									},
 								},
@@ -151,7 +151,7 @@ func TestParseFluentBitRecords(t *testing.T) {
 									{
 										"Name":   "record_modifier",
 										"Match":  "*",
-										"Record": "cluster ${CLUSTER_NAME} in region ${REGION}",
+										"Record": "cluster ${CLUSTER_ID} in region ${REGION}",
 									},
 								},
 							},

--- a/sdk/apis/kubermatic/v1/audit_logging.go
+++ b/sdk/apis/kubermatic/v1/audit_logging.go
@@ -39,7 +39,7 @@ type AuditSidecarSettings struct {
 	// Additional environment variables can be set and passed to the AuditSidecarConfiguration field
 	// to allow passing variables to the fluent-bit configuration.
 	// Only, `Value` field is supported for the environment variables; `ValueFrom` field is not supported.
-	// By default, `CLUSTER_NAME` is set as an environment variable in the audit-logging sidecar.
+	// By default, `CLUSTER_ID` is set as an environment variable in the audit-logging sidecar.
 	ExtraEnvs []corev1.EnvVar `json:"extraEnvs,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the default environment variable CLUSTER_NAME to CLUSTER_ID, as discussed in https://github.com/kubermatic/docs/pull/1864#discussion_r2079578288
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1864
```
