### PR TITLE
Fix OSM template data logic

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -282,6 +282,8 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithDnatControllerImage(r.dnatControllerImage).
 		WithMachineControllerImageTag(r.machineControllerImageTag).
 		WithMachineControllerImageRepository(r.machineControllerImageRepository).
+		WithOperatingSystemManagerImageTag(config.Spec.UserCluster.OperatingSystemManager.ImageTag).
+		WithOperatingSystemManagerImageRepository(config.Spec.UserCluster.OperatingSystemManager.ImageRepository).
 		WithBackupPeriod(r.backupSchedule).
 		WithBackupCount(r.backupCount).
 		WithFailureDomainZoneAntiaffinity(supportsFailureDomainZoneAntiAffinity).

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -72,29 +72,31 @@ type CABundle interface {
 
 // TemplateData is a group of data required for template generation.
 type TemplateData struct {
-	ctx                              context.Context
-	client                           ctrlruntimeclient.Client
-	cluster                          *kubermaticv1.Cluster
-	dc                               *kubermaticv1.Datacenter
-	seed                             *kubermaticv1.Seed
-	config                           *kubermaticv1.KubermaticConfiguration
-	OverwriteRegistry                string
-	nodePortRange                    string
-	nodeAccessNetwork                string
-	etcdDiskSize                     resource.Quantity
-	oidcIssuerURL                    string
-	oidcIssuerClientID               string
-	kubermaticImage                  string
-	dnatControllerImage              string
-	networkIntfMgrImage              string
-	machineControllerImageTag        string
-	machineControllerImageRepository string
-	backupSchedule                   time.Duration
-	backupCount                      *int
-	versions                         kubermatic.Versions
-	caBundle                         CABundle
-	clusterBackupStorageLocation     *kubermaticv1.ClusterBackupStorageLocation
-	apiServerAlternateNames          *certutil.AltNames
+	ctx                                   context.Context
+	client                                ctrlruntimeclient.Client
+	cluster                               *kubermaticv1.Cluster
+	dc                                    *kubermaticv1.Datacenter
+	seed                                  *kubermaticv1.Seed
+	config                                *kubermaticv1.KubermaticConfiguration
+	OverwriteRegistry                     string
+	nodePortRange                         string
+	nodeAccessNetwork                     string
+	etcdDiskSize                          resource.Quantity
+	oidcIssuerURL                         string
+	oidcIssuerClientID                    string
+	kubermaticImage                       string
+	dnatControllerImage                   string
+	networkIntfMgrImage                   string
+	machineControllerImageTag             string
+	machineControllerImageRepository      string
+	operatingSystemManagerImageTag        string
+	operatingSystemManagerImageRepository string
+	backupSchedule                        time.Duration
+	backupCount                           *int
+	versions                              kubermatic.Versions
+	caBundle                              CABundle
+	clusterBackupStorageLocation          *kubermaticv1.ClusterBackupStorageLocation
+	apiServerAlternateNames               *certutil.AltNames
 
 	supportsFailureDomainZoneAntiAffinity bool
 	userClusterMLAEnabled                 bool
@@ -268,6 +270,16 @@ func (td *TemplateDataBuilder) WithMachineControllerImageRepository(repository s
 	return td
 }
 
+func (td *TemplateDataBuilder) WithOperatingSystemManagerImageTag(tag string) *TemplateDataBuilder {
+	td.data.operatingSystemManagerImageTag = tag
+	return td
+}
+
+func (td *TemplateDataBuilder) WithOperatingSystemManagerImageRepository(repository string) *TemplateDataBuilder {
+	td.data.operatingSystemManagerImageRepository = repository
+	return td
+}
+
 func (td *TemplateDataBuilder) WithTunnelingAgentIP(tunnelingAgentIP string) *TemplateDataBuilder {
 	td.data.tunnelingAgentIP = tunnelingAgentIP
 	return td
@@ -417,11 +429,11 @@ func (d *TemplateData) MachineControllerImageRepository() string {
 }
 
 func (d *TemplateData) OperatingSystemManagerImageTag() string {
-	return d.config.Spec.UserCluster.OperatingSystemManager.ImageTag
+	return d.operatingSystemManagerImageTag
 }
 
 func (d *TemplateData) OperatingSystemManagerImageRepository() string {
-	return d.config.Spec.UserCluster.OperatingSystemManager.ImageRepository
+	return d.operatingSystemManagerImageRepository
 }
 
 func (d *TemplateData) OperatingSystemManagerDefaultOSPsDisabled() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
In offline scenarios, we set the value of the OSM image Repo and Tag in the kubermatic configuration! While we run a mirror-image command to copy the images to our repo. We figured out that the configured OSM Image and Tag are considered as the source image (which is intended to be the destination). This happens because template data logic reads unconditionally the ImageRepo and ImageTag from the Kubermatic Configuration. At the same time, we want to read this only when we deploy OSM in user clusters. 

This PR fixes the template data logic to prevent unconditional reads of OSM image and tag from the Kubermatic config in offline scenarios.

We added functions to set the OSM ImageRepo and ImageTag, and we are using these functions to read values from the kubermatic configuration when we deploy OSM. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
