### PR TITLE
Remove cluster-autoscaler from default accessible addons

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -8,7 +8,6 @@ spec:
   api:
     # AccessibleAddons is a list of addons that should be enabled in the API.
     accessibleAddons:
-      - cluster-autoscaler
       - node-exporter
       - kube-state-metrics
       - multus

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -8,7 +8,6 @@ spec:
   api:
     # AccessibleAddons is a list of addons that should be enabled in the API.
     accessibleAddons:
-      - cluster-autoscaler
       - node-exporter
       - kube-state-metrics
       - multus

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -79,7 +79,6 @@ func newSemver(s string) semver.Semver {
 
 var (
 	DefaultAccessibleAddons = []string{
-		"cluster-autoscaler",
 		"node-exporter",
 		"kube-state-metrics",
 		"multus",


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster-autoscaler addon was deprecated in KKP 2.27 in favor of the Application. Hence, we shouldn't have this by default in the accessible addons list.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cluster-autoscaler has been removed from the default accessible addons list. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/milestone KKP 2.28
/assign