### PR TITLE
Fix Azure conformance test VM size for Rocky Linux compatibility

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	azureVMSize = "Standard_F2"
+	azureVMSize = "Standard_F2s_v2"
 )
 
 type azureScenario struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes our conformance tests for Rocky Linux on Azure. `Standard_F2` only supports Gen1 VMs, but the Rocky Linux marketplace image (`resf:rockylinux-x86_64:9-base`) is Gen2-only. We are changing to `Standard_F2s_v2` which supports both Gen1 and Gen2.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
