### PR TITLE
fix issue with load balancer assignment in GCP clusters

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/clusterrolebinding.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/clusterrolebinding.go
@@ -21,6 +21,7 @@ import (
 	"k8c.io/reconciler/pkg/reconciling"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ClusterRoleBindingReconciler returns a func to create/update the ClusterRoleBinding for external cloud controllers.
@@ -41,6 +42,11 @@ func ClusterRoleBindingReconciler() reconciling.NamedClusterRoleBindingReconcile
 					Kind:     "User",
 					Name:     resources.CloudControllerManagerCertUsername,
 					APIGroup: rbacv1.GroupName,
+				},
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      resources.CloudControllerManagerServiceAccountName,
+					Namespace: metav1.NamespaceSystem,
 				},
 			}
 			return crb, nil

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -273,6 +273,8 @@ const (
 
 	// CloudControllerManagerRoleBindingName is the name for the cloud controller manager rolebinding.
 	CloudControllerManagerRoleBindingName = "cloud-controller-manager"
+	// CloudControllerManagerServiceAccountName is the name of the cloud controller manager service account.
+	CloudControllerManagerServiceAccountName = "cloud-provider"
 
 	// DefaultServiceAccountName is the name of Kubernetes default service accounts.
 	DefaultServiceAccountName = "default"


### PR DESCRIPTION
**What this PR does / why we need it**:
After the introduction of Kubernetes 1.33 in KKP Load Balancer assignment is broken because of the cloud provider service account honoring the `use-service-account-credentials` flag and handling updates. In the past it seems this was falling back to the cert user, although `use-service-account-credentials` was always provided, even in previous versions. This PR adds the service account to the binding. This is an issue both in 1.33 and 1.34 Kubernetes clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15121
xref: Support for 1.33 https://github.com/kubermatic/kubermatic/pull/14419, and 1.34 https://github.com/kubermatic/kubermatic/pull/14940

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Load Balancer assignment in Kubernetes 1.33 and 1.34 GCP clusters.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
