### PR TITLE
Fix cluster-autoscaler RBAC permissions

### DIFF
--- a/addons/cluster-autoscaler/_header.txt
+++ b/addons/cluster-autoscaler/_header.txt
@@ -50,6 +50,7 @@ rules:
       - list
       - update
       - watch
+      - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -50,6 +50,7 @@ rules:
       - list
       - update
       - watch
+      - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
+++ b/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
@@ -73,6 +73,7 @@ spec:
         - list
         - update
         - watch
+        - patch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

- Added missing 'patch' verb to ClusterRole rules

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster-autoscaler RBAC permissions.
⚠️ Potentially BREAKING Change: cluster-autoscaler application needs to be re-installed to force recreating ApplicationInstallation resource, in order to get the new updated default values.yaml.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
