### PR TITLE
Migrate grafana agent to grafana alloy in usercluster

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
@@ -33,26 +33,26 @@ import (
 )
 
 const (
-	imageName     = "grafana/agent"
-	imageTag      = "v0.29.0"
+	imageName     = "grafana/alloy"
+	imageTag      = "v1.9.2"
 	appName       = "mla-logging-agent"
-	containerName = "grafana-agent"
+	containerName = "grafana-alloy"
 
 	reloaderImageName = "prometheus-operator/prometheus-config-reloader"
 	reloaderTag       = "v0.60.1"
 
 	configVolumeName         = "config"
-	configVolumeMountPath    = "/etc/agent"
-	configFileName           = "agent.yaml"
+	configVolumeMountPath    = "/etc/alloy"
+	configFileName           = "config.alloy"
 	certificatesVolumeName   = "certificates"
 	runVolumeName            = "run"
-	runVolumeMountPath       = "/run/grafana-agent"
+	runVolumeMountPath       = "/run/grafana-alloy"
 	containerVolumeName      = "containers"
 	containerVolumeMountPath = "/var/lib/docker/containers"
 	podVolumeName            = "pods"
 	podVolumeMountPath       = "/var/log/pods"
 	metricsPortName          = "http-metrics"
-	containerPort            = 3101
+	containerPort            = 12345
 )
 
 var (
@@ -97,9 +97,11 @@ func DaemonSetReconciler(overrides *corev1.ResourceRequirements, imageRewriter r
 					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s:%s", imageName, imageTag))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
-						fmt.Sprintf("-config.file=%s/%s", configVolumeMountPath, configFileName),
-						fmt.Sprintf("-server.http.address=0.0.0.0:%d", containerPort),
-						"-disable-reporting",
+						"run",
+						fmt.Sprintf("%s/%s", configVolumeMountPath, configFileName),
+						fmt.Sprintf("--server.http.listen-addr=0.0.0.0:%d", containerPort),
+						"--storage.path=/tmp/alloy",
+						"--stability.level=generally-available",
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes grafana agent to grafana alloy in userclusters 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15244

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
I am using the same Grafana Alloy that we are using in seed : v1.9.2 
BTW The latest version is v1.12.2
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace Grafana Agent with Grafana Alloy in User Clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
