### PR TITLE
Revert "fix: each openstack cluster reconcile its own router (#14360)"

### DIFF
--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -534,7 +534,32 @@ func reconcileRouter(ctx context.Context, netClient *gophercloud.ServiceClient, 
 		err = attachSubnetsIfNeeded(ctx, netClient, cluster, update)
 		return cluster, err
 	}
-
+	var routerID string
+	// if SubnetID is provided but RouterID not, try to retrieve RouterID
+	if cluster.Spec.Cloud.Openstack.SubnetID != "" {
+		var err error
+		routerID, err = getRouterIDForSubnet(netClient, cluster.Spec.Cloud.Openstack.SubnetID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify that the subnet '%s' has a router attached: %w", cluster.Spec.Cloud.Openstack.SubnetID, err)
+		}
+	}
+	if cluster.Spec.Cloud.Openstack.IPv6SubnetID != "" && routerID == "" {
+		var err error
+		routerID, err = getRouterIDForSubnet(netClient, cluster.Spec.Cloud.Openstack.IPv6SubnetID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to verify that the subnet '%s' has a router attached: %w", cluster.Spec.Cloud.Openstack.IPv6SubnetID, err)
+		}
+	}
+	if routerID != "" {
+		// Update the cluster spec with the new router ID
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+			cluster.Spec.Cloud.Openstack.RouterID = routerID
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to update RouterID in the cluster spec: %w", err)
+		}
+		return cluster, nil
+	}
 	// Router not found by name, create a new router
 	router, err = createRouter(netClient, cluster.Name, cluster.Spec.Cloud.Openstack.FloatingIPPool)
 	if err != nil {


### PR DESCRIPTION
This reverts commit 5be3a5174223b87df726e6043859d6586011de8b.

**What this PR does / why we need it**:
This is a revert of #14360. Reverting the change that forces each cluster to create its own router in the same subnet, as it unnecessarily increases resource usage and complexity. A better approach will be implemented to handle the case in #14058.



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
(revert #14360, please remove release-note from generated changelog.)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
