### PR TITLE
fix kubevirt infra netpol cleanup

### DIFF
--- a/pkg/ee/kubevirt-network-controller/controller.go
+++ b/pkg/ee/kubevirt-network-controller/controller.go
@@ -257,7 +257,7 @@ func cleanUpKubevirtCloudProviderNetworkPolicy(ctx context.Context, kvInfraClien
 		},
 	}
 	if err := kvInfraClient.Delete(ctx, networkPolicy); err != nil {
-		if apierrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/ee/kubevirt-network-controller/controller.go
+++ b/pkg/ee/kubevirt-network-controller/controller.go
@@ -256,5 +256,10 @@ func cleanUpKubevirtCloudProviderNetworkPolicy(ctx context.Context, kvInfraClien
 			Namespace: dc.NamespacedMode.Namespace,
 		},
 	}
-	return kvInfraClient.Delete(ctx, networkPolicy)
+	if err := kvInfraClient.Delete(ctx, networkPolicy); err != nil {
+		if apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**

This pr fixes a bug regarding network policy cleanup up in kubevirt infra clusters when the removal of the finalizer failed after deleting the network policy. At the moment the finalizer won't be removed. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A bug  regarding network policy cleanup up in kubevirt infra clusters when the removal of the finalizer failed after deleting the network policy was fixed.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
