### PR TITLE
Bump oauth2-proxy to appversion v7.14.2

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: 9.9.9-dev
-appVersion: v7.13.0
+appVersion: v7.14.2
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -81,7 +81,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -240,7 +240,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/test/values.extraArgs.yaml.out
+++ b/charts/iap/test/values.extraArgs.yaml.out
@@ -139,7 +139,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -242,7 +242,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc

--- a/charts/iap/test/values.httproute.yaml.out
+++ b/charts/iap/test/values.httproute.yaml.out
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -238,7 +238,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.13.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -424,7 +424,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: alertmanager-iap
-  namespace: default
+  namespace: kubermatic
   labels:
     app: iap
     target: alertmanager
@@ -454,7 +454,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: grafana-iap
-  namespace: default
+  namespace: kubermatic
   labels:
     app: iap
     target: grafana

--- a/charts/iap/test/values.httproute.yaml.out
+++ b/charts/iap/test/values.httproute.yaml.out
@@ -424,7 +424,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: alertmanager-iap
-  namespace: kubermatic
+  namespace: default
   labels:
     app: iap
     target: alertmanager
@@ -454,7 +454,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: grafana-iap
-  namespace: kubermatic
+  namespace: default
   labels:
     app: iap
     target: grafana

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -29,7 +29,7 @@ httpRoute:
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.13.0
+    tag: v7.14.2
     pullPolicy: IfNotPresent
 
   # list of image pull secret references, e.g.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps the oauth2-proxy with latest appversion v7.14.2. The [v7.14.0 ](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.0) brings lot of CVEs fixes and potential breaking change for alpha configuration users. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump oauth2-proxy to appversion v7.14.2. 
- ⚠️ Potentially BREAKING Change: 🗂️ Major Alpha Config YAML parsing revamped for better extensibility and preparing v8. Please take look at https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.0 for more details.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
