### PR TITLE
Support custom pre-defined values based on conditions for helm values managed by application installations

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -42,6 +42,8 @@ presubmits:
               value: "app.kubernetes.io/name"
             - name: NAMES
               value: "aikit"
+            - name: CUSTOM_HELM_VALUES
+              value: "service:\n  type: \"{{- if eq .Cluster.Env \\\"dev\\\" }}LoadBalancer{{- else }}ClusterIP{{- end }}\"\n  port: 8080"
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY

--- a/docs/zz_generated.applicationdata.go.txt
+++ b/docs/zz_generated.applicationdata.go.txt
@@ -20,6 +20,8 @@ type ClusterData struct {
 	MajorMinorVersion string
 	// AutoscalerVersion is the tag which should be used for the cluster autoscaler
 	AutoscalerVersion string
+	// Env is used for templating in the helm values of certain application from the default app catalog
+	Env string
 }
 
 // ClusterAddress stores access and address information of a cluster.

--- a/pkg/applications/providers/template/util.go
+++ b/pkg/applications/providers/template/util.go
@@ -57,6 +57,8 @@ type ClusterData struct {
 	MajorMinorVersion string
 	// AutoscalerVersion is the tag which should be used for the cluster autoscaler
 	AutoscalerVersion string
+	// Env is used for templating in the helm values of certain application from the default app catalog
+	Env string
 }
 
 var (

--- a/pkg/applications/providers/template/util_test.go
+++ b/pkg/applications/providers/template/util_test.go
@@ -166,6 +166,21 @@ func TestRenderValueTemplate(t *testing.T) {
 			want:    nil,
 			wantErr: ErrBadTemplate,
 		},
+		{
+			name: "case 3: rendering helm values for the certain environment should succeed",
+			values: map[string]any{
+				"key1": "{{ .Cluster.Env }}",
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Env: "dev",
+				},
+			},
+			want: map[string]any{
+				"key1": "dev",
+			},
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/seed-controller-manager/default-application-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/default-application-controller/controller.go
@@ -17,10 +17,12 @@ limitations under the License.
 package defaultapplicationcontroller
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"slices"
 	"strconv"
+	"text/template"
 	"time"
 
 	"go.uber.org/zap"
@@ -28,6 +30,7 @@ import (
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/sdk/v2/semver"
+	templateDataCluster "k8c.io/kubermatic/v2/pkg/applications/providers/template"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/controller/util"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -167,6 +170,8 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		ignoreDefaultApplications = true
 	}
 
+	env := cluster.Annotations[kubermaticv1.EnvironmentAnnotation]
+
 	userClusterClient, err := r.userClusterConnectionProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user cluster client: %w", err)
@@ -216,7 +221,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		applicationsNames[application.Name] = true
 
 		// Using reconciler framework here doesn't help since the namespaces are different for the application installations.
-		err := r.ensureApplicationInstallation(ctx, userClusterClient, application)
+		err := r.ensureApplicationInstallation(ctx, userClusterClient, application, &env)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -269,7 +274,7 @@ func (r *Reconciler) ensureApplicationEnforcedAnnotationIsRemoved(ctx context.Co
 	return nil
 }
 
-func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, userClusterClient ctrlruntimeclient.Client, application appskubermaticv1.ApplicationDefinition) error {
+func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, userClusterClient ctrlruntimeclient.Client, application appskubermaticv1.ApplicationDefinition, env *string) error {
 	// First check if the installation is already present to avoid to deploy an application twice in different namespaces by mistake
 	// for this we need to list all existing applications installations
 	existingApplicationList := &appskubermaticv1.ApplicationInstallationList{}
@@ -316,7 +321,7 @@ func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, userClus
 	}
 
 	reconcilers := []reconciling.NamedApplicationInstallationReconcilerFactory{
-		ApplicationInstallationReconciler(r.log, application),
+		ApplicationInstallationReconciler(r.log, application, env),
 	}
 
 	return reconciling.ReconcileApplicationInstallations(ctx, reconcilers, namespaceName, userClusterClient)
@@ -325,6 +330,7 @@ func (r *Reconciler) ensureApplicationInstallation(ctx context.Context, userClus
 func ApplicationInstallationReconciler(
 	logger *zap.SugaredLogger,
 	application appskubermaticv1.ApplicationDefinition,
+	env *string,
 ) reconciling.NamedApplicationInstallationReconcilerFactory {
 	return func() (string, reconciling.ApplicationInstallationReconciler) {
 		applicationName := application.Name
@@ -362,6 +368,11 @@ func ApplicationInstallationReconciler(
 				logger.Debugf("Failed to convert default values to default values block: %v", err)
 			}
 
+			defaultValuesBlock, err := GenerateDefaultValuesFromTemplate(&application.Spec.DefaultValuesBlock, env)
+			if err != nil {
+				return nil, err
+			}
+
 			delete(application.Annotations, corev1.LastAppliedConfigAnnotation)
 
 			annotations := application.Annotations
@@ -385,7 +396,7 @@ func ApplicationInstallationReconciler(
 					Name:    application.Name,
 					Version: appVersion,
 				},
-				ValuesBlock: application.Spec.DefaultValuesBlock,
+				ValuesBlock: defaultValuesBlock,
 				Values:      runtime.RawExtension{Raw: []byte("{}")},
 			}
 
@@ -398,6 +409,27 @@ func ApplicationInstallationReconciler(
 			return app, nil
 		}
 	}
+}
+
+func GenerateDefaultValuesFromTemplate(defaultValuesBlock *string, env *string) (string, error) {
+	configTemplate := template.New("config")
+	parsedTemplate, err := configTemplate.Parse(*defaultValuesBlock)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the template: %w", err)
+	}
+
+	templateData := templateDataCluster.TemplateData{
+		Cluster: templateDataCluster.ClusterData{
+			Env: *env,
+		},
+	}
+
+	var renderedBuffer bytes.Buffer
+	if err := parsedTemplate.Execute(&renderedBuffer, templateData); err != nil {
+		return "", fmt.Errorf("failed to execute the template: %w", err)
+	}
+
+	return renderedBuffer.String(), nil
 }
 
 func (r *Reconciler) getApplicationInstallationNamespace(ctx context.Context, applicationName string) (string, error) {

--- a/sdk/apis/kubermatic/v1/common.go
+++ b/sdk/apis/kubermatic/v1/common.go
@@ -82,6 +82,8 @@ const (
 	// SkipRouterReconciliationAnnotation is used to indicate that the router reconciliation should be skipped.
 	// This annotation is currently used exclusively for OpenStack provider.
 	SkipRouterReconciliationAnnotation = "reconciliation.kubermatic.k8c.io/skip-router"
+
+	EnvironmentAnnotation = "kubermatic.io/environment"
 )
 
 type MachineFlavorFilter struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR introduces support for conditional value overrides in the valueBlock of an Application Installation, allowing kkp admins to define different values for specific keys based on the target environment (e.g., dev, stage, prod).
- Added a call to the template translation function in the E2E tests for the default application catalog to verify correct rendering of environment-based templates into valid Helm values. For testing purposes, the template was added to the `aikit` app arbitrarily, just to ensure at least one application tests this functionality.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14190 

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
You can now use the `kubermatic.io/environment` annotation on seed clusters (e.g., dev, test, prod) to enable environment-based value templating in application installations. This allows dynamic configuration using expressions like `{{ if eq .Env "dev" }}LoadBalancer{{ else }}ClusterIP{{ end }}` for more flexible multi-environment setups.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
