### PR TITLE
Install specific AppDefinitions from the default app catalog

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -643,3 +643,38 @@ presubmits:
               cpu: 2
             limits:
               memory: 6Gi
+
+  - name: pre-kubermatic-app-definitions
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws-e2e-kkp: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+      preset-e2e-ssh: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-3
+          command:
+            - "./hack/ci/run-application-definitions-e2e-test.sh"
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -85,6 +85,7 @@ type DeployOptions struct {
 	MLASkipLogging           bool
 
 	DeployDefaultAppCatalog bool
+	LimitApps               []string
 
 	SkipCharts []string
 }
@@ -214,6 +215,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 			Versions:                           versions,
 			SkipCharts:                         opt.SkipCharts,
 			DeployDefaultAppCatalog:            opt.DeployDefaultAppCatalog,
+			LimitApps:                          opt.LimitApps,
 		}
 
 		// prepare Kubernetes and Helm clients

--- a/cmd/kubermatic-installer/main_ee.go
+++ b/cmd/kubermatic-installer/main_ee.go
@@ -56,4 +56,5 @@ func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.C
 // flags to be only used in EE edition.
 func wrapDeployFlags(flagset *pflag.FlagSet, opt *DeployOptions) {
 	flagset.BoolVar(&opt.DeployDefaultAppCatalog, "deploy-default-app-catalog", false, "Reconcile the default Application Catalog (EE only)")
+	flagset.StringSliceVar(&opt.LimitApps, "limit-apps", []string{}, "Limit the app definitions that are to be installed (EE only)")
 }

--- a/hack/ci/run-application-definitions-e2e-test.sh
+++ b/hack/ci/run-application-definitions-e2e-test.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+### This script is used as a postsubmit job and updates the dev master
+### cluster after every commit to main.
+
 set -euo pipefail
 
 cd $(dirname $0)/../..
@@ -22,20 +25,7 @@ source hack/lib.sh
 TEST_NAME="Pre-warm Go build cache"
 echodate "Attempting to pre-warm Go build cache"
 
-# Directly use environment variables set earlier in the script or passed in.
-APPLICATION_INSTALLATION_NAME="${APPLICATION_INSTALLATION_NAME:-}"
-APPLICATION_NAME="${APPLICATION_NAME:-}"
-APPLICATION_NAMESPACE="${APPLICATION_NAMESPACE:-}"
-APP_LABEL_KEY="${APP_LABEL_KEY:-}"
-NAMES="${NAMES:-}"
-
-# Ensure all environment variables are set
-if [[ -z "$APPLICATION_INSTALLATION_NAME" || -z "$APPLICATION_NAME" || -z "$APPLICATION_NAMESPACE" || -z "$APP_LABEL_KEY" || -z "$NAMES" ]]; then
-  echo "One or more required environment variables are missing."
-  exit 1
-fi
-
-echo "Running test with application name '$APPLICATION_NAME' and version '$APPLICATION_NAME'"
+echo "Running application definitions test"
 
 beforeGocache=$(nowms)
 make download-gocache
@@ -50,7 +40,7 @@ protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-con
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
 kubectl apply -f pkg/crd/k8c.io
-export INSTALLER_FLAGS="--deploy-default-app-catalog"
+export INSTALLER_FLAGS="--deploy-default-app-catalog --limit-apps=argocd,trivy,metallb"
 source hack/ci/setup-kubermatic-in-kind.sh
 
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
@@ -68,34 +58,10 @@ fi
 
 echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
 
-echodate "Running $APPLICATION_NAME tests..."
+echodate "Running tests..."
 
-pathToFile="pkg/ee/default-application-catalog/applicationdefinitions/$APPLICATION_NAME-app.yaml"
-echodate "File path: $pathToFile"
+go_test default_application_catalog_test -timeout 1h -tags e2e -v ./pkg/test/e2e/appdefinitions \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
-if [[ -s "$pathToFile" ]]; then
-  versions=$(yq eval '.spec.versions[].version' "$pathToFile")
-
-  # Extract the defaultValuesBlock (this will capture everything after 'defaultValuesBlock:' until 'documentationURL')
-  defaultValuesBlock=$(yq eval '.spec.defaultValuesBlock' "$pathToFile")
-
-  echodate "Processing default values block: $defaultValuesBlock"
-
-  for version in $versions; do
-    echodate "Processing version: $version"
-    go_test default_application_catalog_test -timeout 1h -tags e2e -v ./pkg/test/e2e/defaultappcatalog \
-      -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
-      -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")" \
-      -application-installation-name "$APPLICATION_INSTALLATION_NAME" \
-      -application-name "$APPLICATION_NAME" \
-      -application-namespace "$APPLICATION_NAMESPACE" \
-      -application-version "$version" \
-      -app-label-key "$APP_LABEL_KEY" \
-      -names "$NAMES" \
-      -default-values-block "$defaultValuesBlock"
-  done
-else
-  echo "File is empty or does not exist."
-fi
-
-echodate "Application $APPLICATION_NAME tests done."
+echodate "Application definitions tests done."

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -174,7 +174,7 @@ TEST_NAME="Install KKP into kind"
   --storageclass copy-default \
   --config "$KUBERMATIC_CONFIG" \
   --helm-values "$HELM_VALUES_FILE" \
-  "$INSTALLER_FLAGS"
+  $INSTALLER_FLAGS
 
 # TODO: The installer should wait for everything to finish reconciling.
 echodate "Waiting for Kubermatic Operator to deploy Master components..."

--- a/pkg/ee/default-application-catalog/application_catalog.go
+++ b/pkg/ee/default-application-catalog/application_catalog.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -84,7 +85,9 @@ func DeployDefaultApplicationCatalog(ctx context.Context, logger *logrus.Entry, 
 			return fmt.Errorf("failed to parse ApplicationDefinition: %w", err)
 		}
 
-		creators = append(creators, applicationDefinitionReconcilerFactory(appDef))
+		if len(opt.LimitApps) == 0 || (len(opt.LimitApps) > 0 && (slices.Contains(opt.LimitApps, appDef.Spec.DisplayName) || slices.Contains(opt.LimitApps, appDef.Name))) {
+			creators = append(creators, applicationDefinitionReconcilerFactory(appDef))
+		}
 	}
 
 	if err = kkpreconciling.ReconcileApplicationDefinitions(ctx, creators, "", kubeClient); err != nil {

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -66,6 +66,7 @@ type DeployOptions struct {
 	MLASkipLogging           bool
 
 	DeployDefaultAppCatalog bool
+	LimitApps               []string
 
 	SkipCharts []string
 }

--- a/pkg/test/e2e/appdefinitions/application_definitions_test.go
+++ b/pkg/test/e2e/appdefinitions/application_definitions_test.go
@@ -1,0 +1,93 @@
+//go:build e2e
+
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultappcatalog
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+
+	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	credentials jig.AWSCredentials
+	logOptions  = utils.DefaultLogOptions
+)
+
+const (
+	projectName                    = "app-definitions-test-project"
+	countOfInstalledAppDefinitions = 4
+)
+
+func init() {
+	credentials.AddFlags(flag.CommandLine)
+	jig.AddFlags(flag.CommandLine)
+	logOptions.AddFlags(flag.CommandLine)
+}
+
+func TestClusters(t *testing.T) {
+	rawLog := log.NewFromOptions(logOptions)
+	ctx := context.Background()
+
+	if err := credentials.Parse(); err != nil {
+		t.Fatalf("Failed to get credentials: %v", err)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		t.Fatalf("failed to build config: %v", err)
+	}
+
+	seedClient, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})
+	if err != nil {
+		t.Fatalf("failed to build ctrlruntime client: %v", err)
+	}
+
+	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
+
+	appDefsList := &appskubermaticv1.ApplicationDefinitionList{}
+	listOptions := &ctrlruntimeclient.ListOptions{
+		Namespace: "", // all namespaces
+	}
+	if err := seedClient.List(ctx, appDefsList, listOptions); err != nil {
+		t.Fatalf("failed to get ApplicationDefinitions in seed cluster: %v", err)
+	}
+
+	fmt.Printf("Found %d ApplicationDefinitions:\n", len(appDefsList.Items))
+	for _, appDef := range appDefsList.Items {
+		t.Logf("- Name: %s, Namespace: %s\n", appDef.Name, appDef.Namespace)
+	}
+
+	if len(appDefsList.Items) != countOfInstalledAppDefinitions {
+		t.Fatalf("the number of the applications definitions in the seed cluster is not correct: %v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
A new --limit-apps flag has been added to the Kubermatic Installer, allowing users to limit which AppDefinitions are installed during the setup process.

The pull request includes an end-to-end test that:
1. Adds three app definitions
2. Verifies that when fetching the app definitions, the response contains exactly 3
3. You’ll see a variable countOfInstalledAppDefinitions = 4, which is 3 + 1, because we also install Cilium as a system application and there's an app definition for Cilium as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14232

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new --limit-apps flag has been added to the Kubermatic Installer, allowing users to limit which AppDefinitions are installed during the setup process. This flag accepts a comma-separated list of AppDefinition names. If the flag is not provided or the list is empty, all available AppDefinitions will be installed—provided the default app catalog is enabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
