### PR TITLE
kubelb: fix templatedata propagation for custom image

### DIFF
--- a/cmd/seed-controller-manager/wrappers_ee.go
+++ b/cmd/seed-controller-manager/wrappers_ee.go
@@ -53,7 +53,7 @@ func setupControllers(ctrlCtx *controllerContext) error {
 		return fmt.Errorf("failed to create GroupProjectBinding controller: %w", err)
 	}
 
-	if err := kubelbcontroller.Add(ctrlCtx.mgr, ctrlCtx.runOptions.workerCount, ctrlCtx.runOptions.workerName, ctrlCtx.runOptions.overwriteRegistry, ctrlCtx.seedGetter, ctrlCtx.projectsGetter, ctrlCtx.clientProvider, ctrlCtx.log, ctrlCtx.versions); err != nil {
+	if err := kubelbcontroller.Add(ctrlCtx.mgr, ctrlCtx.runOptions.workerCount, ctrlCtx.runOptions.workerName, ctrlCtx.runOptions.overwriteRegistry, ctrlCtx.seedGetter, ctrlCtx.projectsGetter, ctrlCtx.clientProvider, ctrlCtx.log, ctrlCtx.versions, ctrlCtx.configGetter); err != nil {
 		return fmt.Errorf("failed to create KubeLB controller: %w", err)
 	}
 

--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -73,13 +73,15 @@ type kubeLBData interface {
 	KubeLBImageTag() string
 }
 
-func NewKubeLBData(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client, overwriteRegistry string, dc kubermaticv1.Datacenter) *resources.TemplateData {
+func NewKubeLBData(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client, overwriteRegistry string, dc kubermaticv1.Datacenter, kubeLB kubermaticv1.KubeLBConfiguration) *resources.TemplateData {
 	return resources.NewTemplateDataBuilder().
 		WithContext(ctx).
 		WithCluster(cluster).
 		WithClient(client).
 		WithOverwriteRegistry(overwriteRegistry).
 		WithDatacenter(&dc).
+		WithKubeLBImageRepository(kubeLB.ImageRepository).
+		WithKubeLBImageTag(kubeLB.ImageTag).
 		Build()
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We found a bug in https://github.com/kubermatic/kubermatic/pull/15159; the template data that is passed to kubelb deployment reconciler was missing the updating kubelb configuration from KubermaticConfiguration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
It's a bug in an unreleased change so the release note is empty.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
