### PR TITLE
Default proxy-mode to nftables for 1.33+

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -25,6 +25,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1/helper"
+	"k8c.io/kubermatic/sdk/v2/semver"
 	"k8c.io/kubermatic/v2/pkg/cni"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -191,7 +192,7 @@ func DefaultClusterSpec(
 	}
 
 	// default cluster networking parameters
-	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName), spec.ExposeStrategy)
+	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName), spec.ExposeStrategy, spec.Version)
 	return nil
 }
 
@@ -231,7 +232,12 @@ func DatacenterForClusterSpec(spec *kubermaticv1.ClusterSpec, seed *kubermaticv1
 	return nil, field.Invalid(field.NewPath("spec", "cloud", "dc"), datacenterName, "invalid datacenter name")
 }
 
-func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConfig, provider kubermaticv1.ProviderType, exposeStrategy kubermaticv1.ExposeStrategy) kubermaticv1.ClusterNetworkingConfig {
+func DefaultClusterNetwork(
+	specClusterNetwork kubermaticv1.ClusterNetworkingConfig,
+	provider kubermaticv1.ProviderType,
+	exposeStrategy kubermaticv1.ExposeStrategy,
+	version semver.Semver,
+) kubermaticv1.ClusterNetworkingConfig {
 	if specClusterNetwork.IPFamily == "" {
 		if len(specClusterNetwork.Pods.CIDRBlocks) < 2 {
 			// single / no pods CIDR means IPv4-only (IPv6-only is not supported yet and not allowed by cluster validation)
@@ -265,7 +271,7 @@ func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConf
 	}
 
 	if specClusterNetwork.ProxyMode == "" {
-		specClusterNetwork.ProxyMode = resources.GetDefaultProxyMode(provider)
+		specClusterNetwork.ProxyMode = resources.GetDefaultProxyMode(provider, version)
 	}
 
 	if specClusterNetwork.ProxyMode == resources.IPVSProxyMode {

--- a/pkg/defaulting/cluster_test.go
+++ b/pkg/defaulting/cluster_test.go
@@ -44,10 +44,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 					Services: kubermaticv1.NetworkRanges{
 						CIDRBlocks: []string{"10.240.16.0/20"},
 					},
-					ProxyMode: "ipvs",
-					IPVS: &kubermaticv1.IPVSConfiguration{
-						StrictArp: ptr.To(true),
-					},
+					ProxyMode:                "nftables",
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](24),
 					NodeLocalDNSCacheEnabled: ptr.To(true),
 					DNSDomain:                "cluster.local",
@@ -70,10 +67,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 					Services: kubermaticv1.NetworkRanges{
 						CIDRBlocks: []string{"10.240.16.0/20", "fd02::/108"},
 					},
-					ProxyMode: "ipvs",
-					IPVS: &kubermaticv1.IPVSConfiguration{
-						StrictArp: ptr.To(true),
-					},
+					ProxyMode:                "nftables",
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](24),
 					NodeCIDRMaskSizeIPv6:     ptr.To[int32](64),
 					NodeLocalDNSCacheEnabled: ptr.To(true),
@@ -99,10 +93,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 					Services: kubermaticv1.NetworkRanges{
 						CIDRBlocks: []string{"10.240.16.0/20", "fd02::/108"},
 					},
-					ProxyMode: "ipvs",
-					IPVS: &kubermaticv1.IPVSConfiguration{
-						StrictArp: ptr.To(true),
-					},
+					ProxyMode:                "nftables",
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](24),
 					NodeCIDRMaskSizeIPv6:     ptr.To[int32](64),
 					NodeLocalDNSCacheEnabled: ptr.To(true),
@@ -132,10 +123,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 					Services: kubermaticv1.NetworkRanges{
 						CIDRBlocks: []string{"10.241.0.0/20", "fd02::/108"},
 					},
-					ProxyMode: "ipvs",
-					IPVS: &kubermaticv1.IPVSConfiguration{
-						StrictArp: ptr.To(true),
-					},
+					ProxyMode:                "nftables",
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](24),
 					NodeCIDRMaskSizeIPv6:     ptr.To[int32](64),
 					NodeLocalDNSCacheEnabled: ptr.To(true),
@@ -144,7 +132,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 			},
 		},
 		{
-			name: "prefilled spec ipv4",
+			name: "prefilled spec ipv4 ipvs",
 			spec: &kubermaticv1.ClusterSpec{
 				ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 					IPFamily: "IPv4",
@@ -176,6 +164,39 @@ func TestDefaultClusterNetwork(t *testing.T) {
 					IPVS: &kubermaticv1.IPVSConfiguration{
 						StrictArp: ptr.To(false),
 					},
+					NodeCIDRMaskSizeIPv4:     ptr.To[int32](32),
+					NodeLocalDNSCacheEnabled: ptr.To(false),
+					DNSDomain:                "cluster.local.test",
+				},
+			},
+		},
+		{
+			name: "prefilled spec ipv4",
+			spec: &kubermaticv1.ClusterSpec{
+				ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+					IPFamily: "IPv4",
+					Pods: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"173.26.0.0/16"},
+					},
+					Services: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"11.241.17.0/20"},
+					},
+					ProxyMode:                "nftables",
+					NodeCIDRMaskSizeIPv4:     ptr.To[int32](32),
+					NodeLocalDNSCacheEnabled: ptr.To(false),
+					DNSDomain:                "cluster.local.test",
+				},
+			},
+			expectedChangedSpec: &kubermaticv1.ClusterSpec{
+				ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+					IPFamily: "IPv4",
+					Pods: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"173.26.0.0/16"},
+					},
+					Services: kubermaticv1.NetworkRanges{
+						CIDRBlocks: []string{"11.241.17.0/20"},
+					},
+					ProxyMode:                "nftables",
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](32),
 					NodeLocalDNSCacheEnabled: ptr.To(false),
 					DNSDomain:                "cluster.local.test",
@@ -227,7 +248,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.spec.ClusterNetwork = DefaultClusterNetwork(tc.spec.ClusterNetwork, kubermaticv1.ProviderType(tc.spec.Cloud.ProviderName), tc.spec.ExposeStrategy)
+			tc.spec.ClusterNetwork = DefaultClusterNetwork(tc.spec.ClusterNetwork, kubermaticv1.ProviderType(tc.spec.Cloud.ProviderName), tc.spec.ExposeStrategy, tc.spec.Version)
 			assert.Equal(t, tc.expectedChangedSpec, tc.spec)
 		})
 	}

--- a/pkg/webhook/cluster/mutation/mutator_test.go
+++ b/pkg/webhook/cluster/mutation/mutator_test.go
@@ -80,21 +80,20 @@ var (
 		jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/nodePortRange", resources.DefaultNodePortRange),
 		jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/replicas", json.Number(fmt.Sprintf("%d", defaulting.DefaultControllerManagerReplicas))),
 		jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/replicas", json.Number(fmt.Sprintf("%d", defaulting.DefaultSchedulerReplicas))),
-		jsonpatch.NewOperation("add", "/spec/kubernetesDashboard", map[string]interface{}{"enabled": true}),
+		jsonpatch.NewOperation("add", "/spec/kubernetesDashboard", map[string]any{"enabled": true}),
 	}
 
 	defaultNetworkingPatchesWithoutProxyMode = []jsonpatch.JsonPatchOperation{
 		jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipFamily", string(kubermaticv1.IPFamilyIPv4)),
-		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []interface{}{resources.DefaultClusterServicesCIDRIPv4}),
-		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []interface{}{resources.DefaultClusterPodsCIDRIPv4}),
+		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []any{resources.DefaultClusterServicesCIDRIPv4}),
+		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []any{resources.DefaultClusterPodsCIDRIPv4}),
 		jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv4", json.Number(fmt.Sprintf("%d", resources.DefaultNodeCIDRMaskSizeIPv4))),
 		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/dnsDomain", "cluster.local"),
 		jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", resources.DefaultNodeLocalDNSCacheEnabled),
 	}
 	defaultNetworkingPatches = append(
 		defaultNetworkingPatchesWithoutProxyMode,
-		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "ipvs"),
-		jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipvs", map[string]interface{}{"strictArp": true}),
+		jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "nftables"),
 	)
 	defaultNetworkingPatchesIptablesProxyMode = append(
 		defaultNetworkingPatchesWithoutProxyMode,
@@ -229,30 +228,30 @@ func TestMutator(t *testing.T) {
 			wantPatches: []jsonpatch.JsonPatchOperation{
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/nodePortRange", "30000-32768"),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/replicas", json.Number("2")),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/tolerations", []interface{}{map[string]interface{}{"effect": "PreferNoSchedule", "key": "test-no-schedule", "operator": "Exists"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/resources", map[string]any{"requests": map[string]any{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/tolerations", []any{map[string]any{"effect": "PreferNoSchedule", "key": "test-no-schedule", "operator": "Exists"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/apiserver/endpointReconcilingDisabled", true),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/replicas", json.Number("2")),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/tolerations", []interface{}{map[string]interface{}{"effect": "PreferNoSchedule", "key": "test-no-schedule", "operator": "Exists"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/resources", map[string]any{"requests": map[string]any{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/tolerations", []any{map[string]any{"effect": "PreferNoSchedule", "key": "test-no-schedule", "operator": "Exists"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/leaderElection/leaseDurationSeconds", json.Number("10")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/leaderElection/renewDeadlineSeconds", json.Number("5")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/controllerManager/leaderElection/retryPeriodSeconds", json.Number("2")),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/tolerations", []interface{}{map[string]interface{}{"effect": "PreferNoSchedule", "key": "test-no-schedule", "operator": "Exists"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/tolerations", []any{map[string]any{"effect": "PreferNoSchedule", "key": "test-no-schedule", "operator": "Exists"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/leaderElection/renewDeadlineSeconds", json.Number("5")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/leaderElection/retryPeriodSeconds", json.Number("2")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/leaderElection/leaseDurationSeconds", json.Number("10")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/replicas", json.Number("2")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/resources", json.Number("5")),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/scheduler/resources", map[string]any{"requests": map[string]any{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/clusterSize", json.Number("7")),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/storageClass", "fast-storage"),
 				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/diskSize", "1G"),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
-				jsonpatch.NewOperation("add", "/spec/componentsOverride/prometheus/resources", map[string]interface{}{"requests": map[string]interface{}{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/etcd/resources", map[string]any{"requests": map[string]any{"memory": "500M"}}),
+				jsonpatch.NewOperation("add", "/spec/componentsOverride/prometheus/resources", map[string]any{"requests": map[string]any{"memory": "500M"}}),
 				jsonpatch.NewOperation("add", "/spec/features/apiserverNetworkPolicy", true),
 				jsonpatch.NewOperation("add", "/spec/features/ccmClusterName", true),
-				jsonpatch.NewOperation("add", "/spec/kubernetesDashboard", map[string]interface{}{"enabled": true}),
+				jsonpatch.NewOperation("add", "/spec/kubernetesDashboard", map[string]any{"enabled": true}),
 				jsonpatch.NewOperation("replace", "/spec/exposeStrategy", string(defaulting.DefaultExposeStrategy)),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/konnectivityEnabled", true),
@@ -287,13 +286,13 @@ func TestMutator(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(
 				defaultPatches,
-				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]interface{}{
+				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]any{
 					"type":    "cilium",
 					"version": cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCilium),
 				}),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipFamily", string(kubermaticv1.IPFamilyIPv4)),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []interface{}{"10.240.32.0/20"}),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []interface{}{"10.241.0.0/16"}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []any{"10.240.32.0/20"}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []any{"10.241.0.0/16"}),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv4", json.Number("24")),
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/dnsDomain", "example.local"),
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", resources.EBPFProxyMode),
@@ -307,7 +306,8 @@ func TestMutator(t *testing.T) {
 		{
 			name: "Create cluster success",
 			newCluster: rawClusterGen{
-				Name: "foo",
+				Name:    "foo",
+				Version: "1.33.0",
 				CloudSpec: kubermaticv1.CloudSpec{
 					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 					DatacenterName: "openstack-dc",
@@ -324,8 +324,6 @@ func TestMutator(t *testing.T) {
 					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](24),
 					DNSDomain:                "example.local",
-					ProxyMode:                resources.IPVSProxyMode,
-					IPVS:                     &kubermaticv1.IPVSConfiguration{StrictArp: ptr.To(true)},
 					NodeLocalDNSCacheEnabled: ptr.To(true),
 				},
 				Features: map[string]bool{
@@ -338,6 +336,7 @@ func TestMutator(t *testing.T) {
 				defaultPatches,
 				jsonpatch.NewOperation("add", "/spec/features/ccmClusterName", true),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/konnectivityEnabled", true),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "nftables"),
 			),
 		},
 		{
@@ -450,8 +449,6 @@ func TestMutator(t *testing.T) {
 					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
 					NodeCIDRMaskSizeIPv4:     ptr.To[int32](24),
 					DNSDomain:                "example.local",
-					ProxyMode:                resources.IPVSProxyMode,
-					IPVS:                     &kubermaticv1.IPVSConfiguration{StrictArp: ptr.To(true)},
 					NodeLocalDNSCacheEnabled: ptr.To(true),
 				},
 				Features: map[string]bool{
@@ -462,12 +459,13 @@ func TestMutator(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(
 				defaultPatches,
-				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]interface{}{
+				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]any{
 					"type":    string(kubermaticv1.CNIPluginTypeCilium),
 					"version": cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCilium),
 				}),
 				jsonpatch.NewOperation("add", "/spec/features/ccmClusterName", true),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/konnectivityEnabled", true),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "nftables"),
 			),
 		},
 		{
@@ -517,7 +515,7 @@ func TestMutator(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(
 				defaultPatches,
-				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]interface{}{
+				jsonpatch.NewOperation("add", "/spec/cniPlugin", map[string]any{
 					"type":    string(kubermaticv1.CNIPluginTypeCilium),
 					"version": cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCilium),
 				}),
@@ -570,10 +568,9 @@ func TestMutator(t *testing.T) {
 			wantPatches: append(
 				defaultPatches,
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipFamily", string(kubermaticv1.IPFamilyIPv4)),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []interface{}{"10.241.0.0/20"}),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []interface{}{"172.26.0.0/16"}),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "ipvs"),
-				jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipvs", map[string]interface{}{"strictArp": true}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []any{"10.241.0.0/20"}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []any{"172.26.0.0/16"}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "nftables"),
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/dnsDomain", "cluster.local"),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", true),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv4", json.Number("24")),
@@ -667,14 +664,13 @@ func TestMutator(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(
 				defaultPatches,
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []interface{}{resources.DefaultClusterServicesCIDRIPv4, resources.DefaultClusterServicesCIDRIPv6}),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []interface{}{resources.DefaultClusterPodsCIDRIPv4, resources.DefaultClusterPodsCIDRIPv6}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/services/cidrBlocks", []any{resources.DefaultClusterServicesCIDRIPv4, resources.DefaultClusterServicesCIDRIPv6}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/pods/cidrBlocks", []any{resources.DefaultClusterPodsCIDRIPv4, resources.DefaultClusterPodsCIDRIPv6}),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv4", json.Number(fmt.Sprintf("%d", resources.DefaultNodeCIDRMaskSizeIPv4))),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv6", json.Number(fmt.Sprintf("%d", resources.DefaultNodeCIDRMaskSizeIPv6))),
 				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/dnsDomain", "cluster.local"),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", resources.DefaultNodeLocalDNSCacheEnabled),
-				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", resources.IPVSProxyMode),
-				jsonpatch.NewOperation("add", "/spec/clusterNetwork/ipvs", map[string]interface{}{"strictArp": true}),
+				jsonpatch.NewOperation("replace", "/spec/clusterNetwork/proxyMode", "nftables"),
 				jsonpatch.NewOperation("add", "/spec/features/externalCloudProvider", true),
 				jsonpatch.NewOperation("add", "/spec/features/ccmClusterName", true),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.OpenstackCloudProvider)),
@@ -712,7 +708,7 @@ func TestMutator(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(
 				append(defaultPatches, defaultNetworkingPatches...),
-				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]interface{}{"ccm-migration.k8c.io/migration-needed": "", "csi-migration.k8c.io/migration-needed": ""}),
+				jsonpatch.NewOperation("add", "/metadata/annotations", map[string]any{"ccm-migration.k8c.io/migration-needed": "", "csi-migration.k8c.io/migration-needed": ""}),
 				jsonpatch.NewOperation("add", "/spec/cloud/openstack/useOctavia", true),
 				jsonpatch.NewOperation("add", "/spec/features/ccmClusterName", true),
 			),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow-up on #15321

This will default new clusters to nftables

**Which issue(s) this PR fixes**:


**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default proxy-mode to nftables for 1.33+
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
