### PR TITLE
Use golangci-lint as an action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,10 @@
+name: setup
+description: "shared setup for Go projects"
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v7
+      with:
+        go-version: 1.26
+        check-latest: true
+        cache: true

--- a/.github/workflows/cis-bench.yml
+++ b/.github/workflows/cis-bench.yml
@@ -130,9 +130,7 @@ jobs:
           echo "IMAGE_REF=quay.io/kubermatic/conformance-ee:${IMAGE_TAG}" >> "$GITHUB_ENV"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+        uses: ./.github/actions/setup
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,28 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  KUBERMATIC_EDITION: ee
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull requests. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.7

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  pull_request:
+
+env:
+  KUBERMATIC_EDITION: ee
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -82,26 +82,6 @@ presubmits:
             - name: KUBERMATIC_EDITION
               value: ee
 
-  - name: pre-kubermatic-lint
-    run_if_changed: "^(cmd/|codegen/|hack/|pkg/|go.mod|go.sum)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-6
-          command:
-            - make
-            - lint
-          resources:
-            requests:
-              memory: 10Gi
-              cpu: 3
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ee
-
   - name: pre-kubermatic-shellcheck
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -82,26 +82,6 @@ presubmits:
             - name: KUBERMATIC_EDITION
               value: ee
 
-  - name: pre-kubermatic-lint
-    run_if_changed: "^(cmd/|codegen/|hack/|pkg/|go.mod|go.sum)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-13
-          command:
-            - make
-            - lint
-          resources:
-            requests:
-              memory: 10Gi
-              cpu: 3
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ee
-
   - name: pre-kubermatic-shellcheck
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces a way to run golangci-lint from running it in prow to GH actions. This gives us code inline comments about lint failures directly in review.

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
