### PR TITLE
Set emulation in kubevirt to allow it to run nested virtualized envs

### DIFF
--- a/charts/local-kubevirt/templates/kubevirt-cr.yaml
+++ b/charts/local-kubevirt/templates/kubevirt-cr.yaml
@@ -21,6 +21,7 @@ spec:
   certificateRotateStrategy: {}
   configuration:
     developerConfiguration:
+      useEmulation: {{ .Values.localKubevirt.useEmulation | default false }}
       featureGates: []
   customizeComponents: {}
   imagePullPolicy: IfNotPresent

--- a/charts/local-kubevirt/values.yaml
+++ b/charts/local-kubevirt/values.yaml
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+localKubevirt:
+  useEmulation: false

--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -29,6 +29,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -224,9 +225,28 @@ func ensureResource(kubeClient ctrlruntimeclient.Client, logger *logrus.Logger, 
 	}
 }
 
-func installKubevirt(logger *logrus.Logger, dir string, helmClient helm.Client, opt LocalOptions) {
+func installKubevirt(logger *logrus.Logger, helmClient helm.Client, opt LocalOptions) {
 	logger.Info("Installing KubeVirt…")
-	err := helmClient.InstallChart("kubevirt", "kubevirt", filepath.Join(opt.ChartsDirectory, "local-kubevirt"), "", nil, []string{"--create-namespace"})
+
+	var helmValues map[string]string = nil
+
+	// check the OS; if it is NOT Linux (e.g., 'darwin' for macOS), enable kubevirt emulation.
+	// reference: https://kubevirt.io/quickstart_kind/
+	if runtime.GOOS != "linux" {
+		logger.Info("enabling KubeVirt emulation.")
+
+		helmValues = make(map[string]string)
+		helmValues["localKubevirt.useEmulation"] = "true"
+	}
+
+	err := helmClient.InstallChart(
+		"kubevirt",
+		"kubevirt",
+		filepath.Join(opt.ChartsDirectory, "local-kubevirt"),
+		"",
+		helmValues,
+		[]string{"--create-namespace"},
+	)
 	if err != nil {
 		logger.Fatalf("Failed to install KubeVirt Helm client: %v", err)
 	}
@@ -446,7 +466,7 @@ func localKindFunc(logger *logrus.Logger, opt LocalOptions) cobraFuncE {
 				helmVersion,
 			)
 		}
-		installKubevirt(logger, exampleDir, helmClient, opt)
+		installKubevirt(logger, helmClient, opt)
 		endpoint := installKubermatic(logger, exampleDir, kubeClient, helmClient, opt)
 		logger.Infoln()
 		logger.Infof("KKP installed successfully, login at http://%v", endpoint)


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR sets `useEmulation` configuration based on OS.
In case of non-linux environments, since 'kind' runs in a virtualized environment, we need to enable kubevirt's emulation.
This is needed for macOS devices, even though emulation affects performance.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set emulation for non-Linux local development environments
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
