### PR TITLE
Add an option to restrict project modification to admins

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -318,6 +318,8 @@ spec:
                   type: boolean
                 restrictProjectDeletion:
                   type: boolean
+                restrictProjectModification:
+                  type: boolean
                 staticLabels:
                   description: StaticLabels are a list of labels that can be used for the clusters.
                   items:
@@ -476,6 +478,7 @@ spec:
                 - mlaGrafanaPrefix
                 - restrictProjectCreation
                 - restrictProjectDeletion
+                - restrictProjectModification
                 - userProjectsLimit
               type: object
           type: object

--- a/sdk/apis/kubermatic/v1/settings.go
+++ b/sdk/apis/kubermatic/v1/settings.go
@@ -87,9 +87,10 @@ type SettingSpec struct {
 	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
 
 	// UserProjectsLimit is the maximum number of projects a user can create.
-	UserProjectsLimit       int64 `json:"userProjectsLimit"`
-	RestrictProjectCreation bool  `json:"restrictProjectCreation"`
-	RestrictProjectDeletion bool  `json:"restrictProjectDeletion"`
+	UserProjectsLimit           int64 `json:"userProjectsLimit"`
+	RestrictProjectCreation     bool  `json:"restrictProjectCreation"`
+	RestrictProjectDeletion     bool  `json:"restrictProjectDeletion"`
+	RestrictProjectModification bool  `json:"restrictProjectModification"`
 
 	EnableExternalClusterImport bool `json:"enableExternalClusterImport"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an option to restrict project modification to admins only via the limits page. 

**Which issue(s) this PR fixes**:
#14785 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add an option to restrict project modification to admins
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
