### PR TITLE
[release/v2.28] Add support for the latest k8s patch releases v1.33.8/v1.32.12

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -596,6 +596,7 @@ spec:
       - v1.33.5
       - v1.33.6
       - v1.33.7
+      - v1.33.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -496,7 +496,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.32.10
+    default: v1.32.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -590,6 +590,7 @@ spec:
       - v1.32.7
       - v1.32.9
       - v1.32.10
+      - v1.32.12
       - v1.33.0
       - v1.33.2
       - v1.33.3

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -596,6 +596,7 @@ spec:
       - v1.33.5
       - v1.33.6
       - v1.33.7
+      - v1.33.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -496,7 +496,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.32.10
+    default: v1.32.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -590,6 +590,7 @@ spec:
       - v1.32.7
       - v1.32.9
       - v1.32.10
+      - v1.32.12
       - v1.33.0
       - v1.33.2
       - v1.33.3

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -215,7 +215,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.32.10"),
+		Default: semver.NewSemverOrDie("v1.32.12"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -247,6 +247,7 @@ var (
 			newSemver("v1.32.7"),
 			newSemver("v1.32.9"),
 			newSemver("v1.32.10"),
+			newSemver("v1.32.12"),
 			// Kubernetes 1.33
 			newSemver("v1.33.0"),
 			newSemver("v1.33.2"),

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -254,6 +254,7 @@ var (
 			newSemver("v1.33.5"),
 			newSemver("v1.33.6"),
 			newSemver("v1.33.7"),
+			newSemver("v1.33.8"),
 		},
 		Updates: []kubermaticv1.Update{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support of the latest k8s patch release v1.33.8/v1.32.12

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for the latest k8s patch release v1.33.8 and v1.32.12
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
