### PR TITLE
Introduce a feature flag for the new application catalog manager

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -65,6 +65,12 @@ const (
 	// and disable related controllers and components such as the userSSHKeySynchronizerFactoryCreator and
 	// usersshkeyprojectownershipcontroller.
 	DisableUserSSHKey = "DisableUserSSHKey"
+
+	// ExternalApplicationCatalogManager enables the external application catalog manager.
+	// It allows the new Application Catalog manager to work, and prevent the current controllers in KKP master to
+	// reconcile ApplicationDefinitions. Setting this feature flag to true will delegate the ApplicationDefinition reconciliation
+	// responsibility to the new external (out-tree) application catalog controller manager.
+	ExternalApplicationCatalogManager = "ExternalApplicationCatalogManager"
 )
 
 // FeatureGate is map of key=value pairs that enables/disables various features.


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds a new feature flag for the new application catalog manager.

If this flag is set, the current controller in KKP master should not reconcile application definitions from the `pkg/ee/default-application-catalog` directory; instead, it should only reconcile system applications and delegate the responsibility of default application catalog reconciliation to the new out-tree implementation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
