### PR TITLE
Improve docs

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -429,7 +429,9 @@ spec:
             rhel: ""
             rockylinux: ""
             ubuntu: ""
-  # DefaultAPIServerAllowedIPRanges specifies CIDR ranges allowed to access user cluster API servers.
+  # DefaultAPIServerAllowedIPRanges defines a set of CIDR ranges that are **always appended**
+  # to the API server's allowed IP ranges for all user clusters in this Seed. These ranges
+  # provide a security baseline that cannot be overridden by cluster-specific configurations.
   defaultAPIServerAllowedIPRanges: null
   # DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used
   # to default all new created clusters

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -432,7 +432,9 @@ spec:
             rhel: ""
             rockylinux: ""
             ubuntu: ""
-  # DefaultAPIServerAllowedIPRanges specifies CIDR ranges allowed to access user cluster API servers.
+  # DefaultAPIServerAllowedIPRanges defines a set of CIDR ranges that are **always appended**
+  # to the API server's allowed IP ranges for all user clusters in this Seed. These ranges
+  # provide a security baseline that cannot be overridden by cluster-specific configurations.
   defaultAPIServerAllowedIPRanges: null
   # DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used
   # to default all new created clusters

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1474,7 +1474,10 @@ spec:
                     across all seeds).
                   type: object
                 defaultAPIServerAllowedIPRanges:
-                  description: DefaultAPIServerAllowedIPRanges specifies CIDR ranges allowed to access user cluster API servers.
+                  description: |-
+                    DefaultAPIServerAllowedIPRanges defines a set of CIDR ranges that are **always appended**
+                    to the API server's allowed IP ranges for all user clusters in this Seed. These ranges
+                    provide a security baseline that cannot be overridden by cluster-specific configurations.
                   items:
                     type: string
                   type: array

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -320,7 +320,9 @@ type SeedSpec struct {
 	// ManagementProxySettings can be used if the KubeAPI of the user clusters
 	// will not be directly available from kkp and a proxy in between should be used
 	ManagementProxySettings *ManagementProxySettings `json:"managementProxySettings,omitempty"`
-	// DefaultAPIServerAllowedIPRanges specifies CIDR ranges allowed to access user cluster API servers.
+	// DefaultAPIServerAllowedIPRanges defines a set of CIDR ranges that are **always appended**
+	// to the API server's allowed IP ranges for all user clusters in this Seed. These ranges
+	// provide a security baseline that cannot be overridden by cluster-specific configurations.
 	DefaultAPIServerAllowedIPRanges []string `json:"defaultAPIServerAllowedIPRanges,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the documentation for `defaultAPIServerAllowedIPRanges` field in the seed. Which is responsible on defining the Allowed IP ranges to access the API server of user-cluster on Seed-Level.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14453

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1866
```
