### PR TITLE
Support IPv4 and IPv6 CIDR Customization for Openstack

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1389,6 +1389,11 @@ spec:
                             The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in
                             future versions as it is considered a workaround only.
                           type: string
+                        ipv6SubnetCIDR:
+                          description: |-
+                            IPv6SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
+                            didn't specify a subnet id for the IPv6 networking.
+                          type: string
                         ipv6SubnetID:
                           description: |-
                             IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
@@ -1439,6 +1444,16 @@ spec:
                           description: |-
                             SecurityGroups is the name of the security group (only supports a singular security group) that will be used for Machines in the cluster.
                             If this field is left empty, a default security group will be created and used.
+                          type: string
+                        subnetAllocationPool:
+                          description: |-
+                            SubnetAllocationPool represents a pool of usable IPs that can be assigned to resources via the DHCP. The format is
+                            first usable ip and last usable ip separated by a dash(e.g: 10.10.0.1-10.10.0.254)
+                          type: string
+                        subnetCIDR:
+                          description: |-
+                            SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
+                            didn't specify a subnet id.
                           type: string
                         subnetID:
                           type: string

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1389,7 +1389,7 @@ spec:
                             The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in
                             future versions as it is considered a workaround only.
                           type: string
-                        ipv6SubnetCIDR:
+                        ipv6SubnetCidr:
                           description: |-
                             IPv6SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
                             didn't specify a subnet id for the IPv6 networking.
@@ -1450,7 +1450,7 @@ spec:
                             SubnetAllocationPool represents a pool of usable IPs that can be assigned to resources via the DHCP. The format is
                             first usable ip and last usable ip separated by a dash(e.g: 10.10.0.1-10.10.0.254)
                           type: string
-                        subnetCIDR:
+                        subnetCidr:
                           description: |-
                             SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
                             didn't specify a subnet id.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1383,7 +1383,7 @@ spec:
                             The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in
                             future versions as it is considered a workaround only.
                           type: string
-                        ipv6SubnetCIDR:
+                        ipv6SubnetCidr:
                           description: |-
                             IPv6SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
                             didn't specify a subnet id for the IPv6 networking.
@@ -1444,7 +1444,7 @@ spec:
                             SubnetAllocationPool represents a pool of usable IPs that can be assigned to resources via the DHCP. The format is
                             first usable ip and last usable ip separated by a dash(e.g: 10.10.0.1-10.10.0.254)
                           type: string
-                        subnetCIDR:
+                        subnetCidr:
                           description: |-
                             SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
                             didn't specify a subnet id.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1383,6 +1383,11 @@ spec:
                             The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in
                             future versions as it is considered a workaround only.
                           type: string
+                        ipv6SubnetCIDR:
+                          description: |-
+                            IPv6SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
+                            didn't specify a subnet id for the IPv6 networking.
+                          type: string
                         ipv6SubnetID:
                           description: |-
                             IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
@@ -1433,6 +1438,16 @@ spec:
                           description: |-
                             SecurityGroups is the name of the security group (only supports a singular security group) that will be used for Machines in the cluster.
                             If this field is left empty, a default security group will be created and used.
+                          type: string
+                        subnetAllocationPool:
+                          description: |-
+                            SubnetAllocationPool represents a pool of usable IPs that can be assigned to resources via the DHCP. The format is
+                            first usable ip and last usable ip separated by a dash(e.g: 10.10.0.1-10.10.0.254)
+                          type: string
+                        subnetCIDR:
+                          description: |-
+                            SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
+                            didn't specify a subnet id.
                           type: string
                         subnetID:
                           type: string

--- a/pkg/provider/cloud/openstack/subnets.go
+++ b/pkg/provider/cloud/openstack/subnets.go
@@ -121,7 +121,6 @@ func createIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, network
 		if subnetIPv6CIDR != "" {
 			subnetOpts.CIDR = subnetIPv6CIDR
 		}
-
 	}
 
 	for _, s := range dnsServers {

--- a/pkg/provider/cloud/openstack/subnets.go
+++ b/pkg/provider/cloud/openstack/subnets.go
@@ -17,36 +17,59 @@ limitations under the License.
 package openstack
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	osrouters "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 	ossubnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 
-	"k8s.io/utils/net"
+	k8snet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 )
 
-func createSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID string, dnsServers []string) (*ossubnets.Subnet, error) {
-	iTrue := true
+func createSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID, subnetPoolAllocation, assignedSubnetCIDR string, dnsServers []string) (*ossubnets.Subnet, error) {
+	var (
+		iTrue            = true
+		firstAvailableIP string
+		lastAvailableIP  string
+	)
+
+	if assignedSubnetCIDR == "" {
+		assignedSubnetCIDR = subnetCIDR
+		firstAvailableIP = subnetFirstAddress
+		lastAvailableIP = subnetLastAddress
+	}
+
+	if assignedSubnetCIDR != subnetCIDR && subnetPoolAllocation != "" {
+		ips := strings.Split(subnetPoolAllocation, "-")
+		if len(ips) != 2 {
+			return nil, errors.New("assigned subnet pool allocation does not contain valid ip addresses")
+		}
+
+		firstAvailableIP = ips[0]
+		lastAvailableIP = ips[1]
+	}
+
 	subnetOpts := ossubnets.CreateOpts{
 		Name:       resourceNamePrefix + clusterName,
 		NetworkID:  networkID,
 		IPVersion:  gophercloud.IPv4,
-		CIDR:       subnetCIDR,
+		CIDR:       assignedSubnetCIDR,
 		GatewayIP:  nil,
 		EnableDHCP: &iTrue,
 		AllocationPools: []ossubnets.AllocationPool{
 			{
-				Start: subnetFirstAddress,
-				End:   subnetLastAddress,
+				Start: firstAvailableIP,
+				End:   lastAvailableIP,
 			},
 		},
 	}
 
 	for _, s := range dnsServers {
-		if net.IsIPv4String(s) {
+		if k8snet.IsIPv4String(s) {
 			subnetOpts.DNSNameservers = append(subnetOpts.DNSNameservers, s)
 		}
 	}
@@ -58,7 +81,7 @@ func createSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID s
 	return res.Extract()
 }
 
-func createIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, networkID, subnetPoolName string, dnsServers []string) (*ossubnets.Subnet, error) {
+func createIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, networkID, subnetPoolName, subnetIPv6CIDR string, dnsServers []string) (*ossubnets.Subnet, error) {
 	subnetOpts := ossubnets.CreateOpts{
 		Name:            resourceNamePrefix + clusterName + "-ipv6",
 		NetworkID:       networkID,
@@ -95,10 +118,14 @@ func createIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, network
 	} else {
 		// if no IPv6 subnet pool was provided / found, use the default IPv6 subnet CIDR
 		subnetOpts.CIDR = defaultIPv6SubnetCIDR
+		if subnetIPv6CIDR != "" {
+			subnetOpts.CIDR = subnetIPv6CIDR
+		}
+
 	}
 
 	for _, s := range dnsServers {
-		if net.IsIPv6String(s) {
+		if k8snet.IsIPv6String(s) {
 			subnetOpts.DNSNameservers = append(subnetOpts.DNSNameservers, s)
 		}
 	}

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -1443,6 +1443,18 @@ type OpenstackCloudSpec struct {
 	FloatingIPPool string `json:"floatingIPPool"`
 	RouterID       string `json:"routerID"`
 	SubnetID       string `json:"subnetID"`
+	// SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
+	// didn't specify a subnet id.
+	// +optional
+	SubnetCIDR string `json:"subnetCIDR,omitempty"`
+	// SubnetAllocationPool represents a pool of usable IPs that can be assigned to resources via the DHCP. The format is
+	// first usable ip and last usable ip separated by a dash(e.g: 10.10.0.1-10.10.0.254)
+	// +optional
+	SubnetAllocationPool string `json:"subnetAllocationPool,omitempty"`
+	// IPv6SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
+	// didn't specify a subnet id for the IPv6 networking.
+	// +optional
+	IPv6SubnetCIDR string `json:"ipv6SubnetCIDR,omitempty"`
 	// IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
 	// If not provided, a new subnet will be created if IPv6 is enabled.
 	// +optional

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -1446,7 +1446,7 @@ type OpenstackCloudSpec struct {
 	// SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
 	// didn't specify a subnet id.
 	// +optional
-	SubnetCIDR string `json:"subnetCIDR,omitempty"`
+	SubnetCIDR string `json:"subnetCidr,omitempty"`
 	// SubnetAllocationPool represents a pool of usable IPs that can be assigned to resources via the DHCP. The format is
 	// first usable ip and last usable ip separated by a dash(e.g: 10.10.0.1-10.10.0.254)
 	// +optional
@@ -1454,7 +1454,7 @@ type OpenstackCloudSpec struct {
 	// IPv6SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
 	// didn't specify a subnet id for the IPv6 networking.
 	// +optional
-	IPv6SubnetCIDR string `json:"ipv6SubnetCIDR,omitempty"`
+	IPv6SubnetCIDR string `json:"ipv6SubnetCidr,omitempty"`
 	// IPv6SubnetID holds the ID of the subnet used for IPv6 networking.
 	// If not provided, a new subnet will be created if IPv6 is enabled.
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to allow setting the CIDR for OpenStack subnets instead of using the default one 192.168.0.0/24 which is hardcoded in KKP. Instead, users can specify the IPv4 and IPv6 CIDR in the cluster spec  in addition to the IPPoolAllocation. KKP would then create that subnet and attach it to the clusters VMs. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14917

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support IPv4 and IPv6 custom subnet for Openstack provider
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
