### PR TITLE
Fix log spam on deleted ResourceQuota objects

### DIFF
--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -98,6 +98,10 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug("resource quota not found, might be deleted: %w", err)
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{}, fmt.Errorf("failed to get resource quota: %w", err)
 	}
 

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -30,7 +30,6 @@ import (
 	"reflect"
 
 	"go.uber.org/zap"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	k8cequality "k8c.io/kubermatic/sdk/v2/apis/equality"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -38,6 +37,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -30,6 +30,7 @@ import (
 	"reflect"
 
 	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	k8cequality "k8c.io/kubermatic/sdk/v2/apis/equality"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -94,6 +95,10 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug("resource quota not found, might be deleted: %w", err)
+			return reconcile.Result{}, nil
+		}
 		return reconcile.Result{}, fmt.Errorf("failed to get resource quota: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the behaviour of the `kkp-master-resource-quota-controller` by gracefully handling cases where a ResourceQuota no longer exists (e.g., after a project is deleted).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14713 

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix log spam on deleted ResourceQuota objects.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
