### PR TITLE
Add skip-charts on KKP installer usercluster-mla

### DIFF
--- a/pkg/install/stack/usercluster-mla/stack.go
+++ b/pkg/install/stack/usercluster-mla/stack.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"time"
 
 	semverlib "github.com/Masterminds/semver/v3"
@@ -170,6 +171,10 @@ func deployMLASecrets(ctx context.Context, logger *logrus.Entry, kubeClient ctrl
 }
 
 func deployAlertmanagerProxy(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, AlertmanagerProxyChartName) {
+		logger.Info("⭕ Skipping Alertmanager Proxy deployment.")
+		return nil
+	}
 	logger.Info("📦 Deploying Alertmanager Proxy…")
 	sublogger := log.Prefix(logger, "   ")
 
@@ -197,6 +202,11 @@ func deployAlertmanagerProxy(ctx context.Context, logger *logrus.Entry, kubeClie
 }
 
 func deployConsul(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, ConsulChartName) {
+		logger.Info("⭕ Skipping Consul deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Consul…")
 	sublogger := log.Prefix(logger, "   ")
 
@@ -234,6 +244,11 @@ func deployConsul(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunt
 }
 
 func deployCortex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, CortexChartName) {
+		logger.Info("⭕ Skipping Cortex deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Cortex…")
 	sublogger := log.Prefix(logger, "   ")
 
@@ -282,6 +297,11 @@ func deployCortex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunt
 }
 
 func deployGrafana(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, GrafanaChartName) {
+		logger.Info("⭕ Skipping Grafana deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Grafana…")
 	sublogger := log.Prefix(logger, "   ")
 
@@ -309,7 +329,7 @@ func deployGrafana(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrun
 }
 
 func deployLoki(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
-	if opt.MLASkipLogging {
+	if opt.MLASkipLogging || slices.Contains(opt.SkipCharts, LokiChartName) {
 		logger.Info("⭕ Skipping Loki deployment.")
 		return nil
 	}
@@ -341,6 +361,11 @@ func deployLoki(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntim
 }
 
 func deployMinio(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, MinioChartName) {
+		logger.Info("⭕ Skipping Minio deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Minio…")
 	sublogger := log.Prefix(logger, "   ")
 
@@ -368,6 +393,11 @@ func deployMinio(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunti
 }
 
 func deployMinioLifecycleMgr(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, MinioLifecycleMgrChartName) {
+		logger.Info("⭕ Skipping Minio Lifecycle Manager deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Minio Bucket Lifecycle Manager…")
 	sublogger := log.Prefix(logger, "   ")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When you deploy the usercluster MLA and decide to skip the chart with `--skip-charts`, you will find that the chart is not skipped. 

This PR will ensure that user can skip charts with `--skip-charts`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the ability to skip charts in the `kubermatic-installer deploy usercluster-mla` command.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
