### PR TITLE
Fix status update for KubermaticConfiguration spec

### DIFF
--- a/pkg/controller/util/status.go
+++ b/pkg/controller/util/status.go
@@ -128,7 +128,7 @@ func UpdateKubermaticConfigurationStatus(ctx context.Context,
 		}
 
 		// update the status
-		return client.Patch(ctx, kc, ctrlruntimeclient.MergeFrom(original))
+		return client.Status().Patch(ctx, kc, ctrlruntimeclient.MergeFrom(original))
 	})
 }
 


### PR DESCRIPTION


**What this PR does / why we need it**:

`UpdateKubermaticConfigurationStatus` incorrectly patches the entire object instead of only the status subresource. When the `kc-status-controller` updates the edition and version fields, any unset fields in the retrieved object overwrite the original spec, causing some configurations to be lost.

This changes the patch call from `client.Patch()` to `client.Status().Patch()`, matching the pattern used by all other status update functions in the codebase.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
