### PR TITLE
Add pod security admission labels for user cluster namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/hashicorp/golang-lru/arc/v2 v2.0.7
 	github.com/opencontainers/image-spec v1.1.0
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/pod-security-admission v0.31.0
 )
 
 require (
@@ -488,7 +489,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/kube-proxy v0.31.1 // indirect
 	k8s.io/kubelet v0.31.1 // indirect
-	k8s.io/pod-security-admission v0.31.0 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect
 	oras.land/oras-go v1.2.6 // indirect
 	sigs.k8s.io/gateway-api v1.3.0 // indirect

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
+	"maps"
 	"net"
 	"strings"
 
@@ -951,9 +952,7 @@ func psaPrivilegedLabeler(namespace string) reconciling.NamedNamespaceReconciler
 			if ns.Labels == nil {
 				ns.Labels = make(map[string]string)
 			}
-			for k, v := range resources.PSALabelsPrivileged() {
-				ns.Labels[k] = v
-			}
+			maps.Copy(ns.Labels, resources.PSALabelsPrivileged())
 			return ns, nil
 		}
 	}
@@ -966,9 +965,7 @@ func psaBaselineLabeler(namespace string) reconciling.NamedNamespaceReconcilerFa
 			if ns.Labels == nil {
 				ns.Labels = make(map[string]string)
 			}
-			for k, v := range resources.PSALabelsBaseline() {
-				ns.Labels[k] = v
-			}
+			maps.Copy(ns.Labels, resources.PSALabelsBaseline())
 			return ns, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/namespace.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cloudinitsettings
 
 import (
+	"maps"
+
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -29,9 +31,7 @@ func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 		if ns.Labels == nil {
 			ns.Labels = make(map[string]string)
 		}
-		for k, v := range resources.PSALabelsPrivileged() {
-			ns.Labels[k] = v
-		}
+		maps.Copy(ns.Labels, resources.PSALabelsPrivileged())
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/cloudinitsettings/namespace.go
@@ -26,6 +26,12 @@ import (
 // NamespaceReconciler creates the namespace for CloudInitSettingsNamespace.
 func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 	return resources.CloudInitSettingsNamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		for k, v := range resources.PSALabelsPrivileged() {
+			ns.Labels[k] = v
+		}
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gatekeeper
 
 import (
+	"maps"
+
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -31,9 +33,7 @@ func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 			ns.Labels = make(map[string]string)
 		}
 		ns.Labels[resources.GatekeeperExemptNamespaceLabel] = "true"
-		for k, v := range resources.PSALabelsPrivileged() {
-			ns.Labels[k] = v
-		}
+		maps.Copy(ns.Labels, resources.PSALabelsPrivileged())
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/namespace.go
@@ -31,6 +31,9 @@ func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 			ns.Labels = make(map[string]string)
 		}
 		ns.Labels[resources.GatekeeperExemptNamespaceLabel] = "true"
+		for k, v := range resources.PSALabelsPrivileged() {
+			ns.Labels[k] = v
+		}
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/namespace.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubernetesdashboard
 
 import (
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,12 @@ import (
 // NamespaceReconciler creates the namespace for the Kubernetes Dashboard.
 func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 	return Namespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		for k, v := range resources.PSALabelsBaseline() {
+			ns.Labels[k] = v
+		}
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/namespace.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kubernetesdashboard
 
 import (
+	"maps"
+
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -29,9 +31,7 @@ func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 		if ns.Labels == nil {
 			ns.Labels = make(map[string]string)
 		}
-		for k, v := range resources.PSALabelsBaseline() {
-			ns.Labels[k] = v
-		}
+		maps.Copy(ns.Labels, resources.PSALabelsBaseline())
 		return ns, nil
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
@@ -26,10 +26,12 @@ import (
 
 func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 	return resources.UserClusterMLANamespace, func(ns *corev1.Namespace) (*corev1.Namespace, error) {
-		if ns.Labels != nil {
-			ns.Labels[common.ComponentLabel] = resources.MLAComponentName
-		} else {
-			ns.SetLabels(map[string]string{common.ComponentLabel: resources.MLAComponentName})
+		if ns.Labels == nil {
+			ns.Labels = make(map[string]string)
+		}
+		ns.Labels[common.ComponentLabel] = resources.MLAComponentName
+		for k, v := range resources.PSALabelsPrivileged() {
+			ns.Labels[k] = v
 		}
 		return ns, nil
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/namespace.go
@@ -17,6 +17,8 @@ limitations under the License.
 package mla
 
 import (
+	"maps"
+
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -30,9 +32,7 @@ func NamespaceReconciler() (string, reconciling.NamespaceReconciler) {
 			ns.Labels = make(map[string]string)
 		}
 		ns.Labels[common.ComponentLabel] = resources.MLAComponentName
-		for k, v := range resources.PSALabelsPrivileged() {
-			ns.Labels[k] = v
-		}
+		maps.Copy(ns.Labels, resources.PSALabelsPrivileged())
 		return ns, nil
 	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	certutil "k8s.io/client-go/util/cert"
+	psaapi "k8s.io/pod-security-admission/api"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -403,6 +404,8 @@ const (
 	// CloudInitSettingsNamespace are used in order to reach, authenticate and be authorized by the api server, to fetch
 	// the machine  provisioning cloud-init.
 	CloudInitSettingsNamespace = "cloud-init-settings"
+	// NamespaceNodeLease is the namespace where node lease objects are stored.
+	NamespaceNodeLease = "kube-node-lease"
 	// DefaultOwnerReadOnlyMode represents file mode with read permission for owner only.
 	DefaultOwnerReadOnlyMode = 0400
 
@@ -1796,4 +1799,22 @@ func containsString(s []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// PSALabelsPrivileged returns Pod Security Admission labels for privileged level.
+func PSALabelsPrivileged() map[string]string {
+	return map[string]string{
+		psaapi.EnforceLevelLabel: string(psaapi.LevelPrivileged),
+		psaapi.AuditLevelLabel:   string(psaapi.LevelBaseline),
+		psaapi.WarnLevelLabel:    string(psaapi.LevelPrivileged),
+	}
+}
+
+// PSALabelsBaseline returns Pod Security Admission labels for baseline level.
+func PSALabelsBaseline() map[string]string {
+	return map[string]string{
+		psaapi.EnforceLevelLabel: string(psaapi.LevelBaseline),
+		psaapi.AuditLevelLabel:   string(psaapi.LevelBaseline),
+		psaapi.WarnLevelLabel:    string(psaapi.LevelBaseline),
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds pod security admission labels to KKP managed namespaces in user clusters to address CIS Kubernetes Benchmark sections 5.2.x (Pod Security) compliance requirements.

System namespaces (like `kube-system`, `kube-public`, `kube-node-lease`, `cloud-init-settings`, `gatekeeper-system`, `mla-system`) are labeled with `enforce=privileged` and `audit=baseline` to allow privileged workloads.
User namespaces (like `default`, `kubernetes-dashboard`) are labeled with `enforce=baseline` to block privileged containers, hostNetwork, hostPID, and other dangerous pod configurations.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15271

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/2053
```
