### PR TITLE
Reconcile audit logging configuration from Seed to existing User Cluster

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -25,6 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addoninstaller"
 	applicationsecretclustercontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/application-secret-cluster-controller"
+	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller"
 	autoupdatecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/auto-update-controller"
 	cloudcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cloud"
 	clustercredentialscontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/cluster-credentials-controller"
@@ -87,6 +88,7 @@ var AllControllers = map[string]controllerCreator{
 	defaultapplicationcontroller.ControllerName:             createDefaultApplicationController,
 	clustercredentialscontroller.ControllerName:             createClusterCredentialsController,
 	applicationsecretclustercontroller.ControllerName:       createApplicationSecretClusterController,
+	auditloggingenforcement.ControllerName:                  createAuditLoggingEnforcementController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -500,5 +502,15 @@ func createApplicationSecretClusterController(ctrlCtx *controllerContext) error 
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.runOptions.namespace,
+	)
+}
+
+func createAuditLoggingEnforcementController(ctrlCtx *controllerContext) error {
+	return auditloggingenforcement.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.seedGetter,
+		ctrlCtx.runOptions.workerCount,
 	)
 }

--- a/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auditloggingenforcement
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// ControllerName is the name of this controller.
+	ControllerName = "kkp-audit-logging-enforcement-controller"
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	recorder                record.EventRecorder
+	seedGetter              provider.SeedGetter
+	seedClient              ctrlruntimeclient.Client
+}
+
+// Add creates a new audit logging enforcement controller.
+func Add(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	seedGetter provider.SeedGetter,
+	numWorkers int,
+) error {
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		recorder:                mgr.GetEventRecorderFor(ControllerName),
+		seedGetter:              seedGetter,
+		seedClient:              mgr.GetClient(),
+	}
+
+	// Handler to enqueue all clusters when a Seed is updated
+	seedHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+		seed, ok := obj.(*kubermaticv1.Seed)
+		if !ok {
+			return nil
+		}
+
+		log.Debugw("Seed handler triggered", "seed", seed.Name)
+
+		// List all clusters and enqueue those using this seed's datacenters
+		clusterList := &kubermaticv1.ClusterList{}
+		if err := reconciler.seedClient.List(ctx, clusterList, &ctrlruntimeclient.ListOptions{LabelSelector: workerSelector}); err != nil {
+			log.Errorw("Failed to list clusters for seed update", zap.Error(err))
+			utilruntime.HandleError(fmt.Errorf("failed to list clusters: %w", err))
+			return nil
+		}
+
+		log.Debugw("Found clusters for potential reconciliation", "count", len(clusterList.Items))
+
+		var requests []reconcile.Request
+		for _, cluster := range clusterList.Items {
+			if cluster.Spec.Cloud.DatacenterName == "" {
+				continue
+			}
+
+			// Check if this cluster's datacenter is in the updated seed
+			if _, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]; found {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name: cluster.Name,
+					},
+				})
+				log.Debugw("Enqueuing cluster for reconciliation", "cluster", cluster.Name, "datacenter", cluster.Spec.Cloud.DatacenterName)
+			}
+		}
+
+		log.Debugw("Total clusters enqueued for reconciliation", "count", len(requests))
+		return requests
+	})
+
+	_, err = builder.ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(&kubermaticv1.Cluster{}, builder.WithPredicates(workerlabel.Predicate(workerName), clusterAuditLoggingPredicate())).
+		Watches(&kubermaticv1.Seed{}, seedHandler, builder.WithPredicates(seedAuditLoggingPredicate(reconciler))).
+		Build(reconciler)
+
+	return err
+}
+
+// clusterAuditLoggingPredicate filters cluster events to only trigger on relevant changes.
+func clusterAuditLoggingPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// Always process new clusters
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, ok := e.ObjectOld.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			newCluster, ok := e.ObjectNew.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+
+			// Reconcile if audit logging configuration changed
+			if !reflect.DeepEqual(oldCluster.Spec.AuditLogging, newCluster.Spec.AuditLogging) {
+				return true
+			}
+
+			// Reconcile if opt-out annotation changed
+			if oldCluster.Annotations[kubermaticv1.SkipAuditLoggingEnforcementAnnotation] !=
+				newCluster.Annotations[kubermaticv1.SkipAuditLoggingEnforcementAnnotation] {
+				return true
+			}
+
+			// Reconcile if pause status changed
+			if oldCluster.Spec.Pause != newCluster.Spec.Pause {
+				return true
+			}
+
+			// Reconcile if datacenter changed
+			if oldCluster.Spec.Cloud.DatacenterName != newCluster.Spec.Cloud.DatacenterName {
+				return true
+			}
+
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Don't reconcile on deletion
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// seedAuditLoggingPredicate filters seed events to only trigger on audit logging changes for the specific seed.
+func seedAuditLoggingPredicate(r *reconciler) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// Only process the seed this controller is responsible for
+			seed, ok := e.Object.(*kubermaticv1.Seed)
+			if !ok {
+				return false
+			}
+
+			// Get our seed name lazily
+			ourSeed, err := r.seedGetter()
+			if err != nil {
+				r.log.Debugw("Seed predicate CreateFunc: failed to get our seed", zap.Error(err))
+				return false
+			}
+
+			if ourSeed.Name != seed.Name {
+				r.log.Debugw("Seed predicate CreateFunc: skipping different seed",
+					"ourSeed", ourSeed.Name, "eventSeed", seed.Name)
+				return false
+			}
+
+			// Process new seeds with audit logging configuration
+			result := seed.Spec.AuditLogging != nil
+			r.log.Debugw("Seed predicate CreateFunc", "seed", seed.Name, "allowed", result)
+			return result
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSeed, ok := e.ObjectOld.(*kubermaticv1.Seed)
+			if !ok {
+				return false
+			}
+			newSeed, ok := e.ObjectNew.(*kubermaticv1.Seed)
+			if !ok {
+				return false
+			}
+
+			// Get our seed name lazily
+			ourSeed, err := r.seedGetter()
+			if err != nil {
+				r.log.Debugw("Seed predicate UpdateFunc: failed to get our seed", zap.Error(err))
+				return false
+			}
+
+			if ourSeed.Name != oldSeed.Name {
+				r.log.Debugw("Seed predicate UpdateFunc: skipping different seed",
+					"ourSeed", ourSeed.Name, "eventSeed", oldSeed.Name)
+				return false
+			}
+
+			// Trigger if audit logging configuration changed
+			// Use field-by-field comparison instead of reflect.DeepEqual to handle omitempty tags correctly
+			auditLoggingChanged := auditLoggingSettingsChanged(oldSeed.Spec.AuditLogging, newSeed.Spec.AuditLogging)
+
+			// Debug: Always log the comparison details to understand what's happening
+			r.log.Debugw("Seed predicate UpdateFunc: comparing audit logging configs",
+				"seed", newSeed.Name,
+				"oldConfigPtr", fmt.Sprintf("%p", oldSeed.Spec.AuditLogging),
+				"newConfigPtr", fmt.Sprintf("%p", newSeed.Spec.AuditLogging),
+				"oldConfigNil", oldSeed.Spec.AuditLogging == nil,
+				"newConfigNil", newSeed.Spec.AuditLogging == nil,
+				"oldConfig", oldSeed.Spec.AuditLogging,
+				"newConfig", newSeed.Spec.AuditLogging,
+				"changed", auditLoggingChanged)
+
+			if auditLoggingChanged {
+				r.log.Infow("Seed predicate UpdateFunc: audit logging config changed",
+					"seed", newSeed.Name,
+					"oldConfig", oldSeed.Spec.AuditLogging,
+					"newConfig", newSeed.Spec.AuditLogging)
+				return true
+			}
+
+			// Trigger if any datacenter's enforceAuditLogging flag changed
+			for dcName, newDC := range newSeed.Spec.Datacenters {
+				oldDC, exists := oldSeed.Spec.Datacenters[dcName]
+				if !exists || oldDC.Spec.EnforceAuditLogging != newDC.Spec.EnforceAuditLogging {
+					r.log.Infow("Seed predicate UpdateFunc: datacenter enforceAuditLogging changed",
+						"seed", newSeed.Name,
+						"datacenter", dcName,
+						"oldValue", oldDC.Spec.EnforceAuditLogging,
+						"newValue", newDC.Spec.EnforceAuditLogging)
+					return true
+				}
+			}
+
+			r.log.Debugw("Seed predicate UpdateFunc: no relevant changes", "seed", newSeed.Name)
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// auditLoggingSettingsChanged compares two AuditLoggingSettings field-by-field.
+// This avoids issues with reflect.DeepEqual and omitempty JSON tags where
+// false values are omitted during serialization, making {} appear equal to {enabled: false}.
+func auditLoggingSettingsChanged(old, current *kubermaticv1.AuditLoggingSettings) bool {
+	// If both are nil, no change
+	if old == nil && current == nil {
+		return false
+	}
+	// If one is nil and the other is not, there's a change
+	if (old == nil) != (current == nil) {
+		return true
+	}
+
+	// Compare individual fields explicitly
+	if old.Enabled != current.Enabled {
+		return true
+	}
+	if old.PolicyPreset != current.PolicyPreset {
+		return true
+	}
+	// Use reflect.DeepEqual for complex nested structs (SidecarSettings, WebhookBackend)
+	if !reflect.DeepEqual(old.SidecarSettings, current.SidecarSettings) {
+		return true
+	}
+	if !reflect.DeepEqual(old.WebhookBackend, current.WebhookBackend) {
+		return true
+	}
+
+	return false
+}
+
+// Reconcile enforces audit logging configuration from Seed to User Clusters.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request.Name)
+	log.Debug("Reconciling audit logging enforcement")
+
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, cluster); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	err := r.reconcile(ctx, cluster, log)
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "AuditLoggingEnforcementError", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, log *zap.SugaredLogger) error {
+	// Skip if cluster is being deleted
+	if !cluster.DeletionTimestamp.IsZero() {
+		log.Debug("Cluster is being deleted, skipping")
+		return nil
+	}
+
+	// Skip if cluster is paused
+	if cluster.Spec.Pause {
+		log.Debug("Cluster is paused, skipping")
+		return nil
+	}
+
+	// Skip if cluster has opt-out annotation
+	if cluster.Annotations[kubermaticv1.SkipAuditLoggingEnforcementAnnotation] == "true" {
+		log.Debug("Cluster has opt-out annotation, skipping enforcement")
+		return nil
+	}
+
+	// Get the seed for this cluster
+	if cluster.Spec.Cloud.DatacenterName == "" {
+		log.Debug("Cluster has no datacenter name, skipping")
+		return nil
+	}
+
+	seed, err := r.seedGetter()
+	if err != nil {
+		return fmt.Errorf("failed to get seed: %w", err)
+	}
+
+	// Get the datacenter to check enforcement flag
+	datacenter, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]
+	if !found {
+		log.Debug("Cluster's datacenter not found in seed, skipping")
+		return nil
+	}
+
+	// Skip enforcement if seed has no audit logging configuration
+	// This prevents accidentally removing audit logging from clusters when the seed config is empty
+	seedAuditLogging := seed.Spec.AuditLogging
+	if seedAuditLogging == nil {
+		log.Debug("Seed has no audit logging configuration, skipping enforcement")
+		return nil
+	}
+
+	// Determine the desired audit logging configuration based on enforcement flag
+	var desiredAuditLogging *kubermaticv1.AuditLoggingSettings
+	if datacenter.Spec.EnforceAuditLogging {
+		// When enforcement is enabled, copy the seed's audit logging configuration
+		desiredAuditLogging = seedAuditLogging.DeepCopy()
+	} else {
+		// When enforcement is disabled, explicitly disable audit logging
+		desiredAuditLogging = &kubermaticv1.AuditLoggingSettings{
+			Enabled: false,
+		}
+	}
+
+	clusterAuditLogging := cluster.Spec.AuditLogging
+
+	if reflect.DeepEqual(desiredAuditLogging, clusterAuditLogging) {
+		log.Debug("Cluster audit logging configuration already matches desired state, no update needed")
+		return nil
+	}
+
+	// Update cluster's audit logging configuration
+	if datacenter.Spec.EnforceAuditLogging {
+		log.Infow("Enforcing audit logging configuration from seed", "seed", seed.Name)
+	} else {
+		log.Infow("Disabling audit logging as enforcement is disabled for datacenter", "datacenter", cluster.Spec.Cloud.DatacenterName)
+	}
+
+	oldCluster := cluster.DeepCopy()
+	cluster.Spec.AuditLogging = desiredAuditLogging
+
+	if err := r.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+		return fmt.Errorf("failed to update cluster audit logging configuration: %w", err)
+	}
+
+	if datacenter.Spec.EnforceAuditLogging {
+		r.recorder.Eventf(cluster, corev1.EventTypeNormal, "AuditLoggingEnforced",
+			"Audit logging configuration enforced from seed %s", seed.Name)
+	} else {
+		r.recorder.Eventf(cluster, corev1.EventTypeNormal, "AuditLoggingDisabled",
+			"Audit logging disabled as enforcement is disabled for datacenter %s", cluster.Spec.Cloud.DatacenterName)
+	}
+
+	log.Info("Successfully updated audit logging configuration")
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auditloggingenforcement
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/test/diff"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+	"k8c.io/kubermatic/v2/pkg/test/generator"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	datacenterName = "test-dc"
+	seedName       = "test-seed"
+)
+
+func TestReconcile(t *testing.T) {
+	// This test verifies the audit logging enforcement controller behavior.
+	// The controller updates the Cluster CR's spec.auditLogging field.
+	// The Kubernetes controller (apiserver/deployment.go) then:
+	//   - Reads cluster.Spec.AuditLogging.Enabled
+	//   - When Enabled=true: creates audit ConfigMaps, Secrets, and fluent-bit sidecar
+	//   - When Enabled=false: removes all audit logging resources
+	//   - When nil: no audit logging resources are created
+	// This ensures disabled state (Enabled=false) is properly propagated to user clusters.
+
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	testCases := []struct {
+		name                     string
+		cluster                  *kubermaticv1.Cluster
+		seed                     *kubermaticv1.Seed
+		expectedAuditLogging     *kubermaticv1.AuditLoggingSettings
+		expectUpdate             bool
+		shouldSkipReconciliation bool
+	}{
+		{
+			name:                 "scenario 1: enforce audit logging from seed to cluster",
+			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
+			expectUpdate:         true,
+		},
+		{
+			name:                 "scenario 2: skip enforcement when cluster has opt-out annotation",
+			cluster:              genClusterWithAuditLogging(datacenterName, nil, true),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: nil,
+			expectUpdate:         false,
+		},
+		{
+			name:                 "scenario 3: disable audit logging when datacenter has EnforceAuditLogging disabled",
+			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: false},
+			expectUpdate:         true,
+		},
+		{
+			name:                     "scenario 4: skip enforcement when cluster is paused",
+			cluster:                  genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:                     genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging:     nil,
+			expectUpdate:             false,
+			shouldSkipReconciliation: true,
+		},
+		{
+			name:                 "scenario 5: no update when audit logging already matches",
+			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
+			expectUpdate:         false,
+		},
+		{
+			name:                 "scenario 6: update audit logging policy when seed changes",
+			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyMetadata), false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
+			expectUpdate:         true,
+		},
+		{
+			name:                 "scenario 7: skip enforcement when seed has no audit logging config",
+			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
+			seed:                 genSeedWithAuditLogging(datacenterName, nil, true),
+			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
+			expectUpdate:         false,
+		},
+		{
+			name:                 "scenario 8: enforce disabled state when seed explicitly disables audit logging",
+			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(false, ""), true),
+			expectedAuditLogging: genAuditLoggingSettings(false, ""),
+			expectUpdate:         true,
+		},
+		{
+			name:                 "scenario 9: enforce disabled state with empty policy preset",
+			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
+			seed:                 genSeedWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{Enabled: false}, true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: false},
+			expectUpdate:         true,
+		},
+		{
+			name:                 "scenario 10: enforce when seed has config and datacenter enforcement is enabled",
+			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
+			expectUpdate:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Handle paused cluster scenario
+			if tc.shouldSkipReconciliation {
+				tc.cluster.Spec.Pause = true
+			}
+
+			seedClient := fake.
+				NewClientBuilder().
+				WithObjects(tc.cluster, tc.seed).
+				Build()
+
+			seedGetter := func() (*kubermaticv1.Seed, error) {
+				return tc.seed, nil
+			}
+
+			r := &reconciler{
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				recorder:                &record.FakeRecorder{},
+				seedGetter:              seedGetter,
+				seedClient:              seedClient,
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.cluster.Name}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			// Get the updated cluster
+			updatedCluster := &kubermaticv1.Cluster{}
+			err = seedClient.Get(ctx, types.NamespacedName{Name: tc.cluster.Name}, updatedCluster)
+			if err != nil {
+				t.Fatalf("failed to get cluster: %v", err)
+			}
+
+			// Check if audit logging matches expected
+			if !diff.SemanticallyEqual(tc.expectedAuditLogging, updatedCluster.Spec.AuditLogging) {
+				t.Fatalf("audit logging config mismatch:\n%v", diff.ObjectDiff(tc.expectedAuditLogging, updatedCluster.Spec.AuditLogging))
+			}
+		})
+	}
+}
+
+func genClusterWithAuditLogging(datacenterName string, auditLogging *kubermaticv1.AuditLoggingSettings, optOut bool) *kubermaticv1.Cluster {
+	cluster := generator.GenDefaultCluster()
+	cluster.Spec.Cloud.DatacenterName = datacenterName
+	cluster.Spec.AuditLogging = auditLogging
+
+	if optOut {
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations[kubermaticv1.SkipAuditLoggingEnforcementAnnotation] = "true"
+	}
+
+	return cluster
+}
+
+func genSeedWithAuditLogging(datacenterName string, auditLogging *kubermaticv1.AuditLoggingSettings, enforceAuditLogging bool) *kubermaticv1.Seed {
+	seed := generator.GenTestSeed()
+	seed.Name = seedName
+	seed.Spec.AuditLogging = auditLogging
+	seed.Spec.Datacenters = map[string]kubermaticv1.Datacenter{
+		datacenterName: {
+			Country:  "US",
+			Location: "Test Location",
+			Spec: kubermaticv1.DatacenterSpec{
+				EnforceAuditLogging: enforceAuditLogging,
+			},
+		},
+	}
+	return seed
+}
+
+func genAuditLoggingSettings(enabled bool, policyPreset kubermaticv1.AuditPolicyPreset) *kubermaticv1.AuditLoggingSettings {
+	return &kubermaticv1.AuditLoggingSettings{
+		Enabled:      enabled,
+		PolicyPreset: policyPreset,
+	}
+}

--- a/pkg/webhook/cluster/mutation/mutator.go
+++ b/pkg/webhook/cluster/mutation/mutator.go
@@ -75,7 +75,7 @@ func (m *Mutator) Mutate(ctx context.Context, oldCluster, newCluster *kubermatic
 		return nil, field.InternalError(nil, err)
 	}
 
-	if err := defaulting.DefaultClusterSpec(ctx, &newCluster.Spec, defaultTemplate, seed, config, provider); err != nil {
+	if err := defaulting.DefaultClusterSpec(ctx, &newCluster.Spec, newCluster.Annotations, defaultTemplate, seed, config, provider); err != nil {
 		return nil, field.InternalError(nil, err)
 	}
 

--- a/sdk/apis/kubermatic/v1/common.go
+++ b/sdk/apis/kubermatic/v1/common.go
@@ -82,6 +82,11 @@ const (
 	// SkipRouterReconciliationAnnotation is used to indicate that the router reconciliation should be skipped.
 	// This annotation is currently used exclusively for OpenStack provider.
 	SkipRouterReconciliationAnnotation = "reconciliation.kubermatic.k8c.io/skip-router"
+
+	// SkipAuditLoggingEnforcementAnnotation is used to opt out of automatic audit logging enforcement.
+	// When set to "true", the cluster will not have its audit logging configuration
+	// automatically reconciled from the Seed.
+	SkipAuditLoggingEnforcementAnnotation = "kubermatic.k8c.io/skip-audit-logging-enforcement"
 )
 
 type MachineFlavorFilter struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an Audit Logging Enforcement Controller that reconciles audit logging configuration from the Seed to User Clusters.
- Changes
1. New audit logging enforcement controller in seed-controller-manager
2. Defaulting webhook skips audit logging when cluster has the skip annotation
- Behavior
1. seed.Spec.AuditLogging == nil → Skip (don't touch cluster)
2. datacenter.Spec.EnforceAuditLogging == true → Copy seed's audit logging config to cluster
3. datacenter.Spec.EnforceAuditLogging == false → Set {Enabled: false} on cluster
4. Cluster has kubermatic.k8c.io/skip-audit-logging-enforcement: "true" → Skip (don't touch cluster)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15127

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduced audit logging enforcement for user clusters via a new controller in the seed-controller-manager. Depending on the datacenter configuration, audit logging is either enforced from the seed configuration or explicitly disabled for user clusters. Enforcement is skipped when the seed does not define audit logging or when a user cluster is annotated with `kubermatic.k8c.io/skip-audit-logging-enforcement: "true"`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
