### PR TITLE
Skip monitoring controller reconciliation when MLA monitoring is disabled

### DIFF
--- a/cmd/conformance-tester/pkg/clients/client_kube.go
+++ b/cmd/conformance-tester/pkg/clients/client_kube.go
@@ -192,6 +192,12 @@ func (c *kubeClient) CreateCluster(ctx context.Context, log *zap.SugaredLogger, 
 		cluster.Spec.ClusterNetwork.IPFamily = kubermaticv1.IPFamilyDualStack
 	}
 
+	// Enable MLA monitoring for e2e tests
+	cluster.Spec.MLA = &kubermaticv1.MLASettings{
+		MonitoringEnabled: true,
+		LoggingEnabled:    false,
+	}
+
 	if err := c.opts.SeedClusterClient.Create(ctx, cluster); err != nil {
 		return nil, fmt.Errorf("failed to create cluster: %w", err)
 	}

--- a/cmd/conformance-tester/pkg/tests/metrics.go
+++ b/cmd/conformance-tester/pkg/tests/metrics.go
@@ -54,6 +54,12 @@ func TestUserClusterMetrics(ctx context.Context, log *zap.SugaredLogger, opts *c
 		return nil
 	}
 
+	// Skip if monitoring is disabled in MLA
+	if cluster.Spec.MLA != nil && !cluster.Spec.MLA.MonitoringEnabled {
+		log.Info("Monitoring is disabled in MLA, skipping prometheus metrics test.")
+		return nil
+	}
+
 	log.Info("Testing user cluster metrics availability...")
 
 	res := opts.SeedGeneratedClient.CoreV1().RESTClient().Get().

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -51,9 +51,10 @@ const (
 	ControllerName  = "kkp-addoninstaller-controller"
 	addonDefaultKey = ".spec.isDefault"
 
-	kubeProxyAddonName = "kube-proxy"
-	openVPNAddonName   = "openvpn"
-	CSIAddonName       = "csi"
+	kubeStatsMetricsAddonName = "kube-state-metrics"
+	kubeProxyAddonName        = "kube-proxy"
+	openVPNAddonName          = "openvpn"
+	CSIAddonName              = "csi"
 )
 
 type Reconciler struct {
@@ -317,6 +318,10 @@ func skipAddonInstallation(addon kubermaticv1.Addon, cluster *kubermaticv1.Clust
 	}
 	if addon.Name == CSIAddonName && cluster.Spec.DisableCSIDriver {
 		return true // skip csi driver installation if DisableCSIDriver is true
+	}
+
+	if addon.Name == kubeStatsMetricsAddonName && !cluster.Spec.MLA.MonitoringEnabled {
+		return true // skip kube-stats-metrics if monitoring is disabled
 	}
 	return false
 }

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -160,7 +160,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log = log.With("cluster", cluster.Name)
 
 	// Skip reconciling if monitoring is disabled in MLA
-	if !cluster.Spec.MLA.MonitoringEnabled {
+	if cluster.Spec.MLA != nil && !cluster.Spec.MLA.MonitoringEnabled {
 		log.Debug("Skipping cluster reconciling because monitoring is disabled in MLA")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -159,6 +159,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	log = log.With("cluster", cluster.Name)
 
+	// Skip reconciling if monitoring is disabled in MLA
+	if !cluster.Spec.MLA.MonitoringEnabled {
+		log.Debug("Skipping cluster reconciling because monitoring is disabled in MLA")
+		return reconcile.Result{}, nil
+	}
+
 	if cluster.DeletionTimestamp != nil {
 		// Cluster got deleted - all monitoring components will be automatically garbage collected (Due to the ownerRef)
 		return reconcile.Result{}, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -533,7 +533,6 @@ func (r *reconciler) reconcileRoleBindings(ctx context.Context, data reconcileDa
 
 func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileData) error {
 	creators := []reconciling.NamedClusterRoleReconcilerFactory{
-		kubestatemetrics.ClusterRoleReconciler(),
 		prometheus.ClusterRoleReconciler(),
 		machinecontroller.ClusterRoleReconciler(),
 		dnatcontroller.ClusterRoleReconciler(),
@@ -556,6 +555,7 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileDa
 	}
 	if r.userClusterMLA.Monitoring {
 		creators = append(creators, mlamonitoringagent.ClusterRoleReconciler())
+		creators = append(creators, kubestatemetrics.ClusterRoleReconciler())
 	}
 
 	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r); err != nil {
@@ -566,7 +566,6 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileDa
 
 func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context, data reconcileData) error {
 	creators := []reconciling.NamedClusterRoleBindingReconcilerFactory{
-		kubestatemetrics.ClusterRoleBindingReconciler(),
 		prometheus.ClusterRoleBindingReconciler(),
 		machinecontroller.ClusterRoleBindingReconciler(),
 		machinecontroller.NodeBootstrapperClusterRoleBindingReconciler(),
@@ -597,6 +596,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context, data reco
 
 	if r.userClusterMLA.Monitoring {
 		creators = append(creators, mlamonitoringagent.ClusterRoleBindingReconciler())
+		creators = append(creators, kubestatemetrics.ClusterRoleBindingReconciler())
 	}
 
 	if r.isKonnectivityEnabled {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR skips deploying kube-state-metrics when MLA monitoring is disabled.

The main motivation is that the monitoring controller was reconciling monitoring components even when MLA monitoring was explicitly disabled on the cluster.

During the investigation, I found that our E2E tests create clusters without MLA enabled, while the conformance tester still checks for Prometheus metrics availability. This used to work because monitoring reconciliation always ran, meaning Prometheus and kube-state-metrics were deployed regardless of the MLA setting.

To fix this properly, the conformance tester was updated to create clusters with MLA enabled, monitoring reconciliation is now skipped when MLA is disabled, and metrics availability checks are no longer executed for clusters without MLA monitoring enabled.

As a result, we now explicitly ensure that MLA monitoring is enabled before triggering the monitoring reconciliation logic.

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15155

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed unexpected kube-state-metrics and Prometheus deployments by skipping monitoring reconciliation and metrics checks when MLA monitoring is disabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
