### PR TITLE
reconcile evicted launcher pods only when strategy is external

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction/controller.go
@@ -77,7 +77,10 @@ func Add(ctx context.Context, log *zap.SugaredLogger, userMgr, kubevirtInfraMgr 
 			&kubevirtv1.VirtualMachineInstance{},
 			&handler.TypedEnqueueRequestForObject[*kubevirtv1.VirtualMachineInstance]{},
 			kubermaticpred.TypedFactory(func(vmi *kubevirtv1.VirtualMachineInstance) bool {
-				return vmi.Status.EvacuationNodeName != ""
+				if *vmi.Spec.EvictionStrategy == kubevirtv1.EvictionStrategyExternal {
+					return vmi.Status.EvacuationNodeName != ""
+				}
+				return false
 			}),
 		)).
 		Build(r)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds a condition to only reconcile evicted kubevirt launcher pods by kkp when evictionStrategy is external. Since the field `status.evacuationNodeName` is set for both strategies (external and liveMigrate) the predicate condition does not work properly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14449

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A bug was fixed where evicted kubevirt vms configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
