### PR TITLE
Refactor: avoid duplicate metrics for controller-runtime

### DIFF
--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-logr/zapr"
 	"github.com/prometheus/client_golang/prometheus"
-	promcollectors "github.com/prometheus/client_golang/prometheus/collectors"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
@@ -145,10 +144,6 @@ func main() {
 
 	// register the global error metric. Ensures that runtime.HandleError() increases the error metric
 	metrics.RegisterRuntimErrorMetricCounter("kubermatic_master_controller_manager", prometheus.DefaultRegisterer)
-
-	// The controller-runtime manager already registers a Go collector since https://github.com/kubernetes-sigs/controller-runtime/pull/3070 was merged, so we must
-	// unregister the one from the default registry to avoid duplicate metrics.
-	prometheus.Unregister(promcollectors.NewGoCollector())
 
 	// prepare a context to use throughout the controller manager
 	ctx := signals.SetupSignalHandler()

--- a/cmd/seed-controller-manager/main.go
+++ b/cmd/seed-controller-manager/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-logr/zapr"
 	constrainttemplatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"github.com/prometheus/client_golang/prometheus"
-	promcollectors "github.com/prometheus/client_golang/prometheus/collectors"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"go.uber.org/zap"
 
@@ -171,10 +170,6 @@ Please install the VerticalPodAutoscaler according to the documentation: https:/
 
 	// Register the global error metric. Ensures that runtime.HandleError() increases the error metric
 	metrics.RegisterRuntimErrorMetricCounter("kubermatic_controller_manager", prometheus.DefaultRegisterer)
-
-	// The controller-runtime manager already registers a Go collector since https://github.com/kubernetes-sigs/controller-runtime/pull/3070 was merged, so we must
-	// unregister the one from the default registry to avoid duplicate metrics.
-	prometheus.Unregister(promcollectors.NewGoCollector())
 
 	// Default to empty JSON object
 	// TODO: Do not create secret and image pull secret if empty


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up of https://github.com/kubermatic/kubermatic/pull/15088 and https://github.com/kubermatic/kubermatic/pull/15043. 

The previous PRs were wrong and "unregistering" the go runtime metrics twice in different places instead of properly taking a look at the code and how it's being handled.

When metric-server was introduced in https://github.com/kubermatic/kubermatic/pull/3218, we were already disabling/unregistering the duplicate metrics coming from controller-runtime that conflict with prometheus's metrics. All we needed to do now was to adapt to the upstream breaking change that was introduced in https://github.com/kubernetes-sigs/controller-runtime/pull/3070. In our codebase, the change required was just a one-liner:

> ctrlruntimemetrics.Registry.Unregister(collectors.NewGoCollector())

To

> ctrlruntimemetrics.Registry.Unregister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll)))

Not sure what was so hard about this but anyways i've fixed it now.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/15081

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
No release note since this re-iterates on an unreleased change.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign
/cc @kron4eg 
