### PR TITLE
Add status subresource to KubermaticConfiguration CRD

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -3370,4 +3370,5 @@ spec:
           type: object
       served: true
       storage: true
-      subresources: {}
+      subresources:
+        status: {}

--- a/sdk/apis/kubermatic/v1/configuration.go
+++ b/sdk/apis/kubermatic/v1/configuration.go
@@ -71,6 +71,7 @@ const (
 
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 // KubermaticConfiguration is the configuration required for running Kubermatic.


### PR DESCRIPTION
**What this PR does / why we need it**:
Our `post-kubermatic-deploy-dev` is broken. This is because of the changes made to the `kc-status-controller` patching the status subresource while that subresource didn't exist. The CI was reporting: `existing installation uses the Community Edition, refusing to change to Enterprise Edition`. The `kc-status-controller` is responsible for updating ` KubermaticConfiguration.Status.KubermaticEdition`. The PR #15291 correctly changed this to update the status but the CRD was missing the field. Master controller manager was showing errors and as a result the status wasn't being patched, hence the installer having the edition mismatch.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
