### PR TITLE
Use etcd 3.5.11's /livez and /readyz endpoints for etcd probes

### DIFF
--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -251,19 +251,17 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 						FailureThreshold:    3,
 						InitialDelaySeconds: 5,
 						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: []string{
-									"/usr/local/bin/etcdctl",
-									"--command-timeout", "10s",
-									"endpoint", "health",
-								},
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/readyz",
+								Port:   intstr.FromInt(2378),
+								Scheme: corev1.URISchemeHTTP,
 							},
 						},
 					},
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/health?exclude=NOSPACE&serializable=true",
+								Path:   "/livez",
 								Port:   intstr.FromInt(2378),
 								Scheme: corev1.URISchemeHTTP,
 							},
@@ -279,7 +277,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 					StartupProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/health?serializable=false",
+								Path:   "/readyz",
 								Port:   intstr.FromInt(2378),
 								Scheme: corev1.URISchemeHTTP,
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, If an `etcd` pods becomes unavailable, the `readinessProbe` for *ALL* `etcd` pods fails.

Although the current probes for etcd pods are old,  for more information:

- https://github.com/kubernetes/kubeadm/issues/3039
- https://github.com/kubernetes/kubernetes/pull/124465

**What type of PR is this?**
/kind bug 
(although a small one)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
No
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use etcd 3.5.11's /livez and /readyz endpoints for etcd probes
```

**Documentation**:
```documentation
NONE
```
