### PR TITLE
Stop adding inappropriate finalizer in openstack provider

### DIFF
--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -292,13 +292,11 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 		kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
 		cluster.Spec.Cloud.Openstack.Network = networkName
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to update network cluster: %w", err)
 	}
 
 	_, err = createUserClusterNetwork(netClient, networkName)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the network: %w", err)
 	}
@@ -364,7 +362,6 @@ func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *goph
 
 	// for each security group, ensure that it exists
 	err := validateSecurityGroupExists(netClient, securityGroup)
-
 	if err != nil {
 		if isNotFoundErr(err) {
 			// group does not yet exist, so we create it
@@ -385,7 +382,6 @@ func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *goph
 			cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 				kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
 			})
-
 			if err != nil {
 				return nil, fmt.Errorf("failed to add security group finalizer: %w", err)
 			}
@@ -397,7 +393,6 @@ func (os *Provider) reconcileSecurityGroups(ctx context.Context, netClient *goph
 	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		cluster.Spec.Cloud.Openstack.SecurityGroups = securityGroup
 	})
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to update security group in cluster: %w", err)
 	}
@@ -444,7 +439,7 @@ func reconcileIPv6Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 			return nil, fmt.Errorf("failed to create the IPv6 subnet: %w", err)
 		}
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			kubernetes.AddFinalizer(cluster, IPv6SubnetCleanupFinalizer, RouterIPv6SubnetLinkCleanupFinalizer)
+			kubernetes.AddFinalizer(cluster, IPv6SubnetCleanupFinalizer)
 			cluster.Spec.Cloud.Openstack.IPv6SubnetID = subnet.ID
 		})
 		if err != nil {
@@ -497,7 +492,7 @@ func reconcileIPv4Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 
 		// Update the cluster spec with the new subnet ID
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
-			kubernetes.AddFinalizer(cluster, SubnetCleanupFinalizer, RouterSubnetLinkCleanupFinalizer)
+			kubernetes.AddFinalizer(cluster, SubnetCleanupFinalizer)
 			cluster.Spec.Cloud.Openstack.SubnetID = subnet.ID
 		})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we incorrectly added `kubermatic.k8c.io/cleanup-openstack-router-subnet-link-v2` finalizer on the event when we created the subnet. And then again when we link a subnet to the router. This is a problem since we have a logic that can skip linking to the router, but the finalizer is mistakenly added anyway.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #14925

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix adding router-link openstack finalizer in the wrong place
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
