### PR TITLE
Force test failure when application path is missing in default application catalog tests

### DIFF
--- a/hack/ci/run-default-application-e2e-test.sh
+++ b/hack/ci/run-default-application-e2e-test.sh
@@ -75,7 +75,13 @@ else
   pathToFile="pkg/ee/default-application-catalog/applicationdefinitions/$APPLICATION_NAME-app.yaml"
 fi
 
-echodate "File path: $pathToFile"
+# Check if the file exists
+if [ ! -f "$pathToFile" ]; then
+  echodate "Error: File '$pathToFile' does not exist."
+  exit 1
+else
+  echodate "File path: $pathToFile"
+fi
 
 if [[ -s "$pathToFile" ]]; then
   versions=$(yq eval '.spec.versions[].version' "$pathToFile")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the default application catalog E2E tests to explicitly fail when the application path is not found. This ensures missing applications are treated as test failures, not silently skipped.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14627

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
