### PR TITLE
Reconcile knp-agent based on cluster spec update

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -1072,7 +1072,11 @@ func (r *reconciler) reconcileDeployments(ctx context.Context, data reconcileDat
 		konnectivityResources := resources.GetOverrides(data.cluster.Spec.ComponentsOverride)
 
 		creators := []reconciling.NamedDeploymentReconcilerFactory{
-			konnectivity.DeploymentReconciler(data.clusterVersion, r.konnectivityServerHost, r.konnectivityServerPort, r.konnectivityKeepaliveTime, r.imageRewriter, konnectivityResources),
+			konnectivity.DeploymentReconciler(
+				data.clusterVersion, data.cluster,
+				r.konnectivityServerHost, r.konnectivityServerPort, r.konnectivityKeepaliveTime,
+				r.imageRewriter, konnectivityResources,
+			),
 			metricsserver.DeploymentReconciler(r.imageRewriter), // deploy metrics-server in user cluster
 		}
 		if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, r); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -2,7 +2,6 @@
 Copyright 2021 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
-
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -493,7 +493,11 @@ func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.Temp
 	}
 
 	if templateData.IsKonnectivityEnabled() {
-		deploymentReconcilers = append(deploymentReconcilers, konnectivity.DeploymentReconciler(templateData.Cluster().Spec.Version, "dummy", 0, kubermaticv1.DefaultKonnectivityKeepaliveTime, registry.GetImageRewriterFunc(templateData.OverwriteRegistry), nil))
+		deploymentReconcilers = append(deploymentReconcilers, konnectivity.DeploymentReconciler(
+			templateData.Cluster().Spec.Version, templateData.Cluster(),
+			"dummy", 0, kubermaticv1.DefaultKonnectivityKeepaliveTime,
+			registry.GetImageRewriterFunc(templateData.OverwriteRegistry), nil,
+		))
 	}
 
 	cronjobReconcilers := kubernetescontroller.GetCronJobReconcilers(templateData)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the user-cluster manager to reconcile Konnectivity agent (deployed in a user cluster) when Cluster's Konnectivity is updated

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14549#issuecomment-2941089243

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
