### PR TITLE
Bump OSM Image to v1.8.0

### DIFF
--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -57,7 +57,7 @@ var (
 )
 
 const (
-	Tag = "3f18bc13f185b35562f79e2766b6f148c2ba4257"
+	Tag = "v1.8.0"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager.yaml
@@ -63,7 +63,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager.yaml
@@ -84,7 +84,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager.yaml
@@ -41,7 +41,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook.yaml
@@ -43,7 +43,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager.yaml
@@ -55,7 +55,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:3f18bc13f185b35562f79e2766b6f148c2ba4257
+        image: quay.io/kubermatic/operating-system-manager:v1.8.0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the OSM image to v1.8.0. We are skipping the OSM GO Dependency update in KKP, as no API changes are expected. The main reason is: postpone controller-runtime 0.22.0 update until after the release! 

We made this decision in our sig-release meeting 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update operating-system-manager to [v1.8.0](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.8.0)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
