### PR TITLE
[release/v2.26] fix: CBSL credentials and status sync to seed for seperate master and seed cluster setup

### DIFF
--- a/pkg/ee/cluster-backup/master/sync-controller/controller.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/controller.go
@@ -34,9 +34,11 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -136,12 +138,19 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return fmt.Errorf("failed to reconcile storage location: %w", err)
 		}
 
+		if cbsl.Spec.Credential != nil {
+			if err := syncCBSLCredentialSecret(ctx, r.masterClient, seedClient, cbsl); err != nil {
+				return fmt.Errorf("failed to sync CBSL credential secret: %w", err)
+			}
+		}
+
 		// fetch the updated CBSL from the cache
 		if err := seedClient.Get(ctx, request.NamespacedName, seedCBSL); err != nil {
 			return fmt.Errorf("failed to fetch storage location on seed cluster: %w", err)
 		}
 
 		if !equality.Semantic.DeepEqual(seedCBSL.Status, cbsl.Status) {
+			seedCBSL.Status = cbsl.Status
 			if err := seedClient.Status().Update(ctx, seedCBSL); err != nil {
 				return fmt.Errorf("failed to update storage location status on seed cluster: %w", err)
 			}
@@ -166,4 +175,27 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 	}
 
 	return kuberneteshelper.TryRemoveFinalizer(ctx, r.masterClient, cbsl, cleanupFinalizer)
+}
+
+func syncCBSLCredentialSecret(
+	ctx context.Context,
+	masterClient ctrlruntimeclient.Client,
+	seedClient ctrlruntimeclient.Client,
+	cbsl *kubermaticv1.ClusterBackupStorageLocation,
+) error {
+	cbslKey := types.NamespacedName{
+		Name:      cbsl.Spec.Credential.Name,
+		Namespace: cbsl.Namespace,
+	}
+
+	cbslSecret := &corev1.Secret{}
+	if err := masterClient.Get(ctx, cbslKey, cbslSecret); err != nil {
+		return fmt.Errorf("failed to get credential secret from master: %w", err)
+	}
+
+	secretReconcilerFactory := []reconciling.NamedSecretReconcilerFactory{
+		secretReconcilerFactory(cbslSecret),
+	}
+
+	return reconciling.ReconcileSecrets(ctx, secretReconcilerFactory, cbslSecret.Namespace, seedClient)
 }

--- a/pkg/ee/cluster-backup/master/sync-controller/resources.go
+++ b/pkg/ee/cluster-backup/master/sync-controller/resources.go
@@ -26,11 +26,14 @@ package synccontroller
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/reconciler/pkg/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
-func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) reconciling.NamedClusterBackupStorageLocationReconcilerFactory {
-	return func() (string, reconciling.ClusterBackupStorageLocationReconciler) {
+func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) kkpreconciling.NamedClusterBackupStorageLocationReconcilerFactory {
+	return func() (string, kkpreconciling.ClusterBackupStorageLocationReconciler) {
 		return cbsl.Name, func(existing *kubermaticv1.ClusterBackupStorageLocation) (*kubermaticv1.ClusterBackupStorageLocation, error) {
 			if existing.ObjectMeta.Labels == nil {
 				existing.ObjectMeta.Labels = map[string]string{}
@@ -39,6 +42,20 @@ func cbslReconcilerFactory(cbsl *kubermaticv1.ClusterBackupStorageLocation) reco
 				existing.ObjectMeta.Labels[k] = v
 			}
 			existing.Spec = cbsl.Spec
+			return existing, nil
+		}
+	}
+}
+
+func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconcilerFactory {
+	return func() (name string, create reconciling.SecretReconciler) {
+		return s.Name, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			if existing.UID != "" && s.UID == existing.UID {
+				return nil, nil
+			}
+			existing.Labels = s.Labels
+			existing.Annotations = s.Annotations
+			existing.Data = s.Data
 			return existing, nil
 		}
 	}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/kubermatic/kubermatic/pull/14703

/assign rajaSahil

```release-note
Fix issue with CBSL credentials and status not syncing to seed clusters.
```