### PR TITLE
mla-secrets: enable safe redeployments

### DIFF
--- a/charts/mla/mla-secrets/Chart.yaml
+++ b/charts/mla/mla-secrets/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: mla-secrets
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0
 description: A Helm chart to manage MLA (Monitoring, Logging, Alerting) related secrets.
 keywords:

--- a/charts/mla/mla-secrets/templates/grafana-secret.yaml
+++ b/charts/mla/mla-secrets/templates/grafana-secret.yaml
@@ -22,7 +22,7 @@ type: Opaque
 data:
   admin-user: {{ index $secret "admin-user" | default ( .Values.mlaSecrets.grafana.adminUser | b64enc | quote ) }}
   admin-password: {{ index $secret "admin-password" | default ( .Values.mlaSecrets.grafana.adminPassword | default ( randAlphaNum 40 ) | b64enc | quote ) }}
-  {{- if and .Values.mlaSecrets.grafana.ldap.enabled .Values.mlaSecrets.grafana.ldap.config }}
+  {{- if or (index $secret "ldap-toml") (and .Values.mlaSecrets.grafana.ldap.enabled .Values.mlaSecrets.grafana.ldap.config) }}
   ldap-toml: {{ index $secret "ldap-toml" | default ( tpl .Values.mlaSecrets.grafana.ldap.config $ | b64enc | quote ) }}
   {{- end }}
 {{- end }}

--- a/charts/mla/mla-secrets/templates/grafana-secret.yaml
+++ b/charts/mla/mla-secrets/templates/grafana-secret.yaml
@@ -13,28 +13,16 @@
 # limitations under the License.
 
 {{- if .Values.mlaSecrets.grafana.enabled }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace "grafana" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "grafana").data | default (dict) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: grafana
 type: Opaque
 data:
-{{- if not $secret }}
-  admin-user: {{ .Values.mlaSecrets.grafana.adminUser | b64enc | quote }}
-  {{- if .Values.mlaSecrets.grafana.adminPassword }}
-  admin-password: {{ .Values.mlaSecrets.grafana.adminPassword | b64enc | quote }}
-  {{- else }}
-  admin-password: {{ randAlphaNum 40 | b64enc | quote }}
-  {{- end }}
+  admin-user: {{ index $secret "admin-user" | default ( .Values.mlaSecrets.grafana.adminUser | b64enc | quote ) }}
+  admin-password: {{ index $secret "admin-password" | default ( .Values.mlaSecrets.grafana.adminPassword | default ( randAlphaNum 40 ) | b64enc | quote ) }}
   {{- if and .Values.mlaSecrets.grafana.ldap.enabled .Values.mlaSecrets.grafana.ldap.config }}
-  ldap-toml: {{ tpl .Values.mlaSecrets.grafana.ldap.config $ | b64enc | quote }}
+  ldap-toml: {{ index $secret "ldap-toml" | default ( tpl .Values.mlaSecrets.grafana.ldap.config $ | b64enc | quote ) }}
   {{- end }}
-{{- else }}
-  admin-user: {{ index $secret.data "admin-user" }}
-  admin-password: {{ index $secret.data "admin-password" }}
-  {{- if index $secret.data "ldap-toml" }}
-  ldap-toml: {{ index $secret.data "ldap-toml" }}
-  {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/mla/mla-secrets/templates/grafana-secret.yaml
+++ b/charts/mla/mla-secrets/templates/grafana-secret.yaml
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 {{- if .Values.mlaSecrets.grafana.enabled }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace "grafana" }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: grafana
 type: Opaque
 data:
+{{- if not $secret }}
   admin-user: {{ .Values.mlaSecrets.grafana.adminUser | b64enc | quote }}
   {{- if .Values.mlaSecrets.grafana.adminPassword }}
   admin-password: {{ .Values.mlaSecrets.grafana.adminPassword | b64enc | quote }}
@@ -28,4 +30,11 @@ data:
   {{- if and .Values.mlaSecrets.grafana.ldap.enabled .Values.mlaSecrets.grafana.ldap.config }}
   ldap-toml: {{ tpl .Values.mlaSecrets.grafana.ldap.config $ | b64enc | quote }}
   {{- end }}
+{{- else }}
+  admin-user: {{ index $secret.data "admin-user" }}
+  admin-password: {{ index $secret.data "admin-password" }}
+  {{- if index $secret.data "ldap-toml" }}
+  ldap-toml: {{ index $secret.data "ldap-toml" }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/mla/mla-secrets/templates/minio-secret.yaml
+++ b/charts/mla/mla-secrets/templates/minio-secret.yaml
@@ -13,50 +13,30 @@
 # limitations under the License.
 
 {{- if .Values.mlaSecrets.minio.enabled }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace "minio" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "minio").data | default (dict) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: minio
 type: Opaque
 data:
-{{- if not $secret }}
-  rootUser: {{ if .Values.mlaSecrets.minio.accessKey }}{{ .Values.mlaSecrets.minio.accessKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
-  rootPassword: {{ if .Values.mlaSecrets.minio.secretKey }}{{ .Values.mlaSecrets.minio.secretKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
+  rootUser: {{ index $secret "rootUser" | default ( .Values.mlaSecrets.minio.accessKey | default ( randAlphaNum 20 ) | toString | b64enc | quote ) }}
+  rootPassword: {{ index $secret "rootPassword" | default ( .Values.mlaSecrets.minio.secretKey | default ( randAlphaNum 40 ) | toString | b64enc | quote ) }}
   {{- if and .Values.mlaSecrets.minio.gcsgateway.enabled .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson }}
-  gcs_key.json: {{ .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson | toString | b64enc | quote }}
+  gcs_key.json: {{ index $secret "gcs_key.json" | default ( .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson | toString | b64enc | quote ) }}
   {{- end }}
   {{- if .Values.mlaSecrets.minio.s3gateway.enabled }}
     {{- if .Values.mlaSecrets.minio.s3gateway.accessKey }}
-  awsAccessKeyId: {{ .Values.mlaSecrets.minio.s3gateway.accessKey | toString | b64enc | quote }}
+  awsAccessKeyId: {{ index $secret "awsAccessKeyId" | default ( .Values.mlaSecrets.minio.s3gateway.accessKey | toString | b64enc | quote ) }}
     {{- end }}
     {{- if .Values.mlaSecrets.minio.s3gateway.secretKey }}
-  awsSecretAccessKey: {{ .Values.mlaSecrets.minio.s3gateway.secretKey | toString | b64enc | quote }}
+  awsSecretAccessKey: {{ index $secret "awsSecretAccessKey" | default ( .Values.mlaSecrets.minio.s3gateway.secretKey | toString | b64enc | quote ) }}
     {{- end }}
   {{- end }}
   {{- if .Values.mlaSecrets.minio.etcd.clientCert }}
-  etcd_client_cert.pem: {{ .Values.mlaSecrets.minio.etcd.clientCert | toString | b64enc | quote }}
+  etcd_client_cert.pem: {{ index $secret "etcd_client_cert.pem" | default ( .Values.mlaSecrets.minio.etcd.clientCert | toString | b64enc | quote ) }}
   {{- end }}
   {{- if .Values.mlaSecrets.minio.etcd.clientCertKey }}
-  etcd_client_cert_key.pem: {{ .Values.mlaSecrets.minio.etcd.clientCertKey | toString | b64enc | quote }}
+  etcd_client_cert_key.pem: {{ index $secret "etcd_client_cert_key.pem" | default ( .Values.mlaSecrets.minio.etcd.clientCertKey | toString | b64enc | quote ) }}
   {{- end }}
-{{- else }}
-  rootUser: {{ index $secret.data "rootUser" }}
-  rootPassword: {{ index $secret.data "rootPassword" }}
-  {{- if index $secret.data "gcs_key.json" }}
-  gcs_key.json: {{ index $secret.data "gcs_key.json" }}
-  {{- end }}
-  {{- if index $secret.data "awsAccessKeyId" }}
-  awsAccessKeyId: {{ index $secret.data "awsAccessKeyId" }}
-  {{- end }}
-  {{- if index $secret.data "awsSecretAccessKey" }}
-  awsSecretAccessKey: {{ index $secret.data "awsSecretAccessKey" }}
-  {{- end }}
-  {{- if index $secret.data "etcd_client_cert.pem" }}
-  etcd_client_cert.pem: {{ index $secret.data "etcd_client_cert.pem" }}
-  {{- end }}
-  {{- if index $secret.data "etcd_client_cert_key.pem" }}
-  etcd_client_cert_key.pem: {{ index $secret.data "etcd_client_cert_key.pem" }}
-  {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/mla/mla-secrets/templates/minio-secret.yaml
+++ b/charts/mla/mla-secrets/templates/minio-secret.yaml
@@ -22,21 +22,19 @@ type: Opaque
 data:
   rootUser: {{ index $secret "rootUser" | default ( .Values.mlaSecrets.minio.accessKey | default ( randAlphaNum 20 ) | toString | b64enc | quote ) }}
   rootPassword: {{ index $secret "rootPassword" | default ( .Values.mlaSecrets.minio.secretKey | default ( randAlphaNum 40 ) | toString | b64enc | quote ) }}
-  {{- if and .Values.mlaSecrets.minio.gcsgateway.enabled .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson }}
+  {{- if or (index $secret "gcs_key.json") (and .Values.mlaSecrets.minio.gcsgateway.enabled .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson) }}
   gcs_key.json: {{ index $secret "gcs_key.json" | default ( .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson | toString | b64enc | quote ) }}
   {{- end }}
-  {{- if .Values.mlaSecrets.minio.s3gateway.enabled }}
-    {{- if .Values.mlaSecrets.minio.s3gateway.accessKey }}
+  {{- if or (index $secret "awsAccessKeyId") (and .Values.mlaSecrets.minio.s3gateway.enabled .Values.mlaSecrets.minio.s3gateway.accessKey) }}
   awsAccessKeyId: {{ index $secret "awsAccessKeyId" | default ( .Values.mlaSecrets.minio.s3gateway.accessKey | toString | b64enc | quote ) }}
-    {{- end }}
-    {{- if .Values.mlaSecrets.minio.s3gateway.secretKey }}
-  awsSecretAccessKey: {{ index $secret "awsSecretAccessKey" | default ( .Values.mlaSecrets.minio.s3gateway.secretKey | toString | b64enc | quote ) }}
-    {{- end }}
   {{- end }}
-  {{- if .Values.mlaSecrets.minio.etcd.clientCert }}
+  {{- if or (index $secret "awsSecretAccessKey") (and .Values.mlaSecrets.minio.s3gateway.enabled .Values.mlaSecrets.minio.s3gateway.secretKey) }}
+  awsSecretAccessKey: {{ index $secret "awsSecretAccessKey" | default ( .Values.mlaSecrets.minio.s3gateway.secretKey | toString | b64enc | quote ) }}
+  {{- end }}
+  {{- if or (index $secret "etcd_client_cert.pem") .Values.mlaSecrets.minio.etcd.clientCert }}
   etcd_client_cert.pem: {{ index $secret "etcd_client_cert.pem" | default ( .Values.mlaSecrets.minio.etcd.clientCert | toString | b64enc | quote ) }}
   {{- end }}
-  {{- if .Values.mlaSecrets.minio.etcd.clientCertKey }}
+  {{- if or (index $secret "etcd_client_cert_key.pem") .Values.mlaSecrets.minio.etcd.clientCertKey }}
   etcd_client_cert_key.pem: {{ index $secret "etcd_client_cert_key.pem" | default ( .Values.mlaSecrets.minio.etcd.clientCertKey | toString | b64enc | quote ) }}
   {{- end }}
 {{- end }}

--- a/charts/mla/mla-secrets/templates/minio-secret.yaml
+++ b/charts/mla/mla-secrets/templates/minio-secret.yaml
@@ -13,29 +13,50 @@
 # limitations under the License.
 
 {{- if .Values.mlaSecrets.minio.enabled }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace "minio" }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: minio
 type: Opaque
 data:
+{{- if not $secret }}
   rootUser: {{ if .Values.mlaSecrets.minio.accessKey }}{{ .Values.mlaSecrets.minio.accessKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 20 | b64enc | quote }}{{ end }}
   rootPassword: {{ if .Values.mlaSecrets.minio.secretKey }}{{ .Values.mlaSecrets.minio.secretKey | toString | b64enc | quote }}{{ else }}{{ randAlphaNum 40 | b64enc | quote }}{{ end }}
-{{- if and .Values.mlaSecrets.minio.gcsgateway.enabled .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson }}
-  gcs_key.json: {{ .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson | toString | b64enc }}
-{{- end }}
-{{- if .Values.mlaSecrets.minio.s3gateway.enabled -}}
-{{- if .Values.mlaSecrets.minio.s3gateway.accessKey }}
+  {{- if and .Values.mlaSecrets.minio.gcsgateway.enabled .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson }}
+  gcs_key.json: {{ .Values.mlaSecrets.minio.gcsgateway.gcsKeyJson | toString | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.mlaSecrets.minio.s3gateway.enabled }}
+    {{- if .Values.mlaSecrets.minio.s3gateway.accessKey }}
   awsAccessKeyId: {{ .Values.mlaSecrets.minio.s3gateway.accessKey | toString | b64enc | quote }}
-{{- end }}
-{{- if .Values.mlaSecrets.minio.s3gateway.secretKey }}
+    {{- end }}
+    {{- if .Values.mlaSecrets.minio.s3gateway.secretKey }}
   awsSecretAccessKey: {{ .Values.mlaSecrets.minio.s3gateway.secretKey | toString | b64enc | quote }}
-{{- end }}
-{{- end }}
-{{- if .Values.mlaSecrets.minio.etcd.clientCert }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.mlaSecrets.minio.etcd.clientCert }}
   etcd_client_cert.pem: {{ .Values.mlaSecrets.minio.etcd.clientCert | toString | b64enc | quote }}
-{{- end }}
-{{- if .Values.mlaSecrets.minio.etcd.clientCertKey }}
+  {{- end }}
+  {{- if .Values.mlaSecrets.minio.etcd.clientCertKey }}
   etcd_client_cert_key.pem: {{ .Values.mlaSecrets.minio.etcd.clientCertKey | toString | b64enc | quote }}
+  {{- end }}
+{{- else }}
+  rootUser: {{ index $secret.data "rootUser" }}
+  rootPassword: {{ index $secret.data "rootPassword" }}
+  {{- if index $secret.data "gcs_key.json" }}
+  gcs_key.json: {{ index $secret.data "gcs_key.json" }}
+  {{- end }}
+  {{- if index $secret.data "awsAccessKeyId" }}
+  awsAccessKeyId: {{ index $secret.data "awsAccessKeyId" }}
+  {{- end }}
+  {{- if index $secret.data "awsSecretAccessKey" }}
+  awsSecretAccessKey: {{ index $secret.data "awsSecretAccessKey" }}
+  {{- end }}
+  {{- if index $secret.data "etcd_client_cert.pem" }}
+  etcd_client_cert.pem: {{ index $secret.data "etcd_client_cert.pem" }}
+  {{- end }}
+  {{- if index $secret.data "etcd_client_cert_key.pem" }}
+  etcd_client_cert_key.pem: {{ index $secret.data "etcd_client_cert_key.pem" }}
+  {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #14520 pointed out an inconsistency which we now can try to safely manage within the mla-secrets chart.
This change introduces lookups to the helm chart mla-secrets, which make sure that pre-existing secrets will not be overwritten by redeployments/upgrades but it will still enable extending them with values.yaml.

Note: existing secrets always take precedence and as such they have to be removed or edited in-place to make changes to existing fields.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
mla-secrets: chart can now be safely redeployed, existing secrets take precedence over provided values.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
