### PR TITLE
Bump oauth2-proxy to appversion v7.13.0

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: 9.9.9-dev
-appVersion: v7.8.2
+appVersion: v7.13.0
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.8.2"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.8.2"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -240,7 +240,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.8.2"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.8.2
+    tag: v7.13.0
     pullPolicy: IfNotPresent
 
   # list of image pull secret references, e.g.


### PR DESCRIPTION
**What this PR does / why we need it**:
Post v7.8.2 until latest release v7.13.0 lot of CVEs are addressed in each of the releases.  https://github.com/oauth2-proxy/oauth2-proxy/releases. Hence, this PR bumps the oauth2-proxy with appversion v7.13.0. 
Note, there is breaking change introduced to fix CVE-2025-54576 in v7.11.0 release and should only affect if using regex pattern in  `skip_auth_routes` entries, hence added details to release notes for same.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump oauth2-proxy to appversion v7.13.0
Potentially Breaking change: If your configuration relies on matching query parameters in `skip_auth_routes` patterns, you must update your regex patterns to match paths only. Review all `skip_auth_routes` entries for potential impact. For detailed information, migration guidance, and security implications, see the upstream [security advisory](https://github.com/oauth2-proxy/oauth2-proxy/security/advisories/GHSA-7rh7-c77v-6434).
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
