### PR TITLE
Upgrade process fix for Seed MLA node-exporter chart

### DIFF
--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -669,6 +669,11 @@ func upgradeNodeExporterDaemonSet(
 	key := types.NamespacedName{Name: NodeExporterReleaseName, Namespace: NodeExporterNamespace}
 
 	err := kubeClient.Get(ctx, key, daemonset)
+
+	if err != nil{
+		return fmt.Errorf("failed get daemonset: %w", err)
+	}
+
 	if err == nil {
 		// 2: if deamonset exists, then store the daemonset for backup
 		backupTS := time.Now().Format("2006-01-02T150405")
@@ -683,11 +688,9 @@ func upgradeNodeExporterDaemonSet(
 		if err := kubeClient.Delete(ctx, daemonset); err != nil {
 			return fmt.Errorf("failed to remove the daemonset: %w\n\nuse backup file to check the changes and restore if needed", err)
 		}
-		return nil
 	}
 
-	logger.Warn("Skipping the backup and cleanup of the old Node-Exporter daemonset")
-	return fmt.Errorf("error querying API for the existing DaemonSet object: %w", err)
+	return nil
 }
 
 func upgradeBlackboxExporterDeployment(

--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -670,7 +670,7 @@ func upgradeNodeExporterDaemonSet(
 
 	err := kubeClient.Get(ctx, key, daemonset)
 
-	if err != nil{
+	if err != nil {
 		return fmt.Errorf("failed get daemonset: %w", err)
 	}
 

--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -178,7 +178,7 @@ func deployNodeExporter(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	if release != nil && release.Version.LessThan(v28) && !chart.Version.LessThan(v28) {
 		sublogger.Warn("Installation process will temporarily remove and then upgrade DaemonSet used by Node Exporter.")
 
-		err = upgradeNodeExporterDaemonSets(ctx, sublogger, kubeClient, helmClient, opt, chart, release)
+		err = upgradeNodeExporterDaemonSet(ctx, sublogger, kubeClient, helmClient, opt, chart, release)
 		if err != nil {
 			return fmt.Errorf("failed to prepare Node Exporter for upgrade: %w", err)
 		}
@@ -646,7 +646,7 @@ func upgradeKubeStateMetricsDeployment(
 	return nil
 }
 
-func upgradeNodeExporterDaemonSets(
+func upgradeNodeExporterDaemonSet(
 	ctx context.Context,
 	logger *logrus.Entry,
 	kubeClient ctrlruntimeclient.Client,
@@ -659,35 +659,33 @@ func upgradeNodeExporterDaemonSets(
 	// 1: find the old daemonset
 	logger.Info("Backing up old Node Exporter daemonset…")
 
-	daemonsetsList := &unstructured.UnstructuredList{}
-	daemonsetsList.SetGroupVersionKind(schema.GroupVersionKind{
+	daemonset := &unstructured.Unstructured{}
+	daemonset.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "apps",
-		Kind:    "DaemonSetList",
+		Kind:    "DaemonSet",
 		Version: "v1",
 	})
 
-	nodeExporterMatcher := ctrlruntimeclient.MatchingLabels{
-		"app.kubernetes.io/name": NodeExporterReleaseName,
-	}
-	if err := kubeClient.List(ctx, daemonsetsList, ctrlruntimeclient.InNamespace(NodeExporterNamespace), nodeExporterMatcher); err != nil {
+	key := types.NamespacedName{Name: NodeExporterReleaseName, Namespace: NodeExporterNamespace}
+
+	if err := kubeClient.Get(ctx, key, daemonset); err != nil {
 		return fmt.Errorf("error querying API for the existing DaemonSet object, aborting upgrade process.")
 	}
 
 	// 2: store the daemonset for backup
 	backupTS := time.Now().Format("2006-01-02T150405")
 	filename := fmt.Sprintf("backup_%s_%s.yaml", NodeExporterReleaseName, backupTS)
-	logger.Infof("Attempting to store the daemonsets in file: %s", filename)
-	if err := util.DumpResources(ctx, filename, daemonsetsList.Items); err != nil {
-		return fmt.Errorf("failed to back up the daemonsets, it is not removed: %w", err)
+	logger.Infof("Attempting to store the daemonset in file: %s", filename)
+	if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*daemonset}); err != nil {
+		return fmt.Errorf("failed to back up the daemonset, it is not removed: %w", err)
 	}
 
 	// 3: delete the daemonset
-	logger.Info("Deleting the daemonsets from the cluster")
-	for _, obj := range daemonsetsList.Items {
-		if err := kubeClient.Delete(ctx, &obj); err != nil {
-			return fmt.Errorf("failed to remove the daemonset: %w\n\nuse backup file to check the changes and restore if needed", err)
-		}
+	logger.Info("Deleting the daemonset from the cluster")
+	if err := kubeClient.Delete(ctx, daemonset); err != nil {
+		return fmt.Errorf("failed to remove the daemonset: %w\n\nuse backup file to check the changes and restore if needed", err)
 	}
+
 	return nil
 }
 

--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -674,20 +674,18 @@ func upgradeNodeExporterDaemonSet(
 		return fmt.Errorf("failed get daemonset: %w", err)
 	}
 
-	if err == nil {
-		// 2: if deamonset exists, then store the daemonset for backup
-		backupTS := time.Now().Format("2006-01-02T150405")
-		filename := fmt.Sprintf("backup_%s_%s.yaml", NodeExporterReleaseName, backupTS)
-		logger.Infof("Attempting to store the daemonset in file: %s", filename)
-		if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*daemonset}); err != nil {
-			return fmt.Errorf("failed to back up the daemonset, it is not removed: %w", err)
-		}
+	// 2: if deamonset exists, then store the daemonset for backup
+	backupTS := time.Now().Format("2006-01-02T150405")
+	filename := fmt.Sprintf("backup_%s_%s.yaml", NodeExporterReleaseName, backupTS)
+	logger.Infof("Attempting to store the daemonset in file: %s", filename)
+	if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*daemonset}); err != nil {
+		return fmt.Errorf("failed to back up the daemonset, it is not removed: %w", err)
+	}
 
-		// 3: delete the daemonset
-		logger.Info("Deleting the daemonset from the cluster")
-		if err := kubeClient.Delete(ctx, daemonset); err != nil {
-			return fmt.Errorf("failed to remove the daemonset: %w\n\nuse backup file to check the changes and restore if needed", err)
-		}
+	// 3: delete the daemonset
+	logger.Info("Deleting the daemonset from the cluster")
+	if err := kubeClient.Delete(ctx, daemonset); err != nil {
+		return fmt.Errorf("failed to remove the daemonset: %w\n\nuse backup file to check the changes and restore if needed", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the upgrade issue for `node-exporter` upstream chart introduced with https://github.com/kubermatic/kubermatic/pull/14176

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14669

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
node-exporter chart is now using the upstream helm chart with app version 1.19.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
