### PR TITLE
Update dex configuration used in local installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -286,11 +286,12 @@ func prepareHelmValues(dir, kkpEndpoint string) (string, error) {
 
 	return prepareYAMLFile(dir, "values", func(doc *yamled.Document) error {
 		doc.Set(yamled.Path{"dex", "config", "enablePasswordDB"}, true)
-		doc.Set(yamled.Path{"dex", "config", "issuer"}, fmt.Sprintf("%s/dex", kkpEndpoint))
+		doc.Set(yamled.Path{"dex", "config", "issuer"}, fmt.Sprintf("http://%s/dex", kkpEndpoint))
 		doc.Set(yamled.Path{"telemetry", "uuid"}, uuid.NewString())
+		doc.Set(yamled.Path{"nginx", "controller", "extraArgs", "update-status"}, "true")
 		doc.Remove(yamled.Path{"minio"})
 
-		doc.Fill(yamled.Path{"dex", "ingress"}, map[string]interface{}{
+		doc.Set(yamled.Path{"dex", "ingress"}, map[string]interface{}{
 			"className": "nginx",
 			"enabled":   true,
 			"annotations": map[string]interface{}{
@@ -316,15 +317,15 @@ func prepareHelmValues(dir, kkpEndpoint string) (string, error) {
 			doc.Set(yamled.Path{"kubermaticOperator", "imagePullSecret"}, imagePullSecret)
 		}
 
-		clients, ok := doc.GetArray(yamled.Path{"dex", "clients"})
+		clients, ok := doc.GetArray(yamled.Path{"dex", "config", "staticClients"})
 		if !ok {
 			return errors.New("expected to find Dex clients, but got none")
 		}
 
 		for i := range clients {
-			doc.Set(yamled.Path{"dex", "clients", i, "secret"}, randomString(32))
+			doc.Set(yamled.Path{"dex", "config", "staticClients", i, "secret"}, randomString(32))
 
-			redirectURIs, _ := doc.GetArray(yamled.Path{"dex", "clients", i, "RedirectURIs"})
+			redirectURIs, _ := doc.GetArray(yamled.Path{"dex", "config", "staticClients", i, "RedirectURIs"})
 			for j, redirectURI := range redirectURIs {
 				if stringURI, ok := redirectURI.(string); ok {
 					u, err := url.Parse(stringURI)
@@ -335,7 +336,7 @@ func prepareHelmValues(dir, kkpEndpoint string) (string, error) {
 					u.Scheme = "http"
 					u.Host = kkpEndpoint
 
-					doc.Set(yamled.Path{"dex", "clients", i, "RedirectURIs", j}, u.String())
+					doc.Set(yamled.Path{"dex", "config", "staticClients", i, "RedirectURIs", j}, u.String())
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the Dex configurations used in `kubermatic-installer local kind` command.

Previously, it was trying to parse clients based on the old format. Instead, it should parse `staticClients` field.

Also, the protocol scheme seems to be needed in Dex issuer, to prevent 404 while accessing OIDC from dashboard-api.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updates `kubermatic-installer local kind` Dex static client configurations
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
