### PR TITLE
make ear sync controller cluster centric and handle cleanup for master secrets

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -305,6 +305,7 @@ func encryptionSecretSynchronizerFactoryCreator(ctrlCtx *controllerContext) seed
 			seedManagerMap,
 			ctrlCtx.namespace,
 			ctrlCtx.log,
+			ctrlCtx.workerName,
 			ctrlCtx.workerCount,
 		)
 	}

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
@@ -263,7 +263,7 @@ func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconciler
 	}
 }
 
-// enqueueAllClustersForEncryptionSecret enqueues all clusters that have encryption enabled
+// enqueueAllClustersForEncryptionSecret enqueues all clusters that have encryption enabled.
 func enqueueAllClustersForEncryptionSecret(clients kuberneteshelper.SeedClientMap, workerSelector labels.Selector, kubermaticNamespace string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
 		secret := obj.(*corev1.Secret)

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
@@ -55,7 +55,7 @@ const (
 	EncryptionSecretCleanupFinalizer = "kubermatic.k8c.io/cleanup-encryption-secrets"
 )
 
-// Reconciler is a controller which is responsible for synchronizing the
+// reconciler is a controller which is responsible for synchronizing the
 // encryption secrets (in the master cluster) as Secrets into the seed
 // clusters when clusters have encryption enabled.
 type reconciler struct {

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller.go
@@ -20,182 +20,232 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 const (
 	ControllerName         = "kkp-encryption-secret-synchronizer"
 	ClusterNameAnnotation  = "kubermatic.io/cluster-name"
 	EncryptionSecretPrefix = "encryption-key-cluster-"
+
+	// EncryptionSecretCleanupFinalizer is the finalizer that is placed on a Cluster object
+	// to indicate that the assigned encryption secrets still need to be cleaned up.
+	EncryptionSecretCleanupFinalizer = "kubermatic.k8c.io/cleanup-encryption-secrets"
 )
 
-type reconciler struct {
+// Reconciler is a controller which is responsible for synchronizing the
+// encryption secrets (in the master cluster) as Secrets into the seed
+// clusters when clusters have encryption enabled.
+type Reconciler struct {
+	masterClient ctrlruntimeclient.Client
 	log          *zap.SugaredLogger
 	recorder     record.EventRecorder
-	masterClient ctrlruntimeclient.Client
-	namespace    string
+	workerName   string
 	seedClients  kuberneteshelper.SeedClientMap
+	namespace    string
 }
 
 func Add(
-	masterManager manager.Manager,
+	mgr manager.Manager,
 	seedManagers map[string]manager.Manager,
 	namespace string,
 	log *zap.SugaredLogger,
+	workerName string,
 	numWorkers int,
 ) error {
-	r := &reconciler{
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &Reconciler{
 		log:          log.Named(ControllerName),
-		recorder:     masterManager.GetEventRecorderFor(ControllerName),
-		masterClient: masterManager.GetClient(),
+		workerName:   workerName,
+		masterClient: mgr.GetClient(),
+		recorder:     mgr.GetEventRecorderFor(ControllerName),
 		seedClients:  kuberneteshelper.SeedClientMap{},
 		namespace:    namespace,
 	}
 
-	for seedName, seedManager := range seedManagers {
-		r.seedClients[seedName] = seedManager.GetClient()
-	}
-
-	_, err := builder.ControllerManagedBy(masterManager).
+	bldr := builder.ControllerManagedBy(mgr).
 		Named(ControllerName).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: numWorkers,
 		}).
-		For(
-			&corev1.Secret{},
-			builder.WithPredicates(
-				predicate.Factory(func(o ctrlruntimeclient.Object) bool {
-					secret := o.(*corev1.Secret)
-					if !strings.HasPrefix(secret.Name, EncryptionSecretPrefix) {
-						return false
-					}
+		Watches(&corev1.Secret{}, enqueueAllClustersForEncryptionSecret(reconciler.seedClients, workerSelector, reconciler.namespace))
 
-					return metav1.HasAnnotation(secret.ObjectMeta, ClusterNameAnnotation)
-				}),
-				predicate.ByNamespace(r.namespace),
-			),
-		).
-		Build(r)
+	for seedName, seedManager := range seedManagers {
+		reconciler.seedClients[seedName] = seedManager.GetClient()
 
+		bldr.WatchesRawSource(source.Kind(
+			seedManager.GetCache(),
+			&kubermaticv1.Cluster{},
+			controllerutil.TypedEnqueueClusterScopedObjectWithSeedName[*kubermaticv1.Cluster](seedName),
+			workerlabel.TypedPredicate[*kubermaticv1.Cluster](workerName),
+		))
+	}
+
+	_, err = bldr.Build(reconciler)
 	return err
 }
 
-func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.log.With("secret", request)
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
 	log.Debug("Processing")
 
-	secret := &corev1.Secret{}
-	if err := r.masterClient.Get(ctx, request.NamespacedName, secret); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, err
-		}
-
-		// handling deletion
-		delSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: request.Name, Namespace: r.namespace}}
-		if err := r.handleDeletion(ctx, log, delSecret); err != nil {
-			err = fmt.Errorf("failed to delete secret: %w", err)
-
-			log.Error("ReconcilingError", zap.Error(err))
-			r.recorder.Event(delSecret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
-	}
-
-	return r.reconcile(ctx, log, secret)
+	err := r.reconcile(ctx, log, request)
+	return reconcile.Result{}, err
 }
 
-func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) (reconcile.Result, error) {
-	clusterName, exists := secret.Annotations[ClusterNameAnnotation]
-	if !exists {
-		return reconcile.Result{}, fmt.Errorf("secret %s missing cluster name annotation %s", secret.Name, ClusterNameAnnotation)
+func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, request reconcile.Request) error {
+	seedClient, ok := r.seedClients[request.Namespace]
+	if !ok {
+		log.Error("Got request for seed we don't have a client for", "seed", request.Namespace)
+		return nil
 	}
 
-	cluster, seedName, err := r.findTargetCluster(ctx, clusterName)
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			log.Debug("Cluster not found, secret will be synced when cluster is created", "cluster", clusterName)
-			return reconcile.Result{}, nil
+	cluster := &kubermaticv1.Cluster{}
+	if err := seedClient.Get(ctx, types.NamespacedName{Name: request.Name}, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug("Could not find cluster")
+			return nil
 		}
-		return reconcile.Result{}, err
+		return fmt.Errorf("failed to get cluster %s from seed %s: %w", request.Name, request.Namespace, err)
 	}
 
-	// Wait for cluster to have a namespace before syncing the secret
 	if cluster.Status.NamespaceName == "" {
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		log.Debug("Skipping cluster reconciling because no namespace is set")
+		return nil
+	}
+
+	if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+		return nil
+	}
+
+	if cluster.Spec.Pause {
+		log.Debug("Skipping cluster reconciling because it was set to paused")
+		return nil
+	}
+
+	// Cleanup secrets on cluster deletion
+	if cluster.DeletionTimestamp != nil {
+		if err := r.cleanupEncryptionSecrets(ctx, log, cluster.Name); err != nil {
+			return fmt.Errorf("failed to cleanup encryption secrets for deleted cluster: %w", err)
+		}
+		return kuberneteshelper.TryRemoveFinalizer(ctx, seedClient, cluster, EncryptionSecretCleanupFinalizer)
 	}
 
 	if !cluster.IsEncryptionEnabled() {
-		return reconcile.Result{}, nil
+		log.Debug("Skipping cluster reconciling because encryption is not enabled")
+		// Remove finalizer if encryption is disabled
+		return kuberneteshelper.TryRemoveFinalizer(ctx, seedClient, cluster, EncryptionSecretCleanupFinalizer)
 	}
 
-	seedClient, exists := r.seedClients[seedName]
-	if !exists {
-		return reconcile.Result{}, fmt.Errorf("seed client not found for %s", seedName)
+	// Get the encryption secret from kubermatic namespace
+	secretName := EncryptionSecretPrefix + cluster.Name
+	secret := &corev1.Secret{}
+	if err := r.masterClient.Get(ctx, types.NamespacedName{
+		Name:      secretName,
+		Namespace: r.namespace,
+	}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug("Encryption secret not found in kubermatic namespace", "secret", secretName)
+			return nil
+		}
+		return fmt.Errorf("failed to get encryption secret %s: %w", secretName, err)
 	}
 
+	// Verify the secret has the correct annotation
+	if clusterName, exists := secret.Annotations[ClusterNameAnnotation]; !exists || clusterName != cluster.Name {
+		log.Debug("Secret missing or incorrect cluster name annotation", "secret", secretName, "expectedCluster", cluster.Name)
+		return nil
+	}
+
+	// Sync the secret to the cluster namespace
 	clusterNamespace := cluster.Status.NamespaceName
+
 	syncSecret := secret.DeepCopy()
 	syncSecret.SetResourceVersion("")
 	syncSecret.SetNamespace(clusterNamespace)
 
-	namedSecretReconcilerFactory := []reconciling.NamedSecretReconcilerFactory{
-		secretReconcilerFactory(syncSecret),
+	if err := reconciling.ReconcileSecrets(
+		ctx,
+		[]reconciling.NamedSecretReconcilerFactory{secretReconcilerFactory(syncSecret)},
+		clusterNamespace,
+		seedClient,
+	); err != nil {
+		return fmt.Errorf("failed to reconcile encryption secret: %w", err)
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, namedSecretReconcilerFactory, clusterNamespace, seedClient); err != nil {
-		return reconcile.Result{}, fmt.Errorf("reconciling encryption secret %s failed: %w", syncSecret.Name, err)
+	// Add finalizer to ensure cleanup on cluster deletion
+	if err := kuberneteshelper.TryAddFinalizer(ctx, seedClient, cluster, EncryptionSecretCleanupFinalizer); err != nil {
+		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
-	return reconcile.Result{}, nil
+	return nil
 }
 
-func (r *reconciler) findTargetCluster(ctx context.Context, clusterName string) (*kubermaticv1.Cluster, string, error) {
-	var targetCluster *kubermaticv1.Cluster
-	var targetSeedName string
+func (r *Reconciler) cleanupEncryptionSecrets(ctx context.Context, log *zap.SugaredLogger, clusterName string) error {
+	secretName := EncryptionSecretPrefix + clusterName
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: r.namespace,
+		},
+	}
 
-	err := r.seedClients.Each(ctx, r.log, func(seedName string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+	if err := r.masterClient.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete encryption secret %s from kubermatic namespace: %w", secretName, err)
+	}
+
+	return r.seedClients.Each(ctx, log, func(seedName string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
 		cluster := &kubermaticv1.Cluster{}
-		err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster)
-		if err == nil {
-			targetCluster = cluster
-			targetSeedName = seedName
-			return nil
-		} else if !apierrors.IsNotFound(err) {
+		if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
+
+		if cluster.Status.NamespaceName == "" {
+			return nil
+		}
+
+		ucSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: cluster.Status.NamespaceName,
+			},
+		}
+
+		if err := seedClient.Delete(ctx, ucSecret); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete encryption secret %s from UC namespace: %w", secretName, err)
+		}
+
 		return nil
 	})
-
-	if err != nil {
-		return nil, "", err
-	}
-
-	if targetCluster == nil {
-		return nil, "", fmt.Errorf("cluster %s not found in any seed", clusterName)
-	}
-
-	return targetCluster, targetSeedName, nil
 }
 
 func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconcilerFactory {
@@ -210,40 +260,50 @@ func secretReconcilerFactory(s *corev1.Secret) reconciling.NamedSecretReconciler
 	}
 }
 
-func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, secret *corev1.Secret) error {
-	if !strings.HasPrefix(secret.Name, EncryptionSecretPrefix) {
-		return nil
-	}
+// enqueueAllClustersForEncryptionSecret enqueues all clusters that have encryption enabled
+func enqueueAllClustersForEncryptionSecret(clients kuberneteshelper.SeedClientMap, workerSelector labels.Selector, kubermaticNamespace string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+		secret := obj.(*corev1.Secret)
 
-	clusterName, exists := secret.Annotations[ClusterNameAnnotation]
-	if !exists {
-		return nil
-	}
+		if !strings.HasPrefix(secret.Name, EncryptionSecretPrefix) {
+			return nil
+		}
 
-	return r.seedClients.Each(ctx, log, func(_ string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
-		cluster := &kubermaticv1.Cluster{}
-		if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil
+		if secret.Namespace != kubermaticNamespace {
+			return nil
+		}
+
+		clusterName, exists := secret.Annotations[ClusterNameAnnotation]
+		if !exists {
+			return nil
+		}
+
+		var requests []reconcile.Request
+
+		listOpts := &ctrlruntimeclient.ListOptions{
+			LabelSelector: workerSelector,
+		}
+
+		for seedName, client := range clients {
+			clusterList := &kubermaticv1.ClusterList{}
+			if err := client.List(ctx, clusterList, listOpts); err != nil {
+				utilruntime.HandleError(fmt.Errorf("failed to list Clusters in seed %s: %w", seedName, err))
+				continue
 			}
-			return err
+
+			for _, cluster := range clusterList.Items {
+				if cluster.Name == clusterName && cluster.IsEncryptionEnabled() {
+					requests = append(requests, reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: seedName,
+							Name:      clusterName,
+						},
+					})
+					break
+				}
+			}
 		}
 
-		if cluster.Status.NamespaceName == "" {
-			return nil
-		}
-
-		err := seedClient.Delete(ctx, &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secret.Name,
-				Namespace: cluster.Status.NamespaceName,
-			},
-		})
-
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-
-		return err
+		return requests
 	})
 }

--- a/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/encryption-secret-synchronizer/controller_test.go
@@ -156,7 +156,7 @@ func TestReconcile(t *testing.T) {
 			}
 			seedClient := fake.NewClientBuilder().WithObjects(seedObjects...).Build()
 
-			r := &Reconciler{
+			r := &reconciler{
 				log:          kubermaticlog.Logger,
 				recorder:     &record.FakeRecorder{},
 				masterClient: masterClient,
@@ -290,7 +290,7 @@ func TestClusterDeletion(t *testing.T) {
 			}
 			seedClient := fake.NewClientBuilder().WithObjects(seedObjects...).Build()
 
-			r := &Reconciler{
+			r := &reconciler{
 				log:          kubermaticlog.Logger,
 				recorder:     &record.FakeRecorder{},
 				masterClient: masterClient,
@@ -412,7 +412,7 @@ func TestEncryptionDisabledCleanup(t *testing.T) {
 
 			seedClient := fake.NewClientBuilder().WithObjects(clusterWithEncryptionDisabled).Build()
 
-			r := &Reconciler{
+			r := &reconciler{
 				log:          kubermaticlog.Logger,
 				recorder:     &record.FakeRecorder{},
 				masterClient: masterClient,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the controller Cluster centric as opposed to only managing kubermatic secrets. It also takes care of handling cleanup of secrets from kubermatic namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15052
xref: [#5946](https://github.com/kubermatic/kubermatic/issues/5946)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
