### PR TITLE
envoy agent connection keepalive

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -90,7 +90,10 @@ static_resources:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           explicit_http_config:
-            http2_protocol_options: {}
+            http2_protocol_options:
+              connection_keepalive:
+                interval: 5s
+                timeout: 2s
       load_assignment:
         cluster_name: proxy_cluster
         endpoints:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -92,8 +92,8 @@ static_resources:
           explicit_http_config:
             http2_protocol_options:
               connection_keepalive:
-                interval: 5s
-                timeout: 2s
+                interval: 2s
+                timeout: 1s
       load_assignment:
         cluster_name: proxy_cluster
         endpoints:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -92,8 +92,8 @@ static_resources:
           explicit_http_config:
             http2_protocol_options:
               connection_keepalive:
-                interval: 2s
-                timeout: 1s
+                interval: 30s
+                timeout: 5s
       load_assignment:
         cluster_name: proxy_cluster
         endpoints:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the `connection_keepalive` configuration for `http2_protocol_options` in the Envoy-Agent cluster configuration.

**Motivation**

In our setup, we are using a Cilium-managed LoadBalancer IP for `nodeport-proxy` service. This IP is announced via ARP on the control plane node. When Cilium performs a failover and reassigns this IP to another node, it announces the new MAC address via ARP. However, the Envoy agent in the usercluster is unaware that the existing TCP connection is now stale or half-open, due to the ARP-based reassignment.

This leads to scenarios where Envoy continues to use a broken TCP connection, resulting in failed or hanging requests. In practice, this causes the kube-apiserver to become unreachable from the user cluster **until the Envoy agent DaemonSets are manually restarted** to force reconnection.

While the Linux kernel will eventually detect and close stale TCP connections (typically after ~20 minutes, depending on system settings), this delay is not acceptable for production-grade control plane access.



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

Envoy provides an HTTP/2 `connection_keepalive` feature that sends periodic HTTP/2 PING frames to verify connection liveness. If no PING ACK is received within the defined `timeout`, Envoy will close the connection and attempt to re-establish it, thereby recovering from stale connections automatically.

https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto.html#envoy-v3-api-msg-config-core-v3-keepalivesettings

```yaml
clusters:
  - name: proxy_cluster
    connect_timeout: 5s
    type: LOGICAL_DNS
    typed_extension_protocol_options:
      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
        explicit_http_config:
          http2_protocol_options:
            connection_keepalive:
              interval: 2s
              timeout: 1s
```


**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add HTTP/2 keepalive functionality enabling Envoy-Agent to detect broken or
half-open TCP connections to the nodeport-proxy and re-establish them
automatically
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
