### PR TITLE
Add helm values validation for new Dex Chart

### DIFF
--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -337,29 +337,7 @@ func validateHelmValues(config *kubermaticv1.KubermaticConfiguration, helmValues
 			staticPasswordsPath = yamled.Path{"dex", "config", "staticPasswords"}
 		}
 
-		if domain, ok := helmValues.GetString(domainPath); domain == "" {
-			// Validate that the path dex.ingress.hosts[0].host exists in the values.yaml.
-			//
-			// We're not enforcing that the value of "host" be non-empty —
-			// it's valid for it to be an empty string. However, the key itself must be present.
-			//
-			// The GetString(domainPath) call returns two values:
-			// - domain: the string value at the specified path (empty string if not present or empty)
-			// - ok: boolean indicating whether the value at the path could be successfully parsed as a string
-			//
-			// If `ok` is false, it means the path does not exist or does not resolve to a string,
-			// which usually indicates a missing structure like:
-			//   dex:
-			//     ingress:
-			//       hosts:
-			//         - host: ""
-			//
-			// In newer versions of the Dex chart (useNewDexChart == true), this field must be defined,
-			// so we raise a validation error if it's missing entirely.
-			if !ok && useNewDexChart {
-				failures = append(failures, fmt.Errorf("Validation error: dex.ingress.hosts[0].host must be defined (even if an empty string)"))
-				return failures
-			}
+		if domain, _ := helmValues.GetString(domainPath); domain == "" {
 			logger.WithField("domain", config.Spec.Ingress.Domain).Warnf("Helm values: %s is empty, setting to spec.ingress.domain from KubermaticConfiguration", domainPath.String())
 			helmValues.Set(domainPath, config.Spec.Ingress.Domain)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds validation and defaulting for the new Dex Chart. The validation now works for both the old and new dex charts. The validation functions will take the correct yaml path based on `useNewDexChart` 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14195

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validation for checks in the installer for the new dex chart. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
