### PR TITLE
Bump the azuredisk-csi-driver for 1.31 and 1.32 kubernetes version

### DIFF
--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -24,10 +24,10 @@
 {{ $version = "v1.30.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.31" }}
-{{ $version = "v1.31.6" }}
+{{ $version = "v1.31.12" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.32" }}
-{{ $version = "v1.32.1" }}
+{{ $version = "v1.32.11" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
 {{ $version = "v1.33.4" }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the version of azuredisk-csi-driver for 1.31 and 1.32 Kubernetes versions. 
It seems that Microsoft deleted the existing images used by KKP.

We detected this issue thanks to mirror-images command: 

<img width="1080" height="119" alt="image" src="https://github.com/user-attachments/assets/eb15543d-1a08-4c98-aca6-5cd3a163e188" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update azuredisk-csi-driver to 1.32.11 for 1.32 kubernetes version and to 1.31.12 for 1.31 kubernetes version
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
