### PR TITLE
[release/v2.28] Add changelogs for KKP patch releases 2.28.3/2.27.8/2.26.13

### DIFF
--- a/docs/changelogs/CHANGELOG-2.26.md
+++ b/docs/changelogs/CHANGELOG-2.26.md
@@ -26,7 +26,7 @@
 ### Bugfixes
 
 - A bug was fixed where evicted KubeVirt VMs configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object ([#14736](https://github.com/kubermatic/kubermatic/pull/14736))
-- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14959](https://github.com/kubermatic/kubermatic/pull/14959))
+- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14959](https://github.com/kubermatic/kubermatic/pull/14959), [#7592](https://github.com/kubermatic/dashboard/pull/7592))
 - Fix web terminal token expiration by refreshing expired tokens automatically ([#7549](https://github.com/kubermatic/dashboard/pull/7549))
 - Move web-terminal cleanup job to seed to fix cleanup not working when the token is expired ([#7547](https://github.com/kubermatic/dashboard/pull/7547))
 

--- a/docs/changelogs/CHANGELOG-2.26.md
+++ b/docs/changelogs/CHANGELOG-2.26.md
@@ -13,6 +13,28 @@
 - [v2.26.10](#v22610)
 - [v2.26.11](#v22611)
 - [v2.26.12](#v22612)
+- [v2.26.13](#v22613)
+
+## v2.26.13
+
+**GitHub release: [v2.26.13](https://github.com/kubermatic/kubermatic/releases/tag/v2.26.13)**
+
+### Supported Kubernetes Versions
+
+- Add support for k8s patch releases v1.31.13 ([#15000](https://github.com/kubermatic/kubermatic/pull/15000))
+
+### Bugfixes
+
+- A bug was fixed where evicted KubeVirt VMs configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object ([#14736](https://github.com/kubermatic/kubermatic/pull/14736))
+- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14959](https://github.com/kubermatic/kubermatic/pull/14959))
+- Fix web terminal token expiration by refreshing expired tokens automatically ([#7549](https://github.com/kubermatic/dashboard/pull/7549))
+- Move web-terminal cleanup job to seed to fix cleanup not working when the token is expired ([#7547](https://github.com/kubermatic/dashboard/pull/7547))
+
+### Updates
+
+- Update Go version to 1.23.12 ([#14958](https://github.com/kubermatic/kubermatic/pull/14958), [#7557](https://github.com/kubermatic/dashboard/pull/7557))
+- Update nginx-ingress-controller version to 1.11.8 ([#15039](https://github.com/kubermatic/kubermatic/pull/15039))
+- Update operating-system-manager version to [v1.6.9](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.6.9) ([#15051](https://github.com/kubermatic/kubermatic/pull/15051))
 
 ## v2.26.12
 

--- a/docs/changelogs/CHANGELOG-2.27.md
+++ b/docs/changelogs/CHANGELOG-2.27.md
@@ -21,7 +21,7 @@
 ### Bugfixes
 
 - A bug was fixed where evicted kubevirt vms configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object ([#14736](https://github.com/kubermatic/kubermatic/pull/14736))
-- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14956](https://github.com/kubermatic/kubermatic/pull/14956))
+- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14956](https://github.com/kubermatic/kubermatic/pull/14956), [#7593](https://github.com/kubermatic/dashboard/pull/7593))
 - Fix web terminal token expiration by refreshing expired tokens automatically ([#7550](https://github.com/kubermatic/dashboard/pull/7550))
 - Move web-terminal cleanup job to seed to fix cleanup not working when the token is expired ([#7451](https://github.com/kubermatic/dashboard/pull/7451))
 

--- a/docs/changelogs/CHANGELOG-2.27.md
+++ b/docs/changelogs/CHANGELOG-2.27.md
@@ -8,6 +8,28 @@
 - [v2.27.5](#v2275)
 - [v2.27.6](#v2276)
 - [v2.27.7](#v2277)
+- [v2.27.8](#v2278)
+
+## v2.27.8
+
+**GitHub release: [v2.27.8](https://github.com/kubermatic/kubermatic/releases/tag/v2.27.8)**
+
+### Supported Kubernetes Versions
+
+- Add support for k8s patch releases v1.32.9/1.31.13 ([#14999](https://github.com/kubermatic/kubermatic/pull/14999))
+
+### Bugfixes
+
+- A bug was fixed where evicted kubevirt vms configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object ([#14736](https://github.com/kubermatic/kubermatic/pull/14736))
+- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14956](https://github.com/kubermatic/kubermatic/pull/14956))
+- Fix web terminal token expiration by refreshing expired tokens automatically ([#7550](https://github.com/kubermatic/dashboard/pull/7550))
+- Move web-terminal cleanup job to seed to fix cleanup not working when the token is expired ([#7451](https://github.com/kubermatic/dashboard/pull/7451))
+
+### Updates
+
+- Update Go version to 1.23.12 ([#14948](https://github.com/kubermatic/kubermatic/pull/14948), [#7556](https://github.com/kubermatic/dashboard/pull/7556))
+- Update machine-controller version to [v1.61.4](https://github.com/kubermatic/machine-controller/releases/tag/v1.61.4) and operating-system-manager version to [v1.6.9](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.6.9) ([#15050](https://github.com/kubermatic/kubermatic/pull/15050))
+- Update nginx-ingress-controller to 1.11.8 ([#15038](https://github.com/kubermatic/kubermatic/pull/15038))
 
 ## v2.27.7
 

--- a/docs/changelogs/CHANGELOG-2.28.md
+++ b/docs/changelogs/CHANGELOG-2.28.md
@@ -3,6 +3,27 @@
 - [v2.28.0](#v2280)
 - [v2.28.1](#v2281)
 - [v2.28.2](#v2282)
+- [v2.28.3](#v2283)
+
+## v2.28.3
+
+**GitHub release: [v2.28.3](https://github.com/kubermatic/kubermatic/releases/tag/v2.28.3)**
+
+### Supported Kubernetes Versions
+
+- Add support for k8s patch releases v1.33.5/1.32.9/1.31.13 ([#14998](https://github.com/kubermatic/kubermatic/pull/14998))
+
+### Bugfixes
+
+- A bug was fixed where evicted kubevirt vms configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object ([#14736](https://github.com/kubermatic/kubermatic/pull/14736))
+- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14955](https://github.com/kubermatic/kubermatic/pull/14955))
+- Fix web terminal token expiration by refreshing expired tokens automatically ([#7551](https://github.com/kubermatic/dashboard/pull/7551))
+
+### Updates
+
+- Update Go version to 1.24.7 ([#14947](https://github.com/kubermatic/kubermatic/pull/14947), [#7555](https://github.com/kubermatic/dashboard/pull/7555))
+- Update machine-controller version to [v1.62.1](https://github.com/kubermatic/machine-controller/releases/tag/v1.62.1) and operating-system-manager version to [v1.7.6](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.7.6) ([#15049](https://github.com/kubermatic/kubermatic/pull/15049))
+- Update nginx-ingress-controller version to 1.12.6 ([#15037](https://github.com/kubermatic/kubermatic/pull/15037))
 
 ## v2.28.2
 

--- a/docs/changelogs/CHANGELOG-2.28.md
+++ b/docs/changelogs/CHANGELOG-2.28.md
@@ -16,7 +16,7 @@
 ### Bugfixes
 
 - A bug was fixed where evicted kubevirt vms configured with evictionStrategy `LiveMigrate` were treated like vms with `External` evictionStrategy by deleting the related machine object ([#14736](https://github.com/kubermatic/kubermatic/pull/14736))
-- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14955](https://github.com/kubermatic/kubermatic/pull/14955))
+- A caching functionality for used http.Transports when initializing minio clients in seed-controller-manager was added to avoid tcp connection leaks ([#14955](https://github.com/kubermatic/kubermatic/pull/14955), [#7594](https://github.com/kubermatic/dashboard/pull/7594))
 - Fix web terminal token expiration by refreshing expired tokens automatically ([#7551](https://github.com/kubermatic/dashboard/pull/7551))
 
 ### Updates


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add changelogs for KKP patch releases v2.28.3/v2.27.8/v2.26.13

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
