### PR TITLE
Add k8s patch releases for 1.33/1.32/1.31/1.30

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -574,14 +574,18 @@ spec:
       - v1.30.9
       - v1.30.11
       - v1.30.12
+      - v1.30.14
       - v1.31.1
       - v1.31.5
       - v1.31.7
       - v1.31.8
+      - v1.31.10
       - v1.32.1
       - v1.32.3
       - v1.32.4
+      - v1.32.6
       - v1.33.0
+      - v1.33.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -574,14 +574,18 @@ spec:
       - v1.30.9
       - v1.30.11
       - v1.30.12
+      - v1.30.14
       - v1.31.1
       - v1.31.5
       - v1.31.7
       - v1.31.8
+      - v1.31.10
       - v1.32.1
       - v1.32.3
       - v1.32.4
+      - v1.32.6
       - v1.33.0
+      - v1.33.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -229,17 +229,21 @@ var (
 			newSemver("v1.30.9"),
 			newSemver("v1.30.11"),
 			newSemver("v1.30.12"),
+			newSemver("v1.30.14"),
 			// Kubernetes 1.31
 			newSemver("v1.31.1"),
 			newSemver("v1.31.5"),
 			newSemver("v1.31.7"),
 			newSemver("v1.31.8"),
+			newSemver("v1.31.10"),
 			// Kubernetes 1.32
 			newSemver("v1.32.1"),
 			newSemver("v1.32.3"),
 			newSemver("v1.32.4"),
+			newSemver("v1.32.6"),
 			// Kubernetes 1.33
 			newSemver("v1.33.0"),
+			newSemver("v1.33.2"),
 		},
 		Updates: []kubermaticv1.Update{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add support for k8s patch releases 1.33.2/1.32.6/1.31.10/1.30.14 which includes CVE fix [CVE-2025-4563](https://github.com/kubernetes/kubernetes/issues/132151)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add 1.33.2/1.32.6/1.31.10/1.30.14 to the list of supported Kubernetes releases.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
