### PR TITLE
KubeLB: Enable kubelb for a cluster by default if it's enforced at the datacenter level

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -133,6 +133,20 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		}
 	}
 
+	// Enable KubeLB if it is enforced by the datacenter.
+	if datacenter.Spec.KubeLB != nil && datacenter.Spec.KubeLB.Enforced {
+		if spec.KubeLB == nil {
+			spec.KubeLB = &kubermaticv1.KubeLB{
+				Enabled:              true,
+				UseLoadBalancerClass: ptr.To(datacenter.Spec.KubeLB.UseLoadBalancerClass),
+				EnableGatewayAPI:     ptr.To(datacenter.Spec.KubeLB.EnableGatewayAPI),
+			}
+		} else {
+			// Enforcement only ensures that the KubeLB is enabled. Users can still change the other settings for KubeLB.
+			spec.KubeLB.Enabled = true
+		}
+	}
+
 	// Add default CNI plugin settings if not present.
 	if spec.CNIPlugin == nil {
 		if spec.Cloud.Edge != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP defaulting will now enable KubeLB for a user cluster if it's enforced for the corresponding datacenter. We want to make sure that the enforcement works when clusters are created via API or CRDs.

The [validations](https://github.com/kubermatic/kubermatic/blob/main/pkg/validation/cluster.go#L225-L230) already ensures that if KubeLB is enforced it cannot be disabled for a cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeLB: KKP defaulting will now enable KubeLB for a cluster if it's enforced at the datacenter level
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @ahmedwaleedmalik 
