### PR TITLE
Support Kubevirt Cloud Provider Load Balancer Disabling  

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -35,7 +35,7 @@ const (
 	kubevirtCPUs               = 2
 	kubevirtMemory             = "4Gi"
 	kubevirtDiskSize           = "25Gi"
-	kubevirtStorageClassName   = "rook-ceph-block"
+	kubevirtStorageClassName   = "local-path"
 )
 
 type kubevirtScenario struct {

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	kubevirtStorageClassName = "kubevirt-rook-ceph-block"
+	kubevirtStorageClassName = "kubevirt-local-path"
 )
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -153,6 +153,8 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
+          # Optional: indicates if the ccm should create and manage the clusters load balancers.
+          ccmLoadBalancerEnabled: null
           # Optional: indicates if region and zone labels from the cloud provider should be fetched.
           ccmZoneAndRegionEnabled: null
           # CSIDriverOperator configures the kubevirt csi driver operator in the user cluster such as the csi driver images overwriting.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -156,6 +156,8 @@ spec:
         kubelb: null
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
+          # Optional: indicates if the ccm should create and manage the clusters load balancers.
+          ccmLoadBalancerEnabled: null
           # Optional: indicates if region and zone labels from the cloud provider should be fetched.
           ccmZoneAndRegionEnabled: null
           # CSIDriverOperator configures the kubevirt csi driver operator in the user cluster such as the csi driver images overwriting.

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -152,10 +152,24 @@ spec:
         kubevirt:
           dnsConfig:
             nameservers:
-              - 8.8.8.8
+              - 1.1.1.1
+          dnsPolicy: None
           infraStorageClasses:
+            - isDefaultClass: false
+              name: longhorn
             - isDefaultClass: true
               name: local-path
+          matchSubnetAndStorageLocation: false
+          namespacedMode:
+            enabled: true
+            name: kkp-e2e-tests
+          providerNetwork:
+            name: kcs
+            vpcs:
+              - name: ovn-cluster
+                subnets:
+                  - name: external
+                  - name: ovn-default
     syseleven-dbl1:
       country: DE
       location: Syseleven - dbl1

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -655,6 +655,9 @@ spec:
                           kubevirt:
                             description: Kubevirt configures a KubeVirt datacenter.
                             properties:
+                              ccmLoadBalancerEnabled:
+                                description: 'Optional: indicates if the ccm should create and manage the clusters load balancers.'
+                                type: boolean
                               ccmZoneAndRegionEnabled:
                                 description: 'Optional: indicates if region and zone labels from the cloud provider should be fetched.'
                                 type: boolean

--- a/pkg/resources/cloudconfig/kubevirt/cloudconfig.go
+++ b/pkg/resources/cloudconfig/kubevirt/cloudconfig.go
@@ -29,10 +29,17 @@ type CloudConfig struct {
 	Namespace string `yaml:"namespace"`
 	// InstancesV2 used in KubeVirt cloud-controller-manager as metadata information about the infra cluster nodes
 	InstancesV2 InstancesV2 `yaml:"instancesV2"`
+	// LoadBalancer configures cloud-controller-manager LoadBalancer interface configurations.
+	LoadBalancer LoadBalancer `yaml:"loadBalancer"`
 }
 
 type InstancesV2 struct {
 	ZoneAndRegionEnabled bool `yaml:"zoneAndRegionEnabled"`
+}
+
+type LoadBalancer struct {
+	// Enabled activates the load balancer interface of the CCM
+	Enabled bool `yaml:"enabled"`
 }
 
 func ForCluster(cluster *kubermaticv1.Cluster, dc *kubermaticv1.Datacenter) CloudConfig {
@@ -41,6 +48,9 @@ func ForCluster(cluster *kubermaticv1.Cluster, dc *kubermaticv1.Datacenter) Clou
 		Namespace:  cluster.Status.NamespaceName,
 		InstancesV2: InstancesV2{
 			ZoneAndRegionEnabled: true,
+		},
+		LoadBalancer: LoadBalancer{
+			Enabled: true,
 		},
 	}
 
@@ -52,6 +62,12 @@ func ForCluster(cluster *kubermaticv1.Cluster, dc *kubermaticv1.Datacenter) Clou
 		dc.Spec.Kubevirt.CCMZoneAndRegionEnabled != nil &&
 		!*dc.Spec.Kubevirt.CCMZoneAndRegionEnabled {
 		cloudConfig.InstancesV2.ZoneAndRegionEnabled = false
+	}
+
+	if dc.Spec.Kubevirt != nil &&
+		dc.Spec.Kubevirt.CCMLoadBalancerEnabled != nil &&
+		!*dc.Spec.Kubevirt.CCMLoadBalancerEnabled {
+		cloudConfig.LoadBalancer.Enabled = false
 	}
 
 	return cloudConfig

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	KubeVirtCCMDeploymentName = "kubevirt-cloud-controller-manager"
-	KubeVirtCCMTag            = "v0.4.0"
+	KubeVirtCCMTag            = "v0.5.1"
 )
 
 var (
@@ -87,7 +87,7 @@ func kubevirtDeploymentReconciler(data *resources.TemplateData) reconciling.Name
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/kubevirt-cloud-controller-manager:" + KubeVirtCCMTag)),
+					Image:        registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubevirt/kubevirt-cloud-controller-manager:" + KubeVirtCCMTag)),
 					Command:      []string{"/bin/kubevirt-cloud-controller-manager"},
 					Args:         getKVFlags(data),
 					Env:          getEnvVars(),

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -896,6 +896,9 @@ type DatacenterSpecKubevirt struct {
 	// Optional: indicates if region and zone labels from the cloud provider should be fetched.
 	CCMZoneAndRegionEnabled *bool `json:"ccmZoneAndRegionEnabled,omitempty"`
 
+	// Optional: indicates if the ccm should create and manage the clusters load balancers.
+	CCMLoadBalancerEnabled *bool `json:"ccmLoadBalancerEnabled,omitempty"`
+
 	// VMEvictionStrategy describes the strategy to follow when a node drain occurs. If not set the default
 	// value is External and the VM will be protected by a PDB.
 	VMEvictionStrategy kubevirtv1.EvictionStrategy `json:"vmEvictionStrategy,omitempty"`

--- a/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2539,6 +2539,11 @@ func (in *DatacenterSpecKubevirt) DeepCopyInto(out *DatacenterSpecKubevirt) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CCMLoadBalancerEnabled != nil {
+		in, out := &in.CCMLoadBalancerEnabled, &out.CCMLoadBalancerEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.CSIDriverOperator != nil {
 		in, out := &in.CSIDriverOperator, &out.CSIDriverOperator
 		*out = new(KubeVirtCSIDriverOperator)


### PR DESCRIPTION
**What this PR does / why we need it**:
If users decides to use a different load balancer controllers such KubeLB, KubeVirt CCM should not try to operate and create a load balancer in the KubeVirt infra. This PR support the disabling of the load balancer interface in the KubeVirt cloud provider.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KubeVirt CCM Load Balancer Interface Disabling 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1874
```
