### PR TITLE
Delete orphaned UserProjectBinding resources on User or Project deletion

### DIFF
--- a/pkg/controller/master-controller-manager/user-project-binding/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller.go
@@ -97,8 +97,8 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.SugaredLogger, projectBinding *kubermaticv1.UserProjectBinding) error {
 	project, err := r.getProjectForBinding(ctx, projectBinding)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.removeFinalizerFromBinding(ctx, projectBinding)
+		if err := r.Delete(ctx, projectBinding); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete orphaned binding %s: %w", projectBinding.Name, err)
 		}
 
 		return fmt.Errorf("failed to get project: %w", err)
@@ -106,8 +106,8 @@ func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.Su
 
 	user, err := r.getUserForBinding(ctx, projectBinding)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return r.removeFinalizerFromBinding(ctx, projectBinding)
+		if err := r.Delete(ctx, projectBinding); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete orphaned binding %s: %w", projectBinding.Name, err)
 		}
 
 		return fmt.Errorf("failed to get user from binding: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds logic to delete orphaned UserProjectBinding resources when either the corresponding User or Project is deleted.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15098 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Delete orphaned UserProjectBinding resources on User or Project deletion.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
