### PR TITLE
Updated Helm values handling to support multiple files

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -66,8 +66,7 @@ type DeployOptions struct {
 	KubeContext string
 
 	HelmBinary         string
-	HelmValues         string // deprecated single-file input (backwards compatibility)
-  HelmValuesFiles    []string
+	HelmValues         []string
 	HelmTimeout        time.Duration
 	SkipDependencies   bool
 	SkipSeedValidation sets.Set[string]
@@ -119,23 +118,13 @@ func DeployCommand(logger *logrus.Logger, versions kubermatic.Versions) *cobra.C
 			if opt.KubeContext == "" {
 				opt.KubeContext = os.Getenv("KUBE_CONTEXT")
 			}
-			if opt.HelmValues == "" {
-				opt.HelmValues = os.Getenv("HELM_VALUES")
+			if len(opt.HelmValues) == 0 {
+				if envVal := os.Getenv("HELM_VALUES"); envVal != "" {
+					opt.HelmValues = []string{envVal}
+				}
 			}
 			if opt.HelmBinary == "" {
 				opt.HelmBinary = os.Getenv("HELM_BINARY")
-			}
-
-			// Backwards compatibility & env support for multiple files:
-			// - If --helm-values not provided as slice, fall back to old single string or $HELM_VALUES
-			if len(opt.HelmValuesFiles) == 0 {
-				source := opt.HelmValues
-				if source == "" {
-					source = os.Getenv("HELM_VALUES")
-				}
-				if source != "" {
-					opt.HelmValuesFiles = []string{source}
-				}
 			}
 		},
 	}
@@ -144,7 +133,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermatic.Versions) *cobra.C
 	cmd.PersistentFlags().StringVar(&opt.Kubeconfig, "kubeconfig", "", "full path to where a kubeconfig with cluster-admin permissions for the target cluster")
 	cmd.PersistentFlags().StringVar(&opt.KubeContext, "kube-context", "", "context to use from the given kubeconfig")
 
-	cmd.PersistentFlags().StringArrayVar(&opt.HelmValuesFiles, "helm-values", nil, "one or more Helm values files (repeat flag)")
+	cmd.PersistentFlags().StringSliceVar(&opt.HelmValues, "helm-values", nil, "full path to the Helm values.yaml used for customizing all charts (can be specified multiple times)")
 	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
 	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "full path to the Helm 3 binary to use")
 	cmd.PersistentFlags().BoolVar(&opt.SkipDependencies, "skip-dependencies", false, "skip pulling Helm chart dependencies (requires chart dependencies to be already downloaded)")
@@ -202,7 +191,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 			return fmt.Errorf("failed to load KubermaticConfiguration: %w", err)
 		}
 
-		helmValues, err := loadAndMergeHelmValues(opt.HelmValuesFiles)
+		helmValues, err := loadHelmValues(opt.HelmValues)
 		if err != nil {
 			return fmt.Errorf("failed to load Helm values: %w", err)
 		}
@@ -410,75 +399,4 @@ func setupKubermaticStack(logger *logrus.Logger, args []string, opt *DeployOptio
 		return nil, fmt.Errorf("unknown stack %q specified", stackName)
 	}
 	return kubermaticStack, nil
-}
-
-// loadAndMergeHelmValues loads multiple Helm values files and performs a deep merge.
-// Merge semantics are aligned with Helm's -f behavior for maps; lists/arrays are replaced by later files.
-func loadAndMergeHelmValues(files []string) (map[string]interface{}, error) {
-	// If no files provided, behave like loadHelmValues("") did before (i.e., nil / empty map).
-	if len(files) == 0 {
-		return nil, nil
-	}
-
-		var merged map[string]interface{}
-		for _, f := range files {
-			if f == "" {
-				continue
-			}
-
-
-			vals, err := loadHelmValues(f)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load Helm values from %s: %w", f, err)
-			}
-
-			if merged == nil {
-				// first file wins as base
-				if vals == nil {
-					merged = map[string]interface{}{}
-				} else {
-					merged = vals
-				}
-				continue
-			}
-
-			merged = deepMergeMaps(merged, vals)
-    }
-
-	return merged, nil
-}
-
-// deepMergeMaps merges b into a (mutating a), recursively for maps.
-// Slices/arrays are REPLACED (not appended), scalars are overwritten by b.
-func deepMergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	if a == nil {
-		return b
-	}
-
-	for k, bv := range b {
-		if av, ok := a[k]; ok {
-			a[k] = mergeNode(av, bv)
-		} else {
-			a[k] = bv
-		}
-	}
-
-	return a
-}
-
-func mergeNode(av, bv interface{}) interface{} {
-	switch a := av.(type) {
-	case map[string]interface{}:
-		if b, ok := bv.(map[string]interface{}); ok {
-			return deepMergeMaps(a, b)
-		}
-		return bv
-
-	case []interface{}:
-		// replace arrays/list as Helm does for -f
-		return bv
-
-	default:
-		return bv
-	}
 }

--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -383,7 +383,9 @@ func installKubermatic(logger *logrus.Logger, dir string, kubeClient ctrlruntime
 	if err != nil {
 		logger.Panicf("Failed to load %v after autoconfiguration: %v", kubermaticPath, err)
 	}
-	v, err := loadHelmValues(valuesPath)
+
+	// the string valuesPath is wrapped in a slice: []string{valuesPath}
+	v, err := loadHelmValues([]string{valuesPath})
 	if err != nil {
 		logger.Panicf("Failed to load %v after autoconfiguration: %v", valuesPath, err)
 	}

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -88,7 +88,7 @@ func loadHelmValues(filenames []string) (*yamled.Document, error) {
 	}
 
 	// We create an empty map into which we merge everything.
-	mergedValues := make(map[string]interface{})
+	mergedValues := make(map[string]any)
 
 	for _, filename := range filenames {
 		if filename == "" {

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	goyaml "gopkg.in/yaml.v3"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -134,7 +134,7 @@ func loadHelmValues(filenames []string) (*yamled.Document, error) {
 	return values, nil
 }
 
-// Help function for deep merging of maps
+// Help function for deep merging of maps.
 func mergeMaps(dest, src map[string]interface{}) error {
 	for k, v := range src {
 		// check whether the key exists in dest and whether both are maps

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	goyaml "gopkg.in/yaml.v3"

--- a/cmd/kubermatic-installer/shared.go
+++ b/cmd/kubermatic-installer/shared.go
@@ -102,7 +102,7 @@ func loadHelmValues(filenames []string) (*yamled.Document, error) {
 		// defer f.Close() is tricky in loops, we close explicitly:
 
 		// decoding the current file
-		currentMap := make(map[string]interface{})
+		currentMap := make(map[string]any)
 		decoder := goyaml.NewDecoder(f)
 		if err := decoder.Decode(&currentMap); err != nil {
 			f.Close()

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/nutanix-cloud-native/prism-go-client => github.com/nutanix-cl
 replace k8c.io/kubermatic/sdk/v2 => ./sdk
 
 require (
-	dario.cat/mergo v1.0.1
+	dario.cat/mergo v1.0.2
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization v1.0.0
@@ -123,7 +123,6 @@ require (
 require (
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/opencontainers/image-spec v1.1.0
-	github.com/imdario/mergo v0.3.16
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 require (
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/opencontainers/image-spec v1.1.0
+	github.com/imdario/mergo v0.3.16
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
+github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/in-toto/attestation v1.1.0 h1:oRWzfmZPDSctChD0VaQV7MJrywKOzyNrtpENQFq//2Q=
 github.com/in-toto/attestation v1.1.0/go.mod h1:DB59ytd3z7cIHgXxwpSX2SABrU6WJUKg/grpdgHVgVs=
 github.com/in-toto/in-toto-golang v0.9.1-0.20240317085821-8e2966059a09 h1:cwCITdi9pF50CF8uh40qDbkJ/VrEVzx5AoaHP7OPdEo=

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ cuelabs.dev/go/oci/ociregistry v0.0.0-20240807094312-a32ad29eed79 h1:EceZITBGET3
 cuelabs.dev/go/oci/ociregistry v0.0.0-20240807094312-a32ad29eed79/go.mod h1:5A4xfTzHTXfeVJBU6RAUf+QrlfTCW+017q/QiW+sMLg=
 cuelang.org/go v0.10.0 h1:Y1Pu4wwga5HkXfLFK1sWAYaSWIBdcsr5Cb5AWj2pOuE=
 cuelang.org/go v0.10.0/go.mod h1:HzlaqqqInHNiqE6slTP6+UtxT9hN6DAzgJgdbNxXvX8=
-dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
-dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
@@ -737,8 +737,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
-github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/in-toto/attestation v1.1.0 h1:oRWzfmZPDSctChD0VaQV7MJrywKOzyNrtpENQFq//2Q=
 github.com/in-toto/attestation v1.1.0/go.mod h1:DB59ytd3z7cIHgXxwpSX2SABrU6WJUKg/grpdgHVgVs=
 github.com/in-toto/in-toto-golang v0.9.1-0.20240317085821-8e2966059a09 h1:cwCITdi9pF50CF8uh40qDbkJ/VrEVzx5AoaHP7OPdEo=


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the `kubermatic-installer` so that it accepts multiple Helm values files via repeated `--helm-values` flags and merges them **in order** (later files override earlier ones). The change aligns the installer with the native Helm UX, where `--values/-f` can be specified multiple times and later files take precedence.

Key points:

- New flag behavior:
  `--helm-values` is now a **StringArray**; pass the flag **multiple times**:

```shell
./kubermatic-installer deploy kubermatic-master \
  --config kubermatic.yaml \
  --helm-values values/defaults.yaml \
  --helm-values values/tst.yaml \
  --helm-values values/secrets.yaml
```

- Backward compatibility:
  The legacy **single-file** path remains supported via the deprecated `HelmValues string` (and `$HELM_VALUES`). If no array flags are given, a single value from the old flag/env is used as one values file.
- Merge semantics:
  - Maps are merged recursively; later files overwrite earlier keys.
  - Lists/arrays are replaced (as with Helm) – no appending.
  - Scalars are overwritten by later files.

This enables clean separation of `defaults.yaml` / `environment.yaml` / `secrets.yaml` without pre-merge and without changes to charts or deploy pipelines.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #INC-8786

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

- Flags
  - `--helm-values` changed from **StringVar ➜ StringArrayVar**.
     Description updated: “one or more Helm values files (repeat flag)”.
- PreRun fallback
  - If no array flags are set, the previous single source (`opt.HelmValues` or `$HELM_VALUES`) is adopted as the **only entry** in `HelmValuesFiles`.
- Loading & Merge
  - Replaces `loadHelmValues(opt.HelmValues)` with `loadAndMergeHelmValues(opt.HelmValuesFiles)`.
  - `loadAndMergeHelmValues`:
    - loads the files in order,
    - maps recursively (map merge),
    - replaces arrays, overwrites scalars (Helm-compliant).
 - No change to Helm binary handling or deploy stacks.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
1. kubermatic-installer: --helm-values can now be specified multiple times to load multiple values files in the specified order (later files overwrite earlier ones). 
2. As is usual with Helm, lists/arrays are not merged, but replaced by later files.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
see PR: https://github.com/kubermatic/docs/pull/2046
```
