### PR TITLE
Add Audit Logging Configuration on Seed Level

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -63,6 +63,8 @@ spec:
         # APIServerServiceType is the service type used for API Server service `apiserver-external` for the user clusters.
         # By default, the type of service that will be used is determined by the `ExposeStrategy` used for the cluster.
         apiServerServiceType: null
+        # Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
+        auditLogging: null
         # AWS configures an Amazon Web Services (AWS) datacenter.
         aws:
           # List of AMIs to use for a given operating system.
@@ -116,12 +118,14 @@ spec:
         # Edge contains settings for clusters using manually created
         # nodes in edge envs.
         edge: {}
+        # Deprecated: use AuditLogging instead.
         # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
         # Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
         # ignoring cluster-specific settings.
         enforcePodSecurityPolicy: false
+        # Deprecated: use AuditLogging instead.
         # Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
         # ignoring cluster-specific settings.
         enforcedAuditWebhookSettings: null

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: kubermatic
 # Spec describes the configuration of the Seed cluster.
 spec:
+  # Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
+  auditLogging: null
   # Optional: Country of the seed as ISO-3166 two-letter code, e.g. DE or UK.
   # For informational purposes in the Kubermatic dashboard only.
   country: ""
@@ -63,8 +65,6 @@ spec:
         # APIServerServiceType is the service type used for API Server service `apiserver-external` for the user clusters.
         # By default, the type of service that will be used is determined by the `ExposeStrategy` used for the cluster.
         apiServerServiceType: null
-        # Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
-        auditLogging: null
         # AWS configures an Amazon Web Services (AWS) datacenter.
         aws:
           # List of AMIs to use for a given operating system.
@@ -118,14 +118,12 @@ spec:
         # Edge contains settings for clusters using manually created
         # nodes in edge envs.
         edge: {}
-        # Deprecated: use AuditLogging instead.
         # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
         # Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
         # ignoring cluster-specific settings.
         enforcePodSecurityPolicy: false
-        # Deprecated: use AuditLogging instead.
         # Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
         # ignoring cluster-specific settings.
         enforcedAuditWebhookSettings: null

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -63,6 +63,8 @@ spec:
         # APIServerServiceType is the service type used for API Server service `apiserver-external` for the user clusters.
         # By default, the type of service that will be used is determined by the `ExposeStrategy` used for the cluster.
         apiServerServiceType: null
+        # Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
+        auditLogging: null
         # AWS configures an Amazon Web Services (AWS) datacenter.
         aws:
           # List of AMIs to use for a given operating system.
@@ -116,12 +118,14 @@ spec:
         # Edge contains settings for clusters using manually created
         # nodes in edge envs.
         edge: {}
+        # Deprecated: use AuditLogging instead.
         # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
         # Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
         # ignoring cluster-specific settings.
         enforcePodSecurityPolicy: false
+        # Deprecated: use AuditLogging instead.
         # Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
         # ignoring cluster-specific settings.
         enforcedAuditWebhookSettings: null

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: kubermatic
 # Spec describes the configuration of the Seed cluster.
 spec:
+  # Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
+  auditLogging: null
   # Optional: Country of the seed as ISO-3166 two-letter code, e.g. DE or UK.
   # For informational purposes in the Kubermatic dashboard only.
   country: ""
@@ -63,8 +65,6 @@ spec:
         # APIServerServiceType is the service type used for API Server service `apiserver-external` for the user clusters.
         # By default, the type of service that will be used is determined by the `ExposeStrategy` used for the cluster.
         apiServerServiceType: null
-        # Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
-        auditLogging: null
         # AWS configures an Amazon Web Services (AWS) datacenter.
         aws:
           # List of AMIs to use for a given operating system.
@@ -118,14 +118,12 @@ spec:
         # Edge contains settings for clusters using manually created
         # nodes in edge envs.
         edge: {}
-        # Deprecated: use AuditLogging instead.
         # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
         # Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
         # ignoring cluster-specific settings.
         enforcePodSecurityPolicy: false
-        # Deprecated: use AuditLogging instead.
         # Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
         # ignoring cluster-specific settings.
         enforcedAuditWebhookSettings: null

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -1159,7 +1159,7 @@ func hostnameToIPList(ctx context.Context, hostname string) ([]net.IP, error) {
 }
 
 func (r *Reconciler) ensureAuditWebhook(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
-	if data.DC().Spec.AuditLogging != nil && data.DC().Spec.AuditLogging.WebhookBackend != nil {
+	if data.DC().Spec.EnforcedAuditWebhookSettings != nil {
 		// if webhook backend is enabled on the DC then create the auditwebhookconfig secret in the user cluster ns.
 		creators := []reconciling.NamedSecretReconcilerFactory{r.auditWebhookSecretReconciler(ctx, data)}
 		if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r); err != nil {
@@ -1173,13 +1173,13 @@ func (r *Reconciler) ensureAuditWebhook(ctx context.Context, c *kubermaticv1.Clu
 // audit webhook configuration for api server audit logs.
 func (r *Reconciler) auditWebhookSecretReconciler(ctx context.Context, data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return data.DC().Spec.AuditLogging.WebhookBackend.AuditWebhookConfig.Name, func(secret *corev1.Secret) (*corev1.Secret, error) {
+		return data.DC().Spec.EnforcedAuditWebhookSettings.AuditWebhookConfig.Name, func(secret *corev1.Secret) (*corev1.Secret, error) {
 			if secret.Data == nil {
 				secret.Data = map[string][]byte{}
 			}
-			if data.DC().Spec.AuditLogging.WebhookBackend != nil {
+			if data.DC().Spec.EnforcedAuditWebhookSettings != nil {
 				webhookBackendSecret := &corev1.Secret{}
-				err := r.Get(ctx, types.NamespacedName{Name: data.DC().Spec.AuditLogging.WebhookBackend.AuditWebhookConfig.Name, Namespace: data.DC().Spec.AuditLogging.WebhookBackend.AuditWebhookConfig.Namespace}, webhookBackendSecret)
+				err := r.Get(ctx, types.NamespacedName{Name: data.DC().Spec.EnforcedAuditWebhookSettings.AuditWebhookConfig.Name, Namespace: data.DC().Spec.EnforcedAuditWebhookSettings.AuditWebhookConfig.Namespace}, webhookBackendSecret)
 				if err != nil {
 					return secret, err
 				} else {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -1159,7 +1159,7 @@ func hostnameToIPList(ctx context.Context, hostname string) ([]net.IP, error) {
 }
 
 func (r *Reconciler) ensureAuditWebhook(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
-	if data.DC().Spec.EnforcedAuditWebhookSettings != nil {
+	if data.DC().Spec.AuditLogging != nil && data.DC().Spec.AuditLogging.WebhookBackend != nil {
 		// if webhook backend is enabled on the DC then create the auditwebhookconfig secret in the user cluster ns.
 		creators := []reconciling.NamedSecretReconcilerFactory{r.auditWebhookSecretReconciler(ctx, data)}
 		if err := reconciling.ReconcileSecrets(ctx, creators, c.Status.NamespaceName, r); err != nil {
@@ -1173,13 +1173,13 @@ func (r *Reconciler) ensureAuditWebhook(ctx context.Context, c *kubermaticv1.Clu
 // audit webhook configuration for api server audit logs.
 func (r *Reconciler) auditWebhookSecretReconciler(ctx context.Context, data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return data.DC().Spec.EnforcedAuditWebhookSettings.AuditWebhookConfig.Name, func(secret *corev1.Secret) (*corev1.Secret, error) {
+		return data.DC().Spec.AuditLogging.WebhookBackend.AuditWebhookConfig.Name, func(secret *corev1.Secret) (*corev1.Secret, error) {
 			if secret.Data == nil {
 				secret.Data = map[string][]byte{}
 			}
-			if data.DC().Spec.EnforcedAuditWebhookSettings != nil {
+			if data.DC().Spec.AuditLogging.WebhookBackend != nil {
 				webhookBackendSecret := &corev1.Secret{}
-				err := r.Get(ctx, types.NamespacedName{Name: data.DC().Spec.EnforcedAuditWebhookSettings.AuditWebhookConfig.Name, Namespace: data.DC().Spec.EnforcedAuditWebhookSettings.AuditWebhookConfig.Namespace}, webhookBackendSecret)
+				err := r.Get(ctx, types.NamespacedName{Name: data.DC().Spec.AuditLogging.WebhookBackend.AuditWebhookConfig.Name, Namespace: data.DC().Spec.AuditLogging.WebhookBackend.AuditWebhookConfig.Namespace}, webhookBackendSecret)
 				if err != nil {
 					return secret, err
 				} else {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -166,6 +166,240 @@ spec:
                               - NodePort
                               - LoadBalancer
                             type: string
+                          auditLogging:
+                            description: 'Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).'
+                            properties:
+                              enabled:
+                                description: Enabled will enable or disable audit logging.
+                                type: boolean
+                              policyPreset:
+                                description: 'Optional: PolicyPreset can be set to utilize a pre-defined set of audit policy rules.'
+                                enum:
+                                  - ""
+                                  - metadata
+                                  - recommended
+                                  - minimal
+                                type: string
+                              sidecar:
+                                description: 'Optional: Configures the fluent-bit sidecar deployed alongside kube-apiserver.'
+                                properties:
+                                  config:
+                                    description: |-
+                                      AuditSidecarConfiguration defines custom configuration for the fluent-bit sidecar deployed with a kube-apiserver.
+                                      Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
+                                    properties:
+                                      filters:
+                                        items:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        type: array
+                                      outputs:
+                                        items:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        type: array
+                                      service:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      ExtraEnvs are the additional environment variables that can be set for the audit logging sidecar.
+                                      Additional environment variables can be set and passed to the AuditSidecarConfiguration field
+                                      to allow passing variables to the fluent-bit configuration.
+                                      Only, `Value` field is supported for the environment variables; `ValueFrom` field is not supported.
+                                      By default, `CLUSTER_NAME` is set as an environment variable in the audit-logging sidecar.
+                                    items:
+                                      description: EnvVar represents an environment variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select in the specified API version.
+                                                  type: string
+                                              required:
+                                                - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to select'
+                                                  type: string
+                                              required:
+                                                - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                                - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: ResourceRequirements describes the compute resource requirements.
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                            request:
+                                              description: |-
+                                                Request is the name chosen for a request in the referenced claim.
+                                                If empty, everything from the claim is made available, otherwise
+                                                only the result of this request.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                type: object
+                              webhookBackend:
+                                description: 'Optional: Configures the webhook backend for audit logs.'
+                                properties:
+                                  auditWebhookConfig:
+                                    description: 'Required : AuditWebhookConfig contains reference to secret holding the audit webhook config file'
+                                    properties:
+                                      name:
+                                        description: name is unique within a namespace to reference a secret resource.
+                                        type: string
+                                      namespace:
+                                        description: namespace defines the space within which the secret name must be unique.
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  auditWebhookInitialBackoff:
+                                    default: 10s
+                                    type: string
+                                required:
+                                  - auditWebhookConfig
+                                type: object
+                            type: object
                           aws:
                             description: AWS configures an Amazon Web Services (AWS) datacenter.
                             properties:
@@ -256,6 +490,7 @@ spec:
                             type: object
                           enforceAuditLogging:
                             description: |-
+                              Deprecated: use AuditLogging instead.
                               Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
                               ignoring cluster-specific settings.
                             type: boolean
@@ -266,6 +501,7 @@ spec:
                             type: boolean
                           enforcedAuditWebhookSettings:
                             description: |-
+                              Deprecated: use AuditLogging instead.
                               Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
                               ignoring cluster-specific settings.
                             properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -61,6 +61,240 @@ spec:
             spec:
               description: Spec describes the configuration of the Seed cluster.
               properties:
+                auditLogging:
+                  description: 'Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).'
+                  properties:
+                    enabled:
+                      description: Enabled will enable or disable audit logging.
+                      type: boolean
+                    policyPreset:
+                      description: 'Optional: PolicyPreset can be set to utilize a pre-defined set of audit policy rules.'
+                      enum:
+                        - ""
+                        - metadata
+                        - recommended
+                        - minimal
+                      type: string
+                    sidecar:
+                      description: 'Optional: Configures the fluent-bit sidecar deployed alongside kube-apiserver.'
+                      properties:
+                        config:
+                          description: |-
+                            AuditSidecarConfiguration defines custom configuration for the fluent-bit sidecar deployed with a kube-apiserver.
+                            Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
+                          properties:
+                            filters:
+                              items:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              type: array
+                            outputs:
+                              items:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              type: array
+                            service:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        extraEnvs:
+                          description: |-
+                            ExtraEnvs are the additional environment variables that can be set for the audit logging sidecar.
+                            Additional environment variables can be set and passed to the AuditSidecarConfiguration field
+                            to allow passing variables to the fluent-bit configuration.
+                            Only, `Value` field is supported for the environment variables; `ValueFrom` field is not supported.
+                            By default, `CLUSTER_NAME` is set as an environment variable in the audit-logging sidecar.
+                          items:
+                            description: EnvVar represents an environment variable present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                      type: object
+                    webhookBackend:
+                      description: 'Optional: Configures the webhook backend for audit logs.'
+                      properties:
+                        auditWebhookConfig:
+                          description: 'Required : AuditWebhookConfig contains reference to secret holding the audit webhook config file'
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which the secret name must be unique.
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        auditWebhookInitialBackoff:
+                          default: 10s
+                          type: string
+                      required:
+                        - auditWebhookConfig
+                      type: object
+                  type: object
                 country:
                   description: |-
                     Optional: Country of the seed as ISO-3166 two-letter code, e.g. DE or UK.
@@ -166,240 +400,6 @@ spec:
                               - NodePort
                               - LoadBalancer
                             type: string
-                          auditLogging:
-                            description: 'Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).'
-                            properties:
-                              enabled:
-                                description: Enabled will enable or disable audit logging.
-                                type: boolean
-                              policyPreset:
-                                description: 'Optional: PolicyPreset can be set to utilize a pre-defined set of audit policy rules.'
-                                enum:
-                                  - ""
-                                  - metadata
-                                  - recommended
-                                  - minimal
-                                type: string
-                              sidecar:
-                                description: 'Optional: Configures the fluent-bit sidecar deployed alongside kube-apiserver.'
-                                properties:
-                                  config:
-                                    description: |-
-                                      AuditSidecarConfiguration defines custom configuration for the fluent-bit sidecar deployed with a kube-apiserver.
-                                      Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
-                                    properties:
-                                      filters:
-                                        items:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                        type: array
-                                      outputs:
-                                        items:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                        type: array
-                                      service:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  extraEnvs:
-                                    description: |-
-                                      ExtraEnvs are the additional environment variables that can be set for the audit logging sidecar.
-                                      Additional environment variables can be set and passed to the AuditSidecarConfiguration field
-                                      to allow passing variables to the fluent-bit configuration.
-                                      Only, `Value` field is supported for the environment variables; `ValueFrom` field is not supported.
-                                      By default, `CLUSTER_NAME` is set as an environment variable in the audit-logging sidecar.
-                                    items:
-                                      description: EnvVar represents an environment variable present in a Container.
-                                      properties:
-                                        name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
-                                          type: string
-                                        value:
-                                          description: |-
-                                            Variable references $(VAR_NAME) are expanded
-                                            using the previously defined environment variables in the container and
-                                            any service environment variables. If a variable cannot be resolved,
-                                            the reference in the input string will be unchanged. Double $$ are reduced
-                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                            Escaped references will never be expanded, regardless of whether the variable
-                                            exists or not.
-                                            Defaults to "".
-                                          type: string
-                                        valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
-                                          properties:
-                                            configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
-                                              properties:
-                                                key:
-                                                  description: The key to select.
-                                                  type: string
-                                                name:
-                                                  default: ""
-                                                  description: |-
-                                                    Name of the referent.
-                                                    This field is effectively required, but due to backwards compatibility is
-                                                    allowed to be empty. Instances of this type with an empty value here are
-                                                    almost certainly wrong.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  type: string
-                                                optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
-                                                  type: boolean
-                                              required:
-                                                - key
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                            fieldRef:
-                                              description: |-
-                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
-                                              properties:
-                                                apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                                  type: string
-                                                fieldPath:
-                                                  description: Path of the field to select in the specified API version.
-                                                  type: string
-                                              required:
-                                                - fieldPath
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                            resourceFieldRef:
-                                              description: |-
-                                                Selects a resource of the container: only resources limits and requests
-                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
-                                              properties:
-                                                containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  description: 'Required: resource to select'
-                                                  type: string
-                                              required:
-                                                - resource
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                            secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
-                                              properties:
-                                                key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
-                                                  type: string
-                                                name:
-                                                  default: ""
-                                                  description: |-
-                                                    Name of the referent.
-                                                    This field is effectively required, but due to backwards compatibility is
-                                                    allowed to be empty. Instances of this type with an empty value here are
-                                                    almost certainly wrong.
-                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  type: string
-                                                optional:
-                                                  description: Specify whether the Secret or its key must be defined
-                                                  type: boolean
-                                              required:
-                                                - key
-                                              type: object
-                                              x-kubernetes-map-type: atomic
-                                          type: object
-                                      required:
-                                        - name
-                                      type: object
-                                    type: array
-                                  resources:
-                                    description: ResourceRequirements describes the compute resource requirements.
-                                    properties:
-                                      claims:
-                                        description: |-
-                                          Claims lists the names of resources, defined in spec.resourceClaims,
-                                          that are used by this container.
-
-                                          This is an alpha field and requires enabling the
-                                          DynamicResourceAllocation feature gate.
-
-                                          This field is immutable. It can only be set for containers.
-                                        items:
-                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                          properties:
-                                            name:
-                                              description: |-
-                                                Name must match the name of one entry in pod.spec.resourceClaims of
-                                                the Pod where this field is used. It makes that resource available
-                                                inside a container.
-                                              type: string
-                                            request:
-                                              description: |-
-                                                Request is the name chosen for a request in the referenced claim.
-                                                If empty, everything from the claim is made available, otherwise
-                                                only the result of this request.
-                                              type: string
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                        x-kubernetes-list-map-keys:
-                                          - name
-                                        x-kubernetes-list-type: map
-                                      limits:
-                                        additionalProperties:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        description: |-
-                                          Limits describes the maximum amount of compute resources allowed.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                        type: object
-                                      requests:
-                                        additionalProperties:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        description: |-
-                                          Requests describes the minimum amount of compute resources required.
-                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-                                        type: object
-                                    type: object
-                                type: object
-                              webhookBackend:
-                                description: 'Optional: Configures the webhook backend for audit logs.'
-                                properties:
-                                  auditWebhookConfig:
-                                    description: 'Required : AuditWebhookConfig contains reference to secret holding the audit webhook config file'
-                                    properties:
-                                      name:
-                                        description: name is unique within a namespace to reference a secret resource.
-                                        type: string
-                                      namespace:
-                                        description: namespace defines the space within which the secret name must be unique.
-                                        type: string
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  auditWebhookInitialBackoff:
-                                    default: 10s
-                                    type: string
-                                required:
-                                  - auditWebhookConfig
-                                type: object
-                            type: object
                           aws:
                             description: AWS configures an Amazon Web Services (AWS) datacenter.
                             properties:
@@ -490,7 +490,6 @@ spec:
                             type: object
                           enforceAuditLogging:
                             description: |-
-                              Deprecated: use AuditLogging instead.
                               Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
                               ignoring cluster-specific settings.
                             type: boolean
@@ -501,7 +500,6 @@ spec:
                             type: boolean
                           enforcedAuditWebhookSettings:
                             description: |-
-                              Deprecated: use AuditLogging instead.
                               Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
                               ignoring cluster-specific settings.
                             properties:

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -95,12 +95,11 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 	}
 
 	// Set the audit logging settings
-	if datacenter.Spec.AuditLogging != nil {
-		spec.AuditLogging = datacenter.Spec.AuditLogging
+	if seed.Spec.AuditLogging != nil {
+		spec.AuditLogging = seed.Spec.AuditLogging
 	}
 
 	// Enforce audit logging
-	//nolint:staticcheck // Deprecated EnforceAuditLogging, Use AuditLogging instead.
 	if datacenter.Spec.EnforceAuditLogging {
 		if spec.AuditLogging == nil {
 			spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
@@ -109,7 +108,6 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 	}
 
 	// Enforce audit webhook backend
-	//nolint:staticcheck // Deprecated EnforcedAuditWebhookSettings, Use AuditLogging instead.
 	if datacenter.Spec.EnforcedAuditWebhookSettings != nil {
 		spec.AuditLogging.WebhookBackend = datacenter.Spec.EnforcedAuditWebhookSettings
 	}

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -96,7 +96,8 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 
 	// Set the audit logging settings
 	if seed.Spec.AuditLogging != nil {
-		spec.AuditLogging = seed.Spec.AuditLogging
+		spec.AuditLogging = new(kubermaticv1.AuditLoggingSettings)
+		(*seed.Spec.AuditLogging).DeepCopyInto(spec.AuditLogging)
 	}
 
 	// Enforce audit logging

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -94,7 +94,13 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		return fieldErr
 	}
 
+	// Set the audit logging settings
+	if datacenter.Spec.AuditLogging != nil {
+		spec.AuditLogging = datacenter.Spec.AuditLogging
+	}
+
 	// Enforce audit logging
+	//nolint:staticcheck // Deprecated EnforceAuditLogging, Use AuditLogging instead.
 	if datacenter.Spec.EnforceAuditLogging {
 		if spec.AuditLogging == nil {
 			spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
@@ -103,6 +109,7 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 	}
 
 	// Enforce audit webhook backend
+	//nolint:staticcheck // Deprecated EnforcedAuditWebhookSettings, Use AuditLogging instead.
 	if datacenter.Spec.EnforcedAuditWebhookSettings != nil {
 		spec.AuditLogging.WebhookBackend = datacenter.Spec.EnforcedAuditWebhookSettings
 	}

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -320,8 +320,13 @@ type SeedSpec struct {
 	// ManagementProxySettings can be used if the KubeAPI of the user clusters
 	// will not be directly available from kkp and a proxy in between should be used
 	ManagementProxySettings *ManagementProxySettings `json:"managementProxySettings,omitempty"`
+<<<<<<< HEAD
 	// DefaultAPIServerAllowedIPRanges specifies CIDR ranges allowed to access user cluster API servers.
 	DefaultAPIServerAllowedIPRanges []string `json:"defaultAPIServerAllowedIPRanges,omitempty"`
+=======
+	// Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
+	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
+>>>>>>> fce733efe (update)
 }
 
 // EtcdBackupRestore holds the configuration of the automatic backup and restores.
@@ -467,18 +472,13 @@ type DatacenterSpec struct {
 	// exactly (i.e. "example.com" will not match "user@test.example.com").
 	RequiredEmails []string `json:"requiredEmails,omitempty"`
 
-	// Deprecated: use AuditLogging instead.
 	// Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
 	// ignoring cluster-specific settings.
 	EnforceAuditLogging bool `json:"enforceAuditLogging,omitempty"`
 
-	// Deprecated: use AuditLogging instead.
 	// Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
 	// ignoring cluster-specific settings.
 	EnforcedAuditWebhookSettings *AuditWebhookBackendSettings `json:"enforcedAuditWebhookSettings,omitempty"`
-
-	// Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
-	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
 
 	// Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
 	// ignoring cluster-specific settings.

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -467,13 +467,18 @@ type DatacenterSpec struct {
 	// exactly (i.e. "example.com" will not match "user@test.example.com").
 	RequiredEmails []string `json:"requiredEmails,omitempty"`
 
+	// Deprecated: use AuditLogging instead.
 	// Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
 	// ignoring cluster-specific settings.
 	EnforceAuditLogging bool `json:"enforceAuditLogging,omitempty"`
 
+	// Deprecated: use AuditLogging instead.
 	// Optional: EnforcedAuditWebhookSettings allows admins to control webhook backend for audit logs of all the clusters within the DC,
 	// ignoring cluster-specific settings.
 	EnforcedAuditWebhookSettings *AuditWebhookBackendSettings `json:"enforcedAuditWebhookSettings,omitempty"`
+
+	// Optional: AuditLogging empowers admins to centrally configure Kubernetes API audit logging for all user clusters in the seed (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/ ).
+	AuditLogging *AuditLoggingSettings `json:"auditLogging,omitempty"`
 
 	// Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
 	// ignoring cluster-specific settings.

--- a/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2268,6 +2268,11 @@ func (in *DatacenterSpec) DeepCopyInto(out *DatacenterSpec) {
 		*out = new(AuditWebhookBackendSettings)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AuditLogging != nil {
+		in, out := &in.AuditLogging, &out.AuditLogging
+		*out = new(AuditLoggingSettings)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ProviderReconciliationInterval != nil {
 		in, out := &in.ProviderReconciliationInterval, &out.ProviderReconciliationInterval
 		*out = new(metav1.Duration)

--- a/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2268,11 +2268,6 @@ func (in *DatacenterSpec) DeepCopyInto(out *DatacenterSpec) {
 		*out = new(AuditWebhookBackendSettings)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.AuditLogging != nil {
-		in, out := &in.AuditLogging, &out.AuditLogging
-		*out = new(AuditLoggingSettings)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.ProviderReconciliationInterval != nil {
 		in, out := &in.ProviderReconciliationInterval, &out.ProviderReconciliationInterval
 		*out = new(metav1.Duration)
@@ -6994,10 +6989,17 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 		*out = new(ManagementProxySettings)
 		(*in).DeepCopyInto(*out)
 	}
+<<<<<<< HEAD
 	if in.DefaultAPIServerAllowedIPRanges != nil {
 		in, out := &in.DefaultAPIServerAllowedIPRanges, &out.DefaultAPIServerAllowedIPRanges
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+=======
+	if in.AuditLogging != nil {
+		in, out := &in.AuditLogging, &out.AuditLogging
+		*out = new(AuditLoggingSettings)
+		(*in).DeepCopyInto(*out)
+>>>>>>> fce733efe (update)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a new `AuditLogging` field in the Seed API, allowing admins to centrally define default audit logging settings, such as webhook backends and sidecar configurations, for all user clusters, while prioritizing enforcement of datacenter-level settings (`EnforcedAuditWebhookSettings` and `EnforceAuditLogging`).

**Which issue(s) this PR fixes**:
Fixes #14456

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `AuditLogging` configuration on seed level.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
