### PR TITLE
fix policy template selector targeting with empty target selectors

### DIFF
--- a/pkg/ee/default-policy-controller/controller.go
+++ b/pkg/ee/default-policy-controller/controller.go
@@ -272,7 +272,7 @@ func (r *Reconciler) handleGlobalWithTarget(ctx context.Context, cluster *kuberm
 		// Global + Target [ClusterSelector]
 		return handleGlobalClusterSelectorOnly(cluster, template)
 	default:
-		return false
+		return true
 	}
 }
 
@@ -286,7 +286,7 @@ func handleProjectWithTarget(cluster *kubermaticv1.Cluster, template *kubermatic
 		return matchesClusterSelector(cluster, template.Spec.Target.ClusterSelector)
 	}
 
-	return false
+	return true
 }
 
 // handleGlobalProjectAndClusterSelectors handles Global + Project + Cluster selectors (AND filtering).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the default policy controller where policy templates with `target: {}` (empty target object with nil selectors) were incorrectly excluded from cluster targeting, preventing PolicyBindings from being applied.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15143

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix policy template selector targeting with empty target selectors.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
