### PR TITLE
chore: add doc.go for resourceQuota controllers

### DIFF
--- a/pkg/ee/resource-quota/default-quota-controller/doc.go
+++ b/pkg/ee/resource-quota/default-quota-controller/doc.go
@@ -1,0 +1,37 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2025 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+/*
+Package defaultcontroller contains a controller that manages default project resource quotas in a Kubernetes cluster.
+
+It is responsible for the following:
+1. Create default resource quotas for all projects if defined in the `KubermaticSetting` resource.
+2. Update existing default quotas to match changes in the `DefaultProjectResourceQuota` configuration.
+3. Delete all default quotas when no default resource quota is specified.
+
+The controller reacts to:
+- Changes in the `DefaultProjectResourceQuota` field of the `KubermaticSetting` resource.
+- Creation of new `Project` resources.
+*/
+package defaultcontroller

--- a/pkg/ee/resource-quota/label-owner-controller/doc.go
+++ b/pkg/ee/resource-quota/label-owner-controller/doc.go
@@ -1,0 +1,36 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2025 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+/*
+Package labelownercontroller implements the "kkp-resource-quota-label-owner-controller".
+
+It is responsible for the following:
+1. Setting labels on `ResourceQuota` objects to indicate their associated subject's `Kind` and `Name`.
+2. Establishing owner references for `ResourceQuota` objects, linking them to their parent resources (e.g., `Project`).
+
+The controller reacts to:
+- Changes in `ResourceQuota` objects.
+- Creation of new object resources that can be attached to ResourceQuota (e.g., `Project`).
+*/
+package labelownercontroller

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/doc.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/doc.go
@@ -1,0 +1,36 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2025 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+/*
+Package resourcequotasynchronizer contains a controller that  synchronizes `ResourceQuota` objects from the master cluster to all seed clusters,
+ensuring consistency across multi-cluster environments.
+
+It is responsible for the following:
+1. Copy `ResourceQuota` objects to seed clusters.
+2. Handle deletion and cleanup of synchronized quotas.
+3. Propagate `GlobalUsage` status from the master to seed clusters.
+
+The controller reacts to changes in `ResourceQuota` objects on the master cluster, ensuring real-time synchronization.
+*/
+package resourcequotasynchronizer


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of my work on implementing the feature request from https://github.com/kubermatic/kubermatic/issues/13888, I explored the `ResourceQuota` implementation in the KKP project. To better understand the role and functionality of each controller in `pkg/ee/resource-quota`, I spent time analyzing their code. 

Adding a concise `doc.go` file for each controller would greatly help developers quickly grasp its purpose and functionality without needing to dive into every line of code, saving time and effort.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
