### PR TITLE
[release/v2.26] update to Go 1.23.10

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -578,7 +578,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -578,7 +578,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: "ee"
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: "ee"
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -203,7 +203,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -242,7 +242,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -203,7 +203,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -242,7 +242,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -210,7 +210,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -164,7 +164,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -210,7 +210,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -169,7 +169,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -169,7 +169,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-12
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-12
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-12
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-12
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
           command:
             - "./hack/release-utility-images.sh"
           env:

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-12
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-12
           command:
             - "./hack/release-utility-images.sh"
           env:

--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -472,7 +472,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.30"
+          image: "docker.io/bitnami/kubectl:1.32"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -472,7 +472,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.30"
+          image: "docker.io/bitnami/kubectl:1.32"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -472,7 +472,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.30"
+          image: "docker.io/bitnami/kubectl:1.32"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
+++ b/charts/monitoring/prometheus/rules/general-vertical-pod-autoscaler.yaml
@@ -21,7 +21,7 @@ groups:
       # of the labels available on the container_* metrics, so we reduce them with the inner query to
       # only contain pod name, namespace and name.
       # Because the VPA does not allow to change the metric name it queries, but only the job selector,
-      # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
+      # we "cheat" by reusing the same metric name and injecting a custom job ("cadvisor-vpa") label.
       - record: container_cpu_usage_seconds_total
         expr: |
           label_replace(

--- a/charts/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/vertical-pod-autoscaler.yaml
@@ -20,7 +20,7 @@ groups:
   # of the labels available on the container_* metrics, so we reduce them with the inner query to
   # only contain pod name, namespace and name.
   # Because the VPA does not allow to change the metric name it queries, but only the job selector,
-  # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
+  # we "cheat" by reusing the same metric name and injecting a custom job ("cadvisor-vpa") label.
 
   - record: container_cpu_usage_seconds_total
     expr: |

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -1340,7 +1340,7 @@ data:
           # of the labels available on the container_* metrics, so we reduce them with the inner query to
           # only contain pod name, namespace and name.
           # Because the VPA does not allow to change the metric name it queries, but only the job selector,
-          # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
+          # we "cheat" by reusing the same metric name and injecting a custom job ("cadvisor-vpa") label.
           - record: container_cpu_usage_seconds_total
             expr: |
               label_replace(

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -1340,7 +1340,7 @@ data:
           # of the labels available on the container_* metrics, so we reduce them with the inner query to
           # only contain pod name, namespace and name.
           # Because the VPA does not allow to change the metric name it queries, but only the job selector,
-          # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
+          # we "cheat" by reusing the same metric name and injecting a custom job ("cadvisor-vpa") label.
           - record: container_cpu_usage_seconds_total
             expr: |
               label_replace(

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -1340,7 +1340,7 @@ data:
           # of the labels available on the container_* metrics, so we reduce them with the inner query to
           # only contain pod name, namespace and name.
           # Because the VPA does not allow to change the metric name it queries, but only the job selector,
-          # we "cheat" by re-using the same metric name and injecting a custom job ("cadvisor-vpa") label.
+          # we "cheat" by reusing the same metric name and injecting a custom job ("cadvisor-vpa") label.
           - record: container_cpu_usage_seconds_total
             expr: |
               label_replace(

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.2 AS builder
+FROM docker.io/golang:1.23.10 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.2 AS builder
+FROM docker.io/golang:1.23.10 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.23.2 AS builder
+FROM docker.io/golang:1.23.10 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/docs/proposals/cni-mgmt-via-applications.md
+++ b/docs/proposals/cni-mgmt-via-applications.md
@@ -123,6 +123,6 @@ Within sig-networking, we also considered 2 other approaches to address the goal
 
 2) Generic multi-CNI operator, running in the user cluster independently (similar to machine-controller):
    - If it provided a common high-level  CNI API, it would again become hard to use any arbitrary CNI features + it would be hard to maintain.
-   - If the API was generic (e.g. possible to provide any Helm values), it would eventually be just a Helm operator providing little value - after all, from KKP perspective it would be similar to just re-using the Applications infra, but without the benefit of having it already integrated with the KKP UI etc.
+   - If the API was generic (e.g. possible to provide any Helm values), it would eventually be just a Helm operator providing little value - after all, from KKP perspective it would be similar to just reusing the Applications infra, but without the benefit of having it already integrated with the KKP UI etc.
 
 Considering the fact that KKP users are already familiar with the Applications infra in KKP, it would be also easier for them to interact with the CNI management in a similar way.

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-4 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-12 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.23.2 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=golang:1.23.10 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.23.2 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=golang:1.23.10 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/update-kubermatic-ca-bundle.sh
+++ b/hack/update-kubermatic-ca-bundle.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.23.2 containerize ./hack/update-kubermatic-ca-bundle.sh
+CONTAINERIZE_IMAGE=golang:1.23.10 containerize ./hack/update-kubermatic-ca-bundle.sh
 
 echodate "Updating CA bundle..."
 curl -Lo charts/kubermatic-operator/static/ca-bundle.pem https://curl.se/ca/cacert.pem

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-4 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-12 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-4 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-12 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -44,7 +44,7 @@ const (
 
 	// NodePortProxyExposeNamespacedAnnotationKey is the annotation key used to indicate that
 	// a service should be exposed by the namespaced NodeportProxy instance.
-	// We use it when clusters get exposed via a LoadBalancer, to allow re-using that LoadBalancer
+	// We use it when clusters get exposed via a LoadBalancer, to allow reusing that LoadBalancer
 	// for both the kube-apiserver and the openVPN server.
 	NodePortProxyExposeNamespacedAnnotationKey = "nodeport-proxy.k8s.io/expose-namespaced"
 	DefaultExposeAnnotationKey                 = "nodeport-proxy.k8s.io/expose"


### PR DESCRIPTION
## Summary
Go 1.23.10 fixes these CVEs:

* CVE-2025-4673: net/http: sensitive headers not cleared on cross-origin redirect
* CVE-2025-0913: os: inconsistent handling of O_CREATE|O_EXCL on Unix and Windows
* CVE-2025-22874: crypto/x509: usage of ExtKeyUsageAny disables policy validation

## What Type of PR Is This?
/kind cleanup

## Release Notes
```release-note
Update to Go 1.23.10.
```
