### PR TITLE
feature(openstack): add LoadBalancer monitor

### DIFF
--- a/pkg/resources/cloudconfig/ini/writer.go
+++ b/pkg/resources/cloudconfig/ini/writer.go
@@ -30,6 +30,7 @@ type File interface {
 type Section interface {
 	AddStringKey(key, value string)
 	AddBoolKey(key string, value bool)
+	AddKey(key string, value any)
 }
 
 type file struct {
@@ -89,6 +90,13 @@ func (s *section) AddBoolKey(key string, value bool) {
 	})
 }
 
+func (s *section) AddKey(key string, value any) {
+	s.pairs = append(s.pairs, &freePair{
+		key:   key,
+		value: value,
+	})
+}
+
 func (s *section) render(out io.Writer) error {
 	if _, err := fmt.Fprintf(out, "[%s]\n", s.name); err != nil {
 		return err
@@ -119,4 +127,13 @@ type boolPair struct {
 
 func (p *boolPair) String() string {
 	return fmt.Sprintf("%s = %s", p.key, strconv.FormatBool(p.value))
+}
+
+type freePair struct {
+	key   string
+	value any
+}
+
+func (p *freePair) String() string {
+	return fmt.Sprintf("%s = %s", p.key, p.value)
 }

--- a/pkg/resources/cloudconfig/openstack/cloudconfig_test.go
+++ b/pkg/resources/cloudconfig/openstack/cloudconfig_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	v1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/cloudconfig/ini"
+)
+
+func checkINI(i ini.File, t *testing.T) {
+	var buffer bytes.Buffer
+	i.Render(&buffer)
+
+	if !regexp.MustCompile(`\[LoadBalancer\]`).MatchString(buffer.String()) {
+		t.Error("CloudConfig INI does not produce \"[LoadBalancer]\" section")
+		t.Error(buffer.String())
+	}
+
+	if !regexp.MustCompile(`create-monitor = true`).MatchString(buffer.String()) {
+		t.Error("CloudConfig INI does not produce values: \"create-monitor = true\"")
+		t.Error(buffer.String())
+	}
+
+	if !regexp.MustCompile(`monitor-delay = 1`).MatchString(buffer.String()) {
+		t.Error("CloudConfig INI does not produce values: \"monitor-delay = 1\"")
+		t.Error(buffer.String())
+	}
+
+	if !regexp.MustCompile(`monitor-max-retries = 2`).MatchString(buffer.String()) {
+		t.Error("CloudConfig INI does not produce values: \"monitor-max-retries = 2\"")
+		t.Error(buffer.String())
+	}
+
+	if !regexp.MustCompile(`monitor-max-retries-down = 3`).MatchString(buffer.String()) {
+		t.Error("CloudConfig INI does not produce values: \"monitor-max-retries-down = 3\"")
+		t.Error(buffer.String())
+	}
+
+	if !regexp.MustCompile(`monitor-timeout = 4`).MatchString(buffer.String()) {
+		t.Error("CloudConfig INI does not produce values: \"monitor-timeout = 4\"")
+		t.Error(buffer.String())
+	}
+}
+
+func TestLoadBalancerOptsToINIEmpty(t *testing.T) {
+	cluster := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			Cloud: v1.CloudSpec{
+				Openstack: &v1.OpenstackCloudSpec{
+					UseOctavia: nil,
+				},
+			},
+		},
+	}
+	datacenter := &v1.Datacenter{
+		Spec: v1.DatacenterSpec{
+			Openstack: &v1.DatacenterSpecOpenstack{
+				LoadBalancerClasses: nil,
+				LoadBalancerMonitor: &v1.DatacenterSpecOpenstackLoadBalancerMonitor{},
+			},
+		},
+	}
+	credentials := resources.Credentials{}
+
+	cc := ForCluster(cluster, datacenter, credentials)
+	i := ini.New()
+	section := i.Section("LoadBalancer", "")
+	cc.LoadBalancer.toINI(section)
+}
+
+func TestLoadBalancerOptsToINIDatacenterOnly(t *testing.T) {
+	cluster := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			Cloud: v1.CloudSpec{
+				Openstack: &v1.OpenstackCloudSpec{
+					UseOctavia: nil,
+				},
+			},
+		},
+	}
+	datacenter := &v1.Datacenter{
+		Spec: v1.DatacenterSpec{
+			Openstack: &v1.DatacenterSpecOpenstack{
+				LoadBalancerClasses: nil,
+				LoadBalancerMonitor: &v1.DatacenterSpecOpenstackLoadBalancerMonitor{
+					Create:         true,
+					Delay:          1,
+					MaxRetries:     2,
+					MaxRetriesDown: 3,
+					Timeout:        4,
+				},
+			},
+		},
+	}
+	credentials := resources.Credentials{}
+
+	cc := ForCluster(cluster, datacenter, credentials)
+	i := ini.New()
+	section := i.Section("LoadBalancer", "")
+	cc.LoadBalancer.toINI(section)
+
+	checkINI(i, t)
+}
+
+func TestLoadBalancerOptsToINIClusterOnly(t *testing.T) {
+	cluster := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			Cloud: v1.CloudSpec{
+				Openstack: &v1.OpenstackCloudSpec{
+					UseOctavia: nil,
+					LoadBalancerMonitor: &v1.OpenstackCloudLoadBalancerMonitorSpec{
+						Create:         true,
+						Delay:          1,
+						MaxRetries:     2,
+						MaxRetriesDown: 3,
+						Timeout:        4,
+					},
+				},
+			},
+		},
+	}
+	datacenter := &v1.Datacenter{
+		Spec: v1.DatacenterSpec{
+			Openstack: &v1.DatacenterSpecOpenstack{
+				LoadBalancerClasses: nil,
+				LoadBalancerMonitor: &v1.DatacenterSpecOpenstackLoadBalancerMonitor{},
+			},
+		},
+	}
+	credentials := resources.Credentials{}
+
+	cc := ForCluster(cluster, datacenter, credentials)
+	i := ini.New()
+	section := i.Section("LoadBalancer", "")
+	cc.LoadBalancer.toINI(section)
+
+	checkINI(i, t)
+}
+
+func TestLoadBalancerOptsToINIClusterOverridingDatacenter(t *testing.T) {
+	cluster := &v1.Cluster{
+		Spec: v1.ClusterSpec{
+			Cloud: v1.CloudSpec{
+				Openstack: &v1.OpenstackCloudSpec{
+					UseOctavia: nil,
+					LoadBalancerMonitor: &v1.OpenstackCloudLoadBalancerMonitorSpec{
+						Create:         true,
+						Delay:          1,
+						MaxRetries:     2,
+						MaxRetriesDown: 3,
+						Timeout:        4,
+					},
+				},
+			},
+		},
+	}
+	datacenter := &v1.Datacenter{
+		Spec: v1.DatacenterSpec{
+			Openstack: &v1.DatacenterSpecOpenstack{
+				LoadBalancerClasses: nil,
+				LoadBalancerMonitor: &v1.DatacenterSpecOpenstackLoadBalancerMonitor{
+					Create:         false,
+					Delay:          11,
+					MaxRetries:     12,
+					MaxRetriesDown: 13,
+					Timeout:        14,
+				},
+			},
+		},
+	}
+	credentials := resources.Credentials{}
+
+	cc := ForCluster(cluster, datacenter, credentials)
+	i := ini.New()
+	section := i.Section("LoadBalancer", "")
+	cc.LoadBalancer.toINI(section)
+
+	checkINI(i, t)
+}

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -1426,6 +1426,24 @@ type AWSCloudSpec struct {
 	DisableIAMReconciling bool `json:"disableIAMReconciling,omitempty"` //nolint:tagliatelle
 }
 
+// OpenstackCloudLoadBalancerMonitorSpec specifies the LoadBalancer monitor config.
+// Reference: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer
+type OpenstackCloudLoadBalancerMonitorSpec struct {
+	// Indicates whether or not to create a health monitor for the service load balancer.
+	// A health monitor required for services that declare `externalTrafficPolicy: Local``.
+	Create bool `json:"create,omitempty"`
+	// The time, in seconds, between sending probes to members of the load balancer.
+	Delay uint `json:"delay,omitempty"`
+	// The number of successful checks before changing the operating status of the load balancer member to ONLINE.
+	// A valid value is from 1 to 10.
+	MaxRetries uint `json:"maxRetries,omitempty"`
+	// The number of unsuccessful checks before changing the operating status of the load balancer member to ERROR.
+	// A valid value is from 1 to 10.
+	MaxRetriesDown uint `json:"maxRetriesDown,omitempty"`
+	// The maximum time, in seconds, that a monitor waits to connect backend before it times out.
+	Timeout uint `json:"timeout,omitempty"`
+}
+
 // OpenstackCloudSpec specifies access data to an OpenStack cloud.
 type OpenstackCloudSpec struct {
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
@@ -1526,6 +1544,9 @@ type OpenstackCloudSpec struct {
 	// OpenStack volume attachment limit.
 	// +optional
 	NodeVolumeAttachLimit *uint `json:"nodeVolumeAttachLimit,omitempty"`
+
+	// LoadBalancerMonitor specifies the LoadBalancer monitor config.
+	LoadBalancerMonitor *OpenstackCloudLoadBalancerMonitorSpec `json:"loadBalancerMonitor,omitempty"`
 }
 
 // NOOP.

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -634,6 +634,24 @@ type DatacenterSpecDigitalocean struct {
 	Region string `json:"region"`
 }
 
+// DatacenterSpecOpenstackLoadBalancerMonitor specifies the LoadBalancer monitor config.
+// Reference: https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer
+type DatacenterSpecOpenstackLoadBalancerMonitor struct {
+	// Indicates whether or not to create a health monitor for the service load balancer.
+	// A health monitor required for services that declare `externalTrafficPolicy: Local`.
+	Create bool `json:"create,omitempty"`
+	// The time, in seconds, between sending probes to members of the load balancer.
+	Delay uint `json:"delay,omitempty"`
+	// The number of successful checks before changing the operating status of the load balancer member to ONLINE.
+	// A valid value is from 1 to 10.
+	MaxRetries uint `json:"maxRetries,omitempty"`
+	// The number of unsuccessful checks before changing the operating status of the load balancer member to ERROR.
+	// A valid value is from 1 to 10.
+	MaxRetriesDown uint `json:"maxRetriesDown,omitempty"`
+	// The maximum time, in seconds, that a monitor waits to connect backend before it times out.
+	Timeout uint `json:"timeout,omitempty"`
+}
+
 // DatacenterSpecOpenstack describes an OpenStack datacenter.
 type DatacenterSpecOpenstack struct {
 	// Authentication URL
@@ -659,6 +677,8 @@ type DatacenterSpecOpenstack struct {
 	// Optional: Gets mapped to the "lb-method" setting in the cloud config.
 	// defaults to "ROUND_ROBIN".
 	LoadBalancerMethod *string `json:"loadBalancerMethod,omitempty"`
+	// DatacenterSpecOpenstackLoadBalancerMonitor specifies the LoadBalancer monitor config.
+	LoadBalancerMonitor *DatacenterSpecOpenstackLoadBalancerMonitor `json:"loadBalancerMonitor,omitempty"`
 	// Optional: Gets mapped to the "use-octavia" setting in the cloud config.
 	// use-octavia is enabled by default in CCM since v1.17.0, and disabled by
 	// default with the in-tree cloud provider.


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to be able to configure the OpenStack cloud provider controller to enable monitors on the LoadBalancer endpoints. This will allow the setting of `externalTrafficPolicy: Local` option in Kubernetes to work properly. At the moment the settings is disregarded and the behaviour is not according to how it should work when properly implemented. At the moment endpoints are being forwarded traffic to, that will not be able to answer.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15460

**What type of PR is this?**
/kind feature
/kind api-change

Classified as feature as allowing the setting is new.

**Special notes for your reviewer**:
Please consider patch-backporting and consider this to be included in the next upcoming minor version bump.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Datacenters and Clusters can now configure OpenStack loadbalancer monitors. Where a Cluster setting overrides a Datacenter setting.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
