### PR TITLE
Remove deprecation notice for defaultComponentSettings in Seed

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -437,7 +437,6 @@ spec:
   # to default all new created clusters
   defaultClusterTemplate: ""
   # DefaultComponentSettings are default values to set for newly created clusters.
-  # Deprecated: Use DefaultClusterTemplate instead.
   defaultComponentSettings:
     # Apiserver configures kube-apiserver settings.
     apiserver:

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -485,7 +485,6 @@ spec:
   # to default all new created clusters
   defaultClusterTemplate: ""
   # DefaultComponentSettings are default values to set for newly created clusters.
-  # Deprecated: Use DefaultClusterTemplate instead.
   defaultComponentSettings:
     # Apiserver configures kube-apiserver settings.
     apiserver:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1725,9 +1725,7 @@ spec:
                     to default all new created clusters
                   type: string
                 defaultComponentSettings:
-                  description: |-
-                    DefaultComponentSettings are default values to set for newly created clusters.
-                    Deprecated: Use DefaultClusterTemplate instead.
+                  description: DefaultComponentSettings are default values to set for newly created clusters.
                   properties:
                     apiserver:
                       description: Apiserver configures kube-apiserver settings.

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -294,7 +294,6 @@ type SeedSpec struct {
 	// Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.
 	MLA *SeedMLASettings `json:"mla,omitempty"`
 	// DefaultComponentSettings are default values to set for newly created clusters.
-	// Deprecated: Use DefaultClusterTemplate instead.
 	DefaultComponentSettings ComponentSettings `json:"defaultComponentSettings,omitempty"`
 	// DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used
 	// to default all new created clusters


### PR DESCRIPTION
**What this PR does / why we need it**:
The deprecation notice dates back to around 4 years. Meanwhile, `defaultComponentSettings` is quite pivotal for our customers to configure defaults for different components. We have been using and regularly updating this struct through out so I believe this deprecation notice is just a left-over and should be removed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
Internal Reference: 8403

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove deprecation notice for `defaultComponentSettings` in the Seed Resource
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
/assign
/cc @kron4eg 
