### PR TITLE
Skip Quota validations for cpus if vCPUs field is used

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	kubevirtImageHTTPServerSvc = "http://image-repo.kube-system.svc/images"
-	kubevirtCPUs               = 2
+	kubevirtVCPUs              = 2
 	kubevirtMemory             = "4Gi"
 	kubevirtDiskSize           = "25Gi"
 	kubevirtStorageClassName   = "local-path"
@@ -86,7 +86,7 @@ func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secret
 	}
 
 	cloudProviderSpec := provider.NewKubevirtConfig().
-		WithCPUs(kubevirtCPUs).
+		WithVCPUs(kubevirtVCPUs).
 		WithMemory(kubevirtMemory).
 		WithPrimaryDiskOSImage(image).
 		WithPrimaryDiskSize(kubevirtDiskSize).

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -63,14 +63,6 @@ func TestGetVMwareCloudDirectorResourceRequirements(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-		{
-			name: "valid Kubevirt configuration",
-			config: &providerconfig.Config{
-				CloudProvider:     providerconfig.CloudProviderKubeVirt,
-				CloudProviderSpec: genFakeKubeVirtSpec(4, "8G", "25G"),
-			},
-			expectedErr: false,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -27,9 +27,9 @@ package machine
 import (
 	"context"
 	"encoding/json"
-	"k8c.io/machine-controller/sdk/cloudprovider/kubevirt"
 	"testing"
 
+	"k8c.io/machine-controller/sdk/cloudprovider/kubevirt"
 	vmwareclouddirectortypes "k8c.io/machine-controller/sdk/cloudprovider/vmwareclouddirector"
 	"k8c.io/machine-controller/sdk/providerconfig"
 

--- a/pkg/machine/provider/kubevirt.go
+++ b/pkg/machine/provider/kubevirt.go
@@ -44,6 +44,11 @@ func (b *kubevirtConfig) WithCPUs(cpus int) *kubevirtConfig {
 	return b
 }
 
+func (b *kubevirtConfig) WithVCPUs(vCPUs int) *kubevirtConfig {
+	b.VirtualMachine.Template.VCPUs.Cores = vCPUs
+	return b
+}
+
 func (b *kubevirtConfig) WithMemory(memory string) *kubevirtConfig {
 	b.VirtualMachine.Template.Memory.Value = memory
 	return b

--- a/pkg/machine/provider/kubevirt_test.go
+++ b/pkg/machine/provider/kubevirt_test.go
@@ -26,7 +26,7 @@ import (
 func TestKubevirtConfigBuilder(t *testing.T) {
 	// call all With* functions once to ensure they all work...
 	config := NewKubevirtConfig().
-		WithCPUs(2).
+		WithVCPUs(2).
 		WithMemory("memory").
 		WithPrimaryDiskOSImage("image").
 		WithPrimaryDiskSize("size").


### PR DESCRIPTION
**What this PR does / why we need it**:
In the KubeVirt provider, we have now a new field called vCPUs, where users can use a dedicate amount of CPUI cores for a KubeVirt VM. When a user create a user cluster, the resource quota controller, checks for the values, that are being used and validate those values: CPU. RAM and Storage. However, it doesn't validate vCPU. 

This PR addresses this issue, where it make sure to validate vCPUs and skip CPUs as it makes no sense to set both fields. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
/kind bug

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KubeVirt vCPUs validation in the resource quota controller
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
