### PR TITLE
add test and fix bug regarding app enforce annotation

### DIFF
--- a/pkg/controller/seed-controller-manager/default-application-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller_test.go
@@ -671,10 +671,8 @@ func compareApplications(installedApps []appskubermaticv1.ApplicationInstallatio
 				}
 				if appDef.Spec.Enforced {
 					expectedAnnotations[appskubermaticv1.ApplicationEnforcedAnnotation] = "true"
-				} else {
-					if annotationsHasChanged {
-						expectedAnnotations[appskubermaticv1.ApplicationEnforcedAnnotation] = "false"
-					}
+				} else if annotationsHasChanged {
+					expectedAnnotations[appskubermaticv1.ApplicationEnforcedAnnotation] = "false"
 				}
 
 				if !reflect.DeepEqual(installedApp.Annotations, expectedAnnotations) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a test for #14646 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A bug was fixed where enforced annotation on application installation were not removed when enforcement for the related application definition was disabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
