### PR TITLE
add egress network policy support for auth webhooks

### DIFF
--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1016,6 +1016,7 @@ const (
 	NetworkPolicySeedApiserverAllow                 = "seed-apiserver-allow"
 	NetworkPolicyApiserverInternalAllow             = "apiserver-internal-allow"
 	NetworkPolicyKyvernoWebhookAllow                = "kyverno-webhook-allow"
+	NetworkPolicyAuthorizationWebhookAllow          = "authorization-webhook-allow"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a network policy configuration that restricts egress traffic from the user cluster’s apiserver when apiserver authorizationconfig is enabled.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
References #14668

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
