### PR TITLE
Remove unsupported Falco version from default Falco Application

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
@@ -31,13 +31,6 @@ spec:
       source:
         helm:
           chartName: falco
-          chartVersion: 4.1.1
-          url: oci://quay.io/kubermatic-mirror/helm-charts
-    version: 0.37.0
-  - template:
-      source:
-        helm:
-          chartName: falco
           chartVersion: 4.21.2
           url: oci://quay.io/kubermatic-mirror/helm-charts
     version: 0.40.0

--- a/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
@@ -31,13 +31,6 @@ spec:
       source:
         helm:
           chartName: falco
-          chartVersion: 3.5.0
-          url: oci://quay.io/kubermatic-mirror/helm-charts
-    version: 0.35.1
-  - template:
-      source:
-        helm:
-          chartName: falco
           chartVersion: 4.1.1
           url: oci://quay.io/kubermatic-mirror/helm-charts
     version: 0.37.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the Falco versions that have trouble running with recent kernel versions, due to a compiler version mismatch.

More details on this issue https://github.com/kubermatic/kubermatic/issues/14313#issuecomment-3113012509

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14313

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Early deprecation of unsupported Falco versions 0.35.1 and 0.37.0 from the default application catalog, since they are not compatible with modern Linux Kernel versions present in machine templates
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
