### PR TITLE
Bump Cert-manager to v1.17.4

### DIFF
--- a/charts/cert-manager/Chart.lock
+++ b/charts/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.16.5
-digest: sha256:e5b71c5f10427571ae48c48ae4e526c562e2491555d643ae1f89e7586dd86974
-generated: "2025-04-25T10:33:32.201434497+05:30"
+  version: v1.17.4
+digest: sha256:b458ce1fb40c3653ea148894eef7048d5990dcc00e7f0b432d6cbc6489cbb248
+generated: "2025-07-21T17:48:28.38981341+05:30"

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: cert-manager
 version: 9.9.9-dev
-appVersion: v1.16.5
+appVersion: v1.17.4
 description: A Helm chart for cert-manager
 keywords:
   - kubermatic
@@ -31,4 +31,4 @@ maintainers:
 dependencies:
   - repository: https://charts.jetstack.io
     name: cert-manager
-    version: 1.16.5
+    version: 1.17.4

--- a/charts/cert-manager/test/default.yaml.out
+++ b/charts/cert-manager/test/default.yaml.out
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,9 +57,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -91,9 +91,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -119,9 +119,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -147,9 +147,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -184,9 +184,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -224,9 +224,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -286,9 +286,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -325,9 +325,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -344,9 +344,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -369,9 +369,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -396,9 +396,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -420,9 +420,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -448,9 +448,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -466,9 +466,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -488,9 +488,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -510,9 +510,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -532,9 +532,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -554,9 +554,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -576,9 +576,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -598,9 +598,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -620,9 +620,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -642,9 +642,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -664,9 +664,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -688,9 +688,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -716,9 +716,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -739,9 +739,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -759,9 +759,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -786,9 +786,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -811,9 +811,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -835,9 +835,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -858,9 +858,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -881,9 +881,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   type: ClusterIP
   ports:
@@ -906,9 +906,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   type: ClusterIP
   ports:
@@ -932,9 +932,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   type: ClusterIP
   ports:
@@ -962,9 +962,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   replicas: 1
   selector:
@@ -979,9 +979,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -995,7 +995,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1029,9 +1029,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   replicas: 1
   selector:
@@ -1046,9 +1046,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1062,13 +1062,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-controller:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.16.5
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.17.4
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -1115,9 +1115,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   replicas: 1
   selector:
@@ -1132,9 +1132,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1148,7 +1148,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1232,9 +1232,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1273,9 +1273,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1327,9 +1327,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-rbac.yaml
 # create certificate role
@@ -1343,9 +1343,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1366,9 +1366,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1393,9 +1393,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1409,9 +1409,9 @@ spec:
         app.kubernetes.io/name: startupapicheck
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "startupapicheck"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
     spec:
       restartPolicy: OnFailure
       serviceAccountName: release-name-cert-manager-startupapicheck
@@ -1422,7 +1422,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-startupapicheck
-          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - check

--- a/charts/cert-manager/test/override-controller-test.yaml.out
+++ b/charts/cert-manager/test/override-controller-test.yaml.out
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,9 +57,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -91,9 +91,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -119,9 +119,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -147,9 +147,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -184,9 +184,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -224,9 +224,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -286,9 +286,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -325,9 +325,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -344,9 +344,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -369,9 +369,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -396,9 +396,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -420,9 +420,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -448,9 +448,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -466,9 +466,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -488,9 +488,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -510,9 +510,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -532,9 +532,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -554,9 +554,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -576,9 +576,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -598,9 +598,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -620,9 +620,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -642,9 +642,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -664,9 +664,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -688,9 +688,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -716,9 +716,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -739,9 +739,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -759,9 +759,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -786,9 +786,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -811,9 +811,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -835,9 +835,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -858,9 +858,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -881,9 +881,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   type: ClusterIP
   ports:
@@ -906,9 +906,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   type: ClusterIP
   ports:
@@ -932,9 +932,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   type: ClusterIP
   ports:
@@ -962,9 +962,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   replicas: 1
   selector:
@@ -979,9 +979,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -995,7 +995,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1036,9 +1036,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   replicas: 1
   selector:
@@ -1053,9 +1053,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1069,13 +1069,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-controller:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.16.5
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.17.4
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -1128,9 +1128,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
 spec:
   replicas: 1
   selector:
@@ -1145,9 +1145,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.16.5"
+        app.kubernetes.io/version: "v1.17.4"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.16.5
+        helm.sh/chart: cert-manager-v1.17.4
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1161,7 +1161,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.16.5"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.17.4"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1251,9 +1251,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/cert-manager-webhook-ca"
 webhooks:
@@ -1292,9 +1292,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.5"
+    app.kubernetes.io/version: "v1.17.4"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.16.5
+    helm.sh/chart: cert-manager-v1.17.4
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/cert-manager-webhook-ca"
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:
The upgrade [notes ](https://cert-manager.io/docs/releases/upgrading/upgrading-1.16-1.17/)for 1.17.4 contain relevant update for us including lot of CVEs fixes and potential breaking changes plus deprecation as listed in the release notes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump cert-manager to v1.17.4
- ⚠️Potentially BREAKING Change: cert-manager now hashes large RSA keys (3072 & 4096bit) with SHA-384 or SHA-512 respectively. If you are using these key sizes in your certificates, make sure your environment can handle the aforementioned hashing algorithms
- ⚠️ Potentially BREAKING Change: Log messages that were not structured have now been replaced with structured logs. If you were matching on specific log strings, this could break your setup.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
