### PR TITLE
Fix azurefile-csi with kubernetes 1.31 and 1.32

### DIFF
--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -27,7 +27,7 @@
 {{ $version = "v1.31.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.32" }}
-{{ $version = "v1.32.1" }}
+{{ $version = "v1.32.5" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
 {{ $version = "v1.33.3" }}
@@ -806,7 +806,7 @@ spec:
         - args:
             - --v=5
             - --endpoint=$(CSI_ENDPOINT)
-            {{- if semverCompare .Cluster.Version ">= 1.32" }}
+            {{- if semverCompare .Cluster.Version ">= 1.33" }}
             - --azurefile-proxy-endpoint=$(AZUREFILE_PROXY_ENDPOINT)
             - --enable-azurefile-proxy=true
             - --enable-kata-cc-mount=false
@@ -837,7 +837,7 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: AZURE_GO_SDK_LOG_LEVEL
-            {{- if semverCompare .Cluster.Version ">= 1.32" }}
+            {{- if semverCompare .Cluster.Version ">= 1.33" }}
             - name: AZUREFILE_PROXY_ENDPOINT
               value: unix:///csi/azurefile-proxy.sock
             {{- end }}
@@ -916,8 +916,8 @@ spec:
               name: registration-dir
       dnsPolicy: Default
       hostNetwork: true
+      {{- if semverCompare .Cluster.Version ">= 1.33" }}
       hostPID: true
-      {{- if semverCompare .Cluster.Version ">= 1.32" }}
       initContainers:
         - command:
             - /azurefile-proxy/init.sh

--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -24,7 +24,7 @@
 {{ $version = "v1.30.9" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.31" }}
-{{ $version = "v1.31.5" }}
+{{ $version = "v1.31.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.32" }}
 {{ $version = "v1.32.1" }}
@@ -806,8 +806,11 @@ spec:
         - args:
             - --v=5
             - --endpoint=$(CSI_ENDPOINT)
+            {{- if semverCompare .Cluster.Version ">= 1.32" }}
             - --azurefile-proxy-endpoint=$(AZUREFILE_PROXY_ENDPOINT)
             - --enable-azurefile-proxy=true
+            - --enable-kata-cc-mount=false
+            {{- end }}
             - --nodeid=$(KUBE_NODE_NAME)
             - --kubeconfig=
             - --drivername=file.csi.azure.com
@@ -823,7 +826,6 @@ spec:
             - --mount-permissions=511
             - --allow-inline-volume-key-access-with-identity=false
             - --metrics-address=0.0.0.0:29615
-            - --enable-kata-cc-mount=false
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: /etc/kubernetes/azure.json
@@ -835,8 +837,10 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: AZURE_GO_SDK_LOG_LEVEL
+            {{- if semverCompare .Cluster.Version ">= 1.32" }}
             - name: AZUREFILE_PROXY_ENDPOINT
               value: unix:///csi/azurefile-proxy.sock
+            {{- end }}
           image: '{{ Image (print "mcr.microsoft.com/oss/kubernetes-csi/azurefile-csi:" $version) }}'
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -913,6 +917,7 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       hostPID: true
+      {{- if semverCompare .Cluster.Version ">= 1.32" }}
       initContainers:
         - command:
             - /azurefile-proxy/init.sh
@@ -942,6 +947,7 @@ spec:
               name: host-usr
             - mountPath: /host/etc
               name: host-etc
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical


### PR DESCRIPTION
**What this PR does / why we need it**:
The azurefile-csi-driver in 1.31 and 1.32 containers doesn't have azurefile-proxy/init.sh scripts. After checking the old Helm charts for these two versions, we figured out that no need to have an init container to set up the Azure Proxy solution. It's something introduced in 1.33. 
When we updated the addons, we forgot to take into consideration 1.31 and 1.32

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix azurefile-csi with kubernetes 1.31 and 1.32
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
