### PR TITLE
rename Vault keys in dev deployment script

### DIFF
--- a/hack/ci/deploy-dev.sh
+++ b/hack/ci/deploy-dev.sh
@@ -24,7 +24,7 @@ source hack/lib.sh
 
 export DEPLOY_STACK=${DEPLOY_STACK:-kubermatic}
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
-export VAULT_VALUES_FIELD=hamburg-values.yaml
+export VAULT_VALUES_FIELD=helm-master.yaml
 
 # per-stack customizations
 case ${DEPLOY_STACK} in
@@ -33,12 +33,12 @@ kubermatic)
   ;;
 
 usercluster-mla)
-  export VAULT_VALUES_FIELD=hamburg-mla-values.yaml
+  export VAULT_VALUES_FIELD=helm-seed-shared-usercluster-mla.yaml
   NO_IMAGES=true BINARY_NAMES="kubermatic-installer" ./hack/ci/release-images.sh
   ;;
 
 seed-mla)
-  export VAULT_VALUES_FIELD=hamburg-values.yaml
+  export VAULT_VALUES_FIELD=helm-seed-shared-mla.yaml
   NO_IMAGES=true BINARY_NAMES="kubermatic-installer" ./hack/ci/release-images.sh
   ;;
 
@@ -51,7 +51,6 @@ export VALUES_FILE=/tmp/values.yaml
 export IMAGE_PULL_SECRET=/tmp/dockercfg
 export KUBERMATIC_CONFIG=/tmp/kubermatic.yaml
 
-# deploy to dev
 vault kv get -field=kubeconfig dev/seed-clusters/dev.kubermatic.io > ${KUBECONFIG}
 vault kv get -field=${VAULT_VALUES_FIELD} dev/seed-clusters/dev.kubermatic.io > ${VALUES_FILE}
 vault kv get -field=.dockerconfigjson dev/seed-clusters/dev.kubermatic.io > ${IMAGE_PULL_SECRET}


### PR DESCRIPTION
**What this PR does / why we need it**:
Over time we have accumulated a heck of a lot weird variants of Helm values in our Vault, to the point that names like "hamburg-dev" had no meaning anymore. This PR cleans up the naming, following https://github.com/kubermatic/infra/pull/3019.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
