### PR TITLE
Set Logger for controller-runtime while deploying master cluster

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -26,8 +26,10 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/go-logr/zapr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
@@ -45,6 +47,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -222,6 +225,8 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 		if err != nil {
 			return fmt.Errorf("failed to get config: %w", err)
 		}
+
+		ctrlruntimelog.SetLogger(zapr.NewLogger(zap.NewNop()))
 
 		mgr, err := manager.New(ctrlConfig, manager.Options{
 			Metrics:                metricsserver.Options{BindAddress: "0"},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR set controller-runtime logger to NoOp while deploying the master cluster, to prevent warnings from controller-runtime's new package.
```
DEBU[0001] $ KUBECONFIG=/tmp/kubeconfig-shx72lzm6p helm --namespace default dependency build charts/nginx-ingress-controller 
DEBU[0011] $ KUBECONFIG=/tmp/kubeconfig-shx72lzm6p helm --namespace default repo remove dep-nginx-ingress-controller-0 
DEBU[0011] $ KUBECONFIG=/tmp/kubeconfig-shx72lzm6p helm --namespace nginx-ingress-controller upgrade --install --timeout 5m0s --values /tmp/helmvalues.2100778229 nginx-ingress-controller charts/nginx-ingress-controller 
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 261 [running]:
        >  runtime/debug.Stack()
        >       runtime/debug/stack.go:26 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       sigs.k8s.io/controller-runtime@v0.21.0/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc0009a0a80, 0x3)
        >       sigs.k8s.io/controller-runtime@v0.21.0/pkg/log/deleg.go:111 +0x32
        >  github.com/go-logr/logr.Logger.Info({{0x4084010?, 0xc0009a0a80?}, 0x350fba0?}, {0x39c1f82, 0x12}, {0xc001a2f1a0, 0x6, 0x6})
        >       github.com/go-logr/logr@v1.4.3/logr.go:276 +0x6e
        >  k8s.io/client-go/tools/cache.(*Reflector).RunWithContext(0xc000202ff0, {0x40767d8, 0xc0022040c0})
        >       k8s.io/client-go@v0.33.4/tools/cache/reflector.go:357 +0x1c8
        >  k8s.io/client-go/tools/cache.(*controller).RunWithContext.(*Group).StartWithContext.func3()
        >       k8s.io/apimachinery@v0.33.4/pkg/util/wait/wait.go:63 +0x1f
        >  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        >       k8s.io/apimachinery@v0.33.4/pkg/util/wait/wait.go:72 +0x4c
        >  created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start in goroutine 172
        >       k8s.io/apimachinery@v0.33.4/pkg/util/wait/wait.go:70 +0x73
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
