### PR TITLE
refine selector targeting logic for templates and improve coverage

### DIFF
--- a/pkg/ee/default-policy-controller/controller.go
+++ b/pkg/ee/default-policy-controller/controller.go
@@ -160,7 +160,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		}
 
 		// Check if the PolicyTemplate targets this cluster
-		if !isClusterTargeted(cluster, &policyTemplate) {
+		if !isClusterTargeted(ctx, r.Client, cluster, &policyTemplate) {
 			continue
 		}
 
@@ -220,51 +220,138 @@ func policyBindingReconcilerFactory(template kubermaticv1.PolicyTemplate) reconc
 }
 
 // isClusterTargeted checks if the PolicyTemplate targets the given cluster.
-func isClusterTargeted(cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate) bool {
-	projectID := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
+func isClusterTargeted(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate) bool {
+	clusterProjectID := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
+
 	// If no target is specified, we check the visibility
 	if template.Spec.Target == nil {
-		// Global policies apply to all clusters
-		if template.Spec.Visibility == kubermaticv1.PolicyTemplateVisibilityGlobal {
-			return true
-		}
+		return handleVisibilityOnly(cluster, template, clusterProjectID)
+	}
 
-		// Project policies apply to clusters in the same project
-		if template.Spec.Visibility == kubermaticv1.PolicyTemplateVisibilityProject &&
-			template.Spec.ProjectID != "" &&
-			projectID == template.Spec.ProjectID {
-			return true
-		}
+	// Handle based on visibility and target combinations
+	switch template.Spec.Visibility {
+	case kubermaticv1.PolicyTemplateVisibilityGlobal:
+		return handleGlobalWithTarget(ctx, client, cluster, template, clusterProjectID)
 
+	case kubermaticv1.PolicyTemplateVisibilityProject:
+		return handleProjectWithTarget(cluster, template, clusterProjectID)
+
+	default:
+		return false
+	}
+}
+
+// handleVisibilityOnly handles when no target is specified - uses visibility rules only.
+func handleVisibilityOnly(cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate, clusterProjectID string) bool {
+	switch template.Spec.Visibility {
+	case kubermaticv1.PolicyTemplateVisibilityGlobal:
+		return true
+	case kubermaticv1.PolicyTemplateVisibilityProject:
+		return template.Spec.ProjectID != "" && clusterProjectID == template.Spec.ProjectID
+	default:
+		return false
+	}
+}
+
+// handleGlobalWithTarget handles Global visibility with Target specified, using the provided client.
+func handleGlobalWithTarget(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate, clusterProjectID string) bool {
+	target := template.Spec.Target
+	hasProjectSelector := target.ProjectSelector != nil
+	hasClusterSelector := target.ClusterSelector != nil
+
+	switch {
+	case hasProjectSelector && hasClusterSelector:
+		// Global + Target [ProjectSelector, ClusterSelector]
+		return handleGlobalProjectAndClusterSelectors(ctx, client, cluster, template, clusterProjectID)
+	case hasProjectSelector && !hasClusterSelector:
+		// Global + Target [ProjectSelector]
+		return handleGlobalProjectSelectorOnly(ctx, client, cluster, template, clusterProjectID)
+	case !hasProjectSelector && hasClusterSelector:
+		// Global + Target [ClusterSelector]
+		return handleGlobalClusterSelectorOnly(cluster, template)
+	default:
+		return false
+	}
+}
+
+// handleProjectWithTarget handles Project visibility with Target specified.
+func handleProjectWithTarget(cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate, clusterProjectID string) bool {
+	if template.Spec.ProjectID != "" && clusterProjectID != template.Spec.ProjectID {
 		return false
 	}
 
-	// Check project selector if specified
-	if template.Spec.Target.ProjectSelector != nil && projectID != "" {
-		selector, err := metav1.LabelSelectorAsSelector(template.Spec.Target.ProjectSelector)
-		if err != nil {
-			return false
-		}
-
-		projectLabels := map[string]string{kubermaticv1.ProjectIDLabelKey: projectID}
-		if !selector.Matches(labels.Set(projectLabels)) {
-			return false
-		}
+	if template.Spec.Target.ClusterSelector != nil {
+		return handleProjectClusterSelector(cluster, template)
 	}
 
-	// Check cluster selector if specified
-	if template.Spec.Target.ClusterSelector != nil {
-		selector, err := metav1.LabelSelectorAsSelector(template.Spec.Target.ClusterSelector)
-		if err != nil {
-			return false
-		}
+	return false
+}
 
-		if !selector.Matches(labels.Set(cluster.Labels)) {
-			return false
-		}
+// handleGlobalProjectAndClusterSelectors handles Global + Project + Cluster selectors (AND filtering).
+func handleGlobalProjectAndClusterSelectors(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate, clusterProjectID string) bool {
+	if !matchesClusterSelector(cluster, template.Spec.Target.ClusterSelector) {
+		return false
+	}
+
+	if !matchesProjectSelector(ctx, client, clusterProjectID, template.Spec.Target.ProjectSelector) {
+		return false
 	}
 
 	return true
+}
+
+// handleGlobalProjectSelectorOnly handles Global + Project selector only.
+func handleGlobalProjectSelectorOnly(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate, clusterProjectID string) bool {
+	return matchesProjectSelector(ctx, client, clusterProjectID, template.Spec.Target.ProjectSelector)
+}
+
+// handleGlobalClusterSelectorOnly handles Global + Cluster selector only.
+func handleGlobalClusterSelectorOnly(cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate) bool {
+	return matchesClusterSelector(cluster, template.Spec.Target.ClusterSelector)
+}
+
+// handleProjectClusterSelector handles Project + Cluster selector.
+func handleProjectClusterSelector(cluster *kubermaticv1.Cluster, template *kubermaticv1.PolicyTemplate) bool {
+	return matchesClusterSelector(cluster, template.Spec.Target.ClusterSelector)
+}
+
+// matchesClusterSelector checks if a cluster matches the given cluster selector.
+func matchesClusterSelector(cluster *kubermaticv1.Cluster, clusterSelector *metav1.LabelSelector) bool {
+	if isLabelSelectorEmpty(clusterSelector) {
+		return true
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(clusterSelector)
+	if err != nil {
+		return false
+	}
+
+	return selector.Matches(labels.Set(cluster.Labels))
+}
+
+// matchesProjectSelector checks if a project (by ID) matches the given project selector.
+func matchesProjectSelector(ctx context.Context, client ctrlruntimeclient.Client, projectID string, projectSelector *metav1.LabelSelector) bool {
+	if isLabelSelectorEmpty(projectSelector) {
+		return true
+	}
+
+	projects := &kubermaticv1.ProjectList{}
+	if err := client.List(ctx, projects); err != nil {
+		return false
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(projectSelector)
+	if err != nil {
+		return false
+	}
+
+	for _, project := range projects.Items {
+		if project.Name == projectID && selector.Matches(labels.Set(project.Labels)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func enqueueClusters(client ctrlruntimeclient.Client, log *zap.SugaredLogger) handler.EventHandler {
@@ -286,7 +373,7 @@ func enqueueClusters(client ctrlruntimeclient.Client, log *zap.SugaredLogger) ha
 		}
 
 		for _, cluster := range clusters.Items {
-			if isClusterTargeted(&cluster, policyTemplate) {
+			if isClusterTargeted(ctx, client, &cluster, policyTemplate) {
 				requests = append(requests, reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name: cluster.Name,
@@ -337,4 +424,12 @@ func withEventFilter() predicate.Predicate {
 			return obj.Spec.Enforced
 		},
 	}
+}
+
+// isLabelSelectorEmpty checks if a LabelSelector is semantically empty.
+func isLabelSelectorEmpty(selector *metav1.LabelSelector) bool {
+	if selector == nil {
+		return true
+	}
+	return len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0
 }

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -19,12 +19,12 @@ package images
 import (
 	"context"
 	"fmt"
+	"iter"
 	"os"
 	"path"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"iter"
 
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -19,12 +19,12 @@ package images
 import (
 	"context"
 	"fmt"
-	"iter"
 	"os"
 	"path"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"iter"
 
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the selector logic in PolicyTemplates when targeting clusters globally and in project scope. The previous implementation wasn't handling the `target` field properly, when empty or when more complex targeting was needed.
This PR also adds more coverage to the function responsible for performing this selection logic:
```
> go tool cover -func=cover.out | grep 'isClusterTargeted'

k8c.io/kubermatic/v2/pkg/ee/default-policy-controller/controller.go:223:    isClusterTargeted      85.7%
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #14383

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
