### PR TITLE
Fix etcd health check failure inside etcd pod for KKP user clusters

### DIFF
--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -200,6 +200,18 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 					},
 				}
 
+				var etcdEndpoints []string
+				for i := range 3 {
+					endpoint := fmt.Sprintf(
+						"https://etcd-%d.%s.%s.svc.cluster.local:2379",
+						i,
+						resources.EtcdServiceName,
+						data.Cluster().Status.NamespaceName,
+					)
+					etcdEndpoints = append(etcdEndpoints, endpoint)
+				}
+				etcdEnv = append(etcdEnv, corev1.EnvVar{Name: "ETCDCTL_ENDPOINTS", Value: strings.Join(etcdEndpoints, ",")})
+
 				etcdPorts = append(etcdPorts, corev1.ContainerPort{
 					ContainerPort: 2381,
 					Protocol:      corev1.ProtocolTCP,


### PR DESCRIPTION
**What this PR does / why we need it**:
We can configure all pods with the environment variable ETCDCTL_ENDPOINTS set to the correct name-based endpoints. With this setup, the etcdctl endpoint health command works as expected and returns no errors.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14443

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added the ETCDCTL_ENDPOINTS environment variable with name-based endpoints in all etcd pods. This enables successful execution of the `etcdctl endpoint health` command without the need for the `--cluster` flag which pulls IP based endpoints from the etcd ring.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
