### PR TITLE
Add omitempty to component settings fields to allow partial configuration

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -3114,13 +3114,6 @@ spec:
                             type: object
                           type: array
                       type: object
-                  required:
-                    - apiserver
-                    - controllerManager
-                    - etcd
-                    - nodePortProxyEnvoy
-                    - prometheus
-                    - scheduler
                   type: object
                 containerRuntime:
                   default: containerd

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -3108,13 +3108,6 @@ spec:
                             type: object
                           type: array
                       type: object
-                  required:
-                    - apiserver
-                    - controllerManager
-                    - etcd
-                    - nodePortProxyEnvoy
-                    - prometheus
-                    - scheduler
                   type: object
                 containerRuntime:
                   default: containerd

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -2967,13 +2967,6 @@ spec:
                             type: object
                           type: array
                       type: object
-                  required:
-                    - apiserver
-                    - controllerManager
-                    - etcd
-                    - nodePortProxyEnvoy
-                    - prometheus
-                    - scheduler
                   type: object
                 disabledCollectors:
                   description: |-

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -841,19 +841,19 @@ const (
 
 type ComponentSettings struct {
 	// Apiserver configures kube-apiserver settings.
-	Apiserver APIServerSettings `json:"apiserver"`
+	Apiserver APIServerSettings `json:"apiserver,omitempty"`
 	// ControllerManager configures kube-controller-manager settings.
-	ControllerManager ControllerSettings `json:"controllerManager"`
+	ControllerManager ControllerSettings `json:"controllerManager,omitempty"`
 	// Scheduler configures kube-scheduler settings.
-	Scheduler ControllerSettings `json:"scheduler"`
+	Scheduler ControllerSettings `json:"scheduler,omitempty"`
 	// Etcd configures the etcd ring used to store Kubernetes data.
-	Etcd EtcdStatefulSetSettings `json:"etcd"`
+	Etcd EtcdStatefulSetSettings `json:"etcd,omitempty"`
 	// Prometheus configures the Prometheus instance deployed into the cluster control plane.
-	Prometheus StatefulSetSettings `json:"prometheus"`
+	Prometheus StatefulSetSettings `json:"prometheus,omitempty"`
 	// NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy that is deployed if
 	// the `LoadBalancer` expose strategy is used. This is not effective if a different expose
 	// strategy is configured.
-	NodePortProxyEnvoy NodeportProxyComponent `json:"nodePortProxyEnvoy"`
+	NodePortProxyEnvoy NodeportProxyComponent `json:"nodePortProxyEnvoy,omitempty"`
 	// KonnectivityProxy configures konnectivity-server and konnectivity-agent components.
 	KonnectivityProxy KonnectivityProxySettings `json:"konnectivityProxy,omitempty"`
 	// UserClusterController configures the KKP usercluster-controller deployed as part of the cluster control plane.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the omitempty flag to the fields in the ComponentSettings struct.
With this change, users can now configure only the desired fields without being required to specify all of them.

Short documentation how this PR helps the KKP administrators:

**Before KKP 2.30**, if we needed to customize etcd diskSize, Seed `defaultCompoentSettings` section / Cluster's `componentsOverride` section / ClusterTemplate's `componentsOverride` section, it would looks like this:

```
   componentsOverride:
     apiserver: {}
     controllerManager: {}
     etcd:
       diskSize: 5Gi
     konnectivityProxy: {}
     nodePortProxyEnvoy: {}
     prometheus: {}
     scheduler: {}
```

**With KKP 2.30**, configuration would be simply like below
```
   componentsOverride:
     etcd:
       diskSize: 5Gi
```
As you can see it much more concise and to the point now.



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15113 

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add omitempty to component settings fields to allow partial configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
