### PR TITLE
kubeLB: update CCM image to v1.1.5

### DIFF
--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -62,7 +62,7 @@ var (
 
 const (
 	imageName = "kubelb-ccm-ee"
-	imageTag  = "v1.1.4"
+	imageTag  = "v1.1.5"
 )
 
 type kubeLBData interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Pinning CCM to the latest image. There are no changes for the CCM between 1.1.4 and 1.1.5 release.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeLB: update CCM image to v1.1.5
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
