### PR TITLE
Bump Dex chart to appversion 2.42.0

### DIFF
--- a/charts/dex/Chart.lock
+++ b/charts/dex/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: dex
   repository: https://charts.dexidp.io
-  version: 0.19.1
-digest: sha256:8b96787ba39f6973b42abfde2ed704596c340bc959d6fc3178f95389dcbbcf93
-generated: "2024-10-09T18:22:28.937055874+02:00"
+  version: 0.23.0
+digest: sha256:1ea89746228c51235fc4fb406040d1e5838d2c1b6edc404ab034bd84150c6457
+generated: "2025-07-21T17:31:20.026107834+05:30"

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: dex
 version: 9.9.9-dev
-appVersion: 2.41.1
+appVersion: 2.42.0
 description: A Helm chart for Dex
 keywords:
   - kubermatic
@@ -30,4 +30,4 @@ maintainers:
 dependencies:
   - repository: https://charts.dexidp.io
     name: dex
-    version: 0.19.1
+    version: 0.23.0

--- a/charts/dex/test/default.yaml.out
+++ b/charts/dex/test/default.yaml.out
@@ -4,11 +4,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: dex/charts/dex/templates/secret.yaml
@@ -16,11 +17,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -59,10 +61,10 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -75,10 +77,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: ClusterRole
@@ -94,11 +96,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["dex.coreos.com"]
@@ -110,16 +113,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: release-name-dex  
+  name: release-name-dex
 subjects:
 - kind: ServiceAccount
   namespace: default
@@ -130,11 +134,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -158,11 +163,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
     
   
@@ -177,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: cfa05e7dd55e652c219a9f9b3397f230ba0d7ac408777391e3b2f1af373fc265
+        checksum/config: 09617abf0250dca6ab8c6d4d505285f7648b8dde447c55c455ccdba985f05621
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -189,7 +195,7 @@ spec:
         - name: dex
           securityContext:
             {}
-          image: "ghcr.io/dexidp/dex:v2.41.1"
+          image: "ghcr.io/dexidp/dex:v2.42.0"
           imagePullPolicy: IfNotPresent
           args:
             - dex
@@ -251,11 +257,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/charts/dex/test/values.example.ce.yaml.out
+++ b/charts/dex/test/values.example.ce.yaml.out
@@ -4,11 +4,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: dex/charts/dex/templates/secret.yaml
@@ -16,11 +17,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -59,10 +61,10 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -75,10 +77,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: ClusterRole
@@ -94,11 +96,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["dex.coreos.com"]
@@ -110,16 +113,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: release-name-dex  
+  name: release-name-dex
 subjects:
 - kind: ServiceAccount
   namespace: default
@@ -130,11 +134,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -158,11 +163,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
     
   
@@ -177,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 2175fca9af2d0514843fbd0294276a6216a00508367df66dd5c032fa6199c91d
+        checksum/config: 30ad8d160980ee36d4618497eb49f8e547ded54e20cf23e7065c4ac3d6864caa
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -189,7 +195,7 @@ spec:
         - name: dex
           securityContext:
             {}
-          image: "ghcr.io/dexidp/dex:v2.41.1"
+          image: "ghcr.io/dexidp/dex:v2.42.0"
           imagePullPolicy: IfNotPresent
           args:
             - dex
@@ -251,11 +257,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/charts/dex/test/values.example.ee.yaml.out
+++ b/charts/dex/test/values.example.ee.yaml.out
@@ -4,11 +4,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: dex/charts/dex/templates/secret.yaml
@@ -16,11 +17,12 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -59,10 +61,10 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -75,10 +77,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: ClusterRole
@@ -94,11 +96,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["dex.coreos.com"]
@@ -110,16 +113,17 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
-  name: release-name-dex  
+  name: release-name-dex
 subjects:
 - kind: ServiceAccount
   namespace: default
@@ -130,11 +134,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -158,11 +163,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
     
   
@@ -177,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 2175fca9af2d0514843fbd0294276a6216a00508367df66dd5c032fa6199c91d
+        checksum/config: 30ad8d160980ee36d4618497eb49f8e547ded54e20cf23e7065c4ac3d6864caa
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -189,7 +195,7 @@ spec:
         - name: dex
           securityContext:
             {}
-          image: "ghcr.io/dexidp/dex:v2.41.1"
+          image: "ghcr.io/dexidp/dex:v2.42.0"
           imagePullPolicy: IfNotPresent
           args:
             - dex
@@ -251,11 +257,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: release-name-dex
+  namespace: default
   labels:
-    helm.sh/chart: dex-0.19.1
+    helm.sh/chart: dex-0.23.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.41.1"
+    app.kubernetes.io/version: "2.42.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump Dex chart to appversion 2.42.0. Since there is no breaking changes https://github.com/dexidp/dex/releases/tag/v2.42.0, this takes care of simple helm chart update. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Dex chart to appversion 2.42.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
