### PR TITLE
skip volumesnapshot validation webhook configuration when csi is disabled

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/deletion.go
@@ -19,6 +19,7 @@ package cloudcontroller
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +31,11 @@ func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resources.CSICloudConfigSecretName,
 				Namespace: namespace,
+			},
+		},
+		&admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resources.CSISnapshotValidationWebhookConfigurationName,
 			},
 		},
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/deletion.go
@@ -33,6 +33,12 @@ func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 				Namespace: namespace,
 			},
 		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSISnapshotWebhookSecretName,
+				Namespace: namespace,
+			},
+		},
 		&admissionregistrationv1.ValidatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: resources.CSISnapshotValidationWebhookConfigurationName,

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -856,7 +856,7 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		)
 	}
 
-	if data.csiCloudConfig != nil {
+	if !data.cluster.Spec.DisableCSIDriver && data.csiCloudConfig != nil {
 		if r.cloudProvider == kubermaticv1.AzureCloudProvider || r.cloudProvider == kubermaticv1.OpenstackCloudProvider || r.cloudProvider == kubermaticv1.VSphereCloudProvider {
 			creators = append(creators, cloudcontroller.CloudConfig(data.csiCloudConfig, resources.CSICloudConfigSecretName))
 		}
@@ -874,8 +874,10 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 		}
 	}
 
-	if r.cloudProvider == kubermaticv1.OpenstackCloudProvider || r.cloudProvider == kubermaticv1.DigitaloceanCloudProvider {
-		creators = append(creators, csisnapshotter.TLSServingCertificateReconciler(resources.CSISnapshotValidationWebhookName, data.caCert))
+	if !data.cluster.Spec.DisableCSIDriver {
+		if r.cloudProvider == kubermaticv1.OpenstackCloudProvider || r.cloudProvider == kubermaticv1.DigitaloceanCloudProvider {
+			creators = append(creators, csisnapshotter.TLSServingCertificateReconciler(resources.CSISnapshotValidationWebhookName, data.caCert))
+		}
 	}
 
 	if r.userSSHKeyAgent {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -687,9 +687,11 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 		creators = append(creators, csimigration.ValidatingwebhookConfigurationReconciler(data.caCert.Cert, metav1.NamespaceSystem, resources.VsphereCSIMigrationWebhookConfigurationWebhookName))
 	}
 
-	if r.cloudProvider == kubermaticv1.VSphereCloudProvider || r.cloudProvider == kubermaticv1.NutanixCloudProvider || r.cloudProvider == kubermaticv1.OpenstackCloudProvider ||
-		r.cloudProvider == kubermaticv1.DigitaloceanCloudProvider {
-		creators = append(creators, csisnapshotter.ValidatingSnapshotWebhookConfigurationReconciler(data.caCert.Cert, metav1.NamespaceSystem, resources.CSISnapshotValidationWebhookConfigurationName))
+	if !data.cluster.Spec.DisableCSIDriver {
+		if r.cloudProvider == kubermaticv1.VSphereCloudProvider || r.cloudProvider == kubermaticv1.NutanixCloudProvider || r.cloudProvider == kubermaticv1.OpenstackCloudProvider ||
+			r.cloudProvider == kubermaticv1.DigitaloceanCloudProvider {
+			creators = append(creators, csisnapshotter.ValidatingSnapshotWebhookConfigurationReconciler(data.caCert.Cert, metav1.NamespaceSystem, resources.CSISnapshotValidationWebhookConfigurationName))
+		}
 	}
 
 	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, creators, "", r); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a condition to skip the deployment of the validating webhook configuration for csi volumesnapshots when `disableCsiDriver` is set to `true` in a cluster spec. The configured service is  in such situations never deployed because this is part of the csi addon. This leads to errors in userclusters when trying to deploy volumesnapshotclasses for custom csi drivers.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where CSI Snapshot validating webhook was being deployed even if the CSI drivers are disabled for a cluster. When the csi driver is disabled after cluster creation the both mentioned resources will be cleaned up now.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
