### PR TITLE
[user-mla] Moved the memcached images to bitnamilegacy until we upgrade the cortex helm-chart

### DIFF
--- a/charts/mla/cortex/test/config.yaml.out
+++ b/charts/mla/cortex/test/config.yaml.out
@@ -1243,7 +1243,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
+          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1374,7 +1374,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
+          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1505,7 +1505,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
+          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/charts/mla/cortex/test/config.yaml.out
+++ b/charts/mla/cortex/test/config.yaml.out
@@ -1243,7 +1243,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
+          image: docker.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1374,7 +1374,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
+          image: docker.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1505,7 +1505,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
+          image: docker.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/charts/mla/cortex/test/default.yaml.out
+++ b/charts/mla/cortex/test/default.yaml.out
@@ -1243,7 +1243,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
+          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1374,7 +1374,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
+          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1505,7 +1505,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/kubermatic-mirror/images/memcached:1.6.19-debian-11-r0
+          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/charts/mla/cortex/test/default.yaml.out
+++ b/charts/mla/cortex/test/default.yaml.out
@@ -1243,7 +1243,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
+          image: docker.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1374,7 +1374,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
+          image: docker.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -1505,7 +1505,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: memcached
-          image: quay.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
+          image: docker.io/bitnamilegacy/memcached:1.6.19-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/charts/mla/cortex/values.yaml
+++ b/charts/mla/cortex/values.yaml
@@ -349,6 +349,9 @@ cortex:
         name: "cortex-runtime-config"
   memcached-blocks-index:
     enabled: true
+    # TODO: TEMP Until we upgrade to latest cortex helm chart
+    image:
+      repository: bitnamilegacy/memcached
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     # Note: this is specifically customized in kubermatic. So keeping it that way.
@@ -357,6 +360,9 @@ cortex:
         cpu: 5m
   memcached-blocks:
     enabled: true
+    # TODO: TEMP Until we upgrade to latest cortex helm chart
+    image:
+      repository: bitnamilegacy/memcached
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     # Note: this is specifically customized in kubermatic. So keeping it that way.
@@ -365,6 +371,9 @@ cortex:
         cpu: 5m
   memcached-blocks-metadata:
     enabled: true
+    # TODO: TEMP Until we upgrade to latest cortex helm chart
+    image:
+      repository: bitnamilegacy/memcached
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     # Note: this is specifically customized in kubermatic. So keeping it that way.

--- a/charts/mla/cortex/values.yaml
+++ b/charts/mla/cortex/values.yaml
@@ -351,6 +351,7 @@ cortex:
     enabled: true
     # TODO: TEMP Until we upgrade to latest cortex helm chart
     image:
+      registry: docker.io
       repository: bitnamilegacy/memcached
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
@@ -362,6 +363,7 @@ cortex:
     enabled: true
     # TODO: TEMP Until we upgrade to latest cortex helm chart
     image:
+      registry: docker.io
       repository: bitnamilegacy/memcached
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
@@ -373,6 +375,7 @@ cortex:
     enabled: true
     # TODO: TEMP Until we upgrade to latest cortex helm chart
     image:
+      registry: docker.io
       repository: bitnamilegacy/memcached
     podAnnotations:
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
Our cortex helm-chart uses bitnami/memcached images which are not available anymore. This PR moves those images to refer from bitnamilegacy until we get to upgrading the cortex chart to it's latest versions.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cortex memcached image is now served from bitnamilegacy docker repo as a interim measure
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
