### PR TITLE
Expose MachineDeployment metrics for user clusters

### DIFF
--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -311,6 +311,26 @@ groups:
     labels:
       kubermatic: federate
 
+  - record: job:machine_deployment_available_replicas:user:sum
+    expr: sum(machine_deployment_available_replicas) by (name, namespace)
+    labels:
+      kubermatic: federate
+
+  - record: job:machine_deployment_ready_replicas:user:sum
+    expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+    labels:
+      kubermatic: federate
+
+  - record: job:machine_deployment_replicas:user:sum
+    expr: sum(machine_deployment_replicas) by (name, namespace)
+    labels:
+      kubermatic: federate
+
+  - record: job:machine_deployment_updated_replicas:user:sum
+    expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+    labels:
+      kubermatic: federate
+
 - name: process.filedescriptors
   rules:
   - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-edge-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-edge-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-edge-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vcd-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vcd-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vcd-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.30.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
@@ -548,6 +548,26 @@ data:
         labels:
           kubermatic: federate
 
+      - record: job:machine_deployment_available_replicas:user:sum
+        expr: sum(machine_deployment_available_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_ready_replicas:user:sum
+        expr: sum(machine_deployment_ready_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_replicas:user:sum
+        expr: sum(machine_deployment_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
+      - record: job:machine_deployment_updated_replicas:user:sum
+        expr: sum(machine_deployment_updated_replicas) by (name, namespace)
+        labels:
+          kubermatic: federate
+
     - name: process.filedescriptors
       rules:
       - expr: process_open_fds / process_max_fds


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Prometheus federation configuration to include machine deployment metrics from the dedicated Prometheus instance of the user cluster into the seed MLA Prometheus.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14648

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated Prometheus federation configuration to include machine deployment metrics from user clusters in the seed MLA Prometheus.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
