### PR TITLE
disallow enforced and namespaced policy templates and improve cleanup of policy bindings

### DIFF
--- a/pkg/ee/kyverno/resources/seed-cluster/admission-controller/cleanup.go
+++ b/pkg/ee/kyverno/resources/seed-cluster/admission-controller/cleanup.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -81,7 +82,7 @@ func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Obj
 func CleanUpResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	resources := ResourcesForDeletion(cluster)
 	for _, resource := range resources {
-		if err := client.Delete(ctx, resource); err != nil {
+		if err := client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/ee/kyverno/resources/seed-cluster/background-controller/cleanup.go
+++ b/pkg/ee/kyverno/resources/seed-cluster/background-controller/cleanup.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -75,7 +76,7 @@ func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Obj
 func CleanUpResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	resources := ResourcesForDeletion(cluster)
 	for _, resource := range resources {
-		if err := client.Delete(ctx, resource); err != nil {
+		if err := client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/ee/kyverno/resources/seed-cluster/cleanup-controller/cleanup.go
+++ b/pkg/ee/kyverno/resources/seed-cluster/cleanup-controller/cleanup.go
@@ -33,6 +33,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -83,7 +84,7 @@ func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Obj
 func CleanUpResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	resources := ResourcesForDeletion(cluster)
 	for _, resource := range resources {
-		if err := client.Delete(ctx, resource); err != nil {
+		if err := client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/ee/kyverno/resources/seed-cluster/reports-controller/cleanup.go
+++ b/pkg/ee/kyverno/resources/seed-cluster/reports-controller/cleanup.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -75,7 +76,7 @@ func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Obj
 func CleanUpResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	resources := ResourcesForDeletion(cluster)
 	for _, resource := range resources {
-		if err := client.Delete(ctx, resource); err != nil {
+		if err := client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/ee/kyverno/resources/user-cluster/cleanup.go
+++ b/pkg/ee/kyverno/resources/user-cluster/cleanup.go
@@ -31,6 +31,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -79,7 +80,7 @@ func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Obj
 func CleanUpResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	resources := ResourcesForDeletion(cluster)
 	for _, resource := range resources {
-		if err := client.Delete(ctx, resource); err != nil {
+		if err := client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/ee/policy-binding-controller/controller.go
+++ b/pkg/ee/policy-binding-controller/controller.go
@@ -172,7 +172,10 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, bind
 	}
 
 	if template.Spec.NamespacedPolicy {
-		return r.reconcileNamespacedPolicy(ctx, log, template, binding)
+		if binding.Spec.KyvernoPolicyNamespace != nil && binding.Spec.KyvernoPolicyNamespace.Name != "" {
+			return r.reconcileNamespacedPolicy(ctx, log, template, binding)
+		}
+		return nil
 	}
 	return r.reconcileClusterPolicy(ctx, log, template, binding)
 }
@@ -369,7 +372,7 @@ func mapPolicyToRequest(namespace string) func(ctx context.Context, p *kyvernov1
 
 // handlePolicyBindingCleanup handles the cleanup of a PolicyBinding and its resources.
 func (r *reconciler) handlePolicyBindingCleanup(ctx context.Context, binding *kubermaticv1.PolicyBinding) error {
-	if err := r.deleteKyvernoResourcesForBinding(ctx, binding); err != nil {
+	if err := r.deleteKyvernoResourcesForBinding(ctx, binding); err != nil && binding.DeletionTimestamp.IsZero() {
 		return err
 	}
 

--- a/pkg/validation/policy_template.go
+++ b/pkg/validation/policy_template.go
@@ -64,6 +64,10 @@ func ValidatePolicyTemplate(template *kubermaticv1.PolicyTemplate) field.ErrorLi
 		}
 	}
 
+	if template.Spec.NamespacedPolicy && template.Spec.Enforced {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("namespacedPolicy"), "namespacedPolicy cannot be true when enforced is true"))
+	}
+
 	if template.Spec.Target != nil {
 		targetPath := specPath.Child("target")
 		if template.Spec.Target.ProjectSelector != nil {

--- a/pkg/webhook/policytemplate/validation/validation_test.go
+++ b/pkg/webhook/policytemplate/validation/validation_test.go
@@ -181,6 +181,14 @@ func TestAdmissionValidationPolicyTemplate(t *testing.T) {
 			wantErrors: false,
 		},
 		{
+			name: "Reject namespaced policy when enforced is true",
+			template: createTestPolicyTemplate("invalid-namespaced-enforced", func(pt *kubermaticv1.PolicyTemplate) {
+				pt.Spec.NamespacedPolicy = true
+				pt.Spec.Enforced = true
+			}),
+			wantErrors: true, errorPaths: []string{"spec.namespacedPolicy"},
+		},
+		{
 			name: "Reject template missing Title",
 			template: createTestPolicyTemplate("invalid-missing-title", func(pt *kubermaticv1.PolicyTemplate) {
 				pt.Spec.Title = ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tightens the PolicyTemplate admission through the policytemplate webhook and improves cleanup for policy bindings. We also short circuit if a namespaced template lacks the `kyvernoPolicyNamespace` and make sure finalizers are removed on cluster deletion. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/dashboard/issues/7574

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
Backport is also needed.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix invalid `PolicyTemplate` resources that set both `spec.enforced` and `spec.namespacedPolicy`, and improve `PolicyBinding` resources cleanup.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```