### PR TITLE
Update default Canal version to v3.30.3 and deprecate v3.27

### DIFF
--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
-		kubermaticv1.CNIPluginTypeCanal:  "v3.29",
+		kubermaticv1.CNIPluginTypeCanal:  "v3.30",
 		kubermaticv1.CNIPluginTypeCilium: "1.18.1",
 	}
 )
@@ -43,7 +43,7 @@ var (
 	// supportedCNIPluginVersions contains a list of all currently supported CNI versions for each CNI type.
 	// Only supported versions are available for selection in KKP UI.
 	supportedCNIPluginVersions = map[kubermaticv1.CNIPluginType]sets.Set[string]{
-		kubermaticv1.CNIPluginTypeCanal: sets.New("v3.27", "v3.28", "v3.29"),
+		kubermaticv1.CNIPluginTypeCanal: sets.New("v3.28", "v3.29", "v3.30"),
 		kubermaticv1.CNIPluginTypeCilium: sets.New(
 			// NOTE: as of 1.13.0, we moved to Application infra for Cilium CNI management and started using real semver
 			// See pkg/cni/cilium docs for details on introducing a new version.
@@ -58,7 +58,7 @@ var (
 	// Deprecated versions are not available for selection in KKP UI, but are still accepted
 	// by the validation webhook for backward compatibility.
 	deprecatedCNIPluginVersions = map[kubermaticv1.CNIPluginType]sets.Set[string]{
-		kubermaticv1.CNIPluginTypeCanal: sets.New("v3.21", "v3.22", "v3.23", "v3.24", "v3.25", "v3.26"),
+		kubermaticv1.CNIPluginTypeCanal: sets.New("v3.21", "v3.22", "v3.23", "v3.24", "v3.25", "v3.26", "v3.27"),
 		kubermaticv1.CNIPluginTypeCilium: sets.New(
 			"v1.11",
 			"v1.12",


### PR DESCRIPTION
**What this PR does / why we need it**:

Canal version was bumped in https://github.com/kubermatic/kubermatic/pull/14940.
This PR sets it as a new default. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14942

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update default Canal version to v3.30.3 and deprecate v3.27.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
