### PR TITLE
Add monitoring for Konnectivity server

### DIFF
--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -162,6 +162,9 @@ func knpServerArgs(data *resources.TemplateData, serverCount int32) ([]string, e
 		"--server-port=0",
 		"--agent-port=8132",
 		"--admin-port=8133",
+		// Bind admin server to all interfaces to allow Prometheus scraping.
+		// By default konnectivity binds to localhost only.
+		"--admin-bind-address=0.0.0.0",
 		"--health-port=8134",
 		"--agent-namespace=kube-system",
 		fmt.Sprintf("--agent-service-account=%s", resources.KonnectivityServiceAccountName),

--- a/pkg/resources/konnectivity/sidecar_test.go
+++ b/pkg/resources/konnectivity/sidecar_test.go
@@ -45,6 +45,7 @@ func TestKnpServerArgs(t *testing.T) {
 			"--server-port=0",
 			"--agent-port=8132",
 			"--admin-port=8133",
+			"--admin-bind-address=0.0.0.0",
 			"--health-port=8134",
 			"--agent-namespace=kube-system",
 			fmt.Sprintf("--agent-service-account=%s", resources.KonnectivityServiceAccountName),

--- a/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-edge-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-edge-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-edge-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vcd-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vcd-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vcd-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.31.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.32.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus-externalCloudProvider.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus.yaml
@@ -130,6 +130,38 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+    # scrape Konnectivity server metrics from apiserver pods
+    - job_name: konnectivity-server
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+          - "cluster-de-test-01"
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        action: keep
+        regex: apiserver
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: keep
+        regex: konnectivity-server
+      - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: $1:8133
+        target_label: __address__
+      - target_label: __metrics_path__
+        replacement: /metrics
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+      - target_label: job
+        replacement: konnectivity-server
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.
@@ -691,6 +723,50 @@ data:
           message: The kubelet on {{ $labels.kubernetes_io_hostname }} could not be scraped.
         expr: up{job="kubernetes-nodes"} == 0
         for: 15m
+        labels:
+          severity: warning
+
+    - name: kubermatic.konnectivity
+      rules:
+      - record: job:konnectivity_ready_backend_connections:count
+        expr: konnectivity_network_proxy_server_ready_backend_connections
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_dial_failure_rate:by_reason
+        expr: sum(rate(konnectivity_network_proxy_server_dial_failure_count[5m])) by (reason)
+        labels:
+          kubermatic: federate
+
+      - record: job:konnectivity_network_proxy_server_full_receive_channels:sum
+        expr: sum(konnectivity_network_proxy_server_full_receive_channels)
+        labels:
+          kubermatic: federate
+
+      - alert: KonnectivityNoAgents
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has no Konnectivity agents connected. New tunnels cannot be established.'
+        expr: |
+          job:konnectivity_ready_backend_connections:count == 0
+        for: 2m
+        labels:
+          severity: critical
+
+      - alert: KonnectivityAgentsUnhealthy
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has only {{ $value }} Konnectivity agent(s) connected (expected: 2).'
+        expr: |
+          job:konnectivity_ready_backend_connections:count < 2
+        for: 3m
+        labels:
+          severity: warning
+
+      - alert: KonnectivityHighDialFailureRate
+        annotations:
+          message: 'Cluster {{ $labels.cluster }} has {{ $value | humanize }} dial failures/sec (reason: {{ $labels.reason }}). Check agent and node health.'
+        expr: |
+          job:konnectivity_dial_failure_rate:by_reason > 0.1
+        for: 10m
         labels:
           severity: warning
 metadata:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver-externalCloudProvider.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-apiserver.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver-externalCloudProvider.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver-externalCloudProvider.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver-externalCloudProvider.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver.yaml
@@ -63,6 +63,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-edge-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver-externalCloudProvider.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver.yaml
@@ -62,6 +62,7 @@ spec:
         - --server-port=0
         - --agent-port=8132
         - --admin-port=8133
+        - --admin-bind-address=0.0.0.0
         - --health-port=8134
         - --agent-namespace=kube-system
         - --agent-service-account=system-konnectivity-agent


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds monitoring and alerting for the Konnectivity network proxy service. The Konnectivity server sidecar now exposes metrics on admin port 8133, which are scraped by user cluster Prometheus and federated to seed cluster Prometheus for centralized monitoring across all user clusters.

This addresses issue #15269 by providing visibility into Konnectivity health through three recording rules (ready agents count, dial failure rate by reason, and full receive channels) and three alerts (no agents, unhealthy agents, and high dial failure rate).

**Which issue(s) this PR fixes**:
Fixes #15269

**What type of PR is this?**:
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Konnectivity server metrics are now scraped and federated to seed Prometheus. New alerts notify administrators when Konnectivity agents are unavailable or experiencing high dial failure rates.
```

**Documentation**:
```documentation
TBD
```
