### PR TITLE
only consider main version tags when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ REPO = $(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && e
 CMD ?= $(filter-out OWNERS nodeport-proxy kubeletdnat-controller network-interface-manager, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS ?= -v
 GOOS ?= $(shell go env GOOS)
-GIT_VERSION = $(shell git describe --tags --always)
+GIT_VERSION = $(shell git describe --tags --always --match='v*')
 TAGS ?= $(GIT_VERSION)
 DOCKERTAGS = $(TAGS) latestbuild
 DOCKER_BUILD_FLAG += $(foreach tag, $(DOCKERTAGS), -t $(REPO):$(tag))


### PR DESCRIPTION
**What this PR does / why we need it**:
`sdk/...` tags are not valid semver and so we must not consider them when determining KKP's version.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
