### PR TITLE
fix duplicates in collecting go metrics

### DIFF
--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -91,9 +91,9 @@ spec:
         - /bin/sh
         - -c
         {{- if .Values.minio.certificateSecret }}
-        - mc --insecure config host add src https://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        - mc --insecure alias set src https://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         {{- else }}
-        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        - mc alias set src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         {{- end }}
         env:
         - name: MINIO_ACCESS_KEY

--- a/charts/minio/test/enable-ingress.yaml.out
+++ b/charts/minio/test/enable-ingress.yaml.out
@@ -189,7 +189,7 @@ spec:
         args:
         - /bin/sh
         - -c
-        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        - mc alias set src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         env:
         - name: MINIO_ACCESS_KEY
           valueFrom:

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -191,7 +191,7 @@ spec:
         args:
         - /bin/sh
         - -c
-        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        - mc alias set src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         env:
         - name: MINIO_ACCESS_KEY
           valueFrom:

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -190,7 +190,7 @@ spec:
         args:
         - /bin/sh
         - -c
-        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        - mc alias set src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         env:
         - name: MINIO_ACCESS_KEY
           valueFrom:

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -190,7 +190,7 @@ spec:
         args:
         - /bin/sh
         - -c
-        - mc config host add src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        - mc alias set src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
         env:
         - name: MINIO_ACCESS_KEY
           valueFrom:

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-logr/zapr"
 	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	promcollectors "github.com/prometheus/client_golang/prometheus/collectors"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"go.uber.org/zap"
 
@@ -170,6 +171,10 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 
 	// Register the global error metric. Ensures that runtime.HandleError() increases the error metric
 	metrics.RegisterRuntimErrorMetricCounter("kubermatic_controller_manager", prometheus.DefaultRegisterer)
+
+	// The controller-runtime manager already registers a Go collector since https://github.com/kubernetes-sigs/controller-runtime/pull/3070 was merged, so we must
+	// unregister the one from the default registry to avoid duplicate metrics.
+	prometheus.Unregister(promcollectors.NewGoCollector())
 
 	// Default to empty JSON object
 	// TODO: Do not create secret and image pull secret if empty

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -26,7 +26,7 @@ spec:
           args:
             - /bin/sh
             - -c
-            - mc --insecure config host add src https://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc --insecure mb src/kkpbackupe2e
+            - mc --insecure alias set src https://minio.minio.svc.cluster.local:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && mc --insecure mb src/kkpbackupe2e
           env:
             - name: MINIO_ACCESS_KEY
               valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the update of controller-runtime package to 0.21.0 the metrics endpoint of master and seed controller manager is broken due to duplicate entries for go stats. This is caused because controller-runtime now enables gocollector similar to the default registerer. This pr removes the gocollector from the default registerer to avoid these duplicates.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
