### PR TITLE
Mirror Images CMD: Filtering providers

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -113,7 +113,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 
 	cmd.PersistentFlags().StringVar(&opt.Config, "config", "", "Path to the KubermaticConfiguration YAML file")
 	cmd.PersistentFlags().StringVar(&opt.VersionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
-	cmd.PersistentFlags().StringArrayVar(&opt.ProviderFilter, "provider-filter", nil, "Cloud providers to mirror images for (e.g., 'aws', 'azure', 'kubevirt'). Can be specified multiple times or as comma-separated values. If not specified, images for all providers will be mirrored")
+	cmd.PersistentFlags().StringArrayVar(&opt.ProviderFilter, "provider-filter", nil, fmt.Sprintf("Cloud providers to mirror images for. Valid values are: %s. Can be specified multiple times. If not specified, images for all providers will be mirrored", strings.Join(allSupportedProviderNames(), ", ")))
 	cmd.PersistentFlags().StringVar(&opt.RegistryPrefix, "registry-prefix", "", "Check source registries against this prefix and only include images that match it")
 	cmd.PersistentFlags().StringVar(&opt.LoadFrom, "load-from", "", "Path to an image-archive to (up)load to the provided registry")
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")

--- a/cmd/kubermatic-installer/cmd_mirror_images_test.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images_test.go
@@ -25,49 +25,61 @@ import (
 func TestParseProviderFilter(t *testing.T) {
 	testCases := []struct {
 		name          string
-		input         string
+		input         []string
 		expectedCount int
 		expectError   bool
 	}{
 		{
 			name:          "empty filter returns nil",
-			input:         "",
+			input:         []string{},
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name:          "nil filter returns nil",
+			input:         nil,
 			expectedCount: 0,
 			expectError:   false,
 		},
 		{
 			name:          "single valid provider",
-			input:         "aws",
+			input:         []string{"aws"},
 			expectedCount: 1,
 			expectError:   false,
 		},
 		{
 			name:          "multiple valid providers",
-			input:         "aws,azure,kubevirt",
+			input:         []string{"aws", "azure", "kubevirt"},
 			expectedCount: 3,
 			expectError:   false,
 		},
 		{
 			name:          "mixed case providers",
-			input:         "AWS,Azure,KubeVirt",
+			input:         []string{"AWS", "Azure", "KubeVirt"},
 			expectedCount: 3,
 			expectError:   false,
 		},
 		{
 			name:          "providers with spaces",
-			input:         " aws , azure , kubevirt ",
+			input:         []string{" aws ", " azure ", " kubevirt "},
 			expectedCount: 3,
 			expectError:   false,
 		},
 		{
 			name:          "invalid provider",
-			input:         "aws,invalid-provider,azure",
+			input:         []string{"aws", "invalid-provider", "azure"},
 			expectedCount: 0,
 			expectError:   true,
 		},
 		{
 			name:          "duplicate providers",
-			input:         "aws,azure,aws",
+			input:         []string{"aws", "azure", "aws"},
+			expectedCount: 2,
+			expectError:   false,
+		},
+		{
+			name:          "empty strings in slice",
+			input:         []string{"aws", "", "azure"},
 			expectedCount: 2,
 			expectError:   false,
 		},

--- a/cmd/kubermatic-installer/cmd_mirror_images_test.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestParseProviderFilter(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         string
+		expectedCount int
+		expectError   bool
+	}{
+		{
+			name:          "empty filter returns nil",
+			input:         "",
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name:          "single valid provider",
+			input:         "aws",
+			expectedCount: 1,
+			expectError:   false,
+		},
+		{
+			name:          "multiple valid providers",
+			input:         "aws,azure,kubevirt",
+			expectedCount: 3,
+			expectError:   false,
+		},
+		{
+			name:          "mixed case providers",
+			input:         "AWS,Azure,KubeVirt",
+			expectedCount: 3,
+			expectError:   false,
+		},
+		{
+			name:          "providers with spaces",
+			input:         " aws , azure , kubevirt ",
+			expectedCount: 3,
+			expectError:   false,
+		},
+		{
+			name:          "invalid provider",
+			input:         "aws,invalid-provider,azure",
+			expectedCount: 0,
+			expectError:   true,
+		},
+		{
+			name:          "duplicate providers",
+			input:         "aws,azure,aws",
+			expectedCount: 2,
+			expectError:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := parseProviderFilter(tc.input)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tc.expectedCount == 0 && result != nil {
+				t.Errorf("expected nil result for empty filter, got %v", result)
+				return
+			}
+
+			if tc.expectedCount > 0 {
+				if result == nil {
+					t.Errorf("expected non-nil result, got nil")
+					return
+				}
+
+				if result.Len() != tc.expectedCount {
+					t.Errorf("expected %d providers, got %d: %v", tc.expectedCount, result.Len(), sets.List(result))
+				}
+			}
+		})
+	}
+}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -826,6 +826,25 @@ func GetCloudSpecs() []kubermaticv1.CloudSpec {
 	}
 }
 
+// GetFilteredCloudSpecs filters the cloud specs based on the provider filter.
+// If providerFilter is nil or empty, all cloud specs are returned.
+func GetFilteredCloudSpecs(providerFilter sets.Set[string]) []kubermaticv1.CloudSpec {
+	allSpecs := GetCloudSpecs()
+
+	if providerFilter == nil || providerFilter.Len() == 0 {
+		return allSpecs
+	}
+
+	var filtered []kubermaticv1.CloudSpec
+	for _, spec := range allSpecs {
+		if providerFilter.Has(spec.ProviderName) {
+			filtered = append(filtered, spec)
+		}
+	}
+
+	return filtered
+}
+
 // list all the supported CNI plugins along with their supported versions.
 func GetCNIPlugins() []*kubermaticv1.CNIPluginSettings {
 	cniPluginSettings := []*kubermaticv1.CNIPluginSettings{}

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -64,8 +64,7 @@ const (
 	DefaultKubeconfigFieldPath = "kubeconfig"
 )
 
-var SupportedProviders = []ProviderType{
-	AKSCloudProvider,
+var InfrastructureProviders = []ProviderType{
 	AlibabaCloudProvider,
 	AnexiaCloudProvider,
 	AWSCloudProvider,
@@ -74,10 +73,7 @@ var SupportedProviders = []ProviderType{
 	BringYourOwnCloudProvider,
 	DigitaloceanCloudProvider,
 	EdgeCloudProvider,
-	EKSCloudProvider,
-	FakeCloudProvider,
 	GCPCloudProvider,
-	GKECloudProvider,
 	HetznerCloudProvider,
 	KubevirtCloudProvider,
 	NutanixCloudProvider,
@@ -85,6 +81,20 @@ var SupportedProviders = []ProviderType{
 	VMwareCloudDirectorCloudProvider,
 	VSphereCloudProvider,
 }
+
+var ManagedKubernetesProviders = []ProviderType{
+	AKSCloudProvider,
+	EKSCloudProvider,
+	GKECloudProvider,
+}
+
+var SupportedProviders = append(
+	InfrastructureProviders,
+	append(
+		ManagedKubernetesProviders,
+		FakeCloudProvider,
+	)...,
+)
 
 func IsProviderSupported(name string) bool {
 	for _, provider := range SupportedProviders {

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	"cmp"
 	"fmt"
+	"slices"
 	"strings"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -88,13 +90,20 @@ var ManagedKubernetesProviders = []ProviderType{
 	GKECloudProvider,
 }
 
-var SupportedProviders = append(
-	InfrastructureProviders,
-	append(
-		ManagedKubernetesProviders,
-		FakeCloudProvider,
-	)...,
-)
+var SupportedProviders = func() []ProviderType {
+	providers := append(
+		InfrastructureProviders,
+		append(
+			ManagedKubernetesProviders,
+			FakeCloudProvider,
+		)...)
+
+	slices.SortFunc(providers, func(a, b ProviderType) int {
+		return cmp.Compare(string(a), string(b))
+	})
+
+	return providers
+}()
 
 func IsProviderSupported(name string) bool {
 	for _, provider := range SupportedProviders {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `--provider-filter` in the mirror-images command to mirror the desired provider images 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--provider-filter` in the mirror-images command to mirror the desired provider images 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
