### PR TITLE
add new field for kubevirt cpu assignment

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -196,6 +196,7 @@ spec:
           dnsPolicy: ""
           # Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
           # Defaults to false.
+          # Deprecated: Use .kubevirt.useDomainCPU instead.
           enableDedicatedCpus: false
           # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
           # Defaults to true.
@@ -253,6 +254,9 @@ spec:
           namespacedMode: null
           # Optional: ProviderNetwork describes the infra cluster network fabric that is being used
           providerNetwork: null
+          # Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
+          # When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
+          useDomainCPU: false
           # VMEvictionStrategy describes the strategy to follow when a node drain occurs. If not set the default
           # value is External and the VM will be protected by a PDB.
           vmEvictionStrategy: ""

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -196,7 +196,7 @@ spec:
           dnsPolicy: ""
           # Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
           # Defaults to false.
-          # Deprecated: Use .kubevirt.useDomainCPU instead.
+          # Deprecated: Use .kubevirt.usePodResourcesCPU instead.
           enableDedicatedCpus: false
           # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
           # Defaults to true.
@@ -254,9 +254,9 @@ spec:
           namespacedMode: null
           # Optional: ProviderNetwork describes the infra cluster network fabric that is being used
           providerNetwork: null
-          # Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
-          # When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
-          useDomainCPU: false
+          # Optional: UsePodResourcesCPU enables CPU assignment via Kubernetes Pod resource requests/limits.
+          # When false (default), CPUs are assigned via KubeVirt's spec.domain.cpu.
+          usePodResourcesCPU: false
           # VMEvictionStrategy describes the strategy to follow when a node drain occurs. If not set the default
           # value is External and the VM will be protected by a PDB.
           vmEvictionStrategy: ""

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -245,6 +245,7 @@ spec:
           dnsPolicy: ""
           # Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
           # Defaults to false.
+          # Deprecated: Use .kubevirt.useDomainCPU instead.
           enableDedicatedCpus: false
           # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
           # Defaults to true.
@@ -302,6 +303,9 @@ spec:
           namespacedMode: null
           # Optional: ProviderNetwork describes the infra cluster network fabric that is being used
           providerNetwork: null
+          # Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
+          # When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
+          useDomainCPU: false
           # VMEvictionStrategy describes the strategy to follow when a node drain occurs. If not set the default
           # value is External and the VM will be protected by a PDB.
           vmEvictionStrategy: ""

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -245,7 +245,7 @@ spec:
           dnsPolicy: ""
           # Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
           # Defaults to false.
-          # Deprecated: Use .kubevirt.useDomainCPU instead.
+          # Deprecated: Use .kubevirt.usePodResourcesCPU instead.
           enableDedicatedCpus: false
           # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
           # Defaults to true.
@@ -303,9 +303,9 @@ spec:
           namespacedMode: null
           # Optional: ProviderNetwork describes the infra cluster network fabric that is being used
           providerNetwork: null
-          # Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
-          # When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
-          useDomainCPU: false
+          # Optional: UsePodResourcesCPU enables CPU assignment via Kubernetes Pod resource requests/limits.
+          # When false (default), CPUs are assigned via KubeVirt's spec.domain.cpu.
+          usePodResourcesCPU: false
           # VMEvictionStrategy describes the strategy to follow when a node drain occurs. If not set the default
           # value is External and the VM will be protected by a PDB.
           vmEvictionStrategy: ""

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1211,7 +1211,7 @@ spec:
                                 description: |-
                                   Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
                                   Defaults to false.
-                                  Deprecated: Use .kubevirt.useDomainCPU instead.
+                                  Deprecated: Use .kubevirt.usePodResourcesCPU instead.
                                 type: boolean
                               enableDefaultNetworkPolicies:
                                 description: |-
@@ -1375,10 +1375,10 @@ spec:
                                 required:
                                   - name
                                 type: object
-                              useDomainCPU:
+                              usePodResourcesCPU:
                                 description: |-
-                                  Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
-                                  When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
+                                  Optional: UsePodResourcesCPU enables CPU assignment via Kubernetes Pod resource requests/limits.
+                                  When false (default), CPUs are assigned via KubeVirt's spec.domain.cpu.
                                 type: boolean
                               vmEvictionStrategy:
                                 description: |-

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1211,6 +1211,7 @@ spec:
                                 description: |-
                                   Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
                                   Defaults to false.
+                                  Deprecated: Use .kubevirt.useDomainCPU instead.
                                 type: boolean
                               enableDefaultNetworkPolicies:
                                 description: |-
@@ -1374,6 +1375,11 @@ spec:
                                 required:
                                   - name
                                 type: object
+                              useDomainCPU:
+                                description: |-
+                                  Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
+                                  When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
+                                type: boolean
                               vmEvictionStrategy:
                                 description: |-
                                   VMEvictionStrategy describes the strategy to follow when a node drain occurs. If not set the default

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -875,12 +875,12 @@ type DatacenterSpecKubevirt struct {
 
 	// Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
 	// Defaults to false.
-	// Deprecated: Use .kubevirt.useDomainCPU instead.
+	// Deprecated: Use .kubevirt.usePodResourcesCPU instead.
 	EnableDedicatedCPUs bool `json:"enableDedicatedCpus,omitempty"`
 
-	// Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
-	// When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
-	UseDomainCPU bool `json:"useDomainCPU,omitempty"`
+	// Optional: UsePodResourcesCPU enables CPU assignment via Kubernetes Pod resource requests/limits.
+	// When false (default), CPUs are assigned via KubeVirt's spec.domain.cpu.
+	UsePodResourcesCPU bool `json:"usePodResourcesCPU,omitempty"`
 
 	// Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
 	// in the dedicated infra KubeVirt cluster. They are added to the defaults.

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -875,7 +875,12 @@ type DatacenterSpecKubevirt struct {
 
 	// Optional: EnableDedicatedCPUs enables the assignment of dedicated cpus instead of resource requests and limits for a virtual machine.
 	// Defaults to false.
+	// Deprecated: Use .kubevirt.useDomainCPU instead.
 	EnableDedicatedCPUs bool `json:"enableDedicatedCpus,omitempty"`
+
+	// Optional: UseDomainCPU enables CPU assignment via KubeVirt's spec.domain.cpu.
+	// When false (default), CPUs are assigned via Kubernetes Pod resource requests/limits.
+	UseDomainCPU bool `json:"useDomainCPU,omitempty"`
 
 	// Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
 	// in the dedicated infra KubeVirt cluster. They are added to the defaults.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
This pr deprecates seed kubevirt config field `enabledDedicatedCPUs` and adds a new field called `useDomainCPU` in seed provider spec to be clearer what it does.

The new field is following a clearer naming regarding what it does and aligns with the naming of other flags  like `useExternalCloudProvider` regarding csi/ccm migration for kube-controller-manager.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The field `enabledDedicatedCPUs` in kubevirt provider spec is now deprecated. A new field called `useDomainCPU`  is introduced which is for the same purpose. When set to `true` cpu will be assigned by `spec.domain.cpu` for a kubevirt virtual machine instead of using resource requests and limits.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
