### PR TITLE
Change system application OCI to quay.io/kubermatic-mirror

### DIFF
--- a/pkg/applicationdefinitions/system-applications/cilium.yaml
+++ b/pkg/applicationdefinitions/system-applications/cilium.yaml
@@ -42,119 +42,119 @@ spec:
           helm:
             chartName: cilium
             chartVersion: 1.13.0
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.0
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.13.3
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.3
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.13.4
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.4
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.13.6
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.6
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.13.7
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.7
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.13.8
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.8
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.13.14
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.13.14
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.14.1
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.14.1
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.14.2
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.14.2
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.14.3
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.14.3
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.14.9
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.14.9
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.14.16
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.14.16
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.15.3
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.15.3
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.15.10
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.15.10
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.15.16
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.15.16
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.16.6
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.16.6
     - template:
         source:
           helm:
             chartName: cilium
             chartVersion: 1.16.9
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.16.9
     - template:
         source:

--- a/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
+++ b/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
@@ -31,7 +31,7 @@ spec:
           helm:
             chartName: cluster-autoscaler
             chartVersion: 9.46.6
-            url: oci://quay.io/kubermatic/helm-charts
+            url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.32.0
   defaultValuesBlock: |
     cloudProvider: clusterapi


### PR DESCRIPTION
**What this PR does / why we need it**:

We decided to mirror all the artifacts and host them in quay.io/kubermatic-mirror. We still use quay.io/kubermatic in our system applications 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
