### PR TITLE
Add Seed-configurable replicas for nodeport-proxy envoy

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -670,6 +670,9 @@ spec:
         # This field will be ignored if the cloud-provider does not support the feature.
         # More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
         sourceRanges: []
+      # Replicas sets the number of pod replicas for the nodeport-proxy-envoy deployment.
+      # If unset, 3 replicas are used.
+      replicas: null
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Claims lists the names of resources, defined in spec.resourceClaims,

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -751,6 +751,9 @@ spec:
         # This field will be ignored if the cloud-provider does not support the feature.
         # More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
         sourceRanges: []
+      # Replicas sets the number of pod replicas for the nodeport-proxy-envoy deployment.
+      # If unset, 3 replicas are used.
+      replicas: null
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Claims lists the names of resources, defined in spec.resourceClaims,

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -40,6 +40,7 @@ const (
 	ServiceAccountName    = "nodeport-proxy"
 	EnvoyDeploymentName   = "nodeport-proxy-envoy"
 	UpdaterDeploymentName = "nodeport-proxy-updater"
+	DefaultEnvoyReplicas  = int32(3)
 	EnvoyPort             = 8002
 	EnvoySNIPort          = 6443
 	EnvoyTunnelingPort    = 8088
@@ -48,7 +49,11 @@ const (
 func EnvoyDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed, supportsFailureDomainZoneAntiAffinity bool, versions kubermatic.Versions) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return EnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Spec.Replicas = ptr.To[int32](3)
+			replicas := DefaultEnvoyReplicas
+			if seed.Spec.NodeportProxy.Envoy.Replicas != nil {
+				replicas = *seed.Spec.NodeportProxy.Envoy.Replicas
+			}
+			d.Spec.Replicas = ptr.To(replicas)
 			d.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					common.NameLabel: EnvoyDeploymentName,

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments_test.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeportproxy
+
+import (
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestEnvoyDeploymentReconcilerReplicas(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name              string
+		configuredReplica *int32
+		expectedReplicas  int32
+	}{
+		{
+			name:              "uses default when replicas are not configured",
+			configuredReplica: nil,
+			expectedReplicas:  DefaultEnvoyReplicas,
+		},
+		{
+			name:              "uses configured replicas",
+			configuredReplica: ptr.To[int32](5),
+			expectedReplicas:  5,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			seed := &kubermaticv1.Seed{}
+			seed.Spec.NodeportProxy.Envoy.Replicas = tc.configuredReplica
+
+			_, reconcile := EnvoyDeploymentReconciler(&kubermaticv1.KubermaticConfiguration{}, seed, false, kubermatic.Versions{
+				KubermaticContainerTag: "v0.0.0-test",
+			})()
+
+			reconciled, err := reconcile(&appsv1.Deployment{})
+			if err != nil {
+				t.Fatalf("failed to reconcile deployment: %v", err)
+			}
+
+			if reconciled.Spec.Replicas == nil {
+				t.Fatal("expected deployment replicas to be set")
+			}
+
+			if *reconciled.Spec.Replicas != tc.expectedReplicas {
+				t.Fatalf("unexpected replica count: got %d, want %d", *reconciled.Spec.Replicas, tc.expectedReplicas)
+			}
+		})
+	}
+}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -3576,6 +3576,13 @@ spec:
                                 type: string
                               type: array
                           type: object
+                        replicas:
+                          description: |-
+                            Replicas sets the number of pod replicas for the nodeport-proxy-envoy deployment.
+                            If unset, 3 replicas are used.
+                          format: int32
+                          minimum: 1
+                          type: integer
                         resources:
                           description: Resources describes the requested and maximum allowed CPU/memory usage.
                           properties:

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -407,7 +407,11 @@ type EnvoyLoadBalancerService struct {
 }
 type NodePortProxyComponentEnvoy struct {
 	NodeportProxyComponent `json:",inline"`
-	LoadBalancerService    EnvoyLoadBalancerService `json:"loadBalancerService,omitempty"`
+	// Replicas sets the number of pod replicas for the nodeport-proxy-envoy deployment.
+	// If unset, 3 replicas are used.
+	// +kubebuilder:validation:Minimum:=1
+	Replicas            *int32                   `json:"replicas,omitempty"`
+	LoadBalancerService EnvoyLoadBalancerService `json:"loadBalancerService,omitempty"`
 }
 
 type NodeportProxyComponent struct {

--- a/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -5917,6 +5917,11 @@ func (in *NetworkRanges) DeepCopy() *NetworkRanges {
 func (in *NodePortProxyComponentEnvoy) DeepCopyInto(out *NodePortProxyComponentEnvoy) {
 	*out = *in
 	in.NodeportProxyComponent.DeepCopyInto(&out.NodeportProxyComponent)
+	if in.Replicas != nil {
+		in, out := &in.Replicas, &out.Replicas
+		*out = new(int32)
+		**out = **in
+	}
 	in.LoadBalancerService.DeepCopyInto(&out.LoadBalancerService)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes Seed `nodeport-proxy-envoy` replicas configurable instead of hardcoded, so operators can scale the component based on Seed specific traffic and connection patterns. The replica count was fixed to 3 in code, which limited operational flexibility during high connection or high churn scenarios.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15463

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
- This intentionally keeps the existing default (`3`) when the field is unset.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added optional Seed setting `spec.nodeportProxy.envoy.replicas` to configure the `nodeport-proxy-envoy` replica count. If unset, existing default behavior remains (`3` replicas).
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
