### PR TITLE
fix default policy catalog reconcile loop timeout from policy spec on installer rerun

### DIFF
--- a/pkg/ee/default-policy-catalog/embed.go
+++ b/pkg/ee/default-policy-catalog/embed.go
@@ -59,8 +59,13 @@ func GetPolicyTemplates() ([]kubermaticv1.PolicyTemplate, error) {
 
 			// Convert the ClusterPolicy to PolicyTemplate
 			template, err := convertClusterPolicyToPolicyTemplate(file)
+			closeErr := file.Close()
+
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert %s: %w", entry.Name(), err)
+			}
+			if closeErr != nil {
+				return nil, fmt.Errorf("failed to close %s: %w", entry.Name(), closeErr)
 			}
 
 			templates = append(templates, template)
@@ -71,8 +76,6 @@ func GetPolicyTemplates() ([]kubermaticv1.PolicyTemplate, error) {
 
 // convertClusterPolicyToPolicyTemplate converts a Kyverno ClusterPolicy to a Kubermatic PolicyTemplate.
 func convertClusterPolicyToPolicyTemplate(file fs.File) (kubermaticv1.PolicyTemplate, error) {
-	defer file.Close()
-
 	content, err := io.ReadAll(file)
 	if err != nil {
 		return kubermaticv1.PolicyTemplate{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the bug we were facing when rerunning the policy catalog through kubermatic installer.

Rerunning the default policy catalog was hitting the retry loop because the `PolicyTemplate.Spec.PolicySpec` we generated from the embedded Kyverno policies wasn’t in canonical json. On every reconcile our desired object differed from what the informer cache held, although they were the same (well, semantically). The reconciling framework updated the resource on each run and then timed out waiting for a change. 

This PR keeps the strict Kyverno validation (from UnmarshalStrict) because of validation safety, but converts `ClusterPolicy.Spec` into an unstructured map and marshals it back to json, ensuring we provide the same bytes to the reconciler. After this step there will be no unnecessary diff detected and the catalog will be deployed as intended.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14884

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the default policy catalog `--deploy-default-policy-template-catalog` flag timing out in the installer.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
