### PR TITLE
add option to configure non root device usage in containerd

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -33,6 +33,8 @@ spec:
               # List of registry mirrors to use
               mirrors:
                 - mirror.gcr.io
+        # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+        enableNonRootDeviceOwnership: false
         # Optional: If set, this proxy will be configured for both HTTP and HTTPS.
         httpProxy: ""
         # Optional: These image registries will be configured as insecure

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -33,6 +33,8 @@ spec:
               # List of registry mirrors to use
               mirrors:
                 - mirror.gcr.io
+        # Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+        enableNonRootDeviceOwnership: false
         # Optional: If set, this proxy will be configured for both HTTP and HTTPS.
         httpProxy: ""
         # Optional: These image registries will be configured as insecure

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -3156,6 +3156,9 @@ spec:
                           description: A map of registries to use to render configs and mirrors for containerd registries
                           type: object
                       type: object
+                    enableNonRootDeviceOwnership:
+                      description: 'Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.'
+                      type: boolean
                     insecureRegistries:
                       description: |-
                         Optional: These image registries will be configured as insecure

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -3150,6 +3150,9 @@ spec:
                           description: A map of registries to use to render configs and mirrors for containerd registries
                           type: object
                       type: object
+                    enableNonRootDeviceOwnership:
+                      description: 'Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.'
+                      type: boolean
                     insecureRegistries:
                       description: |-
                         Optional: These image registries will be configured as insecure

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -335,6 +335,9 @@ spec:
                                 description: A map of registries to use to render configs and mirrors for containerd registries
                                 type: object
                             type: object
+                          enableNonRootDeviceOwnership:
+                            description: 'Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.'
+                            type: boolean
                           httpProxy:
                             description: 'Optional: If set, this proxy will be configured for both HTTP and HTTPS.'
                             type: string

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -1137,6 +1137,8 @@ type ContainerRuntimeOpts struct {
 	PauseImage string `json:"pauseImage,omitempty"`
 	// Optional: ContainerdRegistryMirrors configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors.
 	ContainerdRegistryMirrors *ContainerRuntimeContainerd `json:"containerdRegistryMirrors,omitempty"`
+	// Optional: EnableNonRootDeviceOwnership enables the non-root device ownership feature in the container runtime.
+	EnableNonRootDeviceOwnership bool `json:"enableNonRootDeviceOwnership,omitempty"`
 }
 
 // ContainerRuntimeContainerd defines containerd container runtime registries configs.


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds an option to configure non-root device usage for nodes provisioned by osm and machine-controller.
ref: #14352 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Non-root device usage on worker nodes can now be enabled for containerd runtime by setting seed datacenter value `spec.datacenter.node.enableNonRootDeviceOwnership` to `true`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
