### PR TITLE
Disable Default OSPs Creation 

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -446,6 +446,10 @@ spec:
     nodePortRange: 30000-32767
     # OperatingSystemManager configures the image repo and the tag version for osm deployment.
     operatingSystemManager:
+      # DisableDefaultOperatingSystemProfiles setting this property to true, would disable the creation of OSMs default
+      # OperatingSystemProfiles and users would need to provide a CustomOperatingSystemProfile to configure user clusters
+      # worker nodes.
+      disableDefaultOperatingSystemProfiles: false
       # ImageRepository is used to override the OperatingSystemManager image repository.
       # It is recommended to use this field only for development, tests and PoC purposes. For production environments.
       # it is not recommended, to use this field due to compatibility with the overall KKP stack.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -446,6 +446,10 @@ spec:
     nodePortRange: 30000-32767
     # OperatingSystemManager configures the image repo and the tag version for osm deployment.
     operatingSystemManager:
+      # DisableDefaultOperatingSystemProfiles setting this property to true, would disable the creation of OSMs default
+      # OperatingSystemProfiles and users would need to provide a CustomOperatingSystemProfile to configure user clusters
+      # worker nodes.
+      disableDefaultOperatingSystemProfiles: false
       # ImageRepository is used to override the OperatingSystemManager image repository.
       # It is recommended to use this field only for development, tests and PoC purposes. For production environments.
       # it is not recommended, to use this field due to compatibility with the overall KKP stack.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -2424,6 +2424,12 @@ spec:
                     operatingSystemManager:
                       description: OperatingSystemManager configures the image repo and the tag version for osm deployment.
                       properties:
+                        disableDefaultOperatingSystemProfiles:
+                          description: |-
+                            DisableDefaultOperatingSystemProfiles setting this property to true, would disable the creation of OSMs default
+                            OperatingSystemProfiles and users would need to provide a CustomOperatingSystemProfile to configure user clusters
+                            worker nodes.
+                          type: boolean
                         imageRepository:
                           description: |-
                             ImageRepository is used to override the OperatingSystemManager image repository.

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -424,6 +424,10 @@ func (d *TemplateData) OperatingSystemManagerImageRepository() string {
 	return d.config.Spec.UserCluster.OperatingSystemManager.ImageRepository
 }
 
+func (d *TemplateData) OperatingSystemManagerDefaultOSPsDisabled() bool {
+	return d.config.Spec.UserCluster.OperatingSystemManager.DisableDefaultOperatingSystemProfiles
+}
+
 // ClusterIPByServiceName returns the ClusterIP as string for the
 // Service specified by `name`. Service lookup happens within
 // `Cluster.Status.NamespaceName`. When ClusterIP fails to parse

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -57,7 +57,7 @@ var (
 )
 
 const (
-	Tag = "f21192a17b6fe02239f67461c3ae3c2a315a4513"
+	Tag = "f25b0645bb456e76a2b94971b8c63a62ed9deb45"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -70,6 +70,7 @@ type operatingSystemManagerData interface {
 	ComputedNodePortRange() string
 	OperatingSystemManagerImageTag() string
 	OperatingSystemManagerImageRepository() string
+	OperatingSystemManagerDefaultOSPsDisabled() bool
 }
 
 // DeploymentReconciler returns the function to create and update the operating system manager deployment.
@@ -295,6 +296,10 @@ func getFlags(data operatingSystemManagerData, cs *clusterSpec) []string {
 
 	if imagePullSecret := data.Cluster().Spec.ImagePullSecret; imagePullSecret != nil {
 		flags = append(flags, "-node-registry-credentials-secret", fmt.Sprintf("%s/%s", imagePullSecret.Namespace, imagePullSecret.Name))
+	}
+
+	if disableDefaultOSP := data.OperatingSystemManagerDefaultOSPsDisabled(); disableDefaultOSP {
+		flags = append(flags, "-disable-default-osps")
 	}
 
 	return flags

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:f21192a17b6fe02239f67461c3ae3c2a315a4513
+        image: quay.io/kubermatic/operating-system-manager:f25b0645bb456e76a2b94971b8c63a62ed9deb45
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/sdk/apis/kubermatic/v1/configuration.go
+++ b/sdk/apis/kubermatic/v1/configuration.go
@@ -335,6 +335,10 @@ type OperatingSystemManager struct {
 	// It is recommended to use this field only for development, tests and PoC purposes. For production environments.
 	// it is not recommended, to use this field due to compatibility with the overall KKP stack.
 	ImageTag string `json:"imageTag,omitempty"`
+	// DisableDefaultOperatingSystemProfiles setting this property to true, would disable the creation of OSMs default
+	// OperatingSystemProfiles and users would need to provide a CustomOperatingSystemProfile to configure user clusters
+	// worker nodes.
+	DisableDefaultOperatingSystemProfiles bool `json:"disableDefaultOperatingSystemProfiles,omitempty"`
 }
 
 // KubermaticAddonConfiguration describes the addons for a given cluster runtime.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps OperatingSystsemManager in KKP and also adds a new property in the KubermaticConfigurations under OSM, that disables the creation of the OSM default OSPs. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support disabling  default OperatingSystemProfiles in user clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1873
```
