### PR TITLE
Refactor EtcdRestore Finalizer Removal

### DIFF
--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -346,9 +346,12 @@ func (r *Reconciler) rebuildEtcdStatefulset(ctx context.Context, log *zap.Sugare
 
 	if err := r.updateRestore(ctx, restore, func(restore *kubermaticv1.EtcdRestore) {
 		restore.Status.Phase = kubermaticv1.EtcdRestorePhaseCompleted
-		kuberneteshelper.RemoveFinalizer(restore, FinishRestoreFinalizer)
 	}); err != nil {
 		return nil, fmt.Errorf("failed to mark restore completed: %w", err)
+	}
+
+	if err := kuberneteshelper.TryRemoveFinalizer(ctx, r, restore, FinishRestoreFinalizer); err != nil {
+		return nil, fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 
 	return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors how the EtcdRestore finalizer is removed, where the controller would try to remove the FinishRestoreFinalizer finalizer if it failed it will return an error which would then trigger the reconciling again and retrying to remove the finalizer. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
