### PR TITLE
Add Gateway API support for IAP resources

### DIFF
--- a/charts/iap/templates/httproutes.yaml
+++ b/charts/iap/templates/httproutes.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.migrateGatewayAPI }}
+{{ range .Values.iap.deployments }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .name }}-iap
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: iap
+    target: {{ .name }}
+    app.kubernetes.io/name: iap
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: helm
+spec:
+  parentRefs:
+    - name: {{ $.Values.httpRoute.gatewayName }}
+      namespace: {{ $.Values.httpRoute.gatewayNamespace }}
+  hostnames:
+    - {{ .ingress.host | trim | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .name }}-iap
+          port: {{ $.Values.iap.port }}
+      timeouts:
+        request: {{ $.Values.httpRoute.timeout }}
+        backendRequest: {{ $.Values.httpRoute.timeout }}
+{{ end }}
+{{- end -}}

--- a/charts/iap/templates/httproutes.yaml
+++ b/charts/iap/templates/httproutes.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.migrateGatewayAPI }}
 {{ range .Values.iap.deployments }}
 ---

--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if not .Values.migrateGatewayAPI }}
 {{ range .Values.iap.deployments }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -56,3 +57,4 @@ spec:
             port:
               number: {{ $.Values.iap.port }}
 {{ end }}
+{{- end }}

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -214,6 +214,21 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Source: iap/templates/httproutes.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 # Source: iap/templates/ingresses.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -402,6 +402,21 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Source: iap/templates/httproutes.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 # Source: iap/templates/ingresses.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #

--- a/charts/iap/test/values.extraArgs.yaml.out
+++ b/charts/iap/test/values.extraArgs.yaml.out
@@ -405,6 +405,21 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Source: iap/templates/httproutes.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 # Source: iap/templates/ingresses.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #

--- a/charts/iap/test/values.httproute.yaml
+++ b/charts/iap/test/values.httproute.yaml
@@ -1,0 +1,72 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+migrateGatewayAPI: true
+
+httpRoute:
+  gatewayName: kubermatic
+  gatewayNamespace: kubermatic
+  timeout: 3600s
+
+iap:
+  deployments:
+    alertmanager:
+      name: alertmanager
+      replicas: 3
+      client_id: alertmanager
+      client_secret: xxx
+      encryption_key: xxx
+      config:
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        skip_auth_regex:
+          - '/-/healthy'
+      upstream_service: alertmanager.monitoring.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        host: "alertmanager.kubermatic.tld"
+        annotations: {}
+        class: "nginx"
+    #
+    grafana:
+      name: grafana
+      client_id: grafana
+      client_secret: xxx
+      encryption_key: xxx
+      config:
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        skip_auth_regex:
+          - '/api/health'
+        pass_user_headers: true
+      upstream_service: grafana.monitoring.svc.cluster.local
+      upstream_port: 3000
+      ingress:
+        host: "grafana.kubermatic.tld"
+        annotations: {}
+        class: "nginx"
+
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 25Mi
+    limits:
+      cpu: 100m
+      memory: 50Mi

--- a/charts/iap/test/values.httproute.yaml.out
+++ b/charts/iap/test/values.httproute.yaml.out
@@ -344,6 +344,21 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Source: iap/templates/httproutes.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 # Source: iap/templates/ingresses.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
 #

--- a/charts/iap/test/values.httproute.yaml.out
+++ b/charts/iap/test/values.httproute.yaml.out
@@ -1,0 +1,465 @@
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-alertmanager
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-alertmanager-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: YWxlcnRtYW5hZ2Vy
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-grafana-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: Z3JhZmFuYQ==
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-alertmanager-configmap
+data:
+  config.toml: |
+    approval_prompt = "none"
+    email_domains = ["*"]
+    scope = "groups openid email"
+    skip_auth_regex = ["/-/healthy"]
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-grafana-configmap
+data:
+  config.toml: |
+    approval_prompt = "none"
+    email_domains = ["*"]
+    pass_user_headers = true
+    scope = "groups openid email"
+    skip_auth_regex = ["/api/health"]
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: alertmanager
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: grafana
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-alertmanager
+  labels:
+    app: iap
+    target: alertmanager
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: alertmanager
+      annotations:
+        checksum/config: e975c82a15ca71267003fa817589461188288686dad076f2fab04768d32d858a
+        checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://alertmanager.monitoring.svc.cluster.local:9093
+        - --cookie-name=alertmanager_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.toml
+        envFrom:
+        - secretRef:
+            name: iap-alertmanager-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: iap-alertmanager-configmap
+          items:
+          - key: config.toml
+            path: config.toml
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: alertmanager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-grafana
+  labels:
+    app: iap
+    target: grafana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: grafana
+      annotations:
+        checksum/config: e975c82a15ca71267003fa817589461188288686dad076f2fab04768d32d858a
+        checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://grafana.monitoring.svc.cluster.local:3000
+        - --cookie-name=grafana_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.toml
+        envFrom:
+        - secretRef:
+            name: iap-grafana-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: iap-grafana-configmap
+          items:
+          - key: config.toml
+            path: config.toml
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: grafana
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/configmaps.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/deployments.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/ingresses.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/pdbs.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/secrets.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/services.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/httproutes.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager-iap
+  namespace: default
+  labels:
+    app: iap
+    target: alertmanager
+    app.kubernetes.io/name: iap
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  parentRefs:
+    - name: kubermatic
+      namespace: kubermatic
+  hostnames:
+    - "alertmanager.kubermatic.tld"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: alertmanager-iap
+          port: 3000
+      timeouts:
+        request: 3600s
+        backendRequest: 3600s
+---
+# Source: iap/templates/httproutes.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana-iap
+  namespace: default
+  labels:
+    app: iap
+    target: grafana
+    app.kubernetes.io/name: iap
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  parentRefs:
+    - name: kubermatic
+      namespace: kubermatic
+  hostnames:
+    - "grafana.kubermatic.tld"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: grafana-iap
+          port: 3000
+      timeouts:
+        request: 3600s
+        backendRequest: 3600s

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Gateway API migration: When true, creates HTTPRoute instead of using Ingress.
+# The HTTPRoutes will attach to the kubermatic Gateway (cross-namespace).
+# The kubermatic-installer automatically labels the namespace for Gateway access.
+migrateGatewayAPI: false
+
+# httpRoute configures HTTPRoute for IAP deployments (only used when migrateGatewayAPI: true)
+httpRoute:
+  # Name of the Gateway to attach to (in kubermatic namespace)
+  gatewayName: kubermatic
+  # Namespace of the Gateway
+  gatewayNamespace: kubermatic
+  # Timeout for requests (matching nginx proxy-read-timeout annotation)
+  timeout: 3600s
+
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy

--- a/pkg/install/stack/seed-mla/stack.go
+++ b/pkg/install/stack/seed-mla/stack.go
@@ -26,6 +26,7 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
@@ -465,6 +466,11 @@ func deployIap(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntime
 
 	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, IAPNamespace); err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	// label the namespace to allow HTTPRoute attachment to the kubermatic Gateway.
+	if err := util.EnsureNamespaceLabel(ctx, kubeClient, IAPNamespace, common.GatewayAccessLabelKey, "true"); err != nil {
+		return fmt.Errorf("failed to label namespace for Gateway access: %w", err)
 	}
 
 	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, IAPNamespace, IAPReleaseName)

--- a/pkg/install/stack/usercluster-mla/stack.go
+++ b/pkg/install/stack/usercluster-mla/stack.go
@@ -26,6 +26,7 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/sirupsen/logrus"
 
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
@@ -435,6 +436,11 @@ func deployMLAIap(ctx context.Context, logger *logrus.Entry, kubeClient ctrlrunt
 
 	if err := util.EnsureNamespace(ctx, sublogger, kubeClient, MLAIAPNamespace); err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	// label the namespace to allow HTTPRoute attachment to the kubermatic Gateway.
+	if err := util.EnsureNamespaceLabel(ctx, kubeClient, MLAIAPNamespace, common.GatewayAccessLabelKey, "true"); err != nil {
+		return fmt.Errorf("failed to label namespace for Gateway access: %w", err)
 	}
 
 	release, err := util.CheckHelmRelease(ctx, sublogger, helmClient, MLAIAPNamespace, MLAIAPReleaseName)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Gateway API support to the IAP resources. When `migrateGatewayAPI: true` is set in the Helm values, HTTPRoute resources are created for each IAP deployment instead of Ingress resources. The installer also labels the IAP namespace with `kubermatic.io/gateway-access=true` to allow cross-namespace HTTPRoute attachment to the kubermatic Gateway.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/15296

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
- Traffic flow was tested in a cluster with Envoy Gateway, HTTPRoutes accepted, traffic routed from GatewayAPI to IAP pods, OIDC redirects to Dex, and endpoints bypassing auth

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Gateway API support to the IAP chart, allowing IAP deployments to use HTTPRoute resources instead of Ingress when migrating to Gateway API.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
