### PR TITLE
Bump csi-node-driver-registrar in local-kubevirt

### DIFF
--- a/charts/local-kubevirt/templates/kubevirt-csi-driver.yaml
+++ b/charts/local-kubevirt/templates/kubevirt-csi-driver.yaml
@@ -83,7 +83,7 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/csi.kubevirt.io/csi.sock
-          image: quay.io/openshift/origin-csi-node-driver-registrar:4.13.0
+          image: quay.io/openshift/origin-csi-node-driver-registrar:4.20.0
           imagePullPolicy: Always
           lifecycle:
             preStop:


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR bumps csi-node-driver-registrar in local-kubevirt.  the csi-node-driver-registrar is used by kubevirt-csi-driver-operator. We need to ensure that we are using the same version used by this operator

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
