### PR TITLE
Add rules for Velero resources to allow get, list, and watch operations for users with viewer access

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/rbac/resources.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/resources.go
@@ -22,6 +22,7 @@ import (
 
 	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
@@ -157,6 +158,11 @@ func CreateClusterRole(resourceName string, cr *rbacv1.ClusterRole) (*rbacv1.Clu
 		{
 			APIGroups: []string{configv1alpha1.GroupVersion.Group},
 			Resources: []string{"configs"},
+			Verbs:     verbs,
+		},
+		{
+			APIGroups: []string{velerov1.SchemeGroupVersion.Group},
+			Resources: []string{"backups", "restores", "schedules"},
 			Verbs:     verbs,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds RBAC rules for Velero resources to allow get, list, and watch operations.
These permissions are necessary for users that need to view velero resources.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14730

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds RBAC rules for Velero Backup resources to allow get, list, and watch operations.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
