### PR TITLE
Add nginx config to increase header size

### DIFF
--- a/charts/dex/test/default.yaml.out
+++ b/charts/dex/test/default.yaml.out
@@ -257,6 +257,9 @@ metadata:
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.41.1"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 25m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
 spec:
   ingressClassName: nginx
   tls:

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -39,6 +39,9 @@ dex:
           # Required: must include at least the host chosen
           # above.
           - ""
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
 
   config:
     # Required: Must be set to the ingress.hosts[0].host plus the

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -54,6 +54,7 @@ metadata:
   name: nginx-ingress-controller
   namespace: default
 data:
+  large-client-header-buffers: "4 64k"
   proxy-body-size: "0"
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/clusterrole.yaml

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -54,6 +54,7 @@ metadata:
   name: nginx-ingress-controller
   namespace: default
 data:
+  large-client-header-buffers: "4 64k"
   proxy-body-size: "0"
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/clusterrole.yaml

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -54,6 +54,7 @@ metadata:
   name: nginx-ingress-controller
   namespace: default
 data:
+  large-client-header-buffers: "4 64k"
   proxy-body-size: "0"
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/clusterrole.yaml

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -24,6 +24,7 @@ nginx:
     config:
       # Increased body size to handle Minio workload, , https://github.com/rancher/rancher/issues/14323
       proxy-body-size: "0"
+      large-client-header-buffers: "4 64k"
       #load-balance: "least_conn"
     extraArgs: {}
     resources:
@@ -84,7 +85,7 @@ nginx:
         "helm.sh/resource-policy": keep
       # in case of azure, can specific a specific IP address for the nginx service
       # loadBalancerIP: ""
-    
+
     # Temporarily disable the admission webhooks
     admissionWebhooks:
       enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds nginx config (for dashboard and dex) to increase the allowed header size. This large header size is required when the Access/ID token is too large. Large token size problem was fixed in KKP dashboard with https://github.com/kubermatic/dashboard/pull/7206. Without these nginx configurations, the KKP dashboard would fail because of header size limitations. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref https://github.com/kubermatic/dashboard/issues/7182

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add nginx config to increase header size for Dashboard and Dex.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
