### PR TITLE
Added cinder-csi-retain and changed the volumeBindingMode to Immediate

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -122,9 +122,23 @@ metadata:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
-  name: cinder-csi
+  name: cinder-csi-delete
 provisioner: cinder.csi.openstack.org
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: Immediate 
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+apiVersion: storage.k8s.io/v1
+---
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.beta.kubernetes.io/is-default-class: "false"
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: cinder-csi-retain
+provisioner: cinder.csi.openstack.org
+volumeBindingMode: Immediate 
+reclaimPolicy: Retain
 allowVolumeExpansion: true
 {{ end }}
 {{ else }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This aligns the [default-storage-class](https://github.com/kubermatic/kubermatic/tree/main/addons/default-storage-class) add‑on with the upstream OpenStack Cloud Controller Manager’s  [cinder-csi-plugin chart](https://github.com/kubernetes/cloud-provider-openstack/tree/master/charts/cinder-csi-plugin). 

 It now provides two storage classes—retain and delete—for the `reclaimPolicy`, just like the cinder-csi chart, and keeps `volumeBindingMode` set to Immediate by default.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
This is not fixing https://github.com/kubermatic/kubermatic/issues/13887 but closely related.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
