### PR TITLE
Fix undeleted etcd-launcher ServiceAccount in kube-system

### DIFF
--- a/pkg/clusterdeletion/deletion.go
+++ b/pkg/clusterdeletion/deletion.go
@@ -75,6 +75,11 @@ func (d *Deletion) CleanupCluster(ctx context.Context, log *zap.SugaredLogger, c
 		return err
 	}
 
+	// Cleanup ServiceAccounts
+	if err := d.cleanupServiceAccounts(ctx, cluster); err != nil {
+		return err
+	}
+
 	if err := d.cleanupNodes(ctx, cluster); err != nil {
 		return err
 	}

--- a/pkg/clusterdeletion/serviceaccounts.go
+++ b/pkg/clusterdeletion/serviceaccounts.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdeletion
+
+import (
+	"context"
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// cleanupServiceAccounts removes ServiceAccounts created outside the cluster namespace.
+// Specifically, it removes the etcd-launcher ServiceAccount from the kube-system namespace.
+// This cleanup is part of the namespace cleanup finalizer since these resources are cluster-wide
+// and created during cluster setup.
+func (d *Deletion) cleanupServiceAccounts(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	// Delete etcd-launcher ServiceAccount from kube-system namespace
+	saName := fmt.Sprintf("%s-%s", rbac.EtcdLauncherServiceAccountName, cluster.Name)
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: metav1.NamespaceSystem,
+		},
+	}
+
+	err := d.seedClient.Delete(ctx, sa)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete ServiceAccount %s/%s: %w", metav1.NamespaceSystem, saName, err)
+	}
+
+	if err == nil {
+		d.recorder.Eventf(cluster, corev1.EventTypeNormal, "ServiceAccountCleanup", "Deleted ServiceAccount %s from namespace %s", saName, metav1.NamespaceSystem)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that etcd-launcher service account in kube-system is deleted, once the cluster object is deleted! 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15290

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix undeleted etcd-launcher ServiceAccount in kube-system
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
