### PR TITLE
Enable application catalog manager for headless installation

### DIFF
--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -429,9 +429,10 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, config *kubermati
 			kubermatic.APIDeploymentReconciler(config, r.workerName, r.versions),
 			kubermatic.UIDeploymentReconciler(config, r.versions),
 		)
-		if config.Spec.FeatureGates[features.ExternalApplicationCatalogManager] {
-			reconcilers = append(reconcilers, applicationcatalogmanager.CatalogManagerDeploymentReconciler(config))
-		}
+	}
+
+	if config.Spec.FeatureGates[features.ExternalApplicationCatalogManager] {
+		reconcilers = append(reconcilers, applicationcatalogmanager.CatalogManagerDeploymentReconciler(config))
 	}
 
 	modifiers := []reconciling.ObjectModifier{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the operator reconcile the application catalog manager in a headless installation
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
