### PR TITLE
Prometheus post hook fix

### DIFF
--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         pre.hook.backup.velero.io/timeout: '{{ .Values.prometheus.backup.timeout | default "60m" }}'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
         post.hook.backup.velero.io/container: backup
-        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
+        post.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /backup/* || true"]'
         {{- end }}
     spec:
       {{- if .Values.prometheus.imagePullSecrets }}

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -2111,7 +2111,7 @@ spec:
         pre.hook.backup.velero.io/timeout: '60m'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
         post.hook.backup.velero.io/container: backup
-        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
+        post.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /backup/* || true"]'
     spec:
       containers:
       - name: prometheus

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -2111,7 +2111,7 @@ spec:
         pre.hook.backup.velero.io/timeout: '60m'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
         post.hook.backup.velero.io/container: backup
-        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
+        post.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /backup/* || true"]'
     spec:
       containers:
       - name: prometheus

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -2111,7 +2111,7 @@ spec:
         pre.hook.backup.velero.io/timeout: '60m'
         pre.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /prometheus/snapshots/* && curl -s -XPOST \"http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot?skip_head=true\" && rsync --archive /prometheus/snapshots/*/ /backup"]'
         post.hook.backup.velero.io/container: backup
-        post.hook.backup.velero.io/command: ‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'
+        post.hook.backup.velero.io/command: '["/bin/sh", "-c", "rm -rf /backup/* || true"]'
     spec:
       containers:
       - name: prometheus


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes incorrect Velero hook annotations that used invalid quoting and command formatting. The previous format caused backup hooks to fail with `OCI runtime exec failed: exec failed: unable to start container process: exec: \"‘[“/bin/sh”, “-c”, “rm -rf /backup/* || true”]'\"` errors, resulting in `PartiallyFailed` backups.
By replacing all occurrences with the correct JSON structure and proper ASCII quotes, Velero can now execute post-hooks successfully, ensuring backups complete without errors.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #INC-8751

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

- The fix replaces all invalid hook annotations with the correct Velero format:

```json
{"exec": {"container": "<container-name>", "command": ["/bin/sh", "-c", "rm -rf /backup/* || true"]}}
```
- Verified against Prometheus pods where previous hooks failed.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Velero backup hook annotations have been corrected to use proper JSON format and ASCII quotes, fixing backup failures caused by invalid exec commands.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
