### PR TITLE
KubeLB: Make it easier to indentify the KKP cluster against which the tenant was created

### DIFF
--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -228,6 +228,12 @@ func (r *reconciler) createOrUpdateKubeLBManagementClusterResources(ctx context.
 	tenant := &kubelbv1alpha1.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cluster.Name,
+			Labels: map[string]string{
+				// These labels are used to identify the tenant in the kubelb management cluster.
+				"kubermatic.k8c.io/cluster-name":          cluster.Name,
+				"kubermatic.k8c.io/cluster-external-name": cluster.Status.Address.ExternalName,
+				"kubermatic.k8c.io/cluster-project-id":    cluster.Labels[kubermaticv1.ProjectIDLabelKey],
+			},
 		},
 	}
 	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(tenant), tenant); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We are adding some labels on the Tenant that's created in the KubeLB management cluster to make it easy to determine which KKP instance is this tenant coming from. `cluster.Status.Address.ExternalName` is the best fit for this since it's easier to find the cluster if the `domain` is known.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @ahmedwaleedmalik 
/cc @kron4eg 
