### PR TITLE
added ability to provide override custom arguments for IAP deployment

### DIFF
--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -58,9 +58,13 @@ spec:
         - --reverse-proxy=true
         - --skip-provider-button=true
         - --config=/config/config.toml
-        {{- $extraArgs := .extraArgs | default $.Values.iap.extraArgs }}
-        {{- if $extraArgs }}
-        {{- range $arg := $extraArgs }}
+        {{- if $.Values.iap.extraArgs }}
+        {{- range $arg := $.Values.iap.extraArgs }}
+        - {{ $arg }}
+        {{- end }}
+        {{- end }}
+        {{- if .extraArgs }}
+        {{- range $arg := .extraArgs }}
         - {{ $arg }}
         {{- end }}
         {{- end }}

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -58,6 +58,12 @@ spec:
         - --reverse-proxy=true
         - --skip-provider-button=true
         - --config=/config/config.toml
+        {{- $extraArgs := .extraArgs | default $.Values.iap.extraArgs }}
+        {{- if $extraArgs }}
+        {{- range $arg := $extraArgs }}
+        - {{ $arg }}
+        {{- end }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: iap-{{ .name }}-secret

--- a/charts/iap/test/values.extraArgs.yaml
+++ b/charts/iap/test/values.extraArgs.yaml
@@ -21,7 +21,7 @@ iap:
       client_secret: xxx
       encryption_key: xxx
       extraArgs:
-        - --custom-value=overridden-for-alertmanager
+        - --arg2=added-for-alertmanager
       config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
         scope: "groups openid email"
         email_domains:
@@ -66,7 +66,7 @@ iap:
         class: "nginx"
 
   extraArgs:
-    - --custom-value=common-for-all-deployments
+    - --arg1=added-in-all-deployments
 
   certIssuer:
     name: letsencrypt-prod

--- a/charts/iap/test/values.extraArgs.yaml
+++ b/charts/iap/test/values.extraArgs.yaml
@@ -1,0 +1,81 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iap:
+  deployments:
+    alertmanager:
+      name: alertmanager
+      replicas: 3
+      client_id: alertmanager
+      client_secret: xxx
+      encryption_key: xxx
+      extraArgs:
+        - --custom-value=overridden-for-alertmanager
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## example configuration allowing access only to the mygroup from mygithuborg organization
+        github_org: mygithuborg
+        github_team: mygroup
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/-/healthy'
+      upstream_service: alertmanager.monitoring.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        ## optional name of an existing TLS secret that needs to attached with ingress for this iap deployment.
+        tlsSecretName: ""
+        host: "alertmanager.kubermatic.tld"
+        annotations: {}
+        ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+        class: "nginx"
+    #
+    grafana:
+      name: grafana
+      client_id: grafana
+      client_secret: xxx
+      encryption_key: xxx
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/api/health'
+        ## auto-register users based on their email address
+        ## Grafana is configured to look for the X-Forwarded-Email header
+        pass_user_headers: true
+      upstream_service: grafana.monitoring.svc.cluster.local
+      upstream_port: 3000
+      ingress:
+        host: "grafana.kubermatic.tld"
+        annotations: {}
+        ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
+        class: "nginx"
+
+  extraArgs:
+    - --custom-value=common-for-all-deployments
+
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 25Mi
+    limits:
+      cpu: 100m
+      memory: 50Mi

--- a/charts/iap/test/values.extraArgs.yaml.out
+++ b/charts/iap/test/values.extraArgs.yaml.out
@@ -1,0 +1,465 @@
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-alertmanager
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-alertmanager-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: YWxlcnRtYW5hZ2Vy
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-grafana-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: Z3JhZmFuYQ==
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-alertmanager-configmap
+data:
+  config.toml: |
+    approval_prompt = "none"
+    email_domains = ["*"]
+    github_org = "mygithuborg"
+    github_team = "mygroup"
+    scope = "groups openid email"
+    skip_auth_regex = ["/-/healthy"]
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-grafana-configmap
+data:
+  config.toml: |
+    approval_prompt = "none"
+    email_domains = ["*"]
+    pass_user_headers = true
+    scope = "groups openid email"
+    skip_auth_regex = ["/api/health"]
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: alertmanager
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: grafana
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-alertmanager
+  labels:
+    app: iap
+    target: alertmanager
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: alertmanager
+      annotations:
+        checksum/config: bfef6acd1069e36a2f1d4de5289a013d7ac9a961289aa780a3c1486bcfe75314
+        checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://alertmanager.monitoring.svc.cluster.local:9093
+        - --cookie-name=alertmanager_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.toml
+        - --custom-value=overridden-for-alertmanager
+        envFrom:
+        - secretRef:
+            name: iap-alertmanager-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: iap-alertmanager-configmap
+          items:
+          - key: config.toml
+            path: config.toml
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: alertmanager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-grafana
+  labels:
+    app: iap
+    target: grafana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: grafana
+      annotations:
+        checksum/config: bfef6acd1069e36a2f1d4de5289a013d7ac9a961289aa780a3c1486bcfe75314
+        checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://grafana.monitoring.svc.cluster.local:3000
+        - --cookie-name=grafana_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.toml
+        - --custom-value=common-for-all-deployments
+        envFrom:
+        - secretRef:
+            name: iap-grafana-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: iap-grafana-configmap
+          items:
+          - key: config.toml
+            path: config.toml
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: grafana
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - secretName: alertmanager-tls
+    hosts:
+    - alertmanager.kubermatic.tld
+  rules:
+  - host: alertmanager.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: alertmanager-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - secretName: grafana-tls
+    hosts:
+    - grafana.kubermatic.tld
+  rules:
+  - host: grafana.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/configmaps.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/deployments.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/ingresses.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/pdbs.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/secrets.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/services.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/iap/test/values.extraArgs.yaml.out
+++ b/charts/iap/test/values.extraArgs.yaml.out
@@ -153,7 +153,8 @@ spec:
         - --reverse-proxy=true
         - --skip-provider-button=true
         - --config=/config/config.toml
-        - --custom-value=overridden-for-alertmanager
+        - --arg1=added-in-all-deployments
+        - --arg2=added-for-alertmanager
         envFrom:
         - secretRef:
             name: iap-alertmanager-secret
@@ -255,7 +256,7 @@ spec:
         - --reverse-proxy=true
         - --skip-provider-button=true
         - --config=/config/config.toml
-        - --custom-value=common-for-all-deployments
+        - --arg1=added-in-all-deployments
         envFrom:
         - secretRef:
             name: iap-grafana-secret

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -69,16 +69,24 @@ iap:
     #     class: "nginx"
 
   # extraArgs allows specifying additional arguments to the oauth2-proxy container for each deployment.
+  # you can have "global" extra args that apply to all deployments, and also
+  # per-deployment extra args that can be added on top of global ones.
+  # Extra caution must be taken to not specify the same argument both globally and
+  # per-deployment, as this would lead to duplicate arguments in the container
+  # and cause unexpected results.
   # Example:
-  # deployments:
-  #   grafana:
-  #     extraArgs:
-  #       - --session-cookie-minimal=true
-  #
-  # Or set globally for all deployments (can be overridden per deployment):
+
+  # Global extraArags
   # extraArgs:
   #   - --session-cookie-minimal=true
   extraArgs: []
+
+  # deployments:
+  #   grafana:
+  #     # deployment specific extraArgs
+  #     extraArgs:
+  #       - --session-cookie-minimal=true
+
     #
     # grafana:
     #   name: grafana

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -67,6 +67,18 @@ iap:
     #     annotations: {}
     #     ## (Optional) Allow setting the value for ingressClassName to the different ingress controller such as "cilium". Default is set to "nginx"
     #     class: "nginx"
+
+  # extraArgs allows specifying additional arguments to the oauth2-proxy container for each deployment.
+  # Example:
+  # deployments:
+  #   grafana:
+  #     extraArgs:
+  #       - --session-cookie-minimal=true
+  #
+  # Or set globally for all deployments (can be overridden per deployment):
+  # extraArgs:
+  #   - --session-cookie-minimal=true
+  extraArgs: []
     #
     # grafana:
     #   name: grafana


### PR DESCRIPTION
This change will enable to use appropriate parameter from wide range of supported parameters from oauth2-proxy application

**What this PR does / why we need it**:
Currently, a customer is facing issues in using oauth2-proxy since they have a really large no of headers to forward - which do not fit in 4kb cookie. There is a option available in oauth2-proxy which can help us get past this hurdle. But we do not support providing additional params in oauth2-proxy pod currently.

This PR provide ability to provide generic extraArgs for all deployments configured via IAP chart or we can also specify extraArgs just for one of the deployments. If both extraArgs are provided the one specified for a specific deployment will have priority in that deployment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # NA

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Users can now configure additional arguments to oauth2-proxy pods. (useful for seed and user-mla)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

As a example,

Lets say, you want to add below args to ALL IAP container
`- --session-cookie-minimal=true`
Then you can add a below additional section in your values.yaml for IAP section

```yaml
# values.yaml / values-user-mla.yaml
iap:
  extraArgs:
    - --session-cookie-minimal=true
```

You can also do the same only for one of the IAP deployment e.g. alertmanager:
```yaml
# values.yaml / values-user-mla.yaml
iap:
  deployments:
    alertmanager:
      extraArgs:
        - --session-cookie-minimal=true
```
