### PR TITLE
Bump Dex chart to appversion 2.44.0

### DIFF
--- a/charts/dex/Chart.lock
+++ b/charts/dex/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: dex
   repository: https://charts.dexidp.io
-  version: 0.23.0
-digest: sha256:1ea89746228c51235fc4fb406040d1e5838d2c1b6edc404ab034bd84150c6457
-generated: "2025-07-21T17:31:20.026107834+05:30"
+  version: 0.24.0
+digest: sha256:edc13197d17a4f57be57b6276617398b55c40748b01ff09c800f93a7d344cf05
+generated: "2025-09-12T02:16:26.274458989+05:30"

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: dex
 version: 9.9.9-dev
-appVersion: 2.42.0
+appVersion: 2.44.0
 description: A Helm chart for Dex
 keywords:
   - kubermatic
@@ -30,4 +30,4 @@ maintainers:
 dependencies:
   - repository: https://charts.dexidp.io
     name: dex
-    version: 0.23.0
+    version: 0.24.0

--- a/charts/dex/test/default.yaml.out
+++ b/charts/dex/test/default.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: dex/charts/dex/templates/secret.yaml
@@ -19,10 +19,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -61,10 +61,10 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -77,10 +77,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: ClusterRole
@@ -98,10 +98,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["dex.coreos.com"]
@@ -115,10 +115,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: Role
@@ -136,10 +136,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -165,10 +165,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
     
   
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 09617abf0250dca6ab8c6d4d505285f7648b8dde447c55c455ccdba985f05621
+        checksum/config: c9d19a62d710c06e36b31c1a8676051aabffbe7575de361b74c3c2e93a65b9dc
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -195,7 +195,7 @@ spec:
         - name: dex
           securityContext:
             {}
-          image: "ghcr.io/dexidp/dex:v2.42.0"
+          image: "ghcr.io/dexidp/dex:v2.44.0"
           imagePullPolicy: IfNotPresent
           args:
             - dex
@@ -259,10 +259,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/charts/dex/test/values.example.ce.yaml.out
+++ b/charts/dex/test/values.example.ce.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: dex/charts/dex/templates/secret.yaml
@@ -19,10 +19,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -61,10 +61,10 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -77,10 +77,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: ClusterRole
@@ -98,10 +98,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["dex.coreos.com"]
@@ -115,10 +115,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: Role
@@ -136,10 +136,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -165,10 +165,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
     
   
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 30ad8d160980ee36d4618497eb49f8e547ded54e20cf23e7065c4ac3d6864caa
+        checksum/config: 1489d692ffba34afc26661d995b5f04620dca0e8c1faca5bc3602dc3d12b7972
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -195,7 +195,7 @@ spec:
         - name: dex
           securityContext:
             {}
-          image: "ghcr.io/dexidp/dex:v2.42.0"
+          image: "ghcr.io/dexidp/dex:v2.44.0"
           imagePullPolicy: IfNotPresent
           args:
             - dex
@@ -259,10 +259,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging

--- a/charts/dex/test/values.example.ee.yaml.out
+++ b/charts/dex/test/values.example.ee.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: dex/charts/dex/templates/secret.yaml
@@ -19,10 +19,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -61,10 +61,10 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -77,10 +77,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: ClusterRole
@@ -98,10 +98,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups: ["dex.coreos.com"]
@@ -115,10 +115,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   kind: Role
@@ -136,10 +136,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -165,10 +165,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
     
   
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 30ad8d160980ee36d4618497eb49f8e547ded54e20cf23e7065c4ac3d6864caa
+        checksum/config: 1489d692ffba34afc26661d995b5f04620dca0e8c1faca5bc3602dc3d12b7972
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -195,7 +195,7 @@ spec:
         - name: dex
           securityContext:
             {}
-          image: "ghcr.io/dexidp/dex:v2.42.0"
+          image: "ghcr.io/dexidp/dex:v2.44.0"
           imagePullPolicy: IfNotPresent
           args:
             - dex
@@ -259,10 +259,10 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.23.0
+    helm.sh/chart: dex-0.24.0
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.42.0"
+    app.kubernetes.io/version: "2.44.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump Dex chart to appversion 2.44.0. Since there is no breaking changes and includes CVE fix in https://github.com/dexidp/dex/releases/tag/v2.44.0, this takes care of simple helm chart update.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Dex chart to appversion 2.44.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
