### PR TITLE
test(hetzner): use cpx22 srv type instead of cx32

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	hetznerServerType = "cx32"
+	hetznerServerType = "cpx22"
 )
 
 type hetznerScenario struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the `cpx22` serverType instead of `cx32` within the e2e test. This is because the Hetzner API stopped supporting the `cx32` serverType recently.

[This change makes the Hetzner e2e test scenarios pass](https://github.com/kubermatic/kubermatic/issues/15376#issuecomment-3914339646).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

Relates to #15376

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
