### PR TITLE
[release/v2.27] Add support for k8s patch releases v1.32.8/1.31.12

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -462,7 +462,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.31.8
+    default: v1.31.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -554,9 +554,11 @@ spec:
       - v1.31.5
       - v1.31.7
       - v1.31.8
+      - v1.31.12
       - v1.32.1
       - v1.32.3
       - v1.32.4
+      - v1.32.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -462,7 +462,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.31.8
+    default: v1.31.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -554,9 +554,11 @@ spec:
       - v1.31.5
       - v1.31.7
       - v1.31.8
+      - v1.31.12
       - v1.32.1
       - v1.32.3
       - v1.32.4
+      - v1.32.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.31.8"),
+		Default: semver.NewSemverOrDie("v1.31.12"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -242,10 +242,12 @@ var (
 			newSemver("v1.31.5"),
 			newSemver("v1.31.7"),
 			newSemver("v1.31.8"),
+			newSemver("v1.31.12"),
 			// Kubernetes 1.32
 			newSemver("v1.32.1"),
 			newSemver("v1.32.3"),
 			newSemver("v1.32.4"),
+			newSemver("v1.32.8"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.28 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add support for k8s patch releases v1.32.8/1.31.12. It includes CVE-2025-5187 fix as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for k8s patch releases v1.32.8/1.31.12
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
