### PR TITLE
Add `--insecure` flag to mirror-images command to bypass TLS verification

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -56,6 +56,7 @@ type MirrorImagesOptions struct {
 	ArchivePath               string
 	LoadFrom                  string
 	DryRun                    bool
+	Insecure                  bool
 
 	AddonsPath  string
 	AddonsImage string
@@ -112,6 +113,8 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().StringVar(&opt.RegistryPrefix, "registry-prefix", "", "Check source registries against this prefix and only include images that match it")
 	cmd.PersistentFlags().StringVar(&opt.LoadFrom, "load-from", "", "Path to an image-archive to (up)load to the provided registry")
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
+	cmd.PersistentFlags().BoolVar(&opt.Insecure, "insecure", false, "Insecure option to bypass HTTPS/TLS certificate verification")
+
 	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
 
 	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
@@ -377,7 +380,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 				}
 			} else {
 				logger.WithField("registry", options.Registry).Info("🚀 Mirroring images…")
-				count, fullCount, err = images.CopyImages(ctx, logger, options.DryRun, sets.List(imageSet), options.Registry, userAgent)
+				count, fullCount, err = images.CopyImages(ctx, logger, options.DryRun, options.Insecure, sets.List(imageSet), options.Registry, userAgent)
 				if err != nil {
 					return fmt.Errorf("failed to mirror all images (successfully copied %d/%d): %w", count, fullCount, err)
 				}

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -86,7 +86,7 @@ func TestRetagImageForAllVersions(t *testing.T) {
 		}
 	}
 
-	if _, _, err := CopyImages(context.Background(), log, true, sets.List(imageSet), "test-registry:5000", "kubermatic-installer/test"); err != nil {
+	if _, _, err := CopyImages(context.Background(), log, true, true, sets.List(imageSet), "test-registry:5000", "kubermatic-installer/test"); err != nil {
 		t.Errorf("Error calling processImages: %v", err)
 	}
 }

--- a/pkg/install/images/integration/images_integration_test.go
+++ b/pkg/install/images/integration/images_integration_test.go
@@ -75,7 +75,7 @@ func TestProcessImagesFromHelmChartsAndSystemApps(t *testing.T) {
 	}
 	containerImages = append(containerImages, appImages...)
 
-	if _, _, err := images.CopyImages(context.Background(), log, true, containerImages, "test-registry:5000", "kubermatic-installer/test"); err != nil {
+	if _, _, err := images.CopyImages(context.Background(), log, true, true, containerImages, "test-registry:5000", "kubermatic-installer/test"); err != nil {
 		t.Errorf("Error calling CopyImages: %v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `--insecure` flag to `kubermatic-installer mirror-images` command to bypass the TLS verification


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--insecure`  flag to mirror-images command to bypass TLS verification
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
