### PR TITLE
Fix Seed controller backup Interval arg parsing from kuberamtic cfg

### DIFF
--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -104,7 +104,7 @@ func SeedControllerManagerDeploymentReconciler(workerName string, versions kuber
 			}
 
 			if cfg.Spec.SeedController.BackupInterval.Duration > 0 {
-				args = append(args, fmt.Sprintf("-backup-interval=%s", cfg.Spec.SeedController.BackupInterval.String()))
+				args = append(args, fmt.Sprintf("-backup-interval=%s", cfg.Spec.SeedController.BackupInterval.Duration))
 			}
 
 			if cfg.Spec.SeedController.BackupCount != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the parsing issue in the seed controller manager backup interval flag. We are propagating metav1.Duration from k8c cfg to seed (seed use time.Duration) 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
