### PR TITLE
Support custom pre-defined values based on conditions for helm values managed by application installations

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   - name: pre-kubermatic-appcatalog-aikit
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/aikit-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/aikit-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -59,7 +59,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-argocd
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/argocd-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/argocd-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -106,7 +106,7 @@ presubmits:
   - name: pre-kubermatic-appcatalog-cluster-autoscaler
     # We are testing changes for the cluster-autoscaler application definition and the system applications
     # reconciler through the same job.
-    run_if_changed: "(pkg/applicationdefinitions)"
+    run_if_changed: "(pkg/applicationdefinitions|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -153,7 +153,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-cert-manager
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -198,7 +198,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-falco
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -243,7 +243,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-flux
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/flux2-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/flux2-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -288,7 +288,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-k8sgpt-operator
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/k8sgpt-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -333,7 +333,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-kube-vip
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/kube-vip-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/kube-vip-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -378,7 +378,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-kubevirt
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/kubevirt-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/kubevirt-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -423,7 +423,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-metallb
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -468,7 +468,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-nginx-ingress-controller
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -513,7 +513,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-nvidia-gpu-operator
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -558,7 +558,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-trivy
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/trivy-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/trivy-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -603,7 +603,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-trivy-operator
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/trivy-operator-app.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/trivy-operator-app.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -648,7 +648,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-appcatalog-local-ai
-    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/local-ai.yaml)"
+    run_if_changed: "(pkg/ee/default-application-catalog/applicationdefinitions/local-ai.yaml|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
@@ -693,7 +693,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-app-definitions
-    run_if_changed: "(pkg/ee/default-application-catalog/application_catalog.go|pkg/ee/default-application-catalog/embed.go|hack/ci/run-application-definitions-e2e-test.sh)"
+    run_if_changed: "(pkg/ee/default-application-catalog/application_catalog.go|pkg/ee/default-application-catalog/embed.go|hack/ci/run-application-definitions-e2e-test.|pkg/ee/default-application-catalog/application_test.go)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/docs/zz_generated.applicationdata.go.txt
+++ b/docs/zz_generated.applicationdata.go.txt
@@ -20,6 +20,12 @@ type ClusterData struct {
 	MajorMinorVersion string
 	// AutoscalerVersion is the tag which should be used for the cluster autoscaler
 	AutoscalerVersion string
+	// Annotations holds arbitrary non-identifying metadata attached to the cluster.
+	// Transferred from the Kubermatic cluster object.
+	Annotations map[string]string
+	// Labels are key-value pairs used to organize, categorize, and select clusters.
+	// Transferred from the Kubermatic cluster object.
+	Labels map[string]string
 }
 
 // ClusterAddress stores access and address information of a cluster.

--- a/pkg/applications/providers/template/util.go
+++ b/pkg/applications/providers/template/util.go
@@ -57,6 +57,12 @@ type ClusterData struct {
 	MajorMinorVersion string
 	// AutoscalerVersion is the tag which should be used for the cluster autoscaler
 	AutoscalerVersion string
+	// Annotations holds arbitrary non-identifying metadata attached to the cluster.
+	// Transferred from the Kubermatic cluster object.
+	Annotations map[string]string
+	// Labels are key-value pairs used to organize, categorize, and select clusters.
+	// Transferred from the Kubermatic cluster object.
+	Labels map[string]string
 }
 
 var (
@@ -121,6 +127,8 @@ func GetTemplateData(ctx context.Context, seedClient ctrlruntimeclient.Client, c
 				Version:           fmt.Sprintf("%d.%d.%d", clusterVersion.Major(), clusterVersion.Minor(), clusterVersion.Patch()),
 				MajorMinorVersion: fmt.Sprintf("%d.%d", clusterVersion.Major(), clusterVersion.Minor()),
 				AutoscalerVersion: clusterAutoscalerVersion,
+				Annotations:       cluster.Annotations,
+				Labels:            cluster.Labels,
 			},
 		}, nil
 	}

--- a/pkg/applications/providers/template/util_test.go
+++ b/pkg/applications/providers/template/util_test.go
@@ -166,6 +166,80 @@ func TestRenderValueTemplate(t *testing.T) {
 			want:    nil,
 			wantErr: ErrBadTemplate,
 		},
+		{
+			name: "case 3: rendering cluster labels should succeed",
+			values: map[string]any{
+				"environment": "{{ .Cluster.Labels.environment }}",
+				"tier":        "{{ .Cluster.Labels.tier }}",
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Labels: map[string]string{
+						"environment": "production",
+						"tier":        "frontend",
+					},
+				},
+			},
+			want: map[string]any{
+				"environment": "production",
+				"tier":        "frontend",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "case 4: rendering cluster annotations should succeed",
+			values: map[string]any{
+				"description": "{{ .Cluster.Annotations.description }}",
+				"owner":       "{{ .Cluster.Annotations.owner }}",
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Annotations: map[string]string{
+						"description": "test cluster",
+						"owner":       "team-a",
+					},
+				},
+			},
+			want: map[string]any{
+				"description": "test cluster",
+				"owner":       "team-a",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "case 5: rendering with missing label should return empty string",
+			values: map[string]any{
+				"missing": "{{ .Cluster.Labels.nonexistent }}",
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Labels: map[string]string{
+						"exists": "yes",
+					},
+				},
+			},
+			want: map[string]any{
+				"missing": "",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "case 6: rendering with missing annotation should return empty string",
+			values: map[string]any{
+				"missing": "{{ .Cluster.Annotations.nonexistent }}",
+			},
+			templateData: TemplateData{
+				Cluster: ClusterData{
+					Annotations: map[string]string{
+						"exists": "yes",
+					},
+				},
+			},
+			want: map[string]any{
+				"missing": "",
+			},
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the application templating functionality by:

- Adding annotations and labels to the ClusterData struct in `pkg/applications/providers/template/util.go`
- Enabling the use of these values in Helm templating when creating ApplicationInstallations
- Adding unit tests for the utility functions
- Updating the default application catalog e2e tests to verify the new functionality

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14190

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
You can now use annotations and labels on user clusters to enable templating during application installations. This allows for dynamic configuration using expressions like {{- if eq (index .Cluster.Annotations "env") "dev" }}custom1{{ else }}custom2{{ end }}. This feature is useful for more flexible multi-environment setups, for example.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
