### PR TITLE
[release/v2.26] Update the Helm charts to exclude Bitnami images

### DIFF
--- a/charts/backup/velero/Chart.lock
+++ b/charts/backup/velero/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: velero
-  repository: https://vmware-tanzu.github.io/helm-charts
+  repository: oci://quay.io/kubermatic-mirror/helm-charts
   version: 7.1.0
-digest: sha256:cbe2e0ff8def6233ad51a947f20faac0ca9a90c605bcb1c4927c5e27e533e6dc
-generated: "2024-07-08T11:43:53.5218859+02:00"
+digest: sha256:4305f756b496ce15310f4f6b9ef10eff30e63d322d72b26d3c21cdc465fb1189
+generated: "2025-08-12T17:08:20.242238335+05:00"

--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
   - name: The Kubermatic Kubernetes Platform contributors
     email: support@kubermatic.com
 dependencies:
-  - repository: https://vmware-tanzu.github.io/helm-charts
+  - repository: oci://quay.io/kubermatic-mirror/helm-charts
     name: velero
     version: 7.1.0

--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -153,7 +153,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: node-agent
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring

--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -243,7 +243,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: velero
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring
@@ -472,7 +472,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.32"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -484,7 +484,7 @@ spec:
               name: crds
       containers:
         - name: velero
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           command:
             - /tmp/sh

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -153,7 +153,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: node-agent
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -243,7 +243,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: velero
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring
@@ -472,7 +472,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.32"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -484,7 +484,7 @@ spec:
               name: crds
       containers:
         - name: velero
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           command:
             - /tmp/sh

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -153,7 +153,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: node-agent
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -243,7 +243,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: velero
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring
@@ -472,7 +472,7 @@ spec:
       serviceAccountName: release-name-velero-server-upgrade-crds
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnami/kubectl:1.32"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33.3"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -484,7 +484,7 @@ spec:
               name: crds
       containers:
         - name: velero
-          image: "velero/velero:v1.14.0"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.14.0"
           imagePullPolicy: IfNotPresent
           command:
             - /tmp/sh

--- a/charts/mla/cortex/Chart.lock
+++ b/charts/mla/cortex/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cortex
-  repository: https://cortexproject.github.io/cortex-helm-chart
+  repository: oci://quay.io/kubermatic-mirror/helm-charts
   version: 2.1.0
-digest: sha256:7cddb7331732b8779ba3bd94f8a4f27ee3166a13d3057bb757b7a9830b4e4af6
-generated: "2023-12-21T09:08:18.061272245+05:30"
+digest: sha256:7484dffa864c02d6e6775288aa71b931edd4511aac466d8e3532390fe0355976
+generated: "2025-08-10T15:19:15.334546248+05:00"

--- a/charts/mla/cortex/Chart.yaml
+++ b/charts/mla/cortex/Chart.yaml
@@ -23,5 +23,5 @@ sources:
   - https://github.com/cortexproject/cortex-helm-chart
 dependencies:
 - name: cortex
-  repository: https://cortexproject.github.io/cortex-helm-chart
+  repository: oci://quay.io/kubermatic-mirror/helm-charts
   version: 2.1.0

--- a/charts/mla/cortex/test/config.yaml.out
+++ b/charts/mla/cortex/test/config.yaml.out
@@ -1243,7 +1243,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1287,7 +1287,7 @@ spec:
             - name: tmp
               mountPath: /tmp
         - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached-exporter:0.11.2-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1374,7 +1374,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1418,7 +1418,7 @@ spec:
             - name: tmp
               mountPath: /tmp
         - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached-exporter:0.11.2-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1505,7 +1505,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1549,7 +1549,7 @@ spec:
             - name: tmp
               mountPath: /tmp
         - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached-exporter:0.11.2-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/charts/mla/cortex/test/default.yaml.out
+++ b/charts/mla/cortex/test/default.yaml.out
@@ -1243,7 +1243,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1287,7 +1287,7 @@ spec:
             - name: tmp
               mountPath: /tmp
         - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached-exporter:0.11.2-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1374,7 +1374,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1418,7 +1418,7 @@ spec:
             - name: tmp
               mountPath: /tmp
         - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached-exporter:0.11.2-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1505,7 +1505,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1549,7 +1549,7 @@ spec:
             - name: tmp
               mountPath: /tmp
         - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          image: quay.io/kubermatic-mirror/images/memcached-exporter:0.11.2-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/hack/test-chart-rendering.sh
+++ b/hack/test-chart-rendering.sh
@@ -37,6 +37,13 @@ helm version
 echodate "Fetching dependencies..."
 i=0
 for url in $(yq '.dependencies.[].repository' Chart.yaml); do
+  # Remove quotes from the URL
+  url=${url//\"/}
+  # Skip OCI repositories as they don't need to be added to helm repos
+  if [[ $url == oci://* ]]; then
+    echo "Skipping OCI repository: ${url}"
+    continue
+  fi
   i=$((i + 1))
   helm repo add ${chartname}-dep-${i} ${url}
 done

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -63,6 +63,12 @@ func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) (err
 	}
 
 	for idx, dep := range chart.Dependencies {
+		// Skip OCI repositories as they don't need to be added to helm repos
+		if strings.HasPrefix(dep.Repository, "oci://") {
+			c.logger.Debugf("Skipping OCI repository: %s", dep.Repository)
+			continue
+		}
+
 		repoName := fmt.Sprintf("dep-%s-%d", chart.Name, idx)
 		repoAddFlags := []string{
 			"repo",


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/kubermatic/kubermatic/pull/14873

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replaced Bitnami charts and images with kubermatic-mirror charts and images to address issues identified in bitnami/containers#83267
```
