### PR TITLE
Add validation to prevent user creation with duplicate email

### DIFF
--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -103,12 +103,12 @@ spec:
   name: roxy-admin
 EOF
 
+retry 2 kubectl apply -f user.yaml
+
 echodate "Checking if user exists..."
 if kubectl get user roxy-admin &> /dev/null; then
-  echodate "User roxy-admin already exists, checking email..."
+  echodate "User roxy-admin exists"
 fi
-
-kubectl get user
 
 echodate "Running MLA tests..."
 

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -74,7 +74,7 @@ func WebhookClusterRoleReconciler(cfg *kubermaticv1.KubermaticConfiguration) rec
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"kubermatic.k8c.io"},
-					Resources: []string{"clustertemplates", "projects", "ipamallocations", "resourcequotas"},
+					Resources: []string{"clustertemplates", "projects", "ipamallocations", "resourcequotas", "users"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/validation/user.go
+++ b/pkg/validation/user.go
@@ -101,7 +101,7 @@ func ValidateUserEmailUniqueness(ctx context.Context, client ctrlruntimeclient.C
 			continue
 		}
 
-		if strings.ToLower(user.Spec.Email) == strings.ToLower(email) {
+		if strings.EqualFold(user.Spec.Email, email) {
 			return field.Duplicate(field.NewPath("spec", "email"), email)
 		}
 	}

--- a/pkg/validation/user.go
+++ b/pkg/validation/user.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1/helper"
@@ -100,7 +101,7 @@ func ValidateUserEmailUniqueness(ctx context.Context, client ctrlruntimeclient.C
 			continue
 		}
 
-		if user.Spec.Email == email {
+		if strings.ToLower(user.Spec.Email) == strings.ToLower(email) {
 			return field.Duplicate(field.NewPath("spec", "email"), email)
 		}
 	}

--- a/pkg/webhook/user/validation/validation.go
+++ b/pkg/webhook/user/validation/validation.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"context"
 	"errors"
+	"strings"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1/helper"
@@ -89,7 +90,7 @@ func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 		errs = append(errs, err)
 	}
 
-	if oldUser.Spec.Email != newUser.Spec.Email {
+	if strings.ToLower(oldUser.Spec.Email) != strings.ToLower(newUser.Spec.Email) {
 		if err := validation.ValidateUserEmailUniqueness(ctx, v.client, newUser.Spec.Email, newUser.Name); err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/webhook/user/validation/validation.go
+++ b/pkg/webhook/user/validation/validation.go
@@ -90,7 +90,7 @@ func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 		errs = append(errs, err)
 	}
 
-	if strings.ToLower(oldUser.Spec.Email) != strings.ToLower(newUser.Spec.Email) {
+	if !strings.EqualFold(oldUser.Spec.Email, newUser.Spec.Email) {
 		if err := validation.ValidateUserEmailUniqueness(ctx, v.client, newUser.Spec.Email, newUser.Name); err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/webhook/user/validation/validation.go
+++ b/pkg/webhook/user/validation/validation.go
@@ -64,6 +64,11 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (adm
 		errs = append(errs, err)
 	}
 
+	// Validate email uniqueness
+	if err := validation.ValidateUserEmailUniqueness(ctx, v.client, user.Spec.Email, ""); err != nil {
+		errs = append(errs, err)
+	}
+
 	return nil, errs.ToAggregate()
 }
 
@@ -82,6 +87,12 @@ func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 
 	if err := v.validateProjectRelationship(ctx, newUser, oldUser); err != nil {
 		errs = append(errs, err)
+	}
+
+	if oldUser.Spec.Email != newUser.Spec.Email {
+		if err := validation.ValidateUserEmailUniqueness(ctx, v.client, newUser.Spec.Email, newUser.Name); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return nil, errs.ToAggregate()

--- a/pkg/webhook/user/validation/validation_test.go
+++ b/pkg/webhook/user/validation/validation_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+	"k8c.io/kubermatic/v2/pkg/validation"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestValidateUserEmailUniqueness(t *testing.T) {
+	testCases := []struct {
+		name            string
+		email           string
+		currentUserName string
+		existingUsers   []ctrlruntimeclient.Object
+		expectError     bool
+	}{
+		{
+			name:            "unique email - no existing users",
+			email:           "user@example.com",
+			currentUserName: "",
+			existingUsers:   []ctrlruntimeclient.Object{},
+			expectError:     false,
+		},
+		{
+			name:            "unique email - different existing users",
+			email:           "newuser@example.com",
+			currentUserName: "",
+			existingUsers: []ctrlruntimeclient.Object{
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "user1",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email: "user1@example.com",
+						Name:  "User One",
+					},
+				},
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "user2",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email: "user2@example.com",
+						Name:  "User Two",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:            "duplicate email - should fail",
+			email:           "duplicate@example.com",
+			currentUserName: "",
+			existingUsers: []ctrlruntimeclient.Object{
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-user",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email: "duplicate@example.com",
+						Name:  "Existing User",
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:            "same email but for same user (update scenario)",
+			email:           "user@example.com",
+			currentUserName: "user1",
+			existingUsers: []ctrlruntimeclient.Object{
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "user1",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email: "user@example.com",
+						Name:  "User One",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:            "empty email - should pass (other validators handle this)",
+			email:           "",
+			currentUserName: "",
+			existingUsers:   []ctrlruntimeclient.Object{},
+			expectError:     false,
+		},
+		{
+			name:            "service account email - should check uniqueness",
+			email:           "serviceaccount-test@test.kubermatic.io",
+			currentUserName: "",
+			existingUsers: []ctrlruntimeclient.Object{
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "serviceaccount-existing",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email:   "serviceaccount-test@test.kubermatic.io",
+						Name:    "Service Account",
+						Project: "test-project",
+					},
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithObjects(tc.existingUsers...).Build()
+			ctx := context.Background()
+
+			err := validation.ValidateUserEmailUniqueness(ctx, client, tc.email, tc.currentUserName)
+
+			if tc.expectError && err == nil {
+				t.Error("expected validation error but got none")
+			}
+
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+
+			if err != nil {
+				var fieldErr *field.Error
+				if errors.As(err, &fieldErr) {
+					if fieldErr.Type != field.ErrorTypeDuplicate {
+						t.Errorf("expected error type 'duplicate' but got '%s'", fieldErr.Type)
+					}
+					if fieldErr.Field != "spec.email" {
+						t.Errorf("expected error field 'spec.email' but got '%s'", fieldErr.Field)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidatorCreate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		user          *kubermaticv1.User
+		existingUsers []ctrlruntimeclient.Object
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "valid new user",
+			user: &kubermaticv1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-user",
+				},
+				Spec: kubermaticv1.UserSpec{
+					Email: "newuser@example.com",
+					Name:  "New User",
+				},
+			},
+			existingUsers: []ctrlruntimeclient.Object{},
+			expectError:   false,
+		},
+		{
+			name: "duplicate email on create",
+			user: &kubermaticv1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "new-user",
+				},
+				Spec: kubermaticv1.UserSpec{
+					Email: "existing@example.com",
+					Name:  "New User",
+				},
+			},
+			existingUsers: []ctrlruntimeclient.Object{
+				&kubermaticv1.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-user",
+					},
+					Spec: kubermaticv1.UserSpec{
+						Email: "existing@example.com",
+						Name:  "Existing User",
+					},
+				},
+			},
+			expectError:   true,
+			errorContains: "duplicate",
+		},
+		{
+			name: "missing email field",
+			user: &kubermaticv1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-email-user",
+				},
+				Spec: kubermaticv1.UserSpec{
+					Email: "",
+					Name:  "User Without Email",
+				},
+			},
+			existingUsers: []ctrlruntimeclient.Object{},
+			expectError:   true,
+			errorContains: "required",
+		},
+		{
+			name: "missing name field",
+			user: &kubermaticv1.User{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "no-name-user",
+				},
+				Spec: kubermaticv1.UserSpec{
+					Email: "noname@example.com",
+					Name:  "",
+				},
+			},
+			existingUsers: []ctrlruntimeclient.Object{},
+			expectError:   true,
+			errorContains: "required",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientBuilder().WithObjects(tc.existingUsers...).Build()
+			validator := NewValidator(client, nil, nil)
+			ctx := context.Background()
+
+			_, err := validator.ValidateCreate(ctx, tc.user)
+
+			if tc.expectError && err == nil {
+				t.Error("expected validation error but got none")
+			}
+
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected validation error: %v", err)
+			}
+
+			if tc.expectError && err != nil && tc.errorContains != "" {
+				errStr := strings.ToLower(err.Error())
+				expectedStr := strings.ToLower(tc.errorContains)
+				if !strings.Contains(errStr, expectedStr) {
+					t.Errorf("expected error to contain '%s' but got '%s'", tc.errorContains, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces server-side validation to reject duplicate user objects based on the email field.

Add validation at the Kubernetes API level to ensure:
- Email address uniqueness across all user objects


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15092 

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validation to prevent user creation with duplicate email
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
