### PR TITLE
Update the OpenStack CSI version to v1.34.0

### DIFF
--- a/addons/csi/openstack/Makefile
+++ b/addons/csi/openstack/Makefile
@@ -18,7 +18,7 @@ OUTPUT_FILE = driver.yaml
 REPO_NAME = kkp-addons-csi-openstack
 
 # alpha.1 allows to specify extraEnv in Helm values
-CHART_VERSION = 2.33.1
+CHART_VERSION = 2.34.0
 
 .PHONY: default
 default: setup-helm build clean-helm

--- a/addons/csi/openstack/driver.yaml
+++ b/addons/csi/openstack/driver.yaml
@@ -402,7 +402,7 @@ metadata:
     cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
   labels:
     app: openstack-cinder-csi
-    chart: openstack-cinder-csi-2.33.1
+    chart: openstack-cinder-csi-2.34.0
     component: controllerplugin
     heritage: Helm
     release: openstack-cinder-csi
@@ -426,7 +426,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       labels:
         app: openstack-cinder-csi
-        chart: openstack-cinder-csi-2.33.1
+        chart: openstack-cinder-csi-2.34.0
         component: controllerplugin
         heritage: Helm
         release: openstack-cinder-csi
@@ -442,7 +442,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v4.7.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v4.10.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-attacher
           resources: {}
@@ -461,7 +461,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
           resources: {}
@@ -477,7 +477,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-snapshotter
           resources: {}
@@ -494,7 +494,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.12.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.14.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-resizer
           resources: {}
@@ -508,7 +508,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.14.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.17.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources: {}
@@ -581,7 +581,7 @@ metadata:
     cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
   labels:
     app: openstack-cinder-csi
-    chart: openstack-cinder-csi-2.33.1
+    chart: openstack-cinder-csi-2.34.0
     component: nodeplugin
     heritage: Helm
     release: openstack-cinder-csi
@@ -599,7 +599,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       labels:
         app: openstack-cinder-csi
-        chart: openstack-cinder-csi-2.33.1
+        chart: openstack-cinder-csi-2.34.0
         component: nodeplugin
         heritage: Helm
         release: openstack-cinder-csi
@@ -619,7 +619,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0" }}'
           imagePullPolicy: IfNotPresent
           name: node-driver-registrar
           resources: {}
@@ -634,7 +634,7 @@ spec:
         - args:
             - -v=2
             - --csi-address=/csi/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.14.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.17.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources: {}

--- a/addons/csi/openstack/driver.yaml
+++ b/addons/csi/openstack/driver.yaml
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file was generated, using `make` and then modified (where applicable)
-#
-# - Replace all entries for env CLOUD_CONFIG value from `/etc/config/config` to `/etc/kubernetes/config`
+# This file was generated, DO NOT EDIT.
+# Run `make` instead.
 
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
@@ -528,7 +527,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/config
+              value: /etc/config/config
             - name: CLUSTER_NAME
               value: '{{ .Cluster.Name }}'
             - name: SSL_CERT_FILE
@@ -556,7 +555,7 @@ spec:
             - mountPath: /etc/kubermatic/certs
               name: ca-bundle
               readOnly: true
-            - mountPath: /etc/kubernetes
+            - mountPath: /etc/config
               name: cloud-config
               readOnly: true
       nodeSelector: {}
@@ -655,7 +654,7 @@ spec:
             - name: CSI_ENDPOINT
               value: unix://csi/csi.sock
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/config
+              value: /etc/config/config
             - name: SSL_CERT_FILE
               value: /etc/kubermatic/certs/ca-bundle.pem
           image: '{{ Image (print "registry.k8s.io/provider-os/cinder-csi-plugin:" $version) }}'
@@ -692,7 +691,7 @@ spec:
             - mountPath: /etc/kubermatic/certs
               name: ca-bundle
               readOnly: true
-            - mountPath: /etc/kubernetes
+            - mountPath: /etc/config
               name: cloud-config
               readOnly: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/addons/csi/openstack/helm-values
+++ b/addons/csi/openstack/helm-values
@@ -26,7 +26,7 @@ csi:
         name: ca-bundle
         readOnly: true
       - name: cloud-config
-        mountPath: /etc/kubernetes
+        mountPath: /etc/config
         readOnly: true
     extraEnv:
       # use KKP's CA bundle

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -122,7 +122,7 @@ func OpenStackCCMTag(version semver.Semver) (string, error) {
 	case v133:
 		return "v1.33.1", nil
 	case v134:
-		return "v1.33.1", nil
+		return "v1.34.0", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.33.1
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.34.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to update the OpenStack CSI version to v1.34.0. Also update OpenStack CSI to use `/etc/config/` for cloud.conf as per the upstream https://github.com/kubernetes/cloud-provider-openstack/pull/2892 introduced in 1.33. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update OpenStack CSI version to 1.34.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
