### PR TITLE
Support shared router across user clusters in the same subnet in Openstack

### DIFF
--- a/pkg/provider/cloud/openstack/routers.go
+++ b/pkg/provider/cloud/openstack/routers.go
@@ -22,9 +22,16 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
+	tags "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
 	osrouters "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 )
 
+// createRouter creates a Neutron router and ensures it is tagged correctly.
+// The router is considered invalid without proper tags:
+//   - OpenStack API does not support creating a router with tags directly;
+//     we must first create the router and then tag the resource.
+//   - If tagging fails, the router is deleted to prevent orphaned resources.
+//   - If deletion after tagging failure also fails, it's a critical error requiring manual intervention.
 func createRouter(netClient *gophercloud.ServiceClient, clusterName, extNetworkName string) (*osrouters.Router, error) {
 	extNetwork, err := getNetworkByName(netClient, extNetworkName, true)
 	if err != nil {
@@ -41,10 +48,31 @@ func createRouter(netClient *gophercloud.ServiceClient, clusterName, extNetworkN
 		AdminStateUp: &iTrue,
 		GatewayInfo:  &gwi,
 	})
-	if res.Err != nil {
-		return nil, res.Err
+
+	router, err := res.Extract()
+	if err != nil {
+		return nil, err
 	}
-	return res.Extract()
+
+	// CRITICAL SECTION: Tagging is mandatory for resource management.
+	// - Tags enable lifecycle tracking (e.g., cleanup, cost allocation)
+	// - Retry tagging up to 3 times with exponential backoff for transient failures
+	err = addTags(netClient, clusterName, router.ID)
+	if err != nil {
+		// FALLBACK: Delete the router if tagging fails
+		// - Prevents orphaned routers without required metadata
+		// - Retry deletion 3 times with exponential backoff (transient failures possible)
+		deleteErr := retryOnError(3, func() error { return deleteRouter(netClient, router.ID) })
+		if deleteErr != nil {
+			return nil, fmt.Errorf(
+				"CRITICAL FAILURE: Router %s created but tagging failed, and deletion also failed: %w (original error: %w)",
+				router.ID, deleteErr, err,
+			)
+		}
+		return nil, fmt.Errorf("failed to tag router (rolled back): %w", err)
+	}
+
+	return router, nil
 }
 
 func getRouterByName(netClient *gophercloud.ServiceClient, name string) (*osrouters.Router, error) {
@@ -123,4 +151,31 @@ func ignoreRouterAlreadyHasPortInSubnetError(err error, subnetID string) error {
 	}
 
 	return nil
+}
+
+func addTags(netClient *gophercloud.ServiceClient, clusterName, routerID string) error {
+	return retryOnError(3, func() error {
+		tagOpts := tags.ReplaceAllOpts{
+			Tags: []string{
+				TagManagedByKubermatic,
+				TagPrefixClusterID + clusterName,
+			},
+		}
+		return tags.ReplaceAll(netClient, ResourceTypeRouter, routerID, tagOpts).Err
+	})
+}
+
+// isManagedRouter checks if a router is managed by Kubermatic KKP.
+func isManagedRouter(netClient *gophercloud.ServiceClient, routerID string) bool {
+	return isManagedResource(netClient, ResourceTypeRouter, routerID)
+}
+func ownTheRouter(netClient *gophercloud.ServiceClient, routerID string, clusterName string) error {
+	return addOwnershipToResource(netClient, ResourceTypeRouter, routerID, clusterName)
+}
+
+func removerRouterOwnership(netClient *gophercloud.ServiceClient, routerID string, clusterName string) error {
+	return removeOwnershipFromResource(netClient, ResourceTypeRouter, routerID, clusterName)
+}
+func getRouterOwners(netClient *gophercloud.ServiceClient, routerID string) ([]string, error) {
+	return getResourceOwners(netClient, ResourceTypeRouter, routerID)
 }

--- a/pkg/provider/cloud/openstack/tags.go
+++ b/pkg/provider/cloud/openstack/tags.go
@@ -58,11 +58,11 @@ func isManagedResource(netClient *gophercloud.ServiceClient, resourceType, resou
 }
 
 func addOwnershipToResource(netClient *gophercloud.ServiceClient, resourceType, resourceID, clusterID string) error {
-	return tags.Add(netClient, resourceType, resourceID, fmt.Sprintf("%s%s", TagPrefixClusterID, clusterID)).ExtractErr()
+	return tags.Add(netClient, resourceType, resourceID, OwnershipTag(clusterID)).ExtractErr()
 }
 
 func removeOwnershipFromResource(netClient *gophercloud.ServiceClient, resourceType, resourceID, clusterID string) error {
-	err := tags.Delete(netClient, resourceType, resourceID, fmt.Sprintf("%s%s", TagPrefixClusterID, clusterID)).ExtractErr()
+	err := tags.Delete(netClient, resourceType, resourceID, OwnershipTag(clusterID)).ExtractErr()
 	if err != nil && !isTagNotFound(err) {
 		return err
 	}
@@ -79,4 +79,8 @@ func getResourceOwners(netClient *gophercloud.ServiceClient, resourceType, resou
 
 func isTagNotFound(err error) bool {
 	return strings.Contains(err.Error(), "TagNotFound")
+}
+
+func OwnershipTag(clusterID string) string {
+	return fmt.Sprintf("%s%s", TagPrefixClusterID, clusterID)
 }

--- a/pkg/provider/cloud/openstack/tags.go
+++ b/pkg/provider/cloud/openstack/tags.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	tags "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+)
+
+// TagPrefixClusterID is the prefix used for tags that track cluster ownership.
+// Example: "cluster-id.k8c.io:cluster1".
+const TagPrefixClusterID = "cluster-id.k8c.io:"
+
+// TagManagedByKubermatic is the tag used to identify resources managed by Kubermatic KKP.
+const TagManagedByKubermatic = "managed-by:kubermatic-kkp"
+
+// ResourceTypeRouter is the resource type used for fetching or managing router tags in OpenStack.
+const ResourceTypeRouter = "routers"
+
+func ownersFromTags(tags []string) []string {
+	clusterIDs := []string{}
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, TagPrefixClusterID) {
+			id := strings.TrimPrefix(tag, TagPrefixClusterID)
+			if id != "" {
+				clusterIDs = append(clusterIDs, id)
+			}
+		}
+	}
+	return clusterIDs
+}
+
+// isManagedResource checks if a resource is managed by Kubermatic KKP.
+// Returns true only if:
+// - The resource exists, and It has the tag "managed-by:kubermatic-kkp"
+// Returns false if:
+// - The resource doesn't exist or The tag check fails due to API errors, or The tag is explicitly not present.
+func isManagedResource(netClient *gophercloud.ServiceClient, resourceType, resourceID string) bool {
+	res, _ := tags.Confirm(netClient, resourceType, resourceID, TagManagedByKubermatic).Extract()
+	return res
+}
+
+func addOwnershipToResource(netClient *gophercloud.ServiceClient, resourceType, resourceID, clusterID string) error {
+	return tags.Add(netClient, resourceType, resourceID, fmt.Sprintf("%s%s", TagPrefixClusterID, clusterID)).ExtractErr()
+}
+
+func removeOwnershipFromResource(netClient *gophercloud.ServiceClient, resourceType, resourceID, clusterID string) error {
+	err := tags.Delete(netClient, resourceType, resourceID, fmt.Sprintf("%s%s", TagPrefixClusterID, clusterID)).ExtractErr()
+	if err != nil && !isTagNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func getResourceOwners(netClient *gophercloud.ServiceClient, resourceType, resourceID string) ([]string, error) {
+	resourceTags, err := tags.List(netClient, resourceType, resourceID).Extract()
+	if err != nil {
+		return nil, err
+	}
+	return ownersFromTags(resourceTags), nil
+}
+
+func isTagNotFound(err error) bool {
+	return strings.Contains(err.Error(), "TagNotFound")
+}

--- a/pkg/provider/cloud/openstack/tags_test.go
+++ b/pkg/provider/cloud/openstack/tags_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestOwnersFromTags(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "Multiple cluster-id tags",
+			input:    []string{"cluster-id.k8c.io:id1", "cluster-id.k8c.io:id2", "cluster-id.k8c.io:id3"},
+			expected: []string{"id1", "id2", "id3"},
+		},
+		{
+			name:     "Single cluster-id tag",
+			input:    []string{"cluster-id.k8c.io:id1"},
+			expected: []string{"id1"},
+		},
+		{
+			name:     "No cluster-id tags",
+			input:    []string{"managed-by:kubermatic", "environment:production"},
+			expected: []string{},
+		},
+		{
+			name:     "Empty cluster-id tag",
+			input:    []string{"cluster-id.k8c.io:"},
+			expected: []string{},
+		},
+		{
+			name:     "Mixed tags with one cluster-id tag",
+			input:    []string{"tag1:value1", "cluster-id.k8c.io:id1", "tag2:value2"},
+			expected: []string{"id1"},
+		},
+		{
+			name:     "Empty input tags slice",
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ownersFromTags(tc.input)
+			if !reflect.DeepEqual(result, tc.expected) {
+				fmt.Println(len(result), len(tc.expected))
+				t.Errorf("\nTest %q failed\nGot:    %v\nWanted: %v", tc.name, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables shared router management for user clusters in the same subnet by introducing ownership tagging (`cluster-id.k8c.io:`). Clusters now reuse existing routers when tagged appropriately, and routers are only deleted once all associated clusters are removed. This reduces resource usage and improves lifecycle handling.


**Scenario:**

* **UC1** is created in existing subnet without a router → new router is created and tagged `cluster-id.k8c.io:UC1`.
* **UC2** and **UC3** are created in the same subnet → detect and reuse the existing router, updating the tags array to `cluster-id.k8c.io:UC1`,`cluster-id.k8c.io:UC2`, and `cluster-id.k8c.io:UC3`.
* On deletion:

  * UC1 → router remains (still used by UC2, UC3)
  * UC2 → router remains (still used by UC3)
  * UC3 → no clusters left → router is deleted.

**Which issue(s) this PR fixes**:
Fixes #14058

**What type of PR is this?**
/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
User-clusters in Openstack can share a router, which is deleted only after all associated clusters are removed.
```

**Documentation**:
```documentation
NONE
```
