### PR TITLE
Upgrade process fix for Seed MLA components

### DIFF
--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -565,20 +565,18 @@ func upgradeAlertmanagerStatefulset(
 		return fmt.Errorf("failed get statefulset: %w", err)
 	}
 
-	if err == nil {
-		// 2: store the statefulset for backup
-		backupTS := time.Now().Format("2006-01-02T150405")
-		filename := fmt.Sprintf("backup_%s_%s.yaml", AlertManagerReleaseName, backupTS)
-		logger.Infof("Attempting to store the statefulset in file: %s", filename)
-		if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*statefulset}); err != nil {
-			return fmt.Errorf("failed to back up the statefulsets, it is not removed: %w", err)
-		}
+	// 2: store the statefulset for backup
+	backupTS := time.Now().Format("2006-01-02T150405")
+	filename := fmt.Sprintf("backup_%s_%s.yaml", AlertManagerReleaseName, backupTS)
+	logger.Infof("Attempting to store the statefulset in file: %s", filename)
+	if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*statefulset}); err != nil {
+		return fmt.Errorf("failed to back up the statefulsets, it is not removed: %w", err)
+	}
 
-		// 3: delete the statefulset
-		logger.Info("Deleting the statefulset from the cluster")
-		if err := kubeClient.Delete(ctx, statefulset); err != nil {
-			return fmt.Errorf("failed to remove the statefulset: %w\n\nuse backup file to check the changes and restore if needed", err)
-		}
+	// 3: delete the statefulset
+	logger.Info("Deleting the statefulset from the cluster")
+	if err := kubeClient.Delete(ctx, statefulset); err != nil {
+		return fmt.Errorf("failed to remove the statefulset: %w\n\nuse backup file to check the changes and restore if needed", err)
 	}
 
 	return nil
@@ -611,20 +609,18 @@ func upgradeKubeStateMetricsDeployment(
 		return fmt.Errorf("failed get deployment: %w", err)
 	}
 
-	if err == nil {
-		// 2: store the deployment for backup
-		backupTS := time.Now().Format("2006-01-02T150405")
-		filename := fmt.Sprintf("backup_%s_%s.yaml", KubeStateMetricsReleaseName, backupTS)
-		logger.Infof("Attempting to store the deployments in file: %s", filename)
-		if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*deployment}); err != nil {
-			return fmt.Errorf("failed to back up the deployment, it is not removed: %w", err)
-		}
+	// 2: store the deployment for backup
+	backupTS := time.Now().Format("2006-01-02T150405")
+	filename := fmt.Sprintf("backup_%s_%s.yaml", KubeStateMetricsReleaseName, backupTS)
+	logger.Infof("Attempting to store the deployments in file: %s", filename)
+	if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*deployment}); err != nil {
+		return fmt.Errorf("failed to back up the deployment, it is not removed: %w", err)
+	}
 
-		// 3: delete the deployment
-		logger.Info("Deleting the deployment from the cluster")
-		if err := kubeClient.Delete(ctx, deployment); err != nil {
-			return fmt.Errorf("failed to remove the deployment: %w\n\nuse backup file to check the changes and restore if needed", err)
-		}
+	// 3: delete the deployment
+	logger.Info("Deleting the deployment from the cluster")
+	if err := kubeClient.Delete(ctx, deployment); err != nil {
+		return fmt.Errorf("failed to remove the deployment: %w\n\nuse backup file to check the changes and restore if needed", err)
 	}
 
 	return nil
@@ -702,20 +698,18 @@ func upgradeBlackboxExporterDeployment(
 		return fmt.Errorf("failed get deployment: %w", err)
 	}
 
-	if err == nil {
-		// 2: store the deployment for backup
-		backupTS := time.Now().Format("2006-01-02T150405")
-		filename := fmt.Sprintf("backup_%s_%s.yaml", BlackboxExporterReleaseName, backupTS)
-		logger.Infof("Attempting to store the deployment in file: %s", filename)
-		if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*deployment}); err != nil {
-			return fmt.Errorf("failed to back up the deployment, it is not removed: %w", err)
-		}
+	// 2: store the deployment for backup
+	backupTS := time.Now().Format("2006-01-02T150405")
+	filename := fmt.Sprintf("backup_%s_%s.yaml", BlackboxExporterReleaseName, backupTS)
+	logger.Infof("Attempting to store the deployment in file: %s", filename)
+	if err := util.DumpResources(ctx, filename, []unstructured.Unstructured{*deployment}); err != nil {
+		return fmt.Errorf("failed to back up the deployment, it is not removed: %w", err)
+	}
 
-		// 3: delete the deployment
-		logger.Info("Deleting the deployment from the cluster")
-		if err := kubeClient.Delete(ctx, deployment); err != nil {
-			return fmt.Errorf("failed to remove the deployment: %w\n\nuse backup file to check the changes and restore if needed", err)
-		}
+	// 3: delete the deployment
+	logger.Info("Deleting the deployment from the cluster")
+	if err := kubeClient.Delete(ctx, deployment); err != nil {
+		return fmt.Errorf("failed to remove the deployment: %w\n\nuse backup file to check the changes and restore if needed", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the upgrade issue for `alertmanager `  upstream chart introduced with https://github.com/kubermatic/kubermatic/pull/14175
Also updated the error handling logic for `kube-state-metrics` and `blackbox-exporter`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14389#issuecomment-2951254642

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed upgrade process for Seed MLA components: 
* Alertmanager chart is now using the upstream helm chart with app version v0.28.0
* kube-state-metrics chart is now using the upstream helm chart with app version 2.15.0
* blackbox-exporter chart is now using the upstream helm chart with app version v0.25.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
