### PR TITLE
[release/v2.25] verify that no accidental Go upgrades happen in release branches (#14451)

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -66,12 +66,6 @@ registry.
 The purpose of this is to mirror all images used in a KKP setup
 to prewarm a local Docker registry, for example in offline setups.
 
-## run-ccm-migration-e2e-test-in-kind.sh
-
-This script sets up a local KKP installation in kind, deploys a
-couple of test Presets and Users and then runs the e2e tests for the
-external ccm-migration.
-
 ## run-conformance-tests.sh
 
 Compiles the conformance tests and then runs them in a local Docker

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -79,15 +79,28 @@ This script sets up a local KKP installation in kind, deploys a
 couple of test Presets and Users and then runs the e2e tests for the
 API.
 
+## run-addons-integration-test.sh
+
+TBD
+
 ## run-cilium-e2e-test.sh
 
 This script is used as a postsubmit job and updates the dev master
 cluster after every commit to main.
 
+## run-cluster-backup-e2e-tests.sh
+
+TBD
+
 ## run-conformance-tests.sh
 
 After having set up a local KKP installation, this script is then
 used to run the conformance-tester for a given cloud provider.
+
+## run-default-application-e2e-test.sh
+
+This script is used as a postsubmit job and updates the dev master
+cluster after every commit to main.
 
 ## run-dualstack-e2e-test.sh
 
@@ -98,6 +111,10 @@ TBD
 This script sets up a local KKP installation in kind and then
 runs the conformance-tester to create userclusters and check their
 Kubernetes conformance.
+
+## run-encryption-at-rest-tests.sh
+
+TBD
 
 ## run-etcd-launcher-tests.sh
 
@@ -153,6 +170,10 @@ This serves as the precursor for all other tests.
 This script should be sourced, not called, so callers get the variables
 it sets.
 
+## setup-kubermatic-cluster-backup-in-kind.sh
+
+TBD
+
 ## setup-kubermatic-in-kind.sh
 
 This script creates a local kind cluster, compiles the KKP binaries,
@@ -205,6 +226,11 @@ files, like CRD examples and the Prometheus runbook.
 Runs as a postsubmit and refreshes the gocache by downloading the
 previous version, compiling everything and then tar'ing up the
 Go cache again.
+
+## verify-go-version.sh
+
+This that when we're in a PR targeting a release branch, the minimum
+Go version used to build KKP is not bumped to a different minor version.
 
 ## verify.sh
 

--- a/hack/ci/verify-go-version.sh
+++ b/hack/ci/verify-go-version.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This that when we're in a PR targeting a release branch, the minimum
+### Go version used to build KKP is not bumped to a different minor version.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+TARGET_BRANCH="${PULL_BASE_REF:-}"
+
+if [ -z "$TARGET_BRANCH" ]; then
+  echo "This check can only work in CI when \$PULL_BASE_REF is set."
+  exit 1
+fi
+
+if ! [[ "$TARGET_BRANCH" =~ ^release/ ]]; then
+  echo "This PR is not targeting a release branch, skipping Go version check."
+  exit 0
+fi
+
+go_minor_version() {
+  grep -E '^go 1' "$1" | sed -E 's/^go (1\.[0-9]+).*$/\1/'
+}
+
+go_remote_minor_version() {
+  local branch="$1"
+  local modulePath="$2"
+
+  local url="https://github.com/$REPO_OWNER/$REPO_NAME/raw/refs/heads/$branch/${modulePath}go.mod"
+  wget -O tmp.go.mod --quiet "$url"
+
+  go_minor_version tmp.go.mod
+  rm tmp.go.mod
+}
+
+newVersions="main module: $(go_minor_version go.mod)"
+branchVersions="main module: $(go_remote_minor_version "$TARGET_BRANCH" "")"
+
+if [ -d sdk ]; then
+  newVersions="$newVersions, SDK module: $(go_minor_version sdk/go.mod)"
+  branchVersions="$branchVersions, SDK module: $(go_remote_minor_version "$TARGET_BRANCH" "sdk/")"
+fi
+
+echo "Go releases:"
+frmt="  %-15s : %s\n"
+printf "$frmt" "$TARGET_BRANCH" "$branchVersions"
+printf "$frmt" "This PR" "$newVersions"
+echo
+
+if [[ "$branchVersions" != "$newVersions" ]]; then
+  echo "Error: Go upgrades are not allowed in release branches."
+  exit 1
+fi
+
+echo "Go modules are valid."

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -24,13 +24,14 @@ cd $(dirname $0)/../..
 source hack/lib.sh
 
 EXIT_CODE=0
+SUMMARY=
 
 try() {
   local title="$1"
   shift
 
   heading "$title"
-  echo -e "$@\n"
+  echo
 
   start_time=$(date +%s)
 
@@ -42,12 +43,17 @@ try() {
   elapsed_time=$(($(date +%s) - $start_time))
   TEST_NAME="$title" write_junit $exitCode "$elapsed_time"
 
+  local status
   if [[ $exitCode -eq 0 ]]; then
     echo -e "\n[${elapsed_time}s] SUCCESS :)"
+    status=OK
   else
     echo -e "\n[${elapsed_time}s] FAILED."
+    status=FAIL
     EXIT_CODE=1
   fi
+
+  SUMMARY="$SUMMARY\n$(printf "%-40s %s" "$title" "$status")"
 
   git reset --hard --quiet
   git clean --force
@@ -65,10 +71,19 @@ try "Verify Grafana dashboards" ./hack/verify-grafana-dashboards.sh
 try "Verify Prometheus rules" ./hack/verify-prometheus-rules.sh
 try "Verify User Cluster Prometheus rules" ./hack/ci/verify-user-cluster-prometheus-configs.sh
 try "Display Versioning Information" ./hack/versions-gen.sh
+try "Verify Go Version" ./hack/ci/verify-go-version.sh
 
 # -l        list files whose formatting differs from shfmt's
 # -d        error with a diff when the formatting differs
 # -i uint   indent: 0 for tabs (default), >0 for number of spaces
 try "shfmt" shfmt -l -sr -i 2 -d hack
+
+echo
+echo "SUMMARY"
+echo "======="
+echo
+echo "Check                                    Result"
+echo -n "-----------------------------------------------"
+echo -e "$SUMMARY"
 
 exit $EXIT_CODE


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #14451.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
