### PR TITLE
parse digest if configured for images with overwrite registry

### DIFF
--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -79,10 +79,6 @@ func RewriteImage(image, overwriteRegistry string) (string, error) {
 	}
 
 	domain := reference.Domain(named)
-	origDomain := domain
-	if origDomain == "" {
-		origDomain = RegistryDocker
-	}
 
 	if overwriteRegistry != "" {
 		domain = overwriteRegistry
@@ -99,7 +95,7 @@ func RewriteImage(image, overwriteRegistry string) (string, error) {
 	}
 
 	if digested, ok := named.(reference.Digested); ok {
-		image += ":" + digested.Digest().String()
+		image += "@" + digested.Digest().String()
 	}
 
 	return image, nil

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -98,15 +98,8 @@ func RewriteImage(image, overwriteRegistry string) (string, error) {
 		image += ":" + tagged.Tag()
 	}
 
-	// If the registry (domain) has been changed, remove the
-	// digest as it's unlikely that a) the repo digest has
-	// been kept when mirroring the image and b) the chance
-	// of a local registry being poisoned with bad images is
-	// much lower anyhow.
-	if origDomain == domain {
-		if digested, ok := named.(reference.Digested); ok {
-			image += "@" + string(digested.Digest())
-		}
+	if digested, ok := named.(reference.Digested); ok {
+		image += ":" + digested.Digest().String()
 	}
 
 	return image, nil

--- a/pkg/resources/registry/registry_test.go
+++ b/pkg/resources/registry/registry_test.go
@@ -80,10 +80,10 @@ func TestImageRewriter(t *testing.T) {
 			expected:  "registry.local/foo/bar",
 		},
 		{
-			name:      "a registry overwrite will remove the digest",
+			name:      "a registry overwrite will not remove the digest",
 			overwrite: "registry.local",
 			input:     addDigest("docker.io/foo/bar:v1.2.3"),
-			expected:  "registry.local/foo/bar:v1.2.3",
+			expected:  addDigest("registry.local/foo/bar:v1.2.3"),
 		},
 		{
 			name:      "a NOP rewrite should keep the digest",


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request fixes an issue when parsing images with a digest instead of a tag when using an overwrite registry, for instance in offline environments.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A bug where images with digest instead of a tag are not properly parsed was fixed. This affected mirroring images and all parsing with an overwrite registry configured.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
