### PR TITLE
Upgrade Konnectivity to align with supported Kubernetes releases

### DIFF
--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -143,12 +143,12 @@ func NetworkProxyVersion(clusterVersion semver.Semver) string {
 	// https://github.com/kubernetes-sigs/apiserver-network-proxy#versioning-and-releases
 
 	switch clusterVersion.MajorMinor() {
-	case "1.30":
-		return "v0.30.3"
-	case "1.31":
-		fallthrough
+	case "1.32":
+		return "v0.32.1"
+	case "1.33":
+		return "v0.33.1"
 	default:
-		return "v0.31.0"
+		return "v0.34.0"
 	}
 }
 

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -34,6 +34,12 @@ const (
 	// defaultXfrChannelSize is the default value for the --xfr-channel-size flag.
 	// It sets the receive channel buffer size for packet handling.
 	defaultXfrChannelSize = 150
+
+	// Supported Kubernetes versions.
+	v132 = "1.32"
+	v133 = "1.33"
+	v134 = "1.34"
+	v135 = "1.35"
 )
 
 var (
@@ -143,10 +149,14 @@ func NetworkProxyVersion(clusterVersion semver.Semver) string {
 	// https://github.com/kubernetes-sigs/apiserver-network-proxy#versioning-and-releases
 
 	switch clusterVersion.MajorMinor() {
-	case "1.32":
+	case v132:
 		return "v0.32.1"
-	case "1.33":
+	case v133:
 		return "v0.33.1"
+	case v134:
+		fallthrough
+	case v135:
+		fallthrough
 	default:
 		return "v0.34.0"
 	}

--- a/pkg/resources/konnectivity/sidecar_test.go
+++ b/pkg/resources/konnectivity/sidecar_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/sdk/v2/semver"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
@@ -349,6 +350,28 @@ func TestKnpServerArgs(t *testing.T) {
 				assert.NoError(t, err)
 				assert.ElementsMatch(t, tt.expectedArgs, args)
 			}
+		})
+	}
+}
+
+func TestNetworkProxyVersion(t *testing.T) {
+	tests := []struct {
+		clusterVersion string
+		expected       string
+	}{
+		{"1.32.0", "v0.32.1"},
+		{"1.32.5", "v0.32.1"},
+		{"1.33.0", "v0.33.1"},
+		{"1.33.3", "v0.33.1"},
+		{"1.34.0", "v0.34.0"},
+		{"1.34.1", "v0.34.0"},
+		{"1.35.0", "v0.34.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.clusterVersion, func(t *testing.T) {
+			v := *semver.NewSemverOrDie(tt.clusterVersion)
+			assert.Equal(t, tt.expected, NetworkProxyVersion(v))
 		})
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-apiserver.yaml
@@ -74,7 +74,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.32.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-apiserver.yaml
@@ -73,7 +73,7 @@ spec:
         - --xfr-channel-size=150
         command:
         - /proxy-server
-        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.31.0
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.34.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades apiserver-network-proxy from v0.31.0 to per Kubernetes minor versions following the upstream versioning convention.  The previous version in our system (v0.31.0) corresponds to Kubernetes 1.31 and has reached EOL. The upstream project recommends using the Konnectivity tag that matches the Kubernetes minor version (xref: https://github.com/kubernetes-sigs/apiserver-network-proxy#versioning-and-releases).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15255

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
- Kubernetes 1.35 is released but apiserver-network-proxy v0.35.x does not exist upstream yet. The default case covers 1.35 and future versions with v0.34.0 until the upstream release is cut.
- Upstream PR https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/751 added a `/metrics` endpoint on the health port in v0.34.0. The admin port retains `/metrics` for backward compatibility. We can technically move Prometheus scraping to the health port in a follow up PR, but IMO that is not required.
- Server, agent, metrics and tunnel connectivity were tested manually on 1.33 and 1.34 clusters.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade Konnectivity proxy to per Kubernetes minor versions. K8s 1.34+ clusters will get v0.34.0 until a corresponding version exists in the upstream.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
