### PR TITLE
Add a new toleration to Cilium Operator pod

### DIFF
--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -142,7 +142,7 @@ fi
 # cluster, which will force KKP to pull the correct image.
 docker exec "$KIND_CLUSTER_NAME-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi registry.k8s.io/kube-controller-manager:{}" || true
 
-CILIUM_VERSION="1.18.2"
+CILIUM_VERSION="1.18.1"
 
 helm repo add cilium https://helm.cilium.io/
 helm install cilium cilium/cilium \

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -142,9 +142,11 @@ fi
 # cluster, which will force KKP to pull the correct image.
 docker exec "$KIND_CLUSTER_NAME-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi registry.k8s.io/kube-controller-manager:{}" || true
 
+CILIUM_VERSION="1.18.2"
+
 helm repo add cilium https://helm.cilium.io/
 helm install cilium cilium/cilium \
-  --version 1.14.4 \
+  --version "$CILIUM_VERSION" \
   --namespace kube-system \
   --set image.pullPolicy=IfNotPresent \
   --set ipam.mode=kubernetes \

--- a/hack/mirror-system-application-charts.sh
+++ b/hack/mirror-system-application-charts.sh
@@ -49,7 +49,7 @@ declare -A CHART_URLS=(
 # Default versions for each chart
 declare -A CHART_VERSIONS=(
   ["cluster-autoscaler"]="9.46.6"
-  ["cilium"]="1.18.2"
+  ["cilium"]="1.18.1"
   # Add more default versions here as needed
   ["aikit"]="0.18.0"
   ["argo-cd"]="8.0.0"

--- a/pkg/applicationdefinitions/system-applications/cilium.yaml
+++ b/pkg/applicationdefinitions/system-applications/cilium.yaml
@@ -167,9 +167,9 @@ spec:
         source:
           helm:
             chartName: cilium
-            chartVersion: 1.18.2
+            chartVersion: 1.18.1
             url: oci://quay.io/kubermatic-mirror/helm-charts
-      version: 1.18.2
+      version: 1.18.1
   documentationURL: https://docs.cilium.io/en/stable/
   sourceURL: https://github.com/cilium/cilium
   logo: |+

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -29,7 +29,7 @@ import (
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.30",
-		kubermaticv1.CNIPluginTypeCilium: "1.18.2",
+		kubermaticv1.CNIPluginTypeCilium: "1.18.1",
 	}
 )
 
@@ -50,7 +50,7 @@ var (
 			"1.15.16",
 			"1.16.9",
 			"1.17.7",
-			"1.18.2",
+			"1.18.1",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
 	}

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -418,6 +418,24 @@ func getAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 			},
 		},
 		"podSecurityContext": podSecurityContext,
+		"tolerations": []map[string]any{
+			{
+				"key":      "node-role.kubernetes.io/control-plane",
+				"operator": "Exists",
+			},
+			{
+				"key":      "node-role.kubernetes.io/master", // deprecated
+				"operator": "Exists",
+			},
+			{
+				"key":      "node.kubernetes.io/not-ready",
+				"operator": "Exists",
+			},
+			{
+				"key":      "node.cloudprovider.kubernetes.io/uninitialized",
+				"operator": "Exists",
+			},
+		},
 	}
 	valuesCni := map[string]any{
 		// we run Cilium as non-exclusive CNI to allow for Multus use-cases


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts the default Cilium version to 1.18.1 to resolve issues observed in OpenStack, mainly.
The root cause of the issues in OpenStack is not yet fully discovered; some observations:
- Cilium 1.18.2 is not being installed for fresh OpenStack clusters due to `unable to create new content in namespace cilium-secrets because it is being terminated`,
- hubble-generate-certs job looks suspicious
- Ubuntu fails

Cilium operator is also now configured with tolerations for control-plane and uninitialized nodes. This ensures the Cilium agent can start on all nodes immediately, improving network reliability during cluster startup and upgrades. Otherwise, issues mentioned in the #15095  would arise again
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind regression


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the default version of Cilium to 1.18.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
