### PR TITLE
Create shared scheme setup helper for kubermatic-installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -25,13 +25,11 @@ import (
 	"time"
 
 	semverlib "github.com/Masterminds/semver/v3"
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/zapr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
-	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/stack/common"
@@ -44,7 +42,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/flagopts"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -236,6 +233,10 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 			return fmt.Errorf("failed to construct mgr: %w", err)
 		}
 
+		if err := setupKubermaticInstallerScheme(mgr); err != nil {
+			return fmt.Errorf("failed to setup installer scheme: %w", err)
+		}
+
 		// start the manager in its own goroutine
 		appContext := context.Background()
 
@@ -280,18 +281,6 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 		}
 
 		logger.Info("✅ Provided configuration is valid.")
-
-		if err := apiextensionsv1.AddToScheme(mgr.GetScheme()); err != nil {
-			return fmt.Errorf("failed to add scheme: %w", err)
-		}
-
-		if err := kubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
-			return fmt.Errorf("failed to add scheme: %w", err)
-		}
-
-		if err := certmanagerv1.AddToScheme(mgr.GetScheme()); err != nil {
-			return fmt.Errorf("failed to add scheme: %w", err)
-		}
 
 		// prepare seed access components
 		seedsGetter, err := seedsGetterFactory(appContext, kubeClient)

--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -203,6 +203,10 @@ func localKind(logger *logrus.Logger, dir string) (ctrlruntimeclient.Client, con
 		logger.Fatalf("failed to construct mgr: %v", err)
 	}
 
+	if err := setupKubermaticInstallerScheme(mgr); err != nil {
+		logger.Fatalf("failed to setup installer scheme: %v", err)
+	}
+
 	go func() {
 		if err := mgr.Start(appContext); err != nil {
 			logger.Fatalf("Failed to start Kubernetes client manager: %v", err)

--- a/cmd/kubermatic-installer/scheme.go
+++ b/cmd/kubermatic-installer/scheme.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// setupKubermaticInstallerScheme adds all required API types to the manager's scheme.
+// This includes KKP types, cert-manager and apiextensions.
+func setupKubermaticInstallerScheme(mgr manager.Manager) error {
+	if err := kubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("failed to add Kubermatic v1 scheme: %w", err)
+	}
+
+	if err := certmanagerv1.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("failed to add cert-manager v1 scheme: %w", err)
+	}
+
+	if err := apiextensionsv1.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("failed to add apiextensions v1 scheme: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `deploy` and `local` commands both needed to register API types with the manager's scheme, but the setup was duplicated and placed at different points in the initialization flow.
As a result `local kind` command was failing due to unregistered scheme type

This change introduces `setupKubermaticInstallerScheme()`, a shared helper that registers kubermatic, cert-manager, and apiextensions types immediately after manager creation. Schemes must be registered before mgr.Start() so the client cache knows about all required types during synchronization.

Removes duplicated code from cmd_deploy.go and adds missing scheme setup to cmd_local.go.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The installer now uses a consistent scheme setup for both `deploy` and `local kind` commands.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
