### PR TITLE
Add annotation to propagate ReconciliationInterval from ApplicationDefinition to ApplicationInstallation instances

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -193,6 +193,11 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, appI
 		return r.userClient.Delete(ctx, appInstallation)
 	}
 
+	// Sync ReconciliationInterval from ApplicationDefinition annotation to ApplicationInstallation spec
+	if err := r.syncReconciliationInterval(ctx, log, applicationDef, appInstallation); err != nil {
+		return fmt.Errorf("failed to sync reconciliation interval: %w", err)
+	}
+
 	// get applicationVersion. If it can not be found, there are 2 cases:
 	//   1) KKP admin has removed the applicationVersion, and we have to remove the corresponding ApplicationInstallation(s)
 	//   2) User made a mistake, or applicationDefinition has not been synced yet on this seed. So we just notify the user.
@@ -388,6 +393,38 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 func (r *reconciler) traceWarning(appInstallation *appskubermaticv1.ApplicationInstallation, log *zap.SugaredLogger, eventReason, message string) {
 	log.Warn(message)
 	r.userRecorder.Event(appInstallation, corev1.EventTypeWarning, eventReason, message)
+}
+
+// syncReconciliationInterval syncs the ReconciliationInterval from the ApplicationDefinition annotation
+// to the ApplicationInstallation spec. If the annotation is present and the value is different,
+// the ApplicationInstallation is updated.
+func (r *reconciler) syncReconciliationInterval(ctx context.Context, log *zap.SugaredLogger, applicationDef *appskubermaticv1.ApplicationDefinition, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+	intervalStr, ok := applicationDef.Annotations[appskubermaticv1.ApplicationReconciliationIntervalAnnotation]
+	if !ok {
+		// No annotation set, nothing to sync
+		return nil
+	}
+
+	interval, err := time.ParseDuration(intervalStr)
+	if err != nil {
+		log.Warnf("Invalid reconciliation interval annotation %q on ApplicationDefinition %s: %v", intervalStr, applicationDef.Name, err)
+		return nil
+	}
+
+	// Check if the interval is different from the current value
+	if appInstallation.Spec.ReconciliationInterval.Duration == interval {
+		return nil
+	}
+
+	log.Infof("Syncing reconciliation interval from ApplicationDefinition annotation: %v", interval)
+	oldAppInstallation := appInstallation.DeepCopy()
+	appInstallation.Spec.ReconciliationInterval.Duration = interval
+
+	if err := r.userClient.Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+		return fmt.Errorf("failed to update ApplicationInstallation with reconciliation interval: %w", err)
+	}
+
+	return nil
 }
 
 // enqueueAppInstallationForAppDef fan-out updates from applicationDefinition to the ApplicationInstallation that reference

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -471,6 +472,117 @@ func TestHasLimitedRetries(t *testing.T) {
 
 			if got := hasLimitedRetries(appDefinition, appInstallation); got != tt.want {
 				t.Errorf("hasLimitedRetries() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncReconciliationInterval(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		applicationDefinition     *appskubermaticv1.ApplicationDefinition
+		applicationInstallation   *appskubermaticv1.ApplicationInstallation
+		expectedReconcileInterval time.Duration
+		expectUpdate              bool
+	}{
+		{
+			name: "scenario 1: reconciliation interval annotation is synced to application installation",
+			applicationDefinition: func() *appskubermaticv1.ApplicationDefinition {
+				appDef := genApplicationDefinition("app-def-1", nil)
+				appDef.Annotations = map[string]string{
+					appskubermaticv1.ApplicationReconciliationIntervalAnnotation: "10m",
+				}
+				return appDef
+			}(),
+			applicationInstallation:   genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0),
+			expectedReconcileInterval: 10 * time.Minute,
+			expectUpdate:              true,
+		},
+		{
+			name:                      "scenario 2: no annotation means no update",
+			applicationDefinition:     genApplicationDefinition("app-def-1", nil),
+			applicationInstallation:   genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0),
+			expectedReconcileInterval: 0,
+			expectUpdate:              false,
+		},
+		{
+			name: "scenario 3: invalid duration annotation is handled gracefully",
+			applicationDefinition: func() *appskubermaticv1.ApplicationDefinition {
+				appDef := genApplicationDefinition("app-def-1", nil)
+				appDef.Annotations = map[string]string{
+					appskubermaticv1.ApplicationReconciliationIntervalAnnotation: "invalid-duration",
+				}
+				return appDef
+			}(),
+			applicationInstallation:   genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0),
+			expectedReconcileInterval: 0,
+			expectUpdate:              false,
+		},
+		{
+			name: "scenario 4: same value does not trigger update",
+			applicationDefinition: func() *appskubermaticv1.ApplicationDefinition {
+				appDef := genApplicationDefinition("app-def-1", nil)
+				appDef.Annotations = map[string]string{
+					appskubermaticv1.ApplicationReconciliationIntervalAnnotation: "5m",
+				}
+				return appDef
+			}(),
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Spec.ReconciliationInterval.Duration = 5 * time.Minute
+				return appInstall
+			}(),
+			expectedReconcileInterval: 5 * time.Minute,
+			expectUpdate:              false,
+		},
+		{
+			name: "scenario 5: different value triggers update",
+			applicationDefinition: func() *appskubermaticv1.ApplicationDefinition {
+				appDef := genApplicationDefinition("app-def-1", nil)
+				appDef.Annotations = map[string]string{
+					appskubermaticv1.ApplicationReconciliationIntervalAnnotation: "15m",
+				}
+				return appDef
+			}(),
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Spec.ReconciliationInterval.Duration = 5 * time.Minute
+				return appInstall
+			}(),
+			expectedReconcileInterval: 15 * time.Minute,
+			expectUpdate:              true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+			userClient := kubermaticfake.
+				NewClientBuilder().
+				WithObjects(tc.applicationInstallation).
+				Build()
+
+			r := reconciler{
+				log:        kubermaticlog.Logger,
+				seedClient: userClient,
+				userClient: userClient,
+			}
+
+			err := r.syncReconciliationInterval(ctx, kubermaticlog.Logger, tc.applicationDefinition, tc.applicationInstallation)
+			if err != nil {
+				t.Fatalf("syncReconciliationInterval returned error: %v", err)
+			}
+
+			// Fetch the updated application installation
+			updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+			if err := userClient.Get(ctx, types.NamespacedName{Name: tc.applicationInstallation.Name, Namespace: tc.applicationInstallation.Namespace}, updatedAppInstall); err != nil {
+				t.Fatalf("failed to get application installation: %v", err)
+			}
+
+			if updatedAppInstall.Spec.ReconciliationInterval.Duration != tc.expectedReconcileInterval {
+				t.Errorf("expected reconciliation interval %v, got %v", tc.expectedReconcileInterval, updatedAppInstall.Spec.ReconciliationInterval.Duration)
 			}
 		})
 	}

--- a/sdk/apis/apps.kubermatic/v1/types.go
+++ b/sdk/apis/apps.kubermatic/v1/types.go
@@ -43,4 +43,9 @@ const (
 
 	// ApplicationDefaultedAnnotation marks an ApplicationInstallation as defaulted.
 	ApplicationDefaultedAnnotation = "apps.kubermatic.k8c.io/defaulted"
+
+	// ApplicationReconciliationIntervalAnnotation specifies the reconciliation interval
+	// for ApplicationInstallations created from this ApplicationDefinition.
+	// The value should be a valid Go duration string (e.g., "5m", "1h", "30s").
+	ApplicationReconciliationIntervalAnnotation = "apps.kubermatic.k8c.io/reconciliation-interval"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds `apps.kubermatic.k8c.io/reconciliation-interval` annotation support on ApplicationDefinition
- Automatically propagates the interval value to `spec.reconciliationInterval` on all ApplicationInstallations
- Syncs interval to existing ApplicationInstallations via user-cluster controller

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15104

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for `apps.kubermatic.k8c.io/reconciliation-interval` annotation on ApplicationDefinition to automatically set `spec.reconciliationInterval` on all ApplicationInstallations created from that definition.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
