### PR TITLE
Add LoadBalancerFloatingIPPool field for OpenStack clusters

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1480,6 +1480,20 @@ spec:
                               - name
                             type: object
                           type: array
+                        loadBalancerFloatingIPPool:
+                          description: |-
+                            LoadBalancerFloatingIPPool holds the name of the external network to be used
+                            for LoadBalancer floating IP allocation.
+
+                            When specified, LoadBalancer type Services will receive floating IPs from this pool
+                            instead of the FloatingIPPool. This allows using different external networks for
+                            cluster infrastructure (router) vs. LoadBalancer services.
+                            If not specified, FloatingIPPool is used for LoadBalancers for backward compatibility.
+
+                            This field sets a cluster-wide default for LoadBalancers. Services can override
+                            this default by using the `loadbalancer.openstack.org/class` annotation to select
+                            a specific LoadBalancerClass.
+                          type: string
                         network:
                           description: |-
                             Network holds the name of the internal network

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1474,6 +1474,20 @@ spec:
                               - name
                             type: object
                           type: array
+                        loadBalancerFloatingIPPool:
+                          description: |-
+                            LoadBalancerFloatingIPPool holds the name of the external network to be used
+                            for LoadBalancer floating IP allocation.
+
+                            When specified, LoadBalancer type Services will receive floating IPs from this pool
+                            instead of the FloatingIPPool. This allows using different external networks for
+                            cluster infrastructure (router) vs. LoadBalancer services.
+                            If not specified, FloatingIPPool is used for LoadBalancers for backward compatibility.
+
+                            This field sets a cluster-wide default for LoadBalancers. Services can override
+                            this default by using the `loadbalancer.openstack.org/class` annotation to select
+                            a specific LoadBalancerClass.
+                          type: string
                         network:
                           description: |-
                             Network holds the name of the internal network

--- a/pkg/provider/cloud/openstack/internal/testing/fixtures.go
+++ b/pkg/provider/cloud/openstack/internal/testing/fixtures.go
@@ -60,6 +60,11 @@ var ExternalNetworkFoo = Network{
 	NetworkExternalExt: external.NetworkExternalExt{External: true},
 }
 
+var SecondExternalNetwork = Network{
+	Network:            networks.Network{Name: "second-external-network", ID: "f5e7a7b6-1234-5678-90ab-cdef12345678"},
+	NetworkExternalExt: external.NetworkExternalExt{External: true},
+}
+
 var InternalNetwork = Network{
 	Network: networks.Network{Name: "kubernetes-cluster-xyz", ID: NetworkID},
 }

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -62,6 +62,10 @@ const (
 
 	// FloatingIPPoolIDAnnotation stores the ID of the floating IP pool (external network).
 	FloatingIPPoolIDAnnotation = "kubermatic.k8c.io/openstack-floating-ip-pool-id"
+
+	// LoadBalancerFloatingIPPoolIDAnnotation stores the ID of the floating IP pool
+	// to be used for LoadBalancer floating IP allocation.
+	LoadBalancerFloatingIPPoolIDAnnotation = "kubermatic.k8c.io/openstack-loadbalancer-floating-ip-pool-id"
 )
 
 type getClientFunc func(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error)
@@ -155,6 +159,13 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 		}
 	}
 
+	if spec.Openstack.LoadBalancerFloatingIPPool != "" {
+		_, err := getNetworkByName(netClient, spec.Openstack.LoadBalancerFloatingIPPool, true)
+		if err != nil {
+			return fmt.Errorf("failed to get load balancer floating ip pool %q: %w", spec.Openstack.LoadBalancerFloatingIPPool, err)
+		}
+	}
+
 	if spec.Openstack.IPv6SubnetPool != "" {
 		subnetPool, err := getSubnetPoolByName(netClient, spec.Openstack.IPv6SubnetPool)
 		if err != nil {
@@ -219,7 +230,10 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 		return nil, err
 	}
 
-	// Reconciling the external Network (the floating IP pool used for machines and LBs)
+	// Reconciling the external Network
+	// By default, the same floating IP pool used for machines and LBs.
+	// Optionally, a dedicated floating IP pool can be specified for LBs, to ensure machines and LBs
+	// will use separate floating IP pools.
 	// We don't need the usual if conditional here because the reconcile function doesn't
 	// create anything.
 	cluster, err = reconcileExtNetwork(ctx, netClient, cluster, update)
@@ -307,8 +321,9 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 
 func reconcileExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClient, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	var (
-		err        error
-		extNetwork *NetworkWithExternalExt
+		err          error
+		extNetwork   *NetworkWithExternalExt
+		lbExtNetwork *NetworkWithExternalExt
 	)
 
 	if cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
@@ -325,15 +340,32 @@ func reconcileExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClie
 		}
 	}
 
+	hasLBFloatingIpPool := false
+	if cluster.Spec.Cloud.Openstack.LoadBalancerFloatingIPPool != "" {
+		lbExtNetwork, err = getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.LoadBalancerFloatingIPPool, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get external network for load balancer floating IP pool by name: %w", err)
+		}
+
+		hasLBFloatingIpPool = true
+	}
+
 	// We're just searching for the floating ip pool here & don't create anything. Thus no need to create a finalizer.
 	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
-		// This should be a noop if the floating IP pool was already correctly provided.
 		cluster.Spec.Cloud.Openstack.FloatingIPPool = extNetwork.Name
 
 		if cluster.Annotations == nil {
 			cluster.Annotations = make(map[string]string)
 		}
+
 		cluster.Annotations[FloatingIPPoolIDAnnotation] = extNetwork.ID
+		// by default, the same floating IP pool is used for machines and LBs.
+		cluster.Annotations[LoadBalancerFloatingIPPoolIDAnnotation] = extNetwork.ID
+
+		if hasLBFloatingIpPool && lbExtNetwork != nil {
+			cluster.Spec.Cloud.Openstack.LoadBalancerFloatingIPPool = lbExtNetwork.Name
+			cluster.Annotations[LoadBalancerFloatingIPPoolIDAnnotation] = lbExtNetwork.ID
+		}
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to update cluster floating IP pool: %w", err)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -340,14 +340,14 @@ func reconcileExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClie
 		}
 	}
 
-	hasLBFloatingIpPool := false
+	hasLBFloatingIPPool := false
 	if cluster.Spec.Cloud.Openstack.LoadBalancerFloatingIPPool != "" {
 		lbExtNetwork, err = getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.LoadBalancerFloatingIPPool, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external network for load balancer floating IP pool by name: %w", err)
 		}
 
-		hasLBFloatingIpPool = true
+		hasLBFloatingIPPool = true
 	}
 
 	// We're just searching for the floating ip pool here & don't create anything. Thus no need to create a finalizer.
@@ -362,7 +362,7 @@ func reconcileExtNetwork(ctx context.Context, netClient *gophercloud.ServiceClie
 		// by default, the same floating IP pool is used for machines and LBs.
 		cluster.Annotations[LoadBalancerFloatingIPPoolIDAnnotation] = extNetwork.ID
 
-		if hasLBFloatingIpPool && lbExtNetwork != nil {
+		if hasLBFloatingIPPool && lbExtNetwork != nil {
 			cluster.Spec.Cloud.Openstack.LoadBalancerFloatingIPPool = lbExtNetwork.Name
 			cluster.Annotations[LoadBalancerFloatingIPPoolIDAnnotation] = lbExtNetwork.ID
 		}

--- a/pkg/resources/cloudconfig/openstack/cloudconfig.go
+++ b/pkg/resources/cloudconfig/openstack/cloudconfig.go
@@ -135,10 +135,13 @@ func ForCluster(cluster *kubermaticv1.Cluster, dc *kubermaticv1.Datacenter, cred
 		cc.LoadBalancer.IngressHostnameSuffix = cluster.Spec.Cloud.Openstack.IngressHostnameSuffix
 	}
 
-	// we won't throw an error here for backwards compatibility and instead simply not set
-	// the floating-ip-pool-id field if the annotation is not there.
-	if cluster.Annotations[openstack.FloatingIPPoolIDAnnotation] != "" {
-		cc.LoadBalancer.FloatingNetworkID = cluster.Annotations[openstack.FloatingIPPoolIDAnnotation]
+	if cluster.Annotations != nil {
+		// prefer LoadBalancer-specific floating IP pool if set, otherwise fallback to the default one.
+		if cluster.Annotations[openstack.LoadBalancerFloatingIPPoolIDAnnotation] != "" {
+			cc.LoadBalancer.FloatingNetworkID = cluster.Annotations[openstack.LoadBalancerFloatingIPPoolIDAnnotation]
+		} else if cluster.Annotations[openstack.FloatingIPPoolIDAnnotation] != "" {
+			cc.LoadBalancer.FloatingNetworkID = cluster.Annotations[openstack.FloatingIPPoolIDAnnotation]
+		}
 	}
 
 	return cc

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -1475,8 +1475,23 @@ type OpenstackCloudSpec struct {
 	//
 	// Note that the network is external if the "External" field is set to true
 	FloatingIPPool string `json:"floatingIPPool"`
-	RouterID       string `json:"routerID"`
-	SubnetID       string `json:"subnetID"`
+	// LoadBalancerFloatingIPPool holds the name of the external network to be used
+	// for LoadBalancer floating IP allocation.
+	//
+	// When specified, LoadBalancer type Services will receive floating IPs from this pool
+	// instead of the FloatingIPPool. This allows using different external networks for
+	// cluster infrastructure (router) vs. LoadBalancer services.
+	// If not specified, FloatingIPPool is used for LoadBalancers for backward compatibility.
+	//
+	// This field sets a cluster-wide default for LoadBalancers. Services can override
+	// this default by using the `loadbalancer.openstack.org/class` annotation to select
+	// a specific LoadBalancerClass.
+	// +optional
+	LoadBalancerFloatingIPPool string `json:"loadBalancerFloatingIPPool,omitempty"`
+
+	RouterID string `json:"routerID"`
+	SubnetID string `json:"subnetID"`
+
 	// SubnetCIDR is the CIDR that will be assigned to the subnet that is created for the cluster if the cluster spec
 	// didn't specify a subnet id.
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow specifying a separate floating IP pool for LoadBalancer services independent of the router's external network. This enables using different external networks for infrastructure traffic versus production services.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15222

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Special notes for your reviewer**:

The implementation:
- Adds `LoadBalancerFloatingIPPool` field to `OpenstackCloudSpec`
- Sets `LoadBalancerFloatingIPPoolIDAnnotation` during cloud provider reconciliation
- Cloud config generation reads the annotation and sets `floating-network-id` in the `[LoadBalancer]` section
- Falls back to `FloatingIPPool` if `LoadBalancerFloatingIPPool` is not set (backward compatible)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `loadBalancerFloatingIPPool` field to OpenStack cloud spec to allow specifying a dedicated floating IP pool for LoadBalancer services.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
