### PR TITLE
Use resources.BackupCABundleConfigMapName() everywhere

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -343,7 +344,6 @@ func shouldSkipClusterRBACRoleBindingForNamedResource(projectName string, object
 			Name:       object.GetName(),
 		},
 	)
-
 	if err != nil {
 		return false, generatedRole, err
 	}
@@ -458,7 +458,6 @@ func shouldSkipRBACRoleBindingForNamedResource(projectName string, resourceName 
 			Name:       object.GetName(),
 		},
 	)
-
 	if err != nil {
 		return false, generatedRole, err
 	}
@@ -661,7 +660,6 @@ func shouldSkipRBACRoleForClusterNamespaceResource(projectName string, cluster *
 		policyAPIGroups,
 		kind,
 	)
-
 	if err != nil {
 		return false, generatedRole, err
 	}
@@ -1102,7 +1100,7 @@ func (c *resourcesController) ensureClusterRBACRoleForEtcdLauncher(ctx context.C
 		GenerateActualGroupNameFor(projectName, ViewerGroupNamePrefix),
 		"configmaps",
 		"",
-		fmt.Sprintf("cluster-%s-ca-bundle", cluster.Name),
+		resources.BackupCABundleConfigMapName(cluster),
 		metav1.OwnerReference{
 			APIVersion: kubermaticv1.SchemeGroupVersion.String(),
 			Kind:       kubermaticv1.ClusterKindName,
@@ -1195,7 +1193,7 @@ func (c *resourcesController) ensureRBACForEtcdLauncher(ctx context.Context, cli
 	if err := c.ensureClusterRBACRoleBindingForEtcdLauncher(ctx, cluster.Name, kubermaticv1.ClusterKindName, cluster.Status.NamespaceName, projectName, cluster); err != nil {
 		return fmt.Errorf("failed to sync RBAC ClusterRoleBinding for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
 	}
-	if err := c.ensureClusterRBACRoleBindingForEtcdLauncher(ctx, fmt.Sprintf("cluster-%s-ca-bundle", cluster.Name), "Configmap", cluster.Status.NamespaceName, projectName, cluster); err != nil {
+	if err := c.ensureClusterRBACRoleBindingForEtcdLauncher(ctx, resources.BackupCABundleConfigMapName(cluster), "Configmap", cluster.Status.NamespaceName, projectName, cluster); err != nil {
 		return fmt.Errorf("failed to sync RBAC ClusterRoleBinding for %s resource for %s cluster provider: %w", formatMapping(rmapping), c.providerName, err)
 	}
 	if err := c.ensureRBACRoleForEtcdLauncher(ctx, cluster, kubermaticv1.EtcdRestoreResourceName, kubermaticv1.GroupName, kubermaticv1.EtcdRestoreKindName); err != nil {

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -826,12 +826,8 @@ func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cl
 	return reconciling.ReconcileSecrets(ctx, creators, metav1.NamespaceSystem, r, modifier.Ownership(cluster, "", r.scheme))
 }
 
-func caBundleConfigMapName(cluster *kubermaticv1.Cluster) string {
-	return fmt.Sprintf("cluster-%s-ca-bundle", cluster.Name)
-}
-
 func (r *Reconciler) ensureConfigMaps(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	name := caBundleConfigMapName(cluster)
+	name := resources.BackupCABundleConfigMapName(cluster)
 
 	creators := []reconciling.NamedConfigMapReconcilerFactory{
 		certificates.CABundleConfigMapReconciler(name, r.caBundle),

--- a/pkg/resources/etcd/backup/jobs.go
+++ b/pkg/resources/etcd/backup/jobs.go
@@ -178,7 +178,7 @@ func BackupJob(data etcdBackupData, config *kubermaticv1.EtcdBackupConfig, statu
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: caBundleConfigMapName(data.Cluster()),
+						Name: resources.BackupCABundleConfigMapName(data.Cluster()),
 					},
 				},
 			},
@@ -277,7 +277,7 @@ func BackupDeleteJob(data etcdBackupData, config *kubermaticv1.EtcdBackupConfig,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: caBundleConfigMapName(data.Cluster()),
+						Name: resources.BackupCABundleConfigMapName(data.Cluster()),
 					},
 				},
 			},

--- a/pkg/resources/etcd/backup/utils.go
+++ b/pkg/resources/etcd/backup/utils.go
@@ -42,10 +42,6 @@ func GetEtcdBackupSecretName(cluster *kubermaticv1.Cluster) string {
 	return fmt.Sprintf("cluster-%s-etcd-client-certificate", cluster.Name)
 }
 
-func caBundleConfigMapName(cluster *kubermaticv1.Cluster) string {
-	return fmt.Sprintf("cluster-%s-ca-bundle", cluster.Name)
-}
-
 func isInsecureURL(u string) bool {
 	parsed, err := url.Parse(u)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
There should be only 1 function `resources.BackupCABundleConfigMapName()` to get the name.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
