### PR TITLE
Update Prometheus Cluster Role 

### DIFF
--- a/charts/monitoring/prometheus/templates/clusterrole.yaml
+++ b/charts/monitoring/prometheus/templates/clusterrole.yaml
@@ -39,3 +39,9 @@ rules:
   - /metrics
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - services/node-exporter
+  verbs:
+  - get

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -1907,6 +1907,12 @@ rules:
   - /metrics
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - services/node-exporter
+  verbs:
+  - get
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -1907,6 +1907,12 @@ rules:
   - /metrics
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - services/node-exporter
+  verbs:
+  - get
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -1907,6 +1907,12 @@ rules:
   - /metrics
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - services/node-exporter
+  verbs:
+  - get
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.


### PR DESCRIPTION
**What this PR does / why we need it**:
After the using the upstream monitoring charts, we have encountered an issue with Prometheus scrapping the node exporter metrics. After digging deep into the chart and into the deployment we found out that there should be a new rule added in the cluster role manifest that Prometheus is bound to, that enables the scrapping of the node exporter via kube-rbac-proxy. This PR add this new rule.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
