### PR TITLE
[release/v2.28] Add support for k8s patch releases v1.33.6/v1.32.10/v1.31.14

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -496,7 +496,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.32.9
+    default: v1.32.10
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -582,16 +582,19 @@ spec:
       - v1.31.10
       - v1.31.11
       - v1.31.13
+      - v1.31.14
       - v1.32.1
       - v1.32.3
       - v1.32.4
       - v1.32.6
       - v1.32.7
       - v1.32.9
+      - v1.32.10
       - v1.33.0
       - v1.33.2
       - v1.33.3
       - v1.33.5
+      - v1.33.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -496,7 +496,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.32.9
+    default: v1.32.10
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -582,16 +582,19 @@ spec:
       - v1.31.10
       - v1.31.11
       - v1.31.13
+      - v1.31.14
       - v1.32.1
       - v1.32.3
       - v1.32.4
       - v1.32.6
       - v1.32.7
       - v1.32.9
+      - v1.32.10
       - v1.33.0
       - v1.33.2
       - v1.33.3
       - v1.33.5
+      - v1.33.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -215,7 +215,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.32.9"),
+		Default: semver.NewSemverOrDie("v1.32.10"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -238,6 +238,7 @@ var (
 			newSemver("v1.31.10"),
 			newSemver("v1.31.11"),
 			newSemver("v1.31.13"),
+			newSemver("v1.31.14"),
 			// Kubernetes 1.32
 			newSemver("v1.32.1"),
 			newSemver("v1.32.3"),
@@ -245,11 +246,13 @@ var (
 			newSemver("v1.32.6"),
 			newSemver("v1.32.7"),
 			newSemver("v1.32.9"),
+			newSemver("v1.32.10"),
 			// Kubernetes 1.33
 			newSemver("v1.33.0"),
 			newSemver("v1.33.2"),
 			newSemver("v1.33.3"),
 			newSemver("v1.33.5"),
+			newSemver("v1.33.6"),
 		},
 		Updates: []kubermaticv1.Update{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherrypick PR for https://github.com/kubermatic/kubermatic/pull/15170. This PR is to add support for k8s patch releases v1.33.6/v1.32.10/v1.31.14. Also update default k8s version to v1.32.10.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for k8s patch releases v1.33.6/v1.32.10/v1.31.14
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
