### PR TITLE
Openstack: Add ability to skip router reconciliation

### DIFF
--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -424,6 +424,18 @@ func EnsureAnnotationContains(o metav1.Object, annotation string, separator stri
 	})
 }
 
+// HasAnnotationTrue checks whether the given object has the specified annotation
+// set to "true" (case-insensitive).
+func HasAnnotationTrue(obj metav1.Object, key string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	val, exists := annotations[key]
+	return exists && strings.EqualFold(val, "true")
+}
+
 type SeedClientMap map[string]ctrlruntimeclient.Client
 
 type SeedVisitorFunc func(seedName string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -428,12 +428,7 @@ func EnsureAnnotationContains(o metav1.Object, annotation string, separator stri
 // set to "true" (case-insensitive).
 func HasAnnotationTrue(obj metav1.Object, key string) bool {
 	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-
-	val, exists := annotations[key]
-	return exists && strings.EqualFold(val, "true")
+	return strings.EqualFold(annotations[key], "true")
 }
 
 type SeedClientMap map[string]ctrlruntimeclient.Client

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -254,10 +254,13 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 			return nil, err
 		}
 	}
-	if force || cluster.Spec.Cloud.Openstack.RouterID == "" {
-		cluster, err = reconcileRouter(ctx, netClient, cluster, update)
-		if err != nil {
-			return nil, err
+
+	if !kubernetes.HasAnnotationTrue(cluster, kubermaticv1.SkipRouterReconciliationAnnotation) {
+		if force || cluster.Spec.Cloud.Openstack.RouterID == "" {
+			cluster, err = reconcileRouter(ctx, netClient, cluster, update)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return cluster, nil

--- a/sdk/apis/kubermatic/v1/common.go
+++ b/sdk/apis/kubermatic/v1/common.go
@@ -78,6 +78,10 @@ const (
 	InitialMachineDeploymentRequestAnnotation        = "kubermatic.io/initial-machinedeployment-request"
 	InitialApplicationInstallationsRequestAnnotation = "kubermatic.io/initial-application-installations-request"
 	InitialCNIValuesRequestAnnotation                = "kubermatic.io/initial-cni-values-request"
+
+	// SkipRouterReconciliationAnnotation is used to indicate that the router reconciliation should be skipped.
+	// This annotation is currently used exclusively for OpenStack provider.
+	SkipRouterReconciliationAnnotation = "reconciliation.kubermatic.k8c.io/skip-router"
 )
 
 type MachineFlavorFilter struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a mechanism to optionally skip router reconciliation for specific clusters by leveraging the annotation `reconciliation.kubermatic.k8c.io/skip-router`.

The feature is currently exclusive to the OpenStack provider, allowing users to disable router reconciliation when the annotation is set to "true".

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14463

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the ability to skip router reconciliation in the OpenStack provider.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1997
```
