### PR TITLE
Prevent Cluster deletion: Change name of webhook

### DIFF
--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -622,7 +622,7 @@ func PoliciesWebhookConfigurationReconciler(ctx context.Context, cfg *kubermatic
 
 			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
-					Name:                    appskubermaticv1.ApplicationDefinitionResourceName + "." + appskubermaticv1.GroupName, // this should be a FQDN,
+					Name:                    "policies." + kubermaticv1.GroupName, // this should be a FQDN,
 					AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
 					MatchPolicy:             &matchPolicy,
 					FailurePolicy:           &failurePolicy,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the name of the webhook that prevents deleting clusters
ref: https://github.com/kubermatic/kubermatic/pull/13284
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
