### PR TITLE
Reconcile kube-proxy rollout when Cluster.Network settings change

### DIFF
--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         k8s-app: kube-proxy
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        checksum/config: '{{ printf "%s-%s-%v" .Cluster.Network.ProxyMode (join .Cluster.Network.PodCIDRBlocks ",") .Cluster.Network.StrictArp | sha256sum }}'
+        checksum/config: '{{ printf "%s-%s" .Cluster.Network.ProxyMode (join (sortAlpha .Cluster.Network.PodCIDRBlocks) ",") | sha256sum }}'
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
         k8s-app: kube-proxy
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        checksum/config: '{{ printf "%s-%s-%v" .Cluster.Network.ProxyMode (join .Cluster.Network.PodCIDRBlocks ",") .Cluster.Network.StrictArp | sha256sum }}'
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         k8s-app: kube-proxy
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        checksum/config: '{{ printf "%s-%s" .Cluster.Network.ProxyMode (join (sortAlpha .Cluster.Network.PodCIDRBlocks) ",") | sha256sum }}'
+        checksum/config: '{{ .Cluster.Network.ConfigHash }}'
     spec:
       priorityClassName: system-node-critical
       containers:

--- a/pkg/addon/types.go
+++ b/pkg/addon/types.go
@@ -17,7 +17,11 @@ limitations under the License.
 package addon
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"sort"
 
 	semverlib "github.com/Masterminds/semver/v3"
 
@@ -248,6 +252,28 @@ type ClusterNetwork struct {
 	NodeCIDRMaskSizeIPv6 int32
 	IPAMAllocations      map[string]IPAMAllocation
 	NodePortRange        string
+}
+
+func (n ClusterNetwork) ConfigHash() string {
+	normalized := n
+
+	if len(n.PodCIDRBlocks) > 0 {
+		normalized.PodCIDRBlocks = append([]string(nil), n.PodCIDRBlocks...)
+		sort.Strings(normalized.PodCIDRBlocks)
+	}
+
+	if len(n.ServiceCIDRBlocks) > 0 {
+		normalized.ServiceCIDRBlocks = append([]string(nil), n.ServiceCIDRBlocks...)
+		sort.Strings(normalized.ServiceCIDRBlocks)
+	}
+
+	b, err := json.Marshal(normalized)
+	if err != nil {
+		return ""
+	}
+
+	sum := sha1.Sum(b)
+	return hex.EncodeToString(sum[:])
 }
 
 type IPAMAllocation struct {

--- a/pkg/addon/types_test.go
+++ b/pkg/addon/types_test.go
@@ -105,3 +105,163 @@ func TestNewTemplateData(t *testing.T) {
 		},
 	}, templateData.Cluster.Network.IPAMAllocations)
 }
+
+func TestClusterNetworkConfigHash(t *testing.T) {
+	tests := []struct {
+		name       string
+		a          ClusterNetwork
+		b          ClusterNetwork
+		expectSame bool
+	}{
+		{
+			name: "identical structs produce the same hash",
+			a: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"10.244.0.0/16"},
+			},
+			b: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"10.244.0.0/16"},
+			},
+			expectSame: true,
+		},
+		{
+			name: "different proxy mode produces different hash",
+			a: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"10.244.0.0/16"},
+			},
+			b: ClusterNetwork{
+				ProxyMode:     "ipvs",
+				PodCIDRBlocks: []string{"10.244.0.0/16"},
+				StrictArp:     ptr.To(true),
+			},
+			expectSame: false,
+		},
+		{
+			name: "different PodCIDRBlocks order produces the same hash",
+			a: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"10.244.0.0/16", "fd00::/48"},
+			},
+			b: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"fd00::/48", "10.244.0.0/16"},
+			},
+			expectSame: true,
+		},
+		{
+			name: "different ServiceCIDRBlocks order produces the same hash",
+			a: ClusterNetwork{
+				ProxyMode:         "iptables",
+				ServiceCIDRBlocks: []string{"10.96.0.0/12", "fd01::/108"},
+			},
+			b: ClusterNetwork{
+				ProxyMode:         "iptables",
+				ServiceCIDRBlocks: []string{"fd01::/108", "10.96.0.0/12"},
+			},
+			expectSame: true,
+		},
+		{
+			name: "different StrictArp values produce different hash",
+			a: ClusterNetwork{
+				ProxyMode: "ipvs",
+				StrictArp: ptr.To(true),
+			},
+			b: ClusterNetwork{
+				ProxyMode: "ipvs",
+				StrictArp: ptr.To(false),
+			},
+			expectSame: false,
+		},
+		{
+			name: "nil StrictArp vs non-nil StrictArp produce different hash",
+			a: ClusterNetwork{
+				ProxyMode: "iptables",
+				StrictArp: nil,
+			},
+			b: ClusterNetwork{
+				ProxyMode: "iptables",
+				StrictArp: ptr.To(true),
+			},
+			expectSame: false,
+		},
+		{
+			name:       "empty structs produce the same hash",
+			a:          ClusterNetwork{},
+			b:          ClusterNetwork{},
+			expectSame: true,
+		},
+		{
+			name: "different PodCIDRBlocks values produce different hash",
+			a: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"10.244.0.0/16"},
+			},
+			b: ClusterNetwork{
+				ProxyMode:     "iptables",
+				PodCIDRBlocks: []string{"10.244.0.0/16", "fd00::/48"},
+			},
+			expectSame: false,
+		},
+		{
+			name: "different NodePortRange produces different hash",
+			a: ClusterNetwork{
+				ProxyMode:     "iptables",
+				NodePortRange: "30000-32767",
+			},
+			b: ClusterNetwork{
+				ProxyMode:     "iptables",
+				NodePortRange: "30000-32000",
+			},
+			expectSame: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hashA := tt.a.ConfigHash()
+			hashB := tt.b.ConfigHash()
+
+			if hashA == "" {
+				t.Fatal("ConfigHash returned empty string for a")
+			}
+			if hashB == "" {
+				t.Fatal("ConfigHash returned empty string for b")
+			}
+
+			if tt.expectSame {
+				assert.Equal(t, hashA, hashB, "expected same hash")
+			} else {
+				assert.NotEqual(t, hashA, hashB, "expected different hash")
+			}
+		})
+	}
+}
+
+func TestClusterNetworkConfigHashDoesNotMutate(t *testing.T) {
+	original := []string{"fd00::/48", "10.244.0.0/16"}
+	n := ClusterNetwork{
+		ProxyMode:     "iptables",
+		PodCIDRBlocks: original,
+	}
+
+	n.ConfigHash()
+
+	assert.Equal(t, []string{"fd00::/48", "10.244.0.0/16"}, n.PodCIDRBlocks,
+		"ConfigHash must not mutate the original PodCIDRBlocks slice")
+}
+
+func TestClusterNetworkConfigHashNilStrictArp(t *testing.T) {
+	n := ClusterNetwork{
+		ProxyMode:     "iptables",
+		PodCIDRBlocks: []string{"10.244.0.0/16"},
+		StrictArp:     nil,
+	}
+
+	hash := n.ConfigHash()
+	assert.NotEmpty(t, hash, "ConfigHash must return a valid hash even when StrictArp is nil")
+
+	// Calling again must produce the same result.
+	assert.Equal(t, hash, n.ConfigHash(), "ConfigHash must be deterministic with nil StrictArp")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add checksum-based restart for kube-proxy on cluster network changes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #15433 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Potential BREAKING CHANGE: Add checksum-based restart for kube-proxy on cluster network changes.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
