### PR TITLE
Remove 'enforced' annotation when application is unmarked

### DIFF
--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -206,9 +206,15 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		}
 	}
 
+	applicationsNames := make(map[string]bool)
+
 	// We don't want to fail the reconciliation if one application fails so we collect all the errors and return them as a single error.
 	var errors []error
 	for _, application := range applications {
+		// We append every app name that has the enforced annotation set to true.
+		// This way, we can set the enforced annotation to false in other application installations.
+		applicationsNames[application.Name] = true
+
 		// Using reconciler framework here doesn't help since the namespaces are different for the application installations.
 		err := r.ensureApplicationInstallation(ctx, userClusterClient, application)
 		if err != nil {
@@ -231,7 +237,39 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		}
 	}
 
+	err = r.ensureApplicationEnforcedAnnotationIsRemoved(ctx, userClusterClient, applicationsNames)
+	if err != nil {
+		return &reconcile.Result{RequeueAfter: 10 * time.Second}, fmt.Errorf("failed to ensure the enforced annotation is removed from ApplicationInstallations whose ApplicationDefinitions do not have 'enforced' set to true: %w", err)
+	}
+
 	return nil, kerrors.NewAggregate(errors)
+}
+
+func (r *Reconciler) ensureApplicationEnforcedAnnotationIsRemoved(ctx context.Context, userClusterClient ctrlruntimeclient.Client, applicationNames map[string]bool) error {
+	if len(applicationNames) == 0 {
+		return nil
+	}
+
+	existingApplicationList := &appskubermaticv1.ApplicationInstallationList{}
+	if err := userClusterClient.List(ctx, existingApplicationList); err != nil {
+		return fmt.Errorf("failed to list installed applications: %w", err)
+	}
+
+	for _, existingApplication := range existingApplicationList.Items {
+		if _, ok := applicationNames[existingApplication.Spec.ApplicationRef.Name]; !ok {
+			if existingApplication.Annotations == nil {
+				existingApplication.Annotations = map[string]string{}
+			}
+
+			existingApplication.Annotations[appskubermaticv1.ApplicationEnforcedAnnotation] = "false"
+
+			if err := userClusterClient.Update(ctx, &existingApplication); err != nil {
+				return fmt.Errorf("failed to update ApplicationInstallation %s in namespace %s: %w", existingApplication.Namespace, existingApplication.Name, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, userClusterClient ctrlruntimeclient.Client, application appskubermaticv1.ApplicationDefinition) error {
@@ -247,15 +285,15 @@ func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, userClus
 		return err
 	}
 	var currentApplicationInstallation *appskubermaticv1.ApplicationInstallation
-	for _, exisitingApplication := range existingApplicationList.Items {
+	for _, existingApplication := range existingApplicationList.Items {
 		// if we find an application installation which is defaulted and enforced we found an existing resource
-		if exisitingApplication.Spec.ApplicationRef.Name == application.Name && exisitingApplication.Name == application.Name {
+		if existingApplication.Spec.ApplicationRef.Name == application.Name && existingApplication.Name == application.Name {
 			// we can suppress the error here because the return value will be false if something cannot be parsed
-			appEnforcedEnabled, _ := strconv.ParseBool(exisitingApplication.Annotations[appskubermaticv1.ApplicationEnforcedAnnotation])
-			appDefaultedEnabled, _ := strconv.ParseBool(exisitingApplication.Annotations[appskubermaticv1.ApplicationDefaultedAnnotation])
+			appEnforcedEnabled, _ := strconv.ParseBool(existingApplication.Annotations[appskubermaticv1.ApplicationEnforcedAnnotation])
+			appDefaultedEnabled, _ := strconv.ParseBool(existingApplication.Annotations[appskubermaticv1.ApplicationDefaultedAnnotation])
 			// if enforced and defaulted we found the existing default application installation
 			if appEnforcedEnabled && appDefaultedEnabled {
-				currentApplicationInstallation = &exisitingApplication
+				currentApplicationInstallation = &existingApplication
 				break
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

- When an application is marked as enforced, it is correctly installed on all running clusters. However, if the application definition is later unmarked as enforced, the apps.kubermatic.k8c.io/enforced annotation remains present on the associated ApplicationInstallation objects.

- As a result, the "Delete Application" button in the Kubermatic dashboard remains disabled, preventing users from removing the application from clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14646

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

- I implemented a map that contains the names of ApplicationDefinitions which are marked as enforced. During reconciliation, if the ApplicationRef.Name of existing ApplicationInstallations in the cluster is not present in this map, then we set the apps.kubermatic.k8c.io/enforced annotation on the corresponding ApplicationInstallation to false.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
