### PR TITLE
Add post-backup cleanup hook for Prometheus backups

### DIFF
--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -44,6 +44,8 @@ spec:
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: '{{ .Values.prometheus.backup.timeout | default "60m" }}'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
+        post.hook.backup.velero.io/container: backup
+        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
         {{- end }}
     spec:
       {{- if .Values.prometheus.imagePullSecrets }}

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -2104,6 +2104,8 @@ spec:
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: '60m'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
+        post.hook.backup.velero.io/container: backup
+        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
     spec:
       containers:
       - name: prometheus

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -2104,6 +2104,8 @@ spec:
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: '60m'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
+        post.hook.backup.velero.io/container: backup
+        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
     spec:
       containers:
       - name: prometheus

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -2104,6 +2104,8 @@ spec:
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: '60m'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
+        post.hook.backup.velero.io/container: backup
+        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
     spec:
       containers:
       - name: prometheus


### PR DESCRIPTION

**What this PR does / why we need it**:
Add Velero post-backup hook to clean up /backup/* files after Prometheus backup completion to prevent disk space accumulation.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14246

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

This is not scheduled for the 2.28 release.

### Testing

1. Deploy KKP and set `.prometheus.backup.enabled` to true in seed-mla values.yaml file
2. Run a backup that also targets your pods in `monitoring` namespaces - you can opt for `all namespaces` while running the backup
3.  Check that after backup if the `backup` container still contains data in `/backup` folder

Before adding hooks you should see something below:
```
$ k exec -n monitoring prometheus-0 -c backup -- ls /backup
01JY7J895B66PREGWK39FYDQKX
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
Add Velero post-backup hook to clean up /backup/* files after Prometheus backup completion to prevent disk space accumulation on the node where Prometheus is running.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
