### PR TITLE
WIP - overwrite default apps containers for offline setups

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -429,7 +429,7 @@ func main() {
 		log.Info("Registered constraintsyncer controller")
 	}
 
-	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, runOp.namespace, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace, ClusterName: runOp.clusterName}); err != nil {
+	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, runOp.namespace, runOp.overwriteRegistry, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace, ClusterName: runOp.clusterName}); err != nil {
 		log.Fatalw("Failed to add user Application Installation controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered Application Installation controller")

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -22,7 +22,9 @@ import (
 	"os"
 	"time"
 
+	"dario.cat/mergo"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/sdk/v2/apis/equality"
@@ -34,6 +36,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
@@ -76,9 +79,10 @@ type reconciler struct {
 	clusterIsPaused      userclustercontrollermanager.IsPausedChecker
 	appInstaller         applications.ApplicationInstaller
 	seedClusterNamespace string
+	overwriteRegistry    string
 }
 
-func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterIsPaused userclustercontrollermanager.IsPausedChecker, seedClusterNamespace string, appInstaller applications.ApplicationInstaller) error {
+func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterIsPaused userclustercontrollermanager.IsPausedChecker, seedClusterNamespace, overwriteRegistry string, appInstaller applications.ApplicationInstaller) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
@@ -89,6 +93,7 @@ func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.M
 		clusterIsPaused:      clusterIsPaused,
 		appInstaller:         appInstaller,
 		seedClusterNamespace: seedClusterNamespace,
+		overwriteRegistry:    overwriteRegistry,
 	}
 
 	_, err := builder.ControllerManagedBy(userMgr).
@@ -215,6 +220,13 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, appI
 		return err
 	}
 
+	if r.overwriteRegistry == "" {
+		err := r.useOverwriteRegistry(ctx, applicationDef, appInstallation)
+		if err != nil {
+			return fmt.Errorf("failed to overwrite the registry %w", err)
+		}
+	}
+
 	// install application into the user-cluster
 	if err := r.handleInstallation(ctx, log, applicationDef, appInstallation); err != nil {
 		return fmt.Errorf("handling installation of application installation: %w", err)
@@ -309,6 +321,29 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 	return installErr
 }
 
+func (r *reconciler) useOverwriteRegistry(ctx context.Context, appDefinition *appskubermaticv1.ApplicationDefinition, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+	if IsAppManagedByKKP(appDefinition) {
+		return r.updateValuesBlock(ctx, appDefinition, appInstallation)
+	}
+	return nil
+}
+
+// IsAppManagedByKKP checks if the ApplicationDefinition is managed by KKP
+func IsAppManagedByKKP(appDefinition *appskubermaticv1.ApplicationDefinition) bool {
+	// Check if the appDefinition has labels
+	if appDefinition.Labels == nil {
+		return false
+	}
+
+	// Check for the specific label
+	if managedBy, exists := appDefinition.Labels["apps.kubermatic.k8c.io/managed-by"]; exists {
+		return managedBy == "kkp"
+	}
+
+	// Default to false if the label does not exist or does not match
+	return false
+}
+
 func hasLimitedRetries(appDefinition *appskubermaticv1.ApplicationDefinition, appInstallation *appskubermaticv1.ApplicationInstallation) bool {
 	// todo VGR factorize code with pkg/applications/providers/template/helm.go::getDeployOpts
 	// Read atomic from applicationInstallation.
@@ -386,4 +421,50 @@ func enqueueAppInstallationForAppDef(userClient ctrlruntimeclient.Client) func(c
 
 func handleAddonCleanup(ctx context.Context, applicationName string, seedClusterNamespace string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 	return applicationtemplates.HandleAddonCleanup(ctx, applicationName, seedClusterNamespace, seedClient, log)
+}
+
+// updateValuesBlock updates the valuesBlock of an ApplicationInstallation in-place
+func (r *reconciler) updateValuesBlock(ctx context.Context, appDefinition *appskubermaticv1.ApplicationDefinition, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+	appName := appDefinition.Name
+	getOverrideValues, exists := ValuesGenerators[appName]
+	if !exists {
+		return fmt.Errorf("application '%s' is not managed/supported by KKP", appName)
+	}
+
+	// Unmarshal existing values
+	values, err := appInstallation.Spec.GetParsedValues()
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal CNI values: %w", err)
+	}
+
+	// If (and only if) existing values is empty, use the initial values
+	if len(values) == 0 {
+		initialValues, err := appDefinition.Spec.GetParsedDefaultValues()
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal ApplicationDefinition default values: %w", err)
+		}
+		values = initialValues
+	}
+
+	// Generate the Helm values
+	overrideValues := getOverrideValues(appInstallation, r.overwriteRegistry)
+
+	if err := mergo.Merge(&values, overrideValues, mergo.WithOverride); err != nil {
+		return fmt.Errorf("failed to merge application values: %w", err)
+	}
+
+	// Marshal the values into YAML
+	rawValues, err := yaml.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Helm values for %s: %w", appName, err)
+	}
+
+	// Update the valuesBlock field in-place
+	appInstallation.Spec.ValuesBlock = string(rawValues)
+	// Clear the deprecated .spec.values field to avoid conflicts
+	appInstallation.Spec.Values = runtime.RawExtension{
+		Raw: []byte("{}"),
+	}
+
+	return r.userClient.Update(ctx, appInstallation)
 }

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -434,7 +434,7 @@ func startTestEnvWithCleanup(t *testing.T, applicationInstaller *fake.Applicatio
 
 	isClusterPausedFunc := func(ctx context.Context) (bool, error) { return false, nil }
 
-	if err := Add(ctx, kubermaticlog.Logger, mgr, mgr, isClusterPausedFunc, ns.Name, applicationInstaller); err != nil {
+	if err := Add(ctx, kubermaticlog.Logger, mgr, mgr, isClusterPausedFunc, ns.Name, "", applicationInstaller); err != nil {
 		t.Fatalf("failed to add controller to manager: %s", err)
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ce.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ce.go
@@ -1,0 +1,47 @@
+//go:build !ee
+
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
+)
+
+const (
+	ClusterAutoscalerDefaultRepository = "registry.k8s.io/autoscaling/cluster-autoscaler"
+)
+
+// Function signature for generating Helm values block
+type ValuesGenerator func(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{}
+
+// Map of functions to generate Helm values for different applications
+var ValuesGenerators = map[string]ValuesGenerator{
+	"cluster-autoscaler": generateClusterAutoscalerValues,
+}
+
+func generateClusterAutoscalerValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Build the final values structure
+	values := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage(ClusterAutoscalerDefaultRepository, overwriteRegistry)),
+		},
+	}
+
+	return values
+}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ee.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/wrappers_ee.go
@@ -1,0 +1,317 @@
+//go:build ee
+
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
+)
+
+const (
+	CertManagerRegistryPrefix = "quay.io/jetstack/cert-manager-"
+	Flux2RegistryPrefix       = "ghcr.io/fluxcd/"
+	MetalLBRegistryPrefix     = "quay.io/metallb/"
+)
+
+// Function signature for generating Helm values block
+type ValuesGenerator func(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{}
+
+// Map of functions to generate Helm values for different applications
+var ValuesGenerators = map[string]ValuesGenerator{
+	"argocd":              generateArgoCDValues,
+	"cert-manager":        generateCertManagerValues,
+	"falco":               generateFalcoValues,
+	"flux2":               generateFluxValues,
+	"k8sgpt-operator":     generateK8sGPTValues,
+	"kube-vip":            generateKubeVIPValues,
+	"metallb":             generateMetalLBValues,
+	"nginx":               generateIngressNGINXValues,
+	"nvidia-gpu-operator": generateNVIDIAGPUOperatorValues,
+	"trivy":               generateTrivyAppValues,
+	"trivy-operator":      generateTrivyOperatorValues,
+	"aikit":               generateAiKitValues,
+}
+
+func generateArgoCDValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	globalValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage("quay.io/argoproj/argocd", overwriteRegistry)),
+		},
+	}
+	dexValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage("ghcr.io/dexidp/dex", overwriteRegistry)),
+		},
+	}
+	redisValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage("ecr-public.aws.com/docker/library/redis", overwriteRegistry)),
+		},
+		"exporter": map[string]any{
+			"image": map[string]any{
+				"repository": registry.Must(registry.RewriteImage("ghcr.io/oliver006/redis_exporter", overwriteRegistry)),
+			},
+		},
+	}
+	serverValues := map[string]any{
+		"extensions": map[string]any{
+			"image": map[string]any{
+				"repository": registry.Must(registry.RewriteImage("quay.io/argoprojlabs/argocd-extension-installer", overwriteRegistry)),
+			},
+		},
+	}
+	values := map[string]any{
+		"global": globalValues,
+		"dex":    dexValues,
+		"redis":  redisValues,
+		"server": serverValues,
+	}
+	return values
+}
+
+func generateCertManagerValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	imageValues := map[string]any{
+		"repository": registry.Must(registry.RewriteImage(CertManagerRegistryPrefix+"controller", overwriteRegistry)),
+	}
+	webhookValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage(CertManagerRegistryPrefix+"webhook", overwriteRegistry)),
+		},
+	}
+	cainjectorValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage(CertManagerRegistryPrefix+"cainjector", overwriteRegistry)),
+		},
+	}
+	acmesolverValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage(CertManagerRegistryPrefix+"acmesolver", overwriteRegistry)),
+		},
+	}
+	startupapicheckValues := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage(CertManagerRegistryPrefix+"startupapicheck", overwriteRegistry)),
+		},
+	}
+	values := map[string]any{
+		"image":           imageValues,
+		"webhook":         webhookValues,
+		"cainjector":      cainjectorValues,
+		"acmesolver":      acmesolverValues,
+		"startupapicheck": startupapicheckValues,
+	}
+	return values
+}
+
+func generateFalcoValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	imageValues := map[string]any{
+		"registry": overwriteRegistry,
+	}
+	registryValues := map[string]any{
+		"image": map[string]any{
+			"registry": overwriteRegistry,
+		},
+	}
+	driverValues := map[string]any{
+		"loader": map[string]any{
+			"initContainer": registryValues,
+		},
+	}
+	cliValues := registryValues
+
+	values := map[string]any{
+		"image":    imageValues,
+		"driver":   driverValues,
+		"falcoctl": cliValues,
+	}
+	return values
+}
+
+func generateFluxValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	cliValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"flux-cli", overwriteRegistry)),
+	}
+	helmCtrlValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"helm-controller", overwriteRegistry)),
+	}
+	imgAutomationValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"image-automation-controller", overwriteRegistry)),
+	}
+	imgReflectionValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"image-reflector-controller", overwriteRegistry)),
+	}
+	kustomizeValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"kustomize-controller", overwriteRegistry)),
+	}
+	notificationValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"notification-controller", overwriteRegistry)),
+	}
+	sourceValues := map[string]any{
+		"image": registry.Must(registry.RewriteImage(Flux2RegistryPrefix+"source-controller", overwriteRegistry)),
+	}
+	values := map[string]any{
+		"cli":                       cliValues,
+		"helmController":            helmCtrlValues,
+		"imageAutomationController": imgAutomationValues,
+		"imageReflectionController": imgReflectionValues,
+		"kustomizeController":       kustomizeValues,
+		"notificationController":    notificationValues,
+		"sourceController":          sourceValues,
+	}
+	return values
+}
+
+// generateK8sGPTValues generates Helm values for k8sgpt
+func generateK8sGPTValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Define image repositories for each component
+	kubeRbacProxyValues := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": registry.Must(registry.RewriteImage("quay.io/brancz/kube-rbac-proxy", overwriteRegistry)),
+		},
+	}
+	managerValues := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": registry.Must(registry.RewriteImage("ghcr.io/k8sgpt-ai/k8sgpt-operator", overwriteRegistry)),
+		},
+	}
+
+	// Build the final values structure
+	values := map[string]interface{}{
+		"controllerManager": map[string]interface{}{
+			"kubeRbacProxy": kubeRbacProxyValues,
+			"manager":       managerValues,
+		},
+	}
+
+	return values
+}
+
+// generateKubeVIPValues generates Helm values for kube-vip
+func generateKubeVIPValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Define image repository for kube-vip
+	imageValues := map[string]interface{}{
+		"repository": registry.Must(registry.RewriteImage("ghcr.io/kube-vip/kube-vip", overwriteRegistry)),
+	}
+
+	// Build the final values structure
+	values := map[string]interface{}{
+		"image": imageValues,
+	}
+
+	return values
+}
+
+func generateMetalLBValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Define image repositories for each component
+	controllerValues := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": registry.Must(registry.RewriteImage(MetalLBRegistryPrefix+"controller", overwriteRegistry)),
+		},
+	}
+	speakerValues := map[string]interface{}{
+		"image": map[string]interface{}{
+			"repository": registry.Must(registry.RewriteImage(MetalLBRegistryPrefix+"speaker", overwriteRegistry)),
+		},
+		"frr": map[string]interface{}{
+			"image": map[string]interface{}{
+				"repository": registry.Must(registry.RewriteImage("quay.io/frrouting/frr", overwriteRegistry)),
+			},
+		},
+	}
+
+	// Build the final values structure
+	values := map[string]interface{}{
+		"controller": controllerValues,
+		"speaker":    speakerValues,
+	}
+
+	return values
+}
+
+// generateIngressNGINXValues generates Helm values for ingress-nginx
+func generateIngressNGINXValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Build the final values structure
+	values := map[string]any{
+		"global": map[string]any{
+			"image": map[string]any{
+				"registry": overwriteRegistry,
+			},
+		},
+	}
+
+	return values
+}
+
+func generateNVIDIAGPUOperatorValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Build the final values structure
+	repositoryValues := map[string]any{
+		"repository": overwriteRegistry,
+	}
+	values := map[string]any{
+		"nodeStatusExporter": repositoryValues,
+		"operator":           repositoryValues,
+		"validator":          repositoryValues,
+	}
+
+	return values
+}
+
+func generateTrivyOperatorValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Build the final values structure
+	values := map[string]interface{}{
+		"image": map[string]interface{}{
+			"registry": overwriteRegistry,
+		},
+		"trivy": map[string]interface{}{
+			"image": map[string]interface{}{
+				"registry": overwriteRegistry,
+			},
+		},
+	}
+	return values
+}
+
+func generateTrivyAppValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Build the final values structure
+	values := map[string]interface{}{
+		"image": map[string]interface{}{
+			"registry": overwriteRegistry,
+		},
+	}
+
+	return values
+}
+
+func generateAiKitValues(app *appskubermaticv1.ApplicationInstallation, overwriteRegistry string) map[string]interface{} {
+	// Build the final values structure
+	values := map[string]any{
+		"image": map[string]any{
+			"repository": registry.Must(registry.RewriteImage("ghcr.io/sozercan/llama3", overwriteRegistry)),
+		},
+		"postInstall": map[string]any{
+			"labelNamespace": map[string]any{
+				"image": map[string]any{
+					"repository": registry.Must(registry.RewriteImage("registry.k8s.io/kubectl", overwriteRegistry)),
+				},
+			},
+		},
+	}
+
+	return values
+}

--- a/pkg/ee/default-application-catalog/applicationdefinitions/aikit-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/aikit-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: aikit
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: AIKit is a comprehensive platform to quickly get started to host, deploy, build and fine-tune large language models (LLMs).
   displayName: AIKit

--- a/pkg/ee/default-application-catalog/applicationdefinitions/argocd-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/argocd-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: argocd
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Argo CD - Declarative, GitOps Continuous Delivery Tool for Kubernetes.
   displayName: Argo CD

--- a/pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: cert-manager
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: cert-manager is a Kubernetes addon to automate the management and issuance of TLS certificates from various issuing sources.
   displayName: cert-manager

--- a/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: falco
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Falco is a cloud native runtime security tool for Linux operating systems.
   displayName: Falco

--- a/pkg/ee/default-application-catalog/applicationdefinitions/flux2-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/flux2-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: flux2
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Flux is a tool for keeping Kubernetes clusters in sync with sources of configuration (like Git repositories), and automating updates to configuration when there is new code to deploy.
   displayName: Flux

--- a/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-operator-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: k8sgpt-operator
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: K8sGPT Operator is designed to enable K8sGPT within a Kubernetes cluster. It will allow you to create a custom resource that defines the behaviour and scope of a managed K8sGPT workload.
   displayName: K8sGPT Operator

--- a/pkg/ee/default-application-catalog/applicationdefinitions/kube-vip-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/kube-vip-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: kube-vip
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: kube-vip provides Kubernetes clusters with a virtual IP and load balancer for both the control plane (for building a highly-available cluster) and Kubernetes Services of type LoadBalancer without relying on any external hardware or software.
   displayName: kube-vip

--- a/pkg/ee/default-application-catalog/applicationdefinitions/kubevirt-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/kubevirt-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: kubevirt
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: KubeVirt with Containerized Data Importer
   displayName: KubeVirt

--- a/pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: metallb
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
   displayName: MetalLB

--- a/pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml
@@ -21,7 +21,9 @@
 apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
-  name: nginx
+  name: 
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.
   displayName: NGINX Ingress Controller

--- a/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: nvidia-gpu-operator
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Nvidia GPU management for Kubernetes
   displayName: NVIDIA GPU Operator

--- a/pkg/ee/default-application-catalog/applicationdefinitions/trivy-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/trivy-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: trivy
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Trivy is a simple and comprehensive vulnerability/misconfiguration/secret scanner for containers and other artifacts.
   displayName: Trivy

--- a/pkg/ee/default-application-catalog/applicationdefinitions/trivy-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/trivy-operator-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: trivy-operator
+  labels:
+    apps.kubermatic.k8c.io/managed-by: kkp
 spec:
   description: Trivy-Operator is a Kubernetes-native security toolkit.
   displayName: Trivy Operator


### PR DESCRIPTION
**What this PR does / why we need it**:

In offline scenarios, we are using our offline helm charts, but the releases will use the upstream images, not the mirrored ones. This PR will fix this by adding the ability to deploy default apps, overwriting the image source if overwriteRegistry is defined! 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
