### PR TITLE
set hostname for Gateway HTTPS listener

### DIFF
--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -101,6 +101,7 @@ func GatewayReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace stri
 				}
 				listeners = append(listeners, gatewayapiv1.Listener{
 					Name:     "https",
+					Hostname: ptr.To(gatewayapiv1.Hostname(cfg.Spec.Ingress.Domain)),
 					Protocol: gatewayapiv1.HTTPSProtocolType,
 					Port:     gatewayapiv1.PortNumber(443),
 					AllowedRoutes: &gatewayapiv1.AllowedRoutes{


### PR DESCRIPTION

**What this PR does / why we need it**:

cert-manager requires a non-empty hostname in Gateway listeners to create certificates. This adds the main domain from KubermaticConfiguration as the hostname for the default HTTPS listener.

reference: https://cert-manager.io/docs/usage/gateway/#generate-tls-certs-for-selected-tls-blocks

cert-manager requires the hostname to be set on the gateway level - it can't infer from attached routes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set `hostname` on Gateway while using cert-manager
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
