### PR TITLE
Mirror the Webterminal Image

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -328,6 +328,8 @@ func mirrorImages(ctx context.Context, logger *logrus.Logger, versions kubermati
 	}
 	imageSet.Insert(sets.List(applicationImages)...)
 
+	// finally, add some static images that are not covered by any of the above
+	imageSet.Insert(staticImages()...)
 	return archiveOrCopyImages(ctx, logger, imageSet, options, userAgent)
 }
 
@@ -471,4 +473,9 @@ func loadImages(ctx context.Context, logger *logrus.Logger, options *MirrorImage
 
 	logger.Info("✅ Finished loading images.")
 	return nil
+}
+
+func staticImages() []string {
+	return []string{
+		resources.WEBTerminalImage}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -183,7 +183,8 @@ const (
 	KubernetesDashboardKubeconfigSecretName = "kubernetes-dashboard-kubeconfig"
 	// WEBTerminalKubeconfigSecretName is the name of the kubeconfig secret user for WEB terminal tools pod.
 	WEBTerminalKubeconfigSecretName = "web-terminal-kubeconfig"
-
+	// WEBTerminalImage is the name of the image used for the web terminal tool pod.
+	WEBTerminalImage = RegistryQuay + "/kubermatic/web-terminal:0.11.0"
 	// ImagePullSecretName specifies the name of the dockercfg secret used to access the private repo.
 	ImagePullSecretName = "dockercfg"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
To ensure all necessary images are mirrored, including those not covered by Helm charts, app definitions, or reconciliation refactors, we introduce an explicit list of unsupported images. This guarantees critical images are included in the mirroring process and provides a maintainable way to handle exceptions.


After merging this PR, we need to bump KKP in the dashboard and change this line https://github.com/kubermatic/dashboard/blob/main/modules/api/pkg/handler/websocket/terminal.go#L74

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mirror the Web Terminal Image 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
