### PR TITLE
Fix missing webhook configuration for policytemplate webhook

### DIFF
--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -77,6 +77,9 @@ const (
 	// PoliciesAdmissionWebhookName is the name of the validating webhook that implements deletion policies.
 	PoliciesAdmissionWebhookName = "kubermatic-policies"
 
+	// PolicyTemplateAdmissionWebhookName is the name of the validating webhook for PolicyTemplates.
+	PolicyTemplateAdmissionWebhookName = "kubermatic-policytemplates"
+
 	// we use a shared certificate/CA for all webhooks, because multiple webhooks
 	// run in the same controller manager so it's much easier if they all use the
 	// same certs.

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -191,6 +191,7 @@ func (r *Reconciler) cleanupDeletedConfiguration(ctx context.Context, config *ku
 		common.KubermaticConfigurationAdmissionWebhookName(config),
 		common.GroupProjectBindingAdmissionWebhookName,
 		common.ResourceQuotaAdmissionWebhookName,
+		common.PolicyTemplateAdmissionWebhookName,
 	}
 
 	mutating := []string{
@@ -435,6 +436,7 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 		kubermatic.ResourceQuotaValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		kubermatic.GroupProjectBindingValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		common.PoliciesWebhookConfigurationReconciler(ctx, config, r.Client),
+		common.PolicyTemplateValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 	}
 
 	if !config.Spec.FeatureGates[features.DisableUserSSHKey] {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -691,6 +691,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		common.KubermaticConfigurationAdmissionWebhookReconciler(ctx, cfg, client),
 		kubermaticseed.ClusterValidatingWebhookConfigurationReconciler(ctx, cfg, client),
 		common.ApplicationDefinitionValidatingWebhookConfigurationReconciler(ctx, cfg, client),
+		common.PolicyTemplateValidatingWebhookConfigurationReconciler(ctx, cfg, client),
 		kubermaticseed.IPAMPoolValidatingWebhookConfigurationReconciler(ctx, cfg, client),
 		common.PoliciesWebhookConfigurationReconciler(ctx, cfg, client),
 	}

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -211,6 +211,7 @@ func (r *Reconciler) cleanupDeletedSeed(ctx context.Context, cfg *kubermaticv1.K
 		common.KubermaticConfigurationAdmissionWebhookName(cfg),
 		common.ApplicationDefinitionAdmissionWebhookName,
 		common.PoliciesAdmissionWebhookName,
+		common.PolicyTemplateAdmissionWebhookName,
 		kubermaticseed.ClusterAdmissionWebhookName,
 		kubermaticseed.IPAMPoolAdmissionWebhookName,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The PolicyTemplate webhook was added with this PR: #14432, it is missing registering the webhook for seed and master clusters, where the PolicyTemplate lives.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #14326

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
