### PR TITLE
Update -deploy-default-app-catalog flag's helper message on kubermatic-installer

### DIFF
--- a/cmd/kubermatic-installer/main_ee.go
+++ b/cmd/kubermatic-installer/main_ee.go
@@ -55,6 +55,6 @@ func seedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.C
 
 // flags to be only used in EE edition.
 func wrapDeployFlags(flagset *pflag.FlagSet, opt *DeployOptions) {
-	flagset.BoolVar(&opt.DeployDefaultAppCatalog, "deploy-default-app-catalog", false, "DEPRECATED: This flag is no-op and will have no effect. Use KubermaticConfiguration.Applications.DefaultApplicationCatalog.Disable Reconcile the default Application Catalog (EE only)")
+	flagset.BoolVar(&opt.DeployDefaultAppCatalog, "deploy-default-app-catalog", false, "DEPRECATED: This flag is no-op and will have no effect. Use KubermaticConfiguration.applications.defaultApplicationCatalog.enable to reconcile the default Application Catalog (EE only)")
 	flagset.BoolVar(&opt.DeployDefaultPolicyTemplateCatalog, "deploy-default-policy-template-catalog", false, "Reconcile the default Policy Template Catalog (EE only)")
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR updates kubermatic-installer's --deploy-default-app-catalog flag's helper message, since it contains a discrepancy as of now, compared to the actual KubermaticConfiguration CR.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
