### PR TITLE
update default version for cilium to 1.18.1

### DIFF
--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -29,7 +29,7 @@ import (
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.29",
-		kubermaticv1.CNIPluginTypeCilium: "1.16.9",
+		kubermaticv1.CNIPluginTypeCilium: "1.17.7",
 	}
 )
 

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -29,7 +29,7 @@ import (
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.29",
-		kubermaticv1.CNIPluginTypeCilium: "1.17.7",
+		kubermaticv1.CNIPluginTypeCilium: "1.18.1",
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 After introducing 1.17.7 and 1.18.1 we want to make 1.18.1 our default version when creating new clusters, this PR makes 1.18.1 Cilium the default version for new clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
References https://github.com/kubermatic/kubermatic/issues/14941

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make Cilium 1.18.1 the default version.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
