### PR TITLE
Fix helm4 compatibility

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -235,10 +235,9 @@ func (c *cli) GetValues(namespace string, releaseName string) (*yamled.Document,
 }
 
 func (c *cli) Version() (*semverlib.Version, error) {
-	// add --client to gracefully handle Helm 2 (Helm 3 ignores the flag, thankfully);
 	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
 	// Helm-2-style templating string "{{ .Client.SemVer }}"
-	output, err := c.run("", "version", "--client", "--template", "{{ .Version }}")
+	output, err := c.run("", "version", "--template", "{{ .Version }}")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enabled helm4 to work, as helm3 simply ignored this flag, helm4 have dropped it completely and thus having this flag caused errors.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
internal reference: 8842

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix helm4 compatibility
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
