### PR TITLE
Fix alertmanager service port name reference after upstream chart migration

### DIFF
--- a/charts/monitoring/karma/templates/deployment.yaml
+++ b/charts/monitoring/karma/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
 
           kubectl -n "$ns" get services -l 'app.kubernetes.io/name=seed-proxy' -o "custom-columns=name:{.metadata.labels['app\.kubernetes\.io/instance']}" --no-headers | while read seed; do
             echo "  - name: $seed" >> $out
-            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:web/proxy/" >> $out
+            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:http/proxy/" >> $out
             echo "    proxy: true" >> $out
           done
         volumeMounts:

--- a/charts/monitoring/karma/test/default.yaml.out
+++ b/charts/monitoring/karma/test/default.yaml.out
@@ -242,7 +242,7 @@ spec:
 
           kubectl -n "$ns" get services -l 'app.kubernetes.io/name=seed-proxy' -o "custom-columns=name:{.metadata.labels['app\.kubernetes\.io/instance']}" --no-headers | while read seed; do
             echo "  - name: $seed" >> $out
-            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:web/proxy/" >> $out
+            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:http/proxy/" >> $out
             echo "    proxy: true" >> $out
           done
         volumeMounts:

--- a/charts/monitoring/karma/test/values.example.ce.yaml.out
+++ b/charts/monitoring/karma/test/values.example.ce.yaml.out
@@ -242,7 +242,7 @@ spec:
 
           kubectl -n "$ns" get services -l 'app.kubernetes.io/name=seed-proxy' -o "custom-columns=name:{.metadata.labels['app\.kubernetes\.io/instance']}" --no-headers | while read seed; do
             echo "  - name: $seed" >> $out
-            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:web/proxy/" >> $out
+            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:http/proxy/" >> $out
             echo "    proxy: true" >> $out
           done
         volumeMounts:

--- a/charts/monitoring/karma/test/values.example.ee.yaml.out
+++ b/charts/monitoring/karma/test/values.example.ee.yaml.out
@@ -242,7 +242,7 @@ spec:
 
           kubectl -n "$ns" get services -l 'app.kubernetes.io/name=seed-proxy' -o "custom-columns=name:{.metadata.labels['app\.kubernetes\.io/instance']}" --no-headers | while read seed; do
             echo "  - name: $seed" >> $out
-            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:web/proxy/" >> $out
+            echo "    uri: http://seed-proxy-$seed.$ns.svc.cluster.local:8001/api/v1/namespaces/monitoring/services/alertmanager:http/proxy/" >> $out
             echo "    proxy: true" >> $out
           done
         volumeMounts:

--- a/pkg/controller/master-controller-manager/seed-proxy/controller.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/controller.go
@@ -74,7 +74,7 @@ const (
 	SeedPrometheusService = "prometheus:web"
 
 	// SeedAlertmanagerService is the service exposed by Alertmanager.
-	SeedAlertmanagerService = "alertmanager:web"
+	SeedAlertmanagerService = "alertmanager:http"
 
 	// KubectlProxyPort is the port used by kubectl to provide the
 	// proxy connection on. This is not the port on which any of the


### PR DESCRIPTION
**What this PR does / why we need it**:
The migration to the upstream alertmanager chart (#14175) changed the service port name from `web` to `http`. The karma deployment URI and seed-proxy RBAC were not updated to reflect this change, and this prevents karma from reaching alertmanager on seed clusters. This PR updates the `SeedAlertmanagerService` and the karma depl to use the `http` port, which also fixes the RBAC ResourceNames that blocked access.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #14175

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix alertmanager service port name reference after upstream chart migration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
