### PR TITLE
[release/v2.29] Add changelogs for KKP patch releases Jan 2026

### DIFF
--- a/docs/changelogs/CHANGELOG-2.28.md
+++ b/docs/changelogs/CHANGELOG-2.28.md
@@ -6,6 +6,16 @@
 - [v2.28.3](#v2283)
 - [v2.28.4](#v2284)
 - [v2.28.5](#v2285)
+- [v2.28.6](#v2286)
+
+## v2.28.6
+
+**GitHub release: [v2.28.6](https://github.com/kubermatic/kubermatic/releases/tag/v2.28.6)**
+
+### Updates
+
+- Update Go version to 1.24.12 ([#15325](https://github.com/kubermatic/kubermatic/pull/15325), [#7781](https://github.com/kubermatic/dashboard/pull/7781))
+- Users can now configure additional arguments to oauth2-proxy pods. (useful for seed and user-mla) ([#15279](https://github.com/kubermatic/kubermatic/pull/15279))
 
 ## v2.28.5
 

--- a/docs/changelogs/CHANGELOG-2.29.md
+++ b/docs/changelogs/CHANGELOG-2.29.md
@@ -3,8 +3,27 @@
 - [v2.29.0](#v2290)
 - [v2.29.1](#v2291)
 - [v2.29.2](#v2292)
+- [v2.29.3](#v2293)
 
-## [v2.29.2](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.2)
+## v2.29.3
+
+**GitHub release: [v2.29.3](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.3)**
+
+### New Features
+
+- Add status conditions for policy binding resources ([#15209](https://github.com/kubermatic/kubermatic/pull/15209))
+
+### Bugfixes
+
+- Fix issue where OIDC kubeconfig downloads would fail with RBAC "Forbidden" errors when the identity provider returns uppercase email addresses ([#7740](https://github.com/kubermatic/dashboard/pull/7740))
+
+### Updates
+
+- Update Go version to 1.25.6 ([#15332](https://github.com/kubermatic/kubermatic/pull/15332), [#7782](https://github.com/kubermatic/dashboard/pull/7782))
+
+## v2.29.2
+
+**GitHub release: [v2.29.2](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.2)**
 
 ### Breaking Changes
 
@@ -30,7 +49,9 @@
 - Update machine-controller to [v1.64.1](https://github.com/kubermatic/machine-controller/releases/tag/v1.64.1) ([#15267](https://github.com/kubermatic/kubermatic/pull/15267))
 - Add support of the latest k8s patch releases v1.34.3/v1.33.7 ([#15239](https://github.com/kubermatic/kubermatic/pull/15239))
 
-## [v2.29.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.1)
+## v2.29.1
+
+**GitHub release: [v2.29.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.1)**
 
 ### Supported Kubernetes Versions
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add changelogs for KKP patch releases v2.29.3/v2.28.6 Jan 2026.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
