### PR TITLE
Revert "Add EnableThrottling Flag to NotificationOptions (#15274)"

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -277,10 +277,6 @@ spec:
                 notifications:
                   description: Notifications are the configuration for notifications on dashboard.
                   properties:
-                    enableThrottling:
-                      default: false
-                      description: EnableThrottling limits the frequency of notifications to prevent noise.
-                      type: boolean
                     hideErrorEvents:
                       description: HideErrorEvents will silence error events for the dashboard.
                       type: boolean

--- a/sdk/apis/kubermatic/v1/settings.go
+++ b/sdk/apis/kubermatic/v1/settings.go
@@ -202,10 +202,6 @@ type NotificationsOptions struct {
 	HideErrors bool `json:"hideErrors,omitempty"`
 	// HideErrorEvents will silence error events for the dashboard.
 	HideErrorEvents bool `json:"hideErrorEvents,omitempty"`
-	// EnableThrottling limits the frequency of notifications to prevent noise.
-	// +kubebuilder:default=false
-	// +optional
-	EnableThrottling bool `json:"enableThrottling,omitempty"`
 }
 
 type ProviderConfiguration struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

  This PR reverts the addition of the EnableThrottling flag from NotificationOptions in the KubermaticSettings CRD. The flag was originally added to limit the frequency of notifications to prevent noise, but is being removed as UI PR is also closed due to following [reasons](https://github.com/kubermatic/dashboard/pull/7733#issuecomment-3689244150): 


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
NONE

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
