### PR TITLE
implement controller for syncing secrets for encryption at rest in user clusters

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -26,6 +26,7 @@ import (
 	applicationdefinitionsynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/application-definition-synchronizer"
 	applicationsecretsynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/application-secret-synchronizer"
 	clustertemplatesynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/cluster-template-synchronizer"
+	encryptionsecretsynchonizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/encryption-secret-synchronizer"
 	externalcluster "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster"
 	kcstatuscontroller "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/kc-status-controller"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/kubeone"
@@ -81,6 +82,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 		resourceQuotaSynchronizerFactoryCreator(ctrlCtx),
 		resourceQuotaControllerFactoryCreator(ctrlCtx),
 		policyTemplateSynchronizerFactoryCreator(ctrlCtx),
+		encryptionSecretSynchronizerFactoryCreator(ctrlCtx),
 	}
 
 	// Create the user-ssh-key-synchronizer controller even DisableUserSSHKey feature is set
@@ -290,6 +292,18 @@ func policyTemplateSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedco
 		return policytemplatesynchronizer.ControllerName, policytemplatesynchronizer.Add(
 			masterMgr,
 			seedManagerMap,
+			ctrlCtx.log,
+			ctrlCtx.workerCount,
+		)
+	}
+}
+
+func encryptionSecretSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedcontrollerlifecycle.ControllerFactory {
+	return func(ctx context.Context, masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
+		return encryptionsecretsynchonizer.ControllerName, encryptionsecretsynchonizer.Add(
+			masterMgr,
+			seedManagerMap,
+			ctrlCtx.namespace,
 			ctrlCtx.log,
 			ctrlCtx.workerCount,
 		)

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/OWNERS
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-cluster-management
+
+reviewers:
+  - sig-cluster-management
+
+labels:
+  - sig/cluster-management
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
@@ -87,11 +87,8 @@ func Add(
 					if !strings.HasPrefix(secret.Name, EncryptionSecretPrefix) {
 						return false
 					}
-					if secret.Annotations == nil {
-						return false
-					}
-					_, hasClusterAnnotation := secret.Annotations[ClusterNameAnnotation]
-					return hasClusterAnnotation
+
+					return metav1.HasAnnotation(secret.ObjectMeta, ClusterNameAnnotation)
 				}),
 				predicate.ByNamespace(r.namespace),
 			),

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package encryptionsecretsynchonizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/reconciler/pkg/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	ControllerName           = "kkp-encryption-secret-synchronizer"
+	ClusterNameAnnotation    = "kubermatic.io/cluster-name"
+	EncryptionSecretPrefix   = "encryption-key-cluster-"
+	ClusterNamespaceTemplate = "cluster-%s"
+)
+
+type reconciler struct {
+	log          *zap.SugaredLogger
+	recorder     record.EventRecorder
+	masterClient ctrlruntimeclient.Client
+	namespace    string
+	seedClients  kuberneteshelper.SeedClientMap
+}
+
+func Add(
+	masterManager manager.Manager,
+	seedManagers map[string]manager.Manager,
+	namespace string,
+	log *zap.SugaredLogger,
+	numWorkers int,
+) error {
+	r := &reconciler{
+		log:          log.Named(ControllerName),
+		recorder:     masterManager.GetEventRecorderFor(ControllerName),
+		masterClient: masterManager.GetClient(),
+		seedClients:  kuberneteshelper.SeedClientMap{},
+		namespace:    namespace,
+	}
+
+	for seedName, seedManager := range seedManagers {
+		r.seedClients[seedName] = seedManager.GetClient()
+	}
+
+	_, err := builder.ControllerManagedBy(masterManager).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(
+			&corev1.Secret{},
+			builder.WithPredicates(
+				predicate.Factory(func(o ctrlruntimeclient.Object) bool {
+					secret := o.(*corev1.Secret)
+					if !strings.HasPrefix(secret.Name, EncryptionSecretPrefix) {
+						return false
+					}
+					if secret.Annotations == nil {
+						return false
+					}
+					_, hasClusterAnnotation := secret.Annotations[ClusterNameAnnotation]
+					return hasClusterAnnotation
+				}),
+				predicate.ByNamespace(r.namespace),
+			),
+		).
+		Build(r)
+
+	return err
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("secret", request)
+	log.Debug("Processing")
+
+	secret := &corev1.Secret{}
+	if err := r.masterClient.Get(ctx, request.NamespacedName, secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+
+		// handling deletion
+		delSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: r.namespace}}
+		if err := r.handleDeletion(ctx, log, delSecret); err != nil {
+			err = fmt.Errorf("failed to delete secret: %w", err)
+
+			log.Error("ReconcilingError", zap.Error(err))
+			r.recorder.Event(delSecret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, nil
+	}
+
+	err := r.reconcile(ctx, log, secret)
+	if err != nil {
+		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
+	clusterName, exists := secret.Annotations[ClusterNameAnnotation]
+	if !exists {
+		return fmt.Errorf("secret %s missing cluster name annotation %s", secret.Name, ClusterNameAnnotation)
+	}
+
+	cluster, seedName, err := r.findTargetCluster(ctx, clusterName)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Debug("Cluster not found, secret will be synced when cluster is created", "cluster", clusterName)
+			return nil
+		}
+		return err
+	}
+
+	if !cluster.IsEncryptionEnabled() {
+		log.Debug("Encryption not enabled on cluster, skipping secret sync", "cluster", clusterName)
+		return nil
+	}
+
+	seedClient, exists := r.seedClients[seedName]
+	if !exists {
+		return fmt.Errorf("seed client not found for %s", seedName)
+	}
+
+	clusterNamespace := fmt.Sprintf(ClusterNamespaceTemplate, cluster.Name)
+	syncSecret := secret.DeepCopy()
+	syncSecret.SetResourceVersion("")
+
+	namedSecretReconcilerFactory := []reconciling.NamedSecretReconcilerFactory{
+		secretReconcilerFactory(syncSecret),
+	}
+
+	existingSecret := &corev1.Secret{}
+	if err := seedClient.Get(ctx, ctrlruntimeclient.ObjectKey{
+		Name:      syncSecret.Name,
+		Namespace: clusterNamespace,
+	}, existingSecret); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to fetch Secret on seed cluster: %w", err)
+	}
+
+	if existingSecret.UID != "" && existingSecret.UID == syncSecret.UID {
+		return nil
+	}
+
+	if err := reconciling.ReconcileSecrets(ctx, namedSecretReconcilerFactory, clusterNamespace, seedClient); err != nil {
+		return fmt.Errorf("reconciling encryption secret %s failed: %w", syncSecret.Name, err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) findTargetCluster(ctx context.Context, clusterName string) (*kubermaticv1.Cluster, string, error) {
+	var targetCluster *kubermaticv1.Cluster
+	var targetSeedName string
+
+	err := r.seedClients.Each(ctx, r.log, func(seedName string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		cluster := &kubermaticv1.Cluster{}
+		err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)
+		if err == nil {
+			targetCluster = cluster
+			targetSeedName = seedName
+			return nil
+		} else if !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, "", err
+	}
+
+	if targetCluster == nil {
+		return nil, "", fmt.Errorf("cluster %s not found in any seed", clusterName)
+	}
+
+	return targetCluster, targetSeedName, nil
+}
+
+func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconcilerFactory {
+	return func() (name string, create reconciling.SecretReconciler) {
+		return s.Name, func(existing *corev1.Secret) (*corev1.Secret, error) {
+			existing.Labels = s.Labels
+			existing.Annotations = s.Annotations
+			existing.Data = s.Data
+			existing.Type = s.Type
+			return existing, nil
+		}
+	}
+}
+
+func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
+	if !strings.HasPrefix(secret.Name, EncryptionSecretPrefix) {
+		return nil
+	}
+
+	clusterName := strings.TrimPrefix(secret.Name, EncryptionSecretPrefix)
+	if clusterName == "" {
+		return nil
+	}
+
+	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+		clusterNamespace := fmt.Sprintf(ClusterNamespaceTemplate, clusterName)
+
+		err := seedClient.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secret.Name,
+				Namespace: clusterNamespace,
+			},
+		})
+
+		if apierrors.IsNotFound(err) {
+			log.Debug("Secret already deleted from cluster namespace")
+			return nil
+		}
+
+		return err
+	})
+}

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller_test.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package encryptionsecretsynchonizer
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testClusterName   = "test-cluster"
+	testSecretName    = "encryption-key-cluster-test-cluster"
+	masterNamespace   = "kubermatic"
+	clusterNamespace  = "cluster-test-cluster"
+	testSeedName      = "test-seed"
+	testEncryptionKey = "dGVzdC1lbmNyeXB0aW9uLWtleS10aGF0LWlzLTMyLWJ5dGVz"
+)
+
+func TestReconcile(t *testing.T) {
+	testCases := []struct {
+		name             string
+		masterSecret     *corev1.Secret
+		existingCluster  *kubermaticv1.Cluster
+		existingSecret   *corev1.Secret
+		expectedSecret   *corev1.Secret
+		expectError      bool
+		expectSecretInNS bool
+	}{
+		{
+			name: "scenario 1: secret with annotation, cluster exists with encryption enabled",
+			masterSecret: generateEncryptionSecret(testSecretName, masterNamespace, map[string]string{
+				ClusterNameAnnotation: testClusterName,
+			}),
+			existingCluster: generateCluster(testClusterName, true),
+			expectedSecret: generateEncryptionSecret(testSecretName, clusterNamespace, map[string]string{
+				ClusterNameAnnotation: testClusterName,
+			}),
+			expectSecretInNS: true,
+		},
+		{
+			name: "scenario 2: secret with annotation, cluster exists but encryption disabled",
+			masterSecret: generateEncryptionSecret(testSecretName, masterNamespace, map[string]string{
+				ClusterNameAnnotation: testClusterName,
+			}),
+			existingCluster:  generateCluster(testClusterName, false),
+			expectSecretInNS: false,
+		},
+		{
+			name: "scenario 3: secret with annotation, but cluster doesn't exist",
+			masterSecret: generateEncryptionSecret(testSecretName, masterNamespace, map[string]string{
+				ClusterNameAnnotation: testClusterName,
+			}),
+			expectSecretInNS: false,
+		},
+		{
+			name: "scenario 4: secret without cluster annotation",
+			masterSecret: generateEncryptionSecret(testSecretName, masterNamespace, map[string]string{
+				"other-annotation": "other-value",
+			}),
+			existingCluster:  generateCluster(testClusterName, true),
+			expectError:      true,
+			expectSecretInNS: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup master client
+			var masterObjects []ctrlruntimeclient.Object
+			if tc.masterSecret != nil {
+				masterObjects = append(masterObjects, tc.masterSecret)
+			}
+			masterClient := fake.NewClientBuilder().WithObjects(masterObjects...).Build()
+
+			// Setup seed client
+			var seedObjects []ctrlruntimeclient.Object
+			if tc.existingCluster != nil {
+				seedObjects = append(seedObjects, tc.existingCluster)
+			}
+			if tc.existingSecret != nil {
+				seedObjects = append(seedObjects, tc.existingSecret)
+			}
+			seedClient := fake.NewClientBuilder().WithObjects(seedObjects...).Build()
+
+			r := &reconciler{
+				log:          kubermaticlog.Logger,
+				recorder:     &record.FakeRecorder{},
+				masterClient: masterClient,
+				seedClients:  map[string]ctrlruntimeclient.Client{testSeedName: seedClient},
+				namespace:    masterNamespace,
+			}
+
+			request := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testSecretName,
+					Namespace: masterNamespace,
+				},
+			}
+
+			// Execute reconcile
+			_, err := r.Reconcile(ctx, request)
+
+			// Check error expectation
+			if tc.expectError && err == nil {
+				t.Errorf("expected an error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+
+			// Check if secret should exist in cluster namespace
+			resultSecret := &corev1.Secret{}
+			err = seedClient.Get(ctx, types.NamespacedName{
+				Name:      testSecretName,
+				Namespace: clusterNamespace,
+			}, resultSecret)
+
+			if tc.expectSecretInNS {
+				if err != nil {
+					t.Errorf("expected secret to exist in cluster namespace but got error: %v", err)
+					return
+				}
+
+				if tc.expectedSecret != nil {
+					if resultSecret.Name != tc.expectedSecret.Name {
+						t.Errorf("expected secret name to be %q, got %q", tc.expectedSecret.Name, resultSecret.Name)
+					}
+					if resultSecret.Namespace != tc.expectedSecret.Namespace {
+						t.Errorf("expected secret namespace to be %q, got %q", tc.expectedSecret.Namespace, resultSecret.Namespace)
+					}
+					if !reflect.DeepEqual(resultSecret.Data, tc.expectedSecret.Data) {
+						t.Errorf("expected secret data to be %q, got %q", tc.expectedSecret.Data, resultSecret.Data)
+					}
+					if !reflect.DeepEqual(resultSecret.Annotations, tc.expectedSecret.Annotations) {
+						t.Errorf("expected secret annotations to be %q, got %q", tc.expectedSecret.Annotations, resultSecret.Annotations)
+					}
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected secret not to exist in cluster namespace but it was found")
+				} else if !apierrors.IsNotFound(err) {
+					t.Errorf("expected NotFound error but got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleDeletion(t *testing.T) {
+	testCases := []struct {
+		name                string
+		secretToDelete      *corev1.Secret
+		existingSecretInNS  *corev1.Secret
+		expectSecretDeleted bool
+	}{
+		{
+			name: "deletion of encryption secret should remove secret from cluster namespace",
+			secretToDelete: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretName,
+					Namespace: masterNamespace,
+				},
+			},
+			existingSecretInNS: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSecretName,
+					Namespace: clusterNamespace,
+				},
+				Data: map[string][]byte{
+					"key": []byte(testEncryptionKey),
+				},
+			},
+			expectSecretDeleted: true,
+		},
+		{
+			name: "deletion of non-encryption secret should be ignored",
+			secretToDelete: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "regular-secret",
+					Namespace: masterNamespace,
+				},
+			},
+			existingSecretInNS: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "regular-secret",
+					Namespace: clusterNamespace,
+				},
+				Data: map[string][]byte{
+					"key": []byte("some-data"),
+				},
+			},
+			expectSecretDeleted: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup seed client with existing secret
+			var seedObjects []ctrlruntimeclient.Object
+			if tc.existingSecretInNS != nil {
+				seedObjects = append(seedObjects, tc.existingSecretInNS)
+			}
+			seedClient := fake.NewClientBuilder().WithObjects(seedObjects...).Build()
+
+			r := &reconciler{
+				log:         kubermaticlog.Logger,
+				recorder:    &record.FakeRecorder{},
+				seedClients: map[string]ctrlruntimeclient.Client{testSeedName: seedClient},
+				namespace:   masterNamespace,
+			}
+
+			err := r.handleDeletion(ctx, kubermaticlog.Logger, tc.secretToDelete)
+			if err != nil {
+				t.Errorf("handleDeletion failed: %v", err)
+			}
+
+			resultSecret := &corev1.Secret{}
+			err = seedClient.Get(ctx, types.NamespacedName{
+				Name:      tc.secretToDelete.Name,
+				Namespace: clusterNamespace,
+			}, resultSecret)
+
+			if tc.expectSecretDeleted {
+				if err == nil {
+					t.Errorf("expected secret to be deleted from cluster namespace but it still exists")
+				} else if !apierrors.IsNotFound(err) {
+					t.Errorf("expected NotFound error but got: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected secret to remain in cluster namespace but got error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestFindTargetCluster(t *testing.T) {
+	testCases := []struct {
+		name            string
+		clusterName     string
+		clusters        []*kubermaticv1.Cluster
+		expectedCluster *kubermaticv1.Cluster
+		expectedSeed    string
+		expectError     bool
+	}{
+		{
+			name:        "cluster found in first seed",
+			clusterName: testClusterName,
+			clusters: []*kubermaticv1.Cluster{
+				generateCluster(testClusterName, true),
+			},
+			expectedCluster: generateCluster(testClusterName, true),
+			expectedSeed:    testSeedName,
+		},
+		{
+			name:        "cluster not found in any seed",
+			clusterName: "non-existent-cluster",
+			clusters: []*kubermaticv1.Cluster{
+				generateCluster(testClusterName, true),
+			},
+			expectError: true,
+		},
+		{
+			name:        "no clusters in seeds",
+			clusterName: testClusterName,
+			clusters:    []*kubermaticv1.Cluster{},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var seedObjects []ctrlruntimeclient.Object
+			for _, cluster := range tc.clusters {
+				seedObjects = append(seedObjects, cluster)
+			}
+			seedClient := fake.NewClientBuilder().WithObjects(seedObjects...).Build()
+
+			r := &reconciler{
+				log:         kubermaticlog.Logger,
+				seedClients: map[string]ctrlruntimeclient.Client{testSeedName: seedClient},
+			}
+
+			cluster, seedName, err := r.findTargetCluster(ctx, tc.clusterName)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("expected no error but got: %v", err)
+				return
+			}
+
+			if cluster.Name != tc.expectedCluster.Name {
+				t.Errorf("expected cluster name to be %q, got %q", tc.expectedCluster.Name, cluster.Name)
+			}
+
+			if seedName != tc.expectedSeed {
+				t.Errorf("expected seed name to be %q, got %q", tc.expectedSeed, seedName)
+			}
+		})
+	}
+}
+
+func generateEncryptionSecret(name, namespace string, annotations map[string]string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Data: map[string][]byte{
+			"key": []byte(testEncryptionKey),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+}
+
+func generateCluster(name string, encryptionEnabled bool) *kubermaticv1.Cluster {
+	cluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			Features: map[string]bool{},
+		},
+		Status: kubermaticv1.ClusterStatus{
+			NamespaceName: "cluster-" + name,
+		},
+	}
+
+	if encryptionEnabled {
+		cluster.Spec.Features[kubermaticv1.ClusterFeatureEncryptionAtRest] = true
+		cluster.Spec.EncryptionConfiguration = &kubermaticv1.EncryptionConfiguration{
+			Enabled:   true,
+			Resources: []string{"secrets"},
+			Secretbox: &kubermaticv1.SecretboxEncryptionConfiguration{
+				Keys: []kubermaticv1.SecretboxKey{
+					{
+						Name: "test-key",
+						SecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "encryption-key-cluster-" + name,
+							},
+							Key: "key",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return cluster
+}

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/doc.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/doc.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package encryptionsecretsynchonizer contains a controller that is responsible for synchronizing
+encryption-at-rest secrets from the kubermatic namespace to user cluster namespaces on seed clusters.
+
+This controller monitors secrets with the pattern "encryption-key-cluster-*" that have the
+"kubermatic.io/cluster-name" annotation and ensures they are available in the corresponding
+cluster namespace where the encryption-at-rest-controller can use them.
+*/
+package encryptionsecretsynchonizer


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds encryptionsecretsynchonizer, which is controller that is responsible for synchronizing encryption at rest secrets from the kubermatic namespace to user cluster namespaces on seed clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
References #5946

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
