### PR TITLE
automatically expire the temporary user-ssh-keys-agent image for e2e tests

### DIFF
--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -96,7 +96,8 @@ beforeDockerBuild=$(nowms)
   cd cmd/user-ssh-keys-agent
   make build
   IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
-  time retry 5 docker build -t "${IMAGE_NAME}" .
+  # label the image to auto-expire to save storage space on quay and be good netizens
+  time retry 5 docker build --tag "${IMAGE_NAME}" --label "quay.expires-after=24h" .
   # we use docker push here as the agent is pulled by the worker nodes and therefore needs to be available on quay
   time retry 5 docker push "${IMAGE_NAME}"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This will reduce our storage needs on quay and that is a good thing, no matter what.

See https://docs.redhat.com/it/documentation/red_hat_quay/3.10/html/about_quay_io/working-with-tags for more information.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
