### PR TITLE
Fix error return during generated Role & RoleBinding creation

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -364,11 +364,11 @@ func (c *resourcesController) ensureRBACRoleForNamedResource(ctx context.Context
 			continue
 		}
 		var sharedExistingRole rbacv1.Role
-		key := ctrlruntimeclient.ObjectKey{Name: generatedRole.Name}
+		key := ctrlruntimeclient.ObjectKey{Namespace: generatedRole.Namespace, Name: generatedRole.Name}
 		if err := c.client.Get(ctx, key, &sharedExistingRole); err != nil {
 			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRole); err != nil {
-					return nil
+					return err
 				}
 				continue
 			}
@@ -415,11 +415,11 @@ func (c *resourcesController) ensureRBACRoleBindingForNamedResource(ctx context.
 			},
 		)
 		var sharedExistingRoleBinding rbacv1.RoleBinding
-		key := ctrlruntimeclient.ObjectKey{Name: generatedRoleBinding.Name}
+		key := ctrlruntimeclient.ObjectKey{Namespace: generatedRoleBinding.Namespace, Name: generatedRoleBinding.Name}
 		if err := c.client.Get(ctx, key, &sharedExistingRoleBinding); err != nil {
 			if apierrors.IsNotFound(err) {
 				if err := c.client.Create(ctx, generatedRoleBinding); err != nil {
-					return nil
+					return err
 				}
 				continue
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
After changing the linter config in the codebase, the linter complains about returning `nil` rather than `err` itself -> `error is not nil but it returns nil (nilerr)`. The linter issue was fixed by changing the return but we encountered numerous reconciler errors in `master-controller-manager` about failed to sync of RBAC Role and RoleBinding. After some investigation, we realized that Adding `namespace` in `ObjectKey` fixes this issue. 

**Which issue(s) this PR fixes**:
Fixes reconciler errors: `failed to sync RBAC Role..` after returning `err` itself rather than `nil` while generation of Role and RoleBinding in `ensureRBACRoleForNamedResource` & `ensureRBACRoleBindingForNamedResource`. 

**What type of PR is this?**
<!--
/kind bug
-->

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
**Documentation**:
```documentation
NONE
```
