### PR TITLE
pre-kubermatic-app-definitions shouldn't run for every PR unconditionally

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -647,7 +647,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-app-definitions
-    always_run: true
+    run_if_changed: "(pkg/ee/default-application-catalog/application_catalog.go|pkg/ee/default-application-catalog/embed.go|hack/ci/run-application-definitions-e2e-test.sh)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
I don't really see the point in running the CI job unconditionally for each PR. This is a very small EE only feature that should be tested only when the relevant code is changed. I've updated the job definition with `run_if_changed` block to limit it to only being triggered when certain file(only relevant ones) change.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
I saw this CI job running against my PR https://github.com/kubermatic/kubermatic/pull/14609 which has nothing to do with applications whatsoever. Thus I realised that this needs to change.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @ahmedwaleedmalik 
/cc @iakmc 