### PR TITLE
fix: CBSL credentials and status sync to seed for seperate master and seed cluster setup

### DIFF
--- a/pkg/ee/cluster-backup/master/sync-controller/controller.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/controller.go
@@ -150,6 +150,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 
 		if !equality.Semantic.DeepEqual(seedCBSL.Status, cbsl.Status) {
+			seedCBSL.Status = cbsl.Status
 			if err := seedClient.Status().Update(ctx, seedCBSL); err != nil {
 				return fmt.Errorf("failed to update storage location status on seed cluster: %w", err)
 			}

--- a/pkg/ee/cluster-backup/master/sync-controller/controller.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/controller.go
@@ -197,14 +197,5 @@ func syncCBSLCredentialSecret(
 		secretReconcilerFactory(cbslSecret),
 	}
 
-	seedCBSLSecret := &corev1.Secret{}
-	if err := seedClient.Get(ctx, cbslKey, seedCBSLSecret); err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to fetch CBSL credential secret on seed cluster: %w", err)
-	}
-
-	if seedCBSLSecret.UID != "" && seedCBSLSecret.UID == cbslSecret.UID {
-		return nil
-	}
-
 	return reconciling.ReconcileSecrets(ctx, secretReconcilerFactory, cbslSecret.Namespace, seedClient)
 }

--- a/pkg/ee/cluster-backup/master/sync-controller/controller.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/controller.go
@@ -29,8 +29,6 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"k8c.io/kubermatic/sdk/v2/apis/equality"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -39,6 +37,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/ee/cluster-backup/master/sync-controller/resources.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/resources.go
@@ -26,11 +26,14 @@ package synccontroller
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/reconciler/pkg/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
-func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) reconciling.NamedClusterBackupStorageLocationReconcilerFactory {
-	return func() (string, reconciling.ClusterBackupStorageLocationReconciler) {
+func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) kkpreconciling.NamedClusterBackupStorageLocationReconcilerFactory {
+	return func() (string, kkpreconciling.ClusterBackupStorageLocationReconciler) {
 		return cbsl.Name, func(existing *kubermaticv1.ClusterBackupStorageLocation) (*kubermaticv1.ClusterBackupStorageLocation, error) {
 			if existing.Labels == nil {
 				existing.Labels = map[string]string{}
@@ -39,6 +42,17 @@ func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) reco
 				existing.Labels[k] = v
 			}
 			existing.Spec = cbsl.Spec
+			return existing, nil
+		}
+	}
+}
+
+func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconcilerFactory {
+	return func() (name string, create reconciling.SecretReconciler) {
+		return s.Name, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			existing.Labels = s.Labels
+			existing.Annotations = s.Annotations
+			existing.Data = s.Data
 			return existing, nil
 		}
 	}

--- a/pkg/ee/cluster-backup/master/sync-controller/resources.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/resources.go
@@ -50,6 +50,9 @@ func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) kkpr
 func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconcilerFactory {
 	return func() (name string, create reconciling.SecretReconciler) {
 		return s.Name, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			if existing.UID != "" && s.UID == existing.UID {
+				return nil, nil
+			}
 			existing.Labels = s.Labels
 			existing.Annotations = s.Annotations
 			existing.Data = s.Data


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where the ClusterBackupStorageLocation (CBSL) was reconciled to seed clusters without syncing the referenced credential Secret, causing backup operations to fail.
This PR ensures that the credential Secret is created or updated in each seed cluster during CBSL reconciliation. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14691 and #14645 

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue with CBSL credentials and status not syncing to seed clusters.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
