### PR TITLE
fix duplicates in collecting go metrics

### DIFF
--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/zapr"
 	"github.com/prometheus/client_golang/prometheus"
+	promcollectors "github.com/prometheus/client_golang/prometheus/collectors"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
@@ -144,6 +145,10 @@ func main() {
 
 	// register the global error metric. Ensures that runtime.HandleError() increases the error metric
 	metrics.RegisterRuntimErrorMetricCounter("kubermatic_master_controller_manager", prometheus.DefaultRegisterer)
+
+	// The controller-runtime manager already registers a Go collector since https://github.com/kubernetes-sigs/controller-runtime/pull/3070 was merged, so we must
+	// unregister the one from the default registry to avoid duplicate metrics.
+	prometheus.Unregister(promcollectors.NewGoCollector())
 
 	// prepare a context to use throughout the controller manager
 	ctx := signals.SetupSignalHandler()


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the update of controller-runtime package to 0.21.0 the metrics endpoint of master controller manager is broken due to duplicate entries for go stats. This is caused because controller-runtime now enables gocollector similar to the default registerer. This pr removes the gocollector from the default registerer to avoid these duplicates.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15081

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
