### PR TITLE
Fix dualstack e2e test failures caused by Docker Hub rate limiting

### DIFF
--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -340,9 +340,9 @@ func egressValidatorPod(ipVersion int) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  fmt.Sprintf("egress-validator-%d-container", ipVersion),
-					Image: "docker.io/byrnedo/alpine-curl:0.1.8",
+					Image: "quay.io/kubermatic/util:2.7.0",
 					Command: []string{
-						"/bin/ash",
+						"/bin/sh",
 						"-c",
 						"while true; do sleep 1; done",
 					},

--- a/pkg/test/dualstack/egress-validator-4.yaml
+++ b/pkg/test/dualstack/egress-validator-4.yaml
@@ -17,10 +17,10 @@ spec:
   containers:
     - name: egress-validator-4-container
       ports: []
-      image: docker.io/byrnedo/alpine-curl:0.1.8
+      image: quay.io/kubermatic/util:2.7.0
       imagePullPolicy: IfNotPresent
       command:
-        - /bin/ash
+        - /bin/sh
         - -c
         - while true; do sleep 1; done
       readinessProbe:

--- a/pkg/test/dualstack/egress-validator-6.yaml
+++ b/pkg/test/dualstack/egress-validator-6.yaml
@@ -17,10 +17,10 @@ spec:
   containers:
     - name: egress-validator-6-container
       ports: []
-      image: docker.io/byrnedo/alpine-curl:0.1.8
+      image: quay.io/kubermatic/util:2.7.0
       imagePullPolicy: IfNotPresent
       command:
-        - /bin/ash
+        - /bin/sh
         - -c
         - while true; do sleep 1; done
       readinessProbe:

--- a/pkg/test/dualstack/egress-validator-daemonset.yaml
+++ b/pkg/test/dualstack/egress-validator-daemonset.yaml
@@ -30,10 +30,10 @@ spec:
       hostNetwork: false
       containers:
         - name: egress-validator-4-container
-          image: docker.io/byrnedo/alpine-curl:0.1.8
+          image: quay.io/kubermatic/util:2.7.0
           imagePullPolicy: IfNotPresent
           command:
-            - /bin/ash
+            - /bin/sh
             - -c
             - while true; do sleep 1; done
           readinessProbe:
@@ -81,10 +81,10 @@ spec:
       hostNetwork: false
       containers:
         - name: egress-validator-6-container
-          image: docker.io/byrnedo/alpine-curl:0.1.8
+          image: quay.io/kubermatic/util:2.7.0
           imagePullPolicy: IfNotPresent
           command:
-            - /bin/ash
+            - /bin/sh
             - -c
             - while true; do sleep 1; done
           readinessProbe:


### PR DESCRIPTION
**What this PR does / why we need it**:
All PRs with changes in the dualstack e2e tests consistently fail with 429 errors due to Docker Hub's anonymous pull rate limit. This is blocking today's patch release.

The egress validator DaemonSets are using `docker.io/byrnedo/alpine-curl:0.1.8` solely for curl. We already use `quay.io/kubermatic/util:2.7.0` across the codebase which includes curl and isn't subject to Docker Hub's rate limits. This PR switches to it and unblocks the patch release.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
