### PR TITLE
use OCI helm chart for cluster-autoscaler

### DIFF
--- a/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
+++ b/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
@@ -31,8 +31,8 @@ spec:
           helm:
             chartName: cluster-autoscaler
             chartVersion: 9.46.6
-            url: https://kubernetes.github.io/autoscaler
-      version: 1.32.0
+            url: oci://quay.io/kubermatic/helm-charts
+      version: 9.46.6
   defaultValuesBlock: |
     cloudProvider: clusterapi
     clusterAPIMode: incluster-incluster

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -366,6 +366,8 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 		crane.WithUserAgent(userAgent),
 	}
 
+	options = append(options, crane.Insecure)
+
 	log.Info("Copying image…")
 
 	numTries := 0

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -366,8 +366,6 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 		crane.WithUserAgent(userAgent),
 	}
 
-	options = append(options, crane.Insecure)
-
 	log.Info("Copying image…")
 
 	numTries := 0


### PR DESCRIPTION
**What this PR does / why we need it**:

After mirroring the autoscaler in our OCI quay repo, this PR updates the cluster-autoscaler app def to use our OCI helm chart to make the mirror-images command be able to mirror the charts in offline setups! 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
