### PR TITLE
add delete event to appdef validating webhook configuration

### DIFF
--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -539,6 +539,7 @@ func ApplicationDefinitionValidatingWebhookConfigurationReconciler(ctx context.C
 							Operations: []admissionregistrationv1.OperationType{
 								admissionregistrationv1.Create,
 								admissionregistrationv1.Update,
+								admissionregistrationv1.Delete,
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds delete event to the validating webhook configuration deployed by kkp operator for application definitions. This is required that the deletion prevention by label takes effect.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
ref: #14588 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
