### PR TITLE
updates to kkp gitops to use new dex chart instead of homegrown oauth helm chart

### DIFF
--- a/charts/gitops/kkp-argocd-apps/Chart.yaml
+++ b/charts/gitops/kkp-argocd-apps/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gitops/kkp-argocd-apps/templates/argocd-apps-kkp-core.yaml
+++ b/charts/gitops/kkp-argocd-apps/templates/argocd-apps-kkp-core.yaml
@@ -37,18 +37,18 @@ spec:
   - namespace: argocd
     server: https://kubernetes.default.svc
 
-{{ if .Values.oauth.enable }}
+{{ if .Values.dex.enable }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: oauth
+  name: dex
   namespace: argocd
 spec:
   project: default
   sources:
   - repoURL: '{{ .Values.kkpRepoURL }}'
-    path: {{ template "kkp.chart.pathprefix" . }}/charts/oauth
+    path: {{ template "kkp.chart.pathprefix" . }}/charts/dex
     targetRevision: {{ .Values.kkpVersion }}
     helm:
       valueFiles:
@@ -62,11 +62,11 @@ spec:
     ref: values
   destination:
     server: 'https://kubernetes.default.svc'
-    namespace: oauth
+    namespace: dex
   syncPolicy:
     syncOptions:
       - CreateNamespace=true
-  {{- if .Values.oauth.autoSync }}
+  {{- if .Values.dex.autoSync }}
     automated: {}
   {{ end }}
 {{ end }}

--- a/charts/gitops/kkp-argocd-apps/test/realworld.yaml
+++ b/charts/gitops/kkp-argocd-apps/test/realworld.yaml
@@ -26,7 +26,7 @@ nginx:
   enable: true
 certManager:
   enable: true
-oauth:
+dex:
   enable: true
   autoSync: true
 seedSettings:

--- a/charts/gitops/kkp-argocd-apps/test/realworld.yaml.out
+++ b/charts/gitops/kkp-argocd-apps/test/realworld.yaml.out
@@ -261,13 +261,13 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: oauth
+  name: dex
   namespace: argocd
 spec:
   project: default
   sources:
   - repoURL: 'https://github.com/kubermatic/kubermatic.git'
-    path: ./charts/oauth
+    path: ./charts/dex
     targetRevision: notSet
     helm:
       valueFiles:
@@ -281,7 +281,7 @@ spec:
     ref: values
   destination:
     server: 'https://kubernetes.default.svc'
-    namespace: oauth
+    namespace: dex
   syncPolicy:
     syncOptions:
       - CreateNamespace=true

--- a/charts/gitops/kkp-argocd-apps/values.yaml
+++ b/charts/gitops/kkp-argocd-apps/values.yaml
@@ -36,7 +36,7 @@ envSpecificSettingFolderName: settings
 userMlaValuesFileName: values-usermla.yaml
 
 # KKP Core
-oauth:
+dex:
   enable: false
   autoSync: false
 nginx:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR migrates ArgoCD gitops example to dex helmchart - which was introduced in KKP 2.27.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # NA

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
