### PR TITLE
handle cleanup of bindings when cluster is in deletion

### DIFF
--- a/pkg/ee/policy-binding-controller/controller.go
+++ b/pkg/ee/policy-binding-controller/controller.go
@@ -135,7 +135,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	if !cluster.Spec.IsKyvernoEnabled() {
+	if !cluster.Spec.IsKyvernoEnabled() || !cluster.DeletionTimestamp.IsZero() {
 		if kuberneteshelper.HasFinalizer(binding, cleanupFinalizer) {
 			return reconcile.Result{}, r.handlePolicyBindingCleanup(ctx, binding)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When cluster was being deleted I observed that we were not removing the finalizer from policy bindings, resulting in deletion being stuck. This small PR fixes that.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #14383

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
