### PR TITLE
Consistent support for EventRateLimit enablement checks across defaulting, validation, and rendering

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -304,20 +304,24 @@ func defaultEventRateLimitPlugin(spec *kubermaticv1.ClusterSpec, config *kuberma
 	erl := config.Spec.UserCluster.AdmissionPlugins.EventRateLimit
 	isEnforced := erl.Enforced != nil && *erl.Enforced
 
+	isEnabled := spec.IsEventRateLimitAdmissionPluginEnabled()
+
 	// If enforced, enable the plugin
 	if isEnforced {
 		spec.UseEventRateLimitAdmissionPlugin = true
+		isEnabled = true
 	}
 
 	// Apply enabled default if not already enabled
-	if !spec.UseEventRateLimitAdmissionPlugin && erl.Enabled != nil && *erl.Enabled {
+	if !isEnabled && erl.Enabled != nil && *erl.Enabled {
 		spec.UseEventRateLimitAdmissionPlugin = true
+		isEnabled = true
 	}
 
 	// Apply configuration:
 	// - If enforced AND defaultConfig is set: always apply (overwrite user config)
 	// - If not enforced: only apply if user hasn't specified config
-	if spec.UseEventRateLimitAdmissionPlugin && erl.DefaultConfig != nil {
+	if isEnabled && erl.DefaultConfig != nil {
 		if isEnforced || spec.EventRateLimitConfig == nil {
 			spec.EventRateLimitConfig = erl.DefaultConfig.DeepCopy()
 		}

--- a/pkg/resources/apiserver/admission-control.go
+++ b/pkg/resources/apiserver/admission-control.go
@@ -125,8 +125,7 @@ func usePodNodeSelectorAdmissionPlugin(data *resources.TemplateData) bool {
 }
 
 func useEventRateLimitAdmissionPlugin(data *resources.TemplateData) bool {
-	admissionPlugins := sets.New(data.Cluster().Spec.AdmissionPlugins...)
-	return data.Cluster().Spec.UseEventRateLimitAdmissionPlugin || admissionPlugins.Has(resources.EventRateLimitAdmissionPlugin)
+	return data.Cluster().Spec.IsEventRateLimitAdmissionPluginEnabled()
 }
 
 func getPodNodeSelectorAdmissionPluginConfig(data *resources.TemplateData) (string, error) {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -484,7 +484,7 @@ const (
 	PodNodeSelectorAdmissionPlugin = "PodNodeSelector"
 
 	// EventRateLimitAdmissionPlugin defines the EventRateLimit admission plugin.
-	EventRateLimitAdmissionPlugin = "EventRateLimit"
+	EventRateLimitAdmissionPlugin = kubermaticv1.AdmissionPluginNameEventRateLimit
 
 	// KubeVirtInfraSecretName is the name for the secret containing the kubeconfig of the kubevirt infra cluster.
 	KubeVirtInfraSecretName = "cloud-controller-manager-infra-kubeconfig"

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -1397,7 +1397,7 @@ func ValidateEventRateLimitConfig(spec *kubermaticv1.ClusterSpec, fldPath *field
 	var allErrs field.ErrorList
 
 	config := spec.EventRateLimitConfig
-	pluginEnabled := spec.UseEventRateLimitAdmissionPlugin || slices.Contains(spec.AdmissionPlugins, resources.EventRateLimitAdmissionPlugin)
+	pluginEnabled := spec.IsEventRateLimitAdmissionPluginEnabled()
 
 	// Check if plugin is enabled and no limits are configured, apiserver crashes otherwise
 	hasLimits := config != nil && (config.Server != nil || config.Namespace != nil || config.User != nil || config.SourceAndObject != nil)

--- a/pkg/webhook/cluster/validation/validation.go
+++ b/pkg/webhook/cluster/validation/validation.go
@@ -269,19 +269,19 @@ func (v *validator) validateEventRateLimitEnforcement(
 	}
 
 	isUpdate := oldCluster != nil
+	newPluginEnabled := newCluster.Spec.IsEventRateLimitAdmissionPluginEnabled()
 
 	fieldPath := field.NewPath("spec", "useEventRateLimitAdmissionPlugin")
 	if isUpdate {
 		// Prevent disabling when enforced
-		if oldCluster.Spec.UseEventRateLimitAdmissionPlugin && !newCluster.Spec.UseEventRateLimitAdmissionPlugin {
+		oldPluginEnabled := oldCluster.Spec.IsEventRateLimitAdmissionPluginEnabled()
+		if oldPluginEnabled && !newPluginEnabled {
 			return field.Invalid(fieldPath, false,
 				"EventRateLimit is enforced globally and cannot be disabled")
 		}
-	} else {
-		if !newCluster.Spec.UseEventRateLimitAdmissionPlugin {
-			return field.Invalid(fieldPath, false,
-				"EventRateLimit is enforced globally and must be enabled for new clusters")
-		}
+	} else if !newPluginEnabled {
+		return field.Invalid(fieldPath, false,
+			"EventRateLimit is enforced globally and must be enabled for new clusters")
 	}
 
 	if erl.DefaultConfig != nil && newCluster.Spec.EventRateLimitConfig != nil {

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -72,6 +72,11 @@ const (
 	DefaultKonnectivityKeepaliveTime = "1m"
 )
 
+const (
+	// AdmissionPluginNameEventRateLimit is the EventRateLimit admission plugin name.
+	AdmissionPluginNameEventRateLimit = "EventRateLimit"
+)
+
 // +kubebuilder:validation:Enum=standard;basic
 
 // Azure SKU for Load Balancers. Possible values are `basic` and `standard`.
@@ -288,6 +293,17 @@ type KubernetesDashboard struct {
 
 func (c ClusterSpec) IsKubernetesDashboardEnabled() bool {
 	return c.KubernetesDashboard == nil || c.KubernetesDashboard.Enabled
+}
+
+// HasAdmissionPlugin reports whether the given admission plugin name exists in AdmissionPlugins.
+func (c ClusterSpec) HasAdmissionPlugin(name string) bool {
+	return slices.Contains(c.AdmissionPlugins, name)
+}
+
+// IsEventRateLimitAdmissionPluginEnabled reports whether EventRateLimit is enabled either
+// via the dedicated boolean field or through AdmissionPlugins.
+func (c ClusterSpec) IsEventRateLimitAdmissionPluginEnabled() bool {
+	return c.UseEventRateLimitAdmissionPlugin || c.HasAdmissionPlugin(AdmissionPluginNameEventRateLimit)
 }
 
 // KubeLB contains settings for the kubeLB component as part of the cluster control plane. This component is responsible for managing load balancers.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes inconsistent handling of EventRateLimit enablement when set via `spec.admissionPlugins` instead of `spec.useEventRateLimitAdmissionPlugin`.  The way to enable KKP admission plugins is through dedicated fields when they exist (for EventRateLimit the managed field is `spec.useEventRateLimitAdmissionPlugin`). This is because `EventRateLimit` requires specific configuration via `spec.eventRateLimitConfig`. This has been the idea from it's implementation, with previous PRs (like https://github.com/kubermatic/kubermatic/pull/9566) [mentioning](https://github.com/kubermatic/kubermatic/pull/9566/changes#diff-b7b5c98db3998fcbbf62b9c40031c371c4508f502115ecb1c4252e4ae3941197R172-R178) that the `AdmissionPlugins` field **must not** include plugins that can be enabled through different settings (like `useEventRateLimitAdmissionPlugin`).
In the current state, the `spec.admissionPlugins` list is still accepted with EventRateLimit value for backward compatibility, and this PR makes backend consistent for both inputs for defaulting, validation, enforcement checks, and apiserver rendering. We should evaluate a normalization path for clusters that currently set `EventRateLimit` via `admissionPlugins` (for example, migrating that state toward the dedicated field **and** removing the list entry). 
We should also evaluate updating the current documentation to make the workings of our admission plugins more explicit, the current documentation doesn't mention the use of the dedicated fields like `useEventRateLimitAdmissionPlugin`, but only mentions that plugins like EventRateLimit should not be present in `admissionPlugins`. xref: https://docs.kubermatic.com/kubermatic/v2.29/tutorials-howtos/admission-plugins/

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind cleanup

**Special notes for your reviewer**:
- This PR does not normalize EventRateLimit from `admissionPlugins`, that can be handled separately.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
