### PR TITLE
Introduce cluster and project id as env var for machine controller(KubeVirt Provider_

### DIFF
--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -916,6 +916,8 @@ func (d *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 	}
 	if cluster.Spec.Cloud.Kubevirt != nil {
 		vars = append(vars, corev1.EnvVar{Name: "KUBEVIRT_KUBECONFIG", ValueFrom: refTo(KubeVirtKubeconfig)})
+		vars = append(vars, corev1.EnvVar{Name: "PROJECT_ID", Value: cluster.Labels["project-id"]})
+		vars = append(vars, corev1.EnvVar{Name: "CLUSTER_ID", Value: cluster.Name})
 	}
 	if cluster.Spec.Cloud.Alibaba != nil {
 		vars = append(vars, corev1.EnvVar{Name: "ALIBABA_ACCESS_KEY_ID", ValueFrom: refTo(AlibabaAccessKeyID)})


### PR DESCRIPTION
**What this PR does / why we need it**:
We have introduced two new env vars in machine controller for the KubeVirt provider, cluster id and project id. These two values then, are gonna be introduced as labels on the KubeVirt VMs.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding new env vars for KubeVirt provider in machine controller 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
