### PR TITLE
Only match against main module release tags in github-release.sh

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -36,7 +36,7 @@ export GITHUB_AUTH="Authorization: token $GITHUB_TOKEN"
 
 # this stops execution when GIT_TAG is not overridden and
 # we are not on a tagged revision
-export GIT_TAG="${GIT_TAG:-$(git describe --tags --exact-match)}"
+export GIT_TAG="${GIT_TAG:-$(git describe --tags --exact-match --match='v*')}"
 export GIT_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 export GIT_HEAD="${GIT_HEAD:-$(git rev-parse HEAD)}"
 export GIT_REPO="${GIT_REPO:-kubermatic/kubermatic}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Our pipeline failed for 2.28.0-alpha.4 because this script picked up `sdk/v2.28.0-alpha.4` as tag. This PR makes the script in question match against `v*` to only get the main module tag. @xrstf already discovered this in #14578 but didn't fix it in this script too (boo!).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind regression
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
