### PR TITLE
Fix local kind command ignoring global flags

### DIFF
--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -114,6 +114,11 @@ func localKindCommand(logger *logrus.Logger, opt LocalOptions) *cobra.Command {
 		Short: "Initialize kind environment for simplified local KKP installation",
 		Long:  "Prepares minimal kind environment and auto-configures a non-production KKP installation for evaluation and development purpose.",
 		PreRun: func(cmd *cobra.Command, args []string) {
+			options.CopyInto(&opt.Options)
+			if opt.HelmBinary == "" {
+				opt.HelmBinary = os.Getenv("HELM_BINARY")
+			}
+
 			_, err := exec.LookPath("kind")
 			if err != nil {
 				logger.Fatalf("failed to find 'kind' binary: %v", err)
@@ -139,7 +144,9 @@ func localKindCommand(logger *logrus.Logger, opt LocalOptions) *cobra.Command {
 				logger.Fatalf("failed to find 'helm' binary: %v", err)
 			}
 		},
-		RunE: localKindFunc(logger, opt),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return localKindFunc(logger, opt)(cmd, args)
+		},
 	}
 	return cmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure global options are copied into local options in RunE hook.

The `local kind` command was failing to respect global flags such as `--charts-directory` because the global options were not being correctly propagated to the command's execution context. This commit ensures that is called within the  hook, guaranteeing that it receives the updated configuration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix local kind command ignoring global flags
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
