### PR TITLE
Add Subnet IPv4 CIDR to KubeVirt  Seed

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1344,6 +1344,9 @@ spec:
                                           items:
                                             description: Subnet a smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
                                             properties:
+                                              cidr:
+                                                description: CIDR is the subnet IPV4 CIDR.
+                                                type: string
                                               name:
                                                 type: string
                                               regions:

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -960,6 +960,8 @@ type Subnet struct {
 	// Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
 	// to span multiple regions
 	Regions []string `json:"regions,omitempty"`
+	// CIDR is the subnet IPV4 CIDR.
+	CIDR string `json:"cidr,omitempty"`
 }
 
 type NamespacedMode struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
For KubeVirt cloud provider, when provider network is configured in the seed object, the dashboard will read and display these details out of the seed object directly without the need to access the KubeVirt API, especially when KKP doesn't have permissions to read subnet information from the KubeVirt cluster.

The CIDR property is needed to show map the subnet name to the CIDR for a better user experience instead of showing the subnet name only. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KubeVirt Subnet CIDR in the Seed object
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
