### PR TITLE
update default Cilium version to 1.18.2

### DIFF
--- a/hack/mirror-system-application-charts.sh
+++ b/hack/mirror-system-application-charts.sh
@@ -49,7 +49,7 @@ declare -A CHART_URLS=(
 # Default versions for each chart
 declare -A CHART_VERSIONS=(
   ["cluster-autoscaler"]="9.46.6"
-  ["cilium"]="1.16.9"
+  ["cilium"]="1.18.2"
   # Add more default versions here as needed
   ["aikit"]="0.18.0"
   ["argo-cd"]="8.0.0"

--- a/pkg/applicationdefinitions/system-applications/cilium.yaml
+++ b/pkg/applicationdefinitions/system-applications/cilium.yaml
@@ -167,9 +167,9 @@ spec:
         source:
           helm:
             chartName: cilium
-            chartVersion: 1.18.1
+            chartVersion: 1.18.2
             url: oci://quay.io/kubermatic-mirror/helm-charts
-      version: 1.18.1
+      version: 1.18.2
   documentationURL: https://docs.cilium.io/en/stable/
   sourceURL: https://github.com/cilium/cilium
   logo: |+

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -29,7 +29,7 @@ import (
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.30",
-		kubermaticv1.CNIPluginTypeCilium: "1.18.1",
+		kubermaticv1.CNIPluginTypeCilium: "1.18.2",
 	}
 )
 
@@ -50,7 +50,7 @@ var (
 			"1.15.16",
 			"1.16.9",
 			"1.17.7",
-			"1.18.1",
+			"1.18.2",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cilium 1.18.1 fails to install on Azure clusters because the operator cannot schedule while nodes are tainted with
`node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule` during cloud-node-manager bootstrap.

The upstream PR that fixes this: https://github.com/cilium/cilium/pull/41098
It was released in Cilium 1.18.2 (https://github.com/cilium/cilium/releases/tag/v1.18.2)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes: https://github.com/kubermatic/kubermatic/issues/15094
References: https://github.com/kubermatic/kubermatic/issues/14941

This PR updates the default Cilium version to 1.18.2 to ensure new Azure clusters bootstrap successfully.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update default Cilium version to 1.18.2.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
