### PR TITLE
Fix dashboard-metrics-scraper security context for kubernetes-dashboard namespace workloads

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -115,8 +115,12 @@ func getContainers(imageRewriter registry.ImageRewriter) []corev1.Container {
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:                ptr.To[int64](1001),
 				RunAsGroup:               ptr.To[int64](2001),
+				RunAsNonRoot:             ptr.To(true),
 				ReadOnlyRootFilesystem:   ptr.To(true),
 				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the dashboard-metrics-scraper security context by adding `runAsNonRoot: true` and `capabilities.drop: ["ALL"]`. This improves CIS Kubernetes Benchmark compliance for user workloads (for `kubernetes-dashboard` namespace).

The following CIS checks will be addressed:
- 5.2.7 - Minimize the admission of root containers
- 5.2.9 - Minimize the admission of containers with added capabilities
- 5.2.10 - Minimize the admission of containers with capabilities assigned

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #15076

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed dashboard-metrics-scraper security context with `runAsNonRoot` and dropped `capabilities` for improved CIS compliance.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
