### PR TITLE
introduce Cilium 1.17.7 and 1.18.1 and deprecate 1.14.16

### DIFF
--- a/pkg/applicationdefinitions/system-applications/cilium.yaml
+++ b/pkg/applicationdefinitions/system-applications/cilium.yaml
@@ -156,6 +156,20 @@ spec:
             chartVersion: 1.16.9
             url: oci://quay.io/kubermatic/helm-charts
       version: 1.16.9
+    - template:
+        source:
+          helm:
+            chartName: cilium
+            chartVersion: 1.17.7
+            url: oci://quay.io/kubermatic/helm-charts
+      version: 1.17.7
+    - template:
+        source:
+          helm:
+            chartName: cilium
+            chartVersion: 1.18.1
+            url: oci://quay.io/kubermatic/helm-charts
+      version: 1.18.1
   documentationURL: https://docs.cilium.io/en/stable/
   sourceURL: https://github.com/cilium/cilium
   logo: |+

--- a/pkg/applicationdefinitions/system-applications/cilium.yaml
+++ b/pkg/applicationdefinitions/system-applications/cilium.yaml
@@ -161,14 +161,14 @@ spec:
           helm:
             chartName: cilium
             chartVersion: 1.17.7
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.17.7
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.18.1
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.18.1
   documentationURL: https://docs.cilium.io/en/stable/
   sourceURL: https://github.com/cilium/cilium

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -47,9 +47,10 @@ var (
 		kubermaticv1.CNIPluginTypeCilium: sets.New(
 			// NOTE: as of 1.13.0, we moved to Application infra for Cilium CNI management and started using real semver
 			// See pkg/cni/cilium docs for details on introducing a new version.
-			"1.14.16",
 			"1.15.16",
 			"1.16.9",
+			"1.17.7",
+			"1.18.1",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
 	}
@@ -72,6 +73,7 @@ var (
 			"1.14.2",  // CVE-2023-44487 (High Severity)
 			"1.14.3",  // CVE-2024-28860, CVE-2024-28248 (High Severity)
 			"1.14.9",  // CVE-2024-47825 (Moderate Severity)
+			"1.14.16", // CVE-2025-23028, CVE-2025-23047 (Moderate Severity)
 			"1.15.3",  // CVE-2024-47825 (Moderate Severity)
 			"1.15.10", // CVE-2025-32793 (Moderate Severity)
 			"1.16.6",  // CVE-2025-32793 (Moderate Severity)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for Cilium versions 1.17.7 and 1.18.1. The version 1.16.9 is still kept as the default. 1.14.16 is deprecated due to known CVEs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14941

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Cilium 1.17.7 and 1.18.1 as supported CNI version, deprecate cilium version 1.14.16 as it's impacted by CVEs.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
