### PR TITLE
 Skip Updating System Application Definition Helm Chart Source in Mirror Images

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -346,8 +346,12 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 					sysChart.Version,
 				)
 
-				fmt.Println(removeOCIPrefix(chartImage))
-				imageSet.Insert(removeOCIPrefix(chartImage))
+				// Check if the chartImage starts with "oci://"
+				if strings.HasPrefix(chartImage, "oci://") {
+					// remove oci:// prefix and insert the chartImage into imageSet.
+					imageSet.Insert(chartImage[len("oci://"):])
+				}
+
 				imageSet.Insert(sysChart.WorkloadImages...)
 			}
 
@@ -397,14 +401,4 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 			return nil
 		}
 	})
-}
-
-func removeOCIPrefix(input string) string {
-	// Check if the string starts with "oci://"
-	if strings.HasPrefix(input, "oci://") {
-		// Remove the "oci://" prefix by slicing the string
-		return input[len("oci://"):]
-	}
-	// Return the original string if it doesn't start with "oci://"
-	return input
 }

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -256,12 +256,12 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 				return fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
 			}
 
-			clusterVersions, err := images.GetVersions(logger, kubermaticConfig, options.VersionFilter)
+			_, err = images.GetVersions(logger, kubermaticConfig, options.VersionFilter)
 			if err != nil {
 				return fmt.Errorf("failed to load versions: %w", err)
 			}
 
-			caBundle, err := certificates.NewCABundleFromFile(filepath.Join(options.ChartsDirectory, "kubermatic-operator/static/ca-bundle.pem"))
+			_, err = certificates.NewCABundleFromFile(filepath.Join(options.ChartsDirectory, "kubermatic-operator/static/ca-bundle.pem"))
 			if err != nil {
 				return fmt.Errorf("failed to load CA bundle: %w", err)
 			}
@@ -274,7 +274,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 				defer os.RemoveAll(options.AddonsPath)
 			}
 
-			allAddons, err := addonutil.LoadAddonsFromDirectory(options.AddonsPath)
+			_, err = addonutil.LoadAddonsFromDirectory(options.AddonsPath)
 			if err != nil {
 				return fmt.Errorf("failed to load addons: %w", err)
 			}
@@ -284,11 +284,11 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 			// Using a set here for deduplication
 			imageSet := sets.New[string]()
 
-			imageList, err := CollectImageMatrix(logger, clusterVersions, kubermaticConfig, allAddons, versions, caBundle, options.RegistryPrefix)
-			if err != nil {
-				return err
-			}
-			imageSet.Insert(imageList...)
+			// imageList, err := CollectImageMatrix(logger, clusterVersions, kubermaticConfig, allAddons, versions, caBundle, options.RegistryPrefix)
+			// if err != nil {
+			// 	return err
+			// }
+			// imageSet.Insert(imageList...)
 
 			// Populate the imageSet with images specified in the KubermaticConfiguration's MirrorImages field.
 			// This ensures that all required images for mirroring are included in the set for further processing.
@@ -317,18 +317,18 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 			}
 
 			if options.ChartsDirectory != "" {
-				chartsLogger := logger.WithField("charts-directory", options.ChartsDirectory)
-				chartsLogger.Info("🚀 Rendering Helm charts…")
+				// chartsLogger := logger.WithField("charts-directory", options.ChartsDirectory)
+				// chartsLogger.Info("🚀 Rendering Helm charts…")
 
-				// Because charts can specify a desired kubeVersion and the helm render default is hardcoded to 1.20, we need to set a custom kubeVersion.
-				// Otherwise some charts would fail to render (e.g. consul).
-				// Since we are just rendering from the client-side, it makes sense to use the latest kubeVersion we support.
-				latestClusterVersion := clusterVersions[len(clusterVersions)-1]
-				images, err := images.GetImagesForHelmCharts(ctx, chartsLogger, kubermaticConfig, helmClient, options.ChartsDirectory, options.HelmValuesFile, options.RegistryPrefix, latestClusterVersion.Version.Original())
-				if err != nil {
-					return fmt.Errorf("failed to get images: %w", err)
-				}
-				imageSet.Insert(images...)
+				// // Because charts can specify a desired kubeVersion and the helm render default is hardcoded to 1.20, we need to set a custom kubeVersion.
+				// // Otherwise some charts would fail to render (e.g. consul).
+				// // Since we are just rendering from the client-side, it makes sense to use the latest kubeVersion we support.
+				// latestClusterVersion := clusterVersions[len(clusterVersions)-1]
+				// images, err := images.GetImagesForHelmCharts(ctx, chartsLogger, kubermaticConfig, helmClient, options.ChartsDirectory, options.HelmValuesFile, options.RegistryPrefix, latestClusterVersion.Version.Original())
+				// if err != nil {
+				// 	return fmt.Errorf("failed to get images: %w", err)
+				// }
+				// imageSet.Insert(images...)
 			}
 
 			copyKubermaticConfig := kubermaticConfig.DeepCopy()
@@ -340,17 +340,13 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 					return err
 				}
 
-				chartRepository := sysChart.Template.Source.Helm.URL
-				if copyKubermaticConfig.Spec.UserCluster.SystemApplications.HelmRepository != "" {
-					chartRepository = copyKubermaticConfig.Spec.UserCluster.SystemApplications.HelmRepository
-				}
-
 				chartImage := fmt.Sprintf("%s/%s:%s",
-					chartRepository,
+					sysChart.Template.Source.Helm.URL,
 					sysChart.Template.Source.Helm.ChartName,
 					sysChart.Version,
 				)
 
+				fmt.Println(chartImage)
 				imageSet.Insert(chartImage)
 				imageSet.Insert(sysChart.WorkloadImages...)
 			}

--- a/pkg/applicationdefinitions/application_catalog.go
+++ b/pkg/applicationdefinitions/application_catalog.go
@@ -34,6 +34,7 @@ import (
 func SystemApplicationDefinitionReconcilerFactories(
 	logger *zap.SugaredLogger,
 	config *kubermaticv1.KubermaticConfiguration,
+	mirror bool,
 ) ([]kkpreconciling.NamedApplicationDefinitionReconcilerFactory, error) {
 	if config.Spec.SystemApplications.Disable {
 		logger.Info("System applications are disabled, skipping deployment of system application definitions except Cilium.")
@@ -76,7 +77,7 @@ func SystemApplicationDefinitionReconcilerFactories(
 			}
 		}
 
-		creators = append(creators, systemApplicationDefinitionReconcilerFactory(appDef, config))
+		creators = append(creators, systemApplicationDefinitionReconcilerFactory(appDef, config, mirror))
 	}
 
 	return creators, nil
@@ -86,6 +87,7 @@ func SystemApplicationDefinitionReconcilerFactories(
 func systemApplicationDefinitionReconcilerFactory(
 	fileAppDef *appskubermaticv1.ApplicationDefinition,
 	config *kubermaticv1.KubermaticConfiguration,
+	mirror bool,
 ) kkpreconciling.NamedApplicationDefinitionReconcilerFactory {
 	return func() (string, kkpreconciling.ApplicationDefinitionReconciler) {
 		return fileAppDef.Name, func(clusterAppDef *appskubermaticv1.ApplicationDefinition) (*appskubermaticv1.ApplicationDefinition, error) {
@@ -114,10 +116,16 @@ func systemApplicationDefinitionReconcilerFactory(
 				fileAppDef.Spec.Selector.Datacenters = clusterAppDef.Spec.Selector.Datacenters
 			}
 
-			// Update the application definition (fileAppDef) according to the KubermaticConfiguration.
-			// When KubermaticConfiguration includes HelmRegistryConfigFile, we need to update the application definition
-			// to include the Helm credentials provided by the user in the cluster.
-			updateApplicationDefinition(fileAppDef, config)
+			// Update the application definition (fileAppDef) based on the KubermaticConfiguration.
+			// If the KubermaticConfiguration includes HelmRegistryConfigFile, update the application
+			// definition to incorporate the Helm credentials provided by the user in the cluster.
+			//
+			// When running mirror-images, leave the application definition unchanged. This ensures
+			// that charts are downloaded from the default upstream repositories used by KKP,
+			// preserving the original image references for discovery.
+			if !mirror {
+				updateApplicationDefinition(fileAppDef, config)
+			}
 
 			// Also, we need to ensure that the default values are set correctly. To do this:
 			// 1. Get the default values from the currently being reconciled application definition (clusterAppDef)

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -483,7 +483,7 @@ func (r *Reconciler) reconcileAddonConfigs(ctx context.Context, logger *zap.Suga
 func (r *Reconciler) reconcileApplicationDefinitions(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, logger *zap.SugaredLogger) error {
 	logger.Debug("Reconciling ApplicationDefinitions")
 
-	sysAppDefReconcilers, err := applicationdefinitions.SystemApplicationDefinitionReconcilerFactories(logger, config)
+	sysAppDefReconcilers, err := applicationdefinitions.SystemApplicationDefinitionReconcilerFactories(logger, config, false)
 	if err != nil {
 		return fmt.Errorf("failed to get system application definition reconciler factories: %w", err)
 	}

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -79,7 +79,7 @@ func SystemAppsHelmCharts(
 	}
 
 	log := kubermaticlog.NewDefault().Sugar()
-	sysAppDefReconcilers, err := applicationdefinitions.SystemApplicationDefinitionReconcilerFactories(log, config)
+	sysAppDefReconcilers, err := applicationdefinitions.SystemApplicationDefinitionReconcilerFactories(log, config, true)
 	if err != nil {
 		return func(yield func(*SystemAppsHelmChart, error) bool) {
 			yield(nil, fmt.Errorf("failed to get system application definition reconciler factories: %w", err))

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -365,6 +365,7 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 		crane.WithContext(ctx),
 		crane.WithUserAgent(userAgent),
 	}
+	options = append(options, crane.Insecure)
 
 	log.Info("Copying image…")
 

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -365,7 +365,6 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 		crane.WithContext(ctx),
 		crane.WithUserAgent(userAgent),
 	}
-	options = append(options, crane.Insecure)
 
 	log.Info("Copying image…")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When we run the `mirror-images` command in an **offline setup**, we usually set `systemApplications.HelmRepository` in the `KubermaticConfiguration` to point to our internal Helm registry (used by our offline KKP setup).

However, the `systemApplicationDefinitionReconcilerFactories` will **unconditionally** update the application definitions and replace the default Helm chart sources with the ones from `systemApplications.HelmRepository`.

This behavior is fine during normal reconciliation, but it breaks `mirror-images` — because in that mode, we want to mirror images from the **original upstream sources** used by KKP, not from our internal or rewritten ones.

This PR adds a simple check before updating the chart sources to avoid rewriting them during mirroring.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

I think we don't need to have `release-note` since https://github.com/kubermatic/kubermatic/pull/14509 is not released yet

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
