### PR TITLE
Scrape apiserver_storage_size_bytes by default when User Cluster MLA is enabled

### DIFF
--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -256,6 +256,11 @@ groups:
     labels:
       kubermatic: federate
 
+  - record: job:apiserver_storage_size_bytes:sum
+    expr: sum(apiserver_storage_size_bytes)
+    labels:
+      kubermatic: federate
+
 - name: machine-controller
   rules:
   - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-edge-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-edge-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-edge-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vcd-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vcd-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vcd-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
@@ -493,6 +493,11 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:apiserver_storage_size_bytes:sum
+        expr: sum(apiserver_storage_size_bytes)
+        labels:
+          kubermatic: federate
+
     - name: machine-controller
       rules:
       - alert: MachineControllerTooManyErrors


### PR DESCRIPTION
**What this PR does / why we need it**:
Added apiserver_storage_size_bytes metric to be enabled by default for user clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14131 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
