### PR TITLE
Set node-local-dns metrics port to 9253

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -127,8 +127,8 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 							Protocol:      corev1.ProtocolUDP,
 						},
 						{
-							ContainerPort: 9153,
-							HostPort:      9153,
+							ContainerPort: 9253,
+							HostPort:      9253,
 							Name:          "metrics",
 							Protocol:      corev1.ProtocolTCP,
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

node-local-dns is configured to expose the Prometheus endpoint on [port 9253](https://github.com/kubermatic/kubermatic/blob/v2.28.2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/configmap.go#L108), but the DaemonSet lists port 9153. So this PR changes the port number defined in the DaemonSet to 9253 (which is also used by default in the [upstream manifest](https://github.com/kubernetes/kubernetes/blob/v1.33.4/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L158)).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The "node-local-dns" DaemonSet in user clusters now correctly defines port 9253 as metrics port
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
