### PR TITLE
Add HTTPRoute to Gateway listener sync controller

### DIFF
--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         {{- end }}
         {{- if .Values.migrateGatewayAPI }}
         - -enable-gateway-api
+        {{- if .Values.kubermaticOperator.httpRouteWatchNamespaces }}
+        - -httproute-watch-namespaces={{ join "," .Values.kubermaticOperator.httpRouteWatchNamespaces }}
+        {{- end }}
         {{- end }}
         env:
         - name: SSL_CERT_FILE

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -65,8 +65,8 @@ spec:
         {{- end }}
         {{- if .Values.migrateGatewayAPI }}
         - -enable-gateway-api
-        {{- if .Values.kubermaticOperator.httpRouteWatchNamespaces }}
-        - -httproute-watch-namespaces={{ join "," .Values.kubermaticOperator.httpRouteWatchNamespaces }}
+        {{- with .Values.kubermaticOperator.httpRouteWatchNamespaces }}
+        - -httproute-watch-namespaces={{ join "," . }}
         {{- end }}
         {{- end }}
         env:

--- a/charts/kubermatic-operator/values.yaml
+++ b/charts/kubermatic-operator/values.yaml
@@ -24,6 +24,13 @@ kubermaticOperator:
     # a release prowjob
     tag: "v9.9.9-dev"
 
+  # Namespaces to watch for HTTPRoutes when Gateway API is enabled.
+  # Only used when migrateGatewayAPI=true and HTTPRouteGatewaySync feature gate is enabled.
+  # Default: ["monitoring", "mla"]
+  httpRouteWatchNamespaces:
+    - monitoring
+    - mla
+
   imagePullSecret: |
     {
       "quay.io": {}

--- a/cmd/kubermatic-operator/main.go
+++ b/cmd/kubermatic-operator/main.go
@@ -105,7 +105,7 @@ func main() {
 	}
 
 	httprouteWatchNamespaces := sets.New[string]()
-	for _, ns := range strings.Split(opt.httprouteWatchNamespaces, ",") {
+	for ns := range strings.SplitSeq(opt.httprouteWatchNamespaces, ",") {
 		ns = strings.TrimSpace(ns)
 		if ns != "" {
 			httprouteWatchNamespaces.Insert(ns)

--- a/cmd/kubermatic-operator/main.go
+++ b/cmd/kubermatic-operator/main.go
@@ -105,15 +105,17 @@ func main() {
 	}
 
 	httprouteWatchNamespaces := sets.New[string]()
-	for ns := range strings.SplitSeq(opt.httprouteWatchNamespaces, ",") {
-		ns = strings.TrimSpace(ns)
-		if ns != "" {
-			httprouteWatchNamespaces.Insert(ns)
+	if opt.enableGatewayAPI {
+		for ns := range strings.SplitSeq(opt.httprouteWatchNamespaces, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns != "" {
+				httprouteWatchNamespaces.Insert(ns)
+			}
 		}
-	}
 
-	if httprouteWatchNamespaces.Len() == 0 {
-		log.Fatal("-httproute-watch-namespaces must contain at least one namespace")
+		if httprouteWatchNamespaces.Len() == 0 {
+			log.Fatal("-httproute-watch-namespaces must contain at least one namespace")
+		}
 	}
 
 	versions := kubermatic.GetVersions()

--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -28,6 +28,7 @@ import (
 	clustertemplatesynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/cluster-template-synchronizer"
 	encryptionsecretsynchonizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/encryption-secret-synchronizer"
 	externalcluster "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/external-cluster"
+	httproutegatewaysync "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/httproute-gateway-sync"
 	kcstatuscontroller "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/kc-status-controller"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/kubeone"
 	masterconstraintsynchronizer "k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/master-constraint-controller"
@@ -131,6 +132,12 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	}
 	if err := kcstatuscontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.versions); err != nil {
 		return fmt.Errorf("failed to create kubermatic configuration controller: %w", err)
+	}
+
+	if ctrlCtx.featureGates.Enabled(features.HTTPRouteGatewaySync) {
+		if err := httproutegatewaysync.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.httprouteWatchNamespaces); err != nil {
+			return fmt.Errorf("failed to create httproute-gateway-sync controller: %w", err)
+		}
 	}
 
 	// init CE/EE-only controllers

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/zapr"
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,31 +59,33 @@ const (
 )
 
 type controllerRunOptions struct {
-	internalAddr            string
-	enableLeaderElection    bool
-	leaderElectionNamespace string
-	featureGates            features.FeatureGate
-	configFile              string
+	internalAddr             string
+	enableLeaderElection     bool
+	leaderElectionNamespace  string
+	featureGates             features.FeatureGate
+	configFile               string
+	httprouteWatchNamespaces string
 
 	workerName string
 	namespace  string
 }
 
 type controllerContext struct {
-	ctx                     context.Context
-	mgr                     manager.Manager
-	log                     *zap.SugaredLogger
-	workerCount             int
-	workerName              string
-	workerNameLabelSelector labels.Selector
-	workerNamePredicate     predicate.Predicate
-	seedsGetter             provider.SeedsGetter
-	seedKubeconfigGetter    provider.SeedKubeconfigGetter
-	labelSelectorFunc       func(*metav1.ListOptions)
-	namespace               string
-	versions                kubermatic.Versions
-	overwriteRegistry       string
-	featureGates            features.FeatureGate
+	ctx                      context.Context
+	mgr                      manager.Manager
+	log                      *zap.SugaredLogger
+	workerCount              int
+	workerName               string
+	workerNameLabelSelector  labels.Selector
+	workerNamePredicate      predicate.Predicate
+	seedsGetter              provider.SeedsGetter
+	seedKubeconfigGetter     provider.SeedKubeconfigGetter
+	labelSelectorFunc        func(*metav1.ListOptions)
+	namespace                string
+	versions                 kubermatic.Versions
+	overwriteRegistry        string
+	featureGates             features.FeatureGate
+	httprouteWatchNamespaces []string
 
 	configGetter provider.KubermaticConfigurationGetter
 }
@@ -107,6 +110,7 @@ func main() {
 	flag.StringVar(&runOpts.leaderElectionNamespace, "leader-election-namespace", "", "Leader election namespace. In-cluster discovery will be attempted in such case.")
 	flag.Var(&runOpts.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&runOpts.configFile, "kubermatic-configuration-file", "", "(for development only) path to a KubermaticConfiguration YAML file")
+	flag.StringVar(&runOpts.httprouteWatchNamespaces, "httproute-watch-namespaces", "mla,monitoring", "Comma-separated list of namespaces to watch HTTPRoutes for Gateway listener sync")
 	addFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -118,6 +122,7 @@ func main() {
 	ctrlCtx.workerName = runOpts.workerName
 	ctrlCtx.namespace = runOpts.namespace
 	ctrlCtx.featureGates = runOpts.featureGates
+	ctrlCtx.httprouteWatchNamespaces = strings.Split(runOpts.httprouteWatchNamespaces, ",")
 
 	// Set the logger used by sigs.k8s.io/controller-runtime
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayclientscheme "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/scheme"
 )
 
 const (
@@ -188,6 +189,10 @@ func main() {
 
 	if err := kubermaticv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", kubermaticv1.SchemeGroupVersion), zap.Error(err))
+	}
+
+	if err := gatewayclientscheme.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Fatalw("failed to add Gateway API scheme", zap.Error(err))
 	}
 
 	// these two getters rely on the ctrlruntime manager being started; they

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -111,7 +111,7 @@ func main() {
 	flag.StringVar(&runOpts.leaderElectionNamespace, "leader-election-namespace", "", "Leader election namespace. In-cluster discovery will be attempted in such case.")
 	flag.Var(&runOpts.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&runOpts.configFile, "kubermatic-configuration-file", "", "(for development only) path to a KubermaticConfiguration YAML file")
-	flag.StringVar(&runOpts.httprouteWatchNamespaces, "httproute-watch-namespaces", "mla,monitoring", "Comma-separated list of namespaces to watch HTTPRoutes for Gateway listener sync")
+	flag.StringVar(&runOpts.httprouteWatchNamespaces, "httproute-watch-namespaces", "monitoring,mla", "Comma-separated list of namespaces to watch HTTPRoutes for Gateway listener sync")
 	addFlags(flag.CommandLine)
 	flag.Parse()
 

--- a/pkg/controller/master-controller-manager/httproute-gateway-sync/controller.go
+++ b/pkg/controller/master-controller-manager/httproute-gateway-sync/controller.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httproutegatewaysync
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	// ControllerName is the name of this controller.
+	ControllerName = "kkp-httproute-gateway-sync"
+)
+
+// Reconciler watches HTTPRoutes and syncs Gateway listeners for cert-manager.
+type Reconciler struct {
+	ctrlruntimeclient.Client
+
+	log                 *zap.SugaredLogger
+	recorder            events.EventRecorder
+	namespace           string           // kubermatic namespace where Gateway lives
+	watchedNamespaceSet sets.Set[string] // namespaces to watch HTTPRoutes in
+}
+
+// Add creates a new HTTPRoute-Gateway sync controller.
+func Add(
+	ctx context.Context,
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	namespace string,
+	watchedNamespaces []string,
+) error {
+	r := &Reconciler{
+		Client:              mgr.GetClient(),
+		recorder:            mgr.GetEventRecorder(ControllerName),
+		log:                 log.Named(ControllerName),
+		namespace:           namespace,
+		watchedNamespaceSet: sets.New(watchedNamespaces...),
+	}
+
+	_, err := builder.ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		For(&gatewayapiv1.Gateway{}, builder.WithPredicates(predicate.ByNamespace(namespace))).
+		Watches(&gatewayapiv1.HTTPRoute{}, enqueueGatewayForHTTPRoute(r)).
+		Build(r)
+
+	return err
+}
+
+// enqueueGatewayForHTTPRoute maps HTTPRoute changes to Gateway reconcile requests.
+func enqueueGatewayForHTTPRoute(r *Reconciler) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+		httpRoute, ok := obj.(*gatewayapiv1.HTTPRoute)
+		if !ok {
+			return nil
+		}
+
+		// filter by watched namespaces
+		if !r.watchedNamespaceSet.Has(httpRoute.Namespace) {
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, parentRef := range httpRoute.Spec.ParentRefs {
+			if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+				continue
+			}
+
+			// default to reconciler's namespace (kubermatic)
+			ns := r.namespace
+			if parentRef.Namespace != nil {
+				ns = string(*parentRef.Namespace)
+			}
+
+			// only reconcile Gateways in target namespace
+			if ns != r.namespace {
+				continue
+			}
+
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      string(parentRef.Name),
+					Namespace: ns,
+				},
+			})
+		}
+
+		return requests
+	})
+}

--- a/pkg/controller/master-controller-manager/httproute-gateway-sync/doc.go
+++ b/pkg/controller/master-controller-manager/httproute-gateway-sync/doc.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package httproutegatewaysync contains a controller that synchronizes HTTPRoute
+hostnames to Gateway listeners for cert-manager integration.
+
+cert-manager requires Gateway listeners to have explicit hostnames to create
+certificates. KKP uses a shared Gateway model where multiple HTTPRoutes from
+different namespaces attach to a single Gateway. This controller watches
+HTTPRoutes and dynamically adds HTTPS listeners with explicit hostnames,
+allowing cert-manager to create certificates for each hostname.
+
+The controller watches HTTPRoutes in specified namespaces (mla, monitoring by default)
+and ensures the Gateway has HTTPS listeners with explicit hostnames. It uses
+stateless reconciliation - on each reconcile, it lists all HTTPRoutes, extracts
+unique hostnames, and computes the desired listener state.
+
+HTTPS listeners are named using the pattern: <sanitized-hostname>
+For example, hostname "grafana.lab.kubermatic.io" becomes "grafana-lab-kubermatic-io".
+Note that Gateway API doesn't allow duplicate hostnames on the same port so that's why we use sanitized hostnames.
+More importantly, cert-manager would try to create two certificates for the same hostname, which is unnecessary.
+
+Certificate/Secret names follow the pattern: <namespace>-<httproute-name>
+For example, HTTPRoute "mla/grafana-iap" creates a secret named "mla-grafana-iap".
+*/
+package httproutegatewaysync

--- a/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -196,7 +197,11 @@ func (r *Reconciler) desiredListeners(
 		}
 	}
 
-	for hostname, certName := range hostnameToCertName {
+	hostnames := slices.Collect(maps.Keys(hostnameToCertName))
+	slices.Sort(hostnames)
+
+	for _, hostname := range hostnames {
+		certName := hostnameToCertName[hostname]
 		listener := gatewayapiv1.Listener{
 			Name:     gatewayapiv1.SectionName(sanitizeListenerName(hostname)),
 			Hostname: ptr.To(gatewayapiv1.Hostname(hostname)),

--- a/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httproutegatewaysync
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("gateway", request.NamespacedName)
+	log.Debug("Reconciling")
+
+	gtw := &gatewayapiv1.Gateway{}
+
+	err := r.Get(ctx, request.NamespacedName, gtw)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get gateway: %w", err)
+	}
+
+	err = r.reconcile(ctx, log, gtw)
+	if err != nil {
+		r.recorder.Eventf(gtw, nil, corev1.EventTypeWarning, "ReconcilingFailed", "Reconciling", err.Error())
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile gateway %s: %w", request.Name, err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, l *zap.SugaredLogger, gtw *gatewayapiv1.Gateway) error {
+	if !r.usesCertManager(gtw) {
+		l.Debug("Gateway does not use cert-manager, skipping")
+		return nil
+	}
+
+	if gtw.DeletionTimestamp != nil {
+		// nothing special to do, listeners will be removed with Gateway
+		return nil
+	}
+
+	// list all HTTPRoutes that reference this Gateway
+	httpRoutes, err := r.listHTTPRoutesForGateway(ctx, gtw)
+	if err != nil {
+		return fmt.Errorf("failed to list HTTPRoutes: %w", err)
+	}
+
+	// extract desired listeners from HTTPRoutes
+	desiredListeners := r.desiredListeners(l, gtw, httpRoutes)
+	if len(desiredListeners) > 64 {
+		return fmt.Errorf("listener limit reached: %d listeners (max 64)", len(desiredListeners))
+	}
+
+	// patch Gateway if listeners changed
+	return r.patchGatewayListeners(ctx, gtw, desiredListeners)
+}
+
+// usesCertManager checks if Gateway has cert-manager annotations.
+func (r *Reconciler) usesCertManager(gtw *gatewayapiv1.Gateway) bool {
+	annotations := gtw.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	_, hasIssuer := annotations[certmanagerv1.IngressIssuerNameAnnotationKey]
+	_, hasClusterIssuer := annotations[certmanagerv1.IngressClusterIssuerNameAnnotationKey]
+	return hasIssuer || hasClusterIssuer
+}
+
+func (r *Reconciler) listHTTPRoutesForGateway(ctx context.Context, gtw *gatewayapiv1.Gateway) ([]gatewayapiv1.HTTPRoute, error) {
+	var routes []gatewayapiv1.HTTPRoute
+
+	for _, ns := range r.watchedNamespaceSet.UnsortedList() {
+		routeList := &gatewayapiv1.HTTPRouteList{}
+		if err := r.List(ctx, routeList, ctrlruntimeclient.InNamespace(ns)); err != nil {
+			return nil, fmt.Errorf("failed to list HTTPRoutes in namespace %s: %w", ns, err)
+		}
+
+		for _, route := range routeList.Items {
+			if r.referencesGateway(route, gtw) {
+				routes = append(routes, route)
+			}
+		}
+	}
+
+	return routes, nil
+}
+
+func (r *Reconciler) referencesGateway(route gatewayapiv1.HTTPRoute, gtw *gatewayapiv1.Gateway) bool {
+	for _, parentRef := range route.Spec.ParentRefs {
+		if parentRef.Kind != nil && *parentRef.Kind != "Gateway" {
+			continue
+		}
+		if string(parentRef.Name) != gtw.Name {
+			continue
+		}
+
+		ns := route.Namespace
+		if parentRef.Namespace != nil {
+			ns = string(*parentRef.Namespace)
+		}
+
+		if ns == gtw.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) desiredListeners(
+	log *zap.SugaredLogger,
+	gateway *gatewayapiv1.Gateway,
+	httpRoutes []gatewayapiv1.HTTPRoute,
+) []gatewayapiv1.Listener {
+	// preserve the core HTTP and HTTPs listeners.
+	listeners := make([]gatewayapiv1.Listener, 0)
+	for _, l := range gateway.Spec.Listeners {
+		if l.Protocol == gatewayapiv1.HTTPProtocolType && l.Name == "http" {
+			listeners = append(listeners, l)
+		} else if l.Protocol == gatewayapiv1.HTTPSProtocolType && l.Name == "https" {
+			listeners = append(listeners, l)
+		}
+	}
+
+	// sort routes for deterministic certificate naming: the first route with a hostname
+	// determines the certificate name.
+	slices.SortFunc(httpRoutes, func(a, b gatewayapiv1.HTTPRoute) int {
+		if a.Namespace != b.Namespace {
+			return strings.Compare(a.Namespace, b.Namespace)
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// track hostnames and their certificate names
+	// this controller acts as a bridge and does not filter hostnames.
+	// certificate issuance (including wildcard support) is cert-manager's responsibility.
+	hostnameToCertName := make(map[string]string)
+	for _, route := range httpRoutes {
+		for _, hostname := range route.Spec.Hostnames {
+			h := string(hostname)
+			if _, exists := hostnameToCertName[h]; !exists {
+				// first HTTPRoute with this hostname determines cert name
+				hostnameToCertName[h] = fmt.Sprintf("%s-%s", route.Namespace, route.Name)
+			}
+		}
+	}
+
+	for hostname, certName := range hostnameToCertName {
+		listener := gatewayapiv1.Listener{
+			Name:     gatewayapiv1.SectionName(sanitizeListenerName(hostname)),
+			Hostname: ptr.To(gatewayapiv1.Hostname(hostname)),
+			Port:     gatewayapiv1.PortNumber(443),
+			Protocol: gatewayapiv1.HTTPSProtocolType,
+			TLS: &gatewayapiv1.ListenerTLSConfig{
+				Mode: ptr.To(gatewayapiv1.TLSModeTerminate),
+				CertificateRefs: []gatewayapiv1.SecretObjectReference{
+					{
+						Name:  gatewayapiv1.ObjectName(certName),
+						Group: (*gatewayapiv1.Group)(ptr.To("")),
+						Kind:  (*gatewayapiv1.Kind)(ptr.To("Secret")),
+					},
+				},
+			},
+			AllowedRoutes: &gatewayapiv1.AllowedRoutes{
+				Namespaces: &gatewayapiv1.RouteNamespaces{
+					From: ptr.To(gatewayapiv1.NamespacesFromSelector),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							common.GatewayAccessLabelKey: "true",
+						},
+					},
+				},
+			},
+		}
+		listeners = append(listeners, listener)
+	}
+
+	return listeners
+}
+
+// sanitizeListenerName converts a hostname to a valid listener name.
+// Wildcard hostnames (*.example.com) are prefixed with "w-" and the asterisk is removed.
+func sanitizeListenerName(hostname string) string {
+	name := strings.ToLower(hostname)
+
+	if rest, found := strings.CutPrefix(name, "*."); found {
+		name = "w-" + rest
+	}
+
+	name = strings.ReplaceAll(name, ".", "-")
+	if len(name) > 63 {
+		name = name[:63]
+	}
+
+	return strings.TrimRight(name, "-")
+}
+
+func (r *Reconciler) patchGatewayListeners(
+	ctx context.Context,
+	gtw *gatewayapiv1.Gateway,
+	desiredListeners []gatewayapiv1.Listener,
+) error {
+	if reflect.DeepEqual(gtw.Spec.Listeners, desiredListeners) {
+		return nil
+	}
+
+	oldGateway := gtw.DeepCopy()
+	gtw.Spec.Listeners = desiredListeners
+
+	return r.Patch(ctx, gtw, ctrlruntimeclient.MergeFrom(oldGateway))
+}

--- a/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httproutegatewaysync
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestSanitizeListenerName(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostname        string
+		want            string
+		wantLen         int // expected length (0 means use len(want))
+		checkHashSuffix bool
+	}{
+		{
+			name:     "simple hostname",
+			hostname: "grafana.example.com",
+			want:     "grafana-example-com",
+		},
+		{
+			name:     "wildcard hostname",
+			hostname: "*.example.com",
+			want:     "w-example-com",
+		},
+		{
+			name:     "uppercase converted to lowercase",
+			hostname: "Grafana.Example.COM",
+			want:     "grafana-example-com",
+		},
+		{
+			name:     "exactly 63 chars without hash",
+			hostname: strings.Repeat("a", 63) + ".example.com",
+			wantLen:  63,
+		},
+		{
+			name:            "long hostname requiring truncation with hash",
+			hostname:        "this-is-a-very-long-hostname-that-exceeds-the-sixty-three-character-limit.example.com",
+			checkHashSuffix: true,
+			wantLen:         maxListenerNameLength,
+		},
+		{
+			name:            "long hostname with same prefix gets different hash",
+			hostname:        "this-is-a-very-long-hostname-that-exceeds-the-sixty-three-character-other.example.com",
+			checkHashSuffix: true,
+			wantLen:         maxListenerNameLength,
+		},
+		{
+			name:     "trailing dash in segment preserved",
+			hostname: "test-.example.com",
+			want:     "test--example-com",
+		},
+		{
+			name:            "wildcard long hostname",
+			hostname:        "*.this-is-a-very-long-hostname-that-exceeds-the-sixty-three-character-limit.example.com",
+			checkHashSuffix: true,
+			// Length may be less than maxListenerNameLength due to trailing dash trimming
+		},
+		{
+			name:     "empty hostname",
+			hostname: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeListenerName(tt.hostname)
+
+			// verify length constraint
+			if len(got) > maxListenerNameLength {
+				t.Errorf("sanitizeListenerName() result too long: %d chars (max %d)", len(got), maxListenerNameLength)
+			}
+
+			// verify no trailing dash
+			if strings.HasSuffix(got, "-") {
+				t.Errorf("sanitizeListenerName() has trailing dash: %q", got)
+			}
+
+			// verify no leading dash (invalid DNS label)
+			if len(got) > 0 && strings.HasPrefix(got, "-") {
+				t.Errorf("sanitizeListenerName() has leading dash: %q", got)
+			}
+
+			// check expected length if specified
+			if tt.wantLen > 0 && len(got) != tt.wantLen {
+				t.Errorf("sanitizeListenerName() length = %d, want %d", len(got), tt.wantLen)
+			}
+
+			// for exact matches (non-hash cases)
+			if tt.want != "" && !tt.checkHashSuffix {
+				if got != tt.want {
+					t.Errorf("sanitizeListenerName() = %q, want %q", got, tt.want)
+				}
+			}
+
+			// verify hash suffix format for long names
+			if tt.checkHashSuffix {
+				parts := strings.Split(got, "-")
+				if len(parts) < 2 {
+					t.Errorf("expected hash suffix in %q", got)
+				}
+				lastPart := parts[len(parts)-1]
+				if len(lastPart) != listenerNameHashLen {
+					t.Errorf("hash suffix length = %d, want %d", len(lastPart), listenerNameHashLen)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeListenerNameUniqueness(t *testing.T) {
+	// two long hostnames with same 54-char prefix should produce different results
+	host1 := "this-is-a-very-long-hostname-that-exceeds-the-sixty-three-character-first.example.com"
+	host2 := "this-is-a-very-long-hostname-that-exceeds-the-sixty-three-character-second.example.com"
+
+	name1 := sanitizeListenerName(host1)
+	name2 := sanitizeListenerName(host2)
+
+	if name1 == name2 {
+		t.Errorf("expected different names for different hostnames, got same: %s", name1)
+	}
+
+	// verify both are within length limit
+	if len(name1) > 63 || len(name2) > 63 {
+		t.Errorf("names exceed 63 chars: name1=%d, name2=%d", len(name1), len(name2))
+	}
+}
+
+func TestReferencesGateway(t *testing.T) {
+	kindGateway := gatewayapiv1.Kind("Gateway")
+
+	tests := []struct {
+		name      string
+		route     gatewayapiv1.HTTPRoute
+		gatewayNS string
+		want      bool
+	}{
+		{
+			name: "references gateway in same namespace",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kubermatic"},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: "kubermatic", Kind: &kindGateway},
+						},
+					},
+				},
+			},
+			gatewayNS: "kubermatic",
+			want:      true,
+		},
+		{
+			name: "references gateway via explicit namespace",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "monitoring"},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{
+								Name:      "kubermatic",
+								Kind:      &kindGateway,
+								Namespace: (*gatewayapiv1.Namespace)(ptr.To("kubermatic")),
+							},
+						},
+					},
+				},
+			},
+			gatewayNS: "kubermatic",
+			want:      true,
+		},
+		{
+			name: "different gateway name",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kubermatic"},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: "other-gateway", Kind: &kindGateway},
+						},
+					},
+				},
+			},
+			gatewayNS: "kubermatic",
+			want:      false,
+		},
+		{
+			name: "different namespace",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "other"},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: "kubermatic", Kind: &kindGateway},
+						},
+					},
+				},
+			},
+			gatewayNS: "kubermatic",
+			want:      false,
+		},
+		{
+			name: "no parent refs",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kubermatic"},
+				Spec:       gatewayapiv1.HTTPRouteSpec{},
+			},
+			gatewayNS: "kubermatic",
+			want:      false,
+		},
+		{
+			name: "kind not gateway",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kubermatic"},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: "kubermatic", Kind: ptr.To(gatewayapiv1.Kind("NotGateway"))},
+						},
+					},
+				},
+			},
+			gatewayNS: "kubermatic",
+			want:      false,
+		},
+		{
+			name: "nil kind defaults to gateway",
+			route: gatewayapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "kubermatic"},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: "kubermatic"}, // Kind is nil
+						},
+					},
+				},
+			},
+			gatewayNS: "kubermatic",
+			want:      true,
+		},
+	}
+
+	r := &Reconciler{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gtw := &gatewayapiv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubermatic",
+					Namespace: tt.gatewayNS,
+				},
+			}
+			got := r.referencesGateway(tt.route, gtw)
+			if got != tt.want {
+				t.Errorf("referencesGateway() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/operator/master/controller.go
+++ b/pkg/controller/operator/master/controller.go
@@ -63,15 +63,17 @@ func Add(
 	numWorkers int,
 	workerName string,
 	enableGatewayAPI bool,
+	httprouteWatchNamespaces []string,
 ) error {
 	reconciler := &Reconciler{
-		Client:            mgr.GetClient(),
-		scheme:            mgr.GetScheme(),
-		recorder:          mgr.GetEventRecorder(ControllerName),
-		log:               log.Named(ControllerName),
-		workerName:        workerName,
-		versions:          kubermatic.GetVersions(),
-		gatewayAPIEnabled: enableGatewayAPI,
+		Client:                   mgr.GetClient(),
+		scheme:                   mgr.GetScheme(),
+		recorder:                 mgr.GetEventRecorder(ControllerName),
+		log:                      log.Named(ControllerName),
+		workerName:               workerName,
+		versions:                 kubermatic.GetVersions(),
+		gatewayAPIEnabled:        enableGatewayAPI,
+		httprouteWatchNamespaces: httprouteWatchNamespaces,
 	}
 
 	bldr := builder.ControllerManagedBy(mgr).

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -64,6 +64,8 @@ type Reconciler struct {
 	// It will create Gateway and HTTPRoute resources when enabled for Kubermatic API and Dashboard.
 	// It will be by default true in the future releases as Gateway API becomes the default.
 	gatewayAPIEnabled bool
+	// httprouteWatchNamespaces is a list of namespaces to watch HTTPRoutes for Gateway listener sync.
+	httprouteWatchNamespaces []string
 }
 
 // Reconcile acts upon requests and will restore the state of resources
@@ -428,7 +430,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, config *kubermati
 	logger.Debug("Reconciling Deployments")
 
 	reconcilers := []reconciling.NamedDeploymentReconcilerFactory{
-		kubermatic.MasterControllerManagerDeploymentReconciler(config, r.workerName, r.versions),
+		kubermatic.MasterControllerManagerDeploymentReconciler(config, r.workerName, r.versions, r.httprouteWatchNamespaces),
 		common.WebhookDeploymentReconciler(config, r.versions, nil, false),
 	}
 

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -18,6 +18,7 @@ package kubermatic
 
 import (
 	"fmt"
+	"strings"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
@@ -38,7 +39,7 @@ func masterControllerManagerPodLabels() map[string]string {
 	}
 }
 
-func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerName string, versions kubermatic.Versions) reconciling.NamedDeploymentReconcilerFactory {
+func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerName string, versions kubermatic.Versions, httprouteWatchNamespaces []string) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return common.MasterControllerManagerDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 			labels := masterControllerManagerPodLabels()
@@ -65,6 +66,7 @@ func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticCon
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.MasterController.PProfEndpoint),
 				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
 				fmt.Sprintf("-overwrite-registry=%s", cfg.Spec.UserCluster.OverwriteRegistry),
+				fmt.Sprintf("-httproute-watch-namespaces=%s", strings.Join(httprouteWatchNamespaces, ",")),
 			}
 
 			if cfg.Spec.MasterController.DebugLog {

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -22,6 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -66,7 +67,10 @@ func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticCon
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.MasterController.PProfEndpoint),
 				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
 				fmt.Sprintf("-overwrite-registry=%s", cfg.Spec.UserCluster.OverwriteRegistry),
-				fmt.Sprintf("-httproute-watch-namespaces=%s", strings.Join(httprouteWatchNamespaces, ",")),
+			}
+
+			if cfg.Spec.FeatureGates[features.HTTPRouteGatewaySync] && len(httprouteWatchNamespaces) > 0 {
+				args = append(args, fmt.Sprintf("-httproute-watch-namespaces=%s", strings.Join(httprouteWatchNamespaces, ",")))
 			}
 
 			if cfg.Spec.MasterController.DebugLog {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -75,6 +75,11 @@ const (
 
 	// DynamicResourceAllocation if enabled, it lets Kubernetes allocate resources to your Pods with DRA.
 	DynamicResourceAllocation = "DynamicResourceAllocation"
+
+	// HTTPRouteGatewaySync enables the HTTPRoute to Gateway listener sync controller
+	// for cert-manager integration. This controller watches HTTPRoutes and ensures
+	// Gateway listeners have explicit hostnames so cert-manager can create certificates.
+	HTTPRouteGatewaySync = "HTTPRouteGatewaySync"
 )
 
 // FeatureGate is map of key=value pairs that enables/disables various features.

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -475,7 +475,7 @@ func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.Temp
 	deploymentReconcilers := kubernetescontroller.GetDeploymentReconcilers(templateData, kubernetescontroller.Features{}, kubermaticVersions)
 	deploymentReconcilers = append(deploymentReconcilers, monitoring.GetDeploymentReconcilers(templateData)...)
 	deploymentReconcilers = append(deploymentReconcilers, masteroperator.APIDeploymentReconciler(config, "", kubermaticVersions))
-	deploymentReconcilers = append(deploymentReconcilers, masteroperator.MasterControllerManagerDeploymentReconciler(config, "", kubermaticVersions))
+	deploymentReconcilers = append(deploymentReconcilers, masteroperator.MasterControllerManagerDeploymentReconciler(config, "", kubermaticVersions, nil))
 	deploymentReconcilers = append(deploymentReconcilers, masteroperator.UIDeploymentReconciler(config, kubermaticVersions))
 	deploymentReconcilers = append(deploymentReconcilers, seedoperatorkubermatic.SeedControllerManagerDeploymentReconciler("", kubermaticVersions, config, seed))
 	deploymentReconcilers = append(deploymentReconcilers, seedoperatornodeportproxy.EnvoyDeploymentReconciler(config, seed, false, kubermaticVersions))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a controller that watches HTTPRoutes in specified namespaces and dynamically configures HTTPS listeners on the Gateway with explicit hostnames. This enables cert-manager to automatically create certificates for KKP optional componenents like grafana, dex and prometheus.

The controller is disabled by default and can be enabled via the HTTPRouteGatewaySync feature gate.

- Add a new controller that watches HTTPRoutes and dynamically creates HTTPS listeners on the Gateway with explicit hostnames
- Enables cert-manager to automatically issue certificates for KKP components (grafana, dex, prometheus, etc.)
- Bridges the gap between KKP's shared Gateway model and cert-manager's requirement for explicit listener hostnames

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Special notes for your reviewer**:
This controller is a workaround for a current limitation in Gateway API (XListenerSet) + cert-manager combination.
For more details on this constraint, see the upstream cert-manager issue: https://github.com/cert-manager/cert-manager/issues/7473

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add HTTPRoute-Gateway sync controller to enable automatic certificate provisioning via cert-manager for KKP components
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/2088
```

The documentation will be updated accordingly
