### PR TITLE
Default proxy mode to nftables for k8s v1.35

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -116,6 +116,40 @@ presubmits:
             limits:
               memory: 6Gi
 
+  - name: pre-kubermatic-canal-e2e
+    run_if_changed: ".*(canal|kube-proxy|apis|addon|connectivity-check|defaults|cni|validation|operator|webhook|crd|.prow|go.mod).*"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws-e2e-kkp: "true"
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+      preset-e2e-ssh: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-6
+          command:
+            - "./hack/ci/run-canal-e2e-test.sh"
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi
+
   - name: pre-kubermatic-gateway-api-e2e
     run_if_changed: ".*(envoy[-_]gateway|gateway[-_]api|GatewayAPI|pkg/test/e2e/gateway-api/|hack/ci/run-gateway-api|.prow/|gateway/|gateway\\.go)"
     decorate: true

--- a/hack/ci/run-canal-e2e-test.sh
+++ b/hack/ci/run-canal-e2e-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script runs Canal CNI e2e tests, verifying Canal networking
+### and kube-proxy proxy mode handling.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+TEST_NAME="Pre-warm Go build cache"
+echodate "Attempting to pre-warm Go build cache"
+
+beforeGocache=$(nowms)
+make download-gocache
+pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
+export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
+export KUBERMATIC_YAML=hack/ci/testdata/kubermatic.yaml
+source hack/ci/setup-kind-cluster.sh
+
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+
+source hack/ci/setup-kubermatic-in-kind.sh
+
+export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
+
+if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
+  echodate "Getting default SSH pubkey for machines from Vault"
+  retry 5 vault_ci_login
+  E2E_SSH_PUBKEY="$(mktemp)"
+  vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
+else
+  E2E_SSH_PUBKEY_CONTENT="${E2E_SSH_PUBKEY}"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  echo "${E2E_SSH_PUBKEY_CONTENT}" > "${E2E_SSH_PUBKEY}"
+fi
+
+echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
+
+echodate "Running Canal tests..."
+
+go_test canal_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/canal \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
+
+echodate "Canal tests done."
+

--- a/hack/ci/run-canal-e2e-test.sh
+++ b/hack/ci/run-canal-e2e-test.sh
@@ -61,4 +61,3 @@ go_test canal_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/canal \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Canal tests done."
-

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	"dario.cat/mergo"
 	"go.uber.org/zap"
+	"k8c.io/kubermatic/sdk/v2/semver"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1/helper"
@@ -191,7 +192,7 @@ func DefaultClusterSpec(
 	}
 
 	// default cluster networking parameters
-	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName), spec.ExposeStrategy)
+	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName), spec.ExposeStrategy, spec.Version)
 	return nil
 }
 
@@ -231,7 +232,7 @@ func DatacenterForClusterSpec(spec *kubermaticv1.ClusterSpec, seed *kubermaticv1
 	return nil, field.Invalid(field.NewPath("spec", "cloud", "dc"), datacenterName, "invalid datacenter name")
 }
 
-func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConfig, provider kubermaticv1.ProviderType, exposeStrategy kubermaticv1.ExposeStrategy) kubermaticv1.ClusterNetworkingConfig {
+func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConfig, provider kubermaticv1.ProviderType, exposeStrategy kubermaticv1.ExposeStrategy, clusterVersion semver.Semver) kubermaticv1.ClusterNetworkingConfig {
 	if specClusterNetwork.IPFamily == "" {
 		if len(specClusterNetwork.Pods.CIDRBlocks) < 2 {
 			// single / no pods CIDR means IPv4-only (IPv6-only is not supported yet and not allowed by cluster validation)
@@ -265,7 +266,7 @@ func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConf
 	}
 
 	if specClusterNetwork.ProxyMode == "" {
-		specClusterNetwork.ProxyMode = resources.GetDefaultProxyMode(provider)
+		specClusterNetwork.ProxyMode = resources.GetDefaultProxyMode(provider, clusterVersion)
 	}
 
 	if specClusterNetwork.ProxyMode == resources.IPVSProxyMode {

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -22,10 +22,10 @@ import (
 
 	"dario.cat/mergo"
 	"go.uber.org/zap"
-	"k8c.io/kubermatic/sdk/v2/semver"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1/helper"
+	"k8c.io/kubermatic/sdk/v2/semver"
 	"k8c.io/kubermatic/v2/pkg/cni"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"go.uber.org/zap"
+	"k8c.io/kubermatic/sdk/v2/semver"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
@@ -1755,7 +1756,11 @@ func GetDefaultServicesCIDRIPv4(provider kubermaticv1.ProviderType) string {
 }
 
 // GetDefaultProxyMode returns the default proxy mode for the given provider.
-func GetDefaultProxyMode(provider kubermaticv1.ProviderType) string {
+func GetDefaultProxyMode(provider kubermaticv1.ProviderType, clusterVersion semver.Semver) string {
+	// default to nftables for Kubernetes 1.35+ as iptables is deprecated and will be removed in Kubernetes 1.36
+	if clusterVersion.Semver() != nil && clusterVersion.Semver().Minor() >= 35 {
+		return NFTablesProxyMode
+	}
 	if provider == kubermaticv1.HetznerCloudProvider {
 		// IPVS causes issues with Hetzner's LoadBalancers, which should
 		// be addressed via https://github.com/kubernetes/enhancements/pull/1392

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"go.uber.org/zap"
-	"k8c.io/kubermatic/sdk/v2/semver"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/sdk/v2/semver"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/util/s3"

--- a/pkg/test/e2e/canal/canal_test.go
+++ b/pkg/test/e2e/canal/canal_test.go
@@ -1,0 +1,442 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package canal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+
+	apiv1 "k8c.io/kubermatic/sdk/v2/api/v1"
+	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/cni"
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
+	yamlutil "k8c.io/kubermatic/v2/pkg/util/yaml"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	userconfig  string
+	credentials jig.AWSCredentials
+	logOptions  = utils.DefaultLogOptions
+)
+
+const (
+	projectName  = "canal-test-project"
+	canalTestNs  = "canal-test"
+	nginxAppName = "nginx-canal-test"
+)
+
+func init() {
+	flag.StringVar(&userconfig, "userconfig", "", "path to kubeconfig of usercluster")
+	credentials.AddFlags(flag.CommandLine)
+	jig.AddFlags(flag.CommandLine)
+	logOptions.AddFlags(flag.CommandLine)
+}
+
+func TestInExistingCluster(t *testing.T) {
+	if userconfig == "" {
+		t.Logf("kubeconfig for usercluster not provided, test passes vacuously.")
+		t.Logf("to run against an existing usercluster use following command:")
+		t.Logf("go test ./pkg/test/e2e/canal -v -tags e2e -timeout 30m -run TestInExistingCluster -userconfig <USERCLUSTER KUBECONFIG>")
+		return
+	}
+
+	rawLog := log.NewFromOptions(logOptions)
+	logger := rawLog.Sugar()
+
+	config, err := clientcmd.BuildConfigFromFlags("", userconfig)
+	if err != nil {
+		t.Fatalf("failed to build config: %v", err)
+	}
+
+	client, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})
+	if err != nil {
+		t.Fatalf("failed to build ctrlruntime client: %v", err)
+	}
+
+	// set the logger used by sigs.k8s.io/controller-runtime
+	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
+
+	testUserCluster(context.Background(), t, logger, client)
+}
+
+func TestCanalClusters(t *testing.T) {
+	rawLog := log.NewFromOptions(logOptions)
+	logger := rawLog.Sugar()
+	ctx := context.Background()
+
+	if err := credentials.Parse(); err != nil {
+		t.Fatalf("Failed to get credentials: %v", err)
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		t.Fatalf("failed to build config: %v", err)
+	}
+
+	seedClient, err := ctrlruntimeclient.New(config, ctrlruntimeclient.Options{})
+	if err != nil {
+		t.Fatalf("failed to build ctrlruntime client: %v", err)
+	}
+
+	testAppDefs, err := resourcesFromYaml("./testdata/test-app-def.yaml")
+	if err != nil {
+		t.Fatalf("failed to read objects from yaml: %v", err)
+	}
+	for _, testAppDef := range testAppDefs {
+		if err := seedClient.Create(ctx, testAppDef); err != nil {
+			t.Fatalf("failed to apply resource: %v", err)
+		}
+
+		logger.Infow("Created object", "kind", testAppDef.GetObjectKind(), "name", testAppDef.GetName())
+	}
+
+	// set the logger used by sigs.k8s.io/controller-runtime
+	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLog.WithOptions(zap.AddCallerSkip(1))))
+
+	tests := []struct {
+		name      string
+		proxyMode string
+	}{
+		{
+			name:      "ipvs proxy mode test",
+			proxyMode: resources.IPVSProxyMode,
+		},
+		{
+			name:      "iptables proxy mode test",
+			proxyMode: resources.IPTablesProxyMode,
+		},
+		{
+			name:      "nftables proxy mode test",
+			proxyMode: resources.NFTablesProxyMode,
+		},
+	}
+
+	for _, test := range tests {
+		proxyMode := test.proxyMode
+		t.Run(test.name, func(t *testing.T) {
+			client, cleanup, tLogger, err := createUserCluster(ctx, t, logger.With("proxymode", proxyMode), seedClient, proxyMode)
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			if err != nil {
+				t.Fatalf("failed to create user cluster: %v", err)
+			}
+
+			testUserCluster(ctx, t, tLogger, client)
+		})
+	}
+}
+
+func testUserCluster(ctx context.Context, t *testing.T, log *zap.SugaredLogger, client ctrlruntimeclient.Client) {
+	log.Info("Waiting for Canal and kube-proxy pods to get ready...")
+	err := waitForPods(ctx, t, log, client, "kube-system", "k8s-app", []string{
+		"calico-kube-controllers",
+		"canal",
+		"kube-proxy",
+	})
+	if err != nil {
+		t.Fatalf("Canal/kube-proxy pods never became ready: %v", err)
+	}
+
+	log.Info("Verifying kube-proxy DaemonSet has config hash annotation...")
+	err = verifyKubeProxyConfigHash(ctx, log, client)
+	if err != nil {
+		t.Fatalf("kube-proxy config hash verification failed: %v", err)
+	}
+
+	log.Info("Verifying kube-proxy ConfigMap exists...")
+	cm := &corev1.ConfigMap{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "kube-proxy", Namespace: "kube-system"}, cm); err != nil {
+		t.Fatalf("failed to get kube-proxy ConfigMap: %v", err)
+	}
+
+	if _, ok := cm.Data["config.conf"]; !ok {
+		t.Fatal("kube-proxy ConfigMap is missing config.conf key")
+	}
+
+	// --- Connectivity checks ---
+	log.Info("Running Canal connectivity tests...")
+	ns := corev1.Namespace{}
+	ns.Name = canalTestNs
+	if err := client.Create(ctx, &ns); err != nil {
+		t.Fatalf("failed to create %q namespace: %v", canalTestNs, err)
+	}
+	defer func() {
+		if err := client.Delete(ctx, &ns); err != nil {
+			log.Errorw("failed to delete connectivity-test namespace", zap.Error(err))
+		}
+	}()
+
+	log = log.With("namespace", canalTestNs)
+	log.Debug("Namespace created")
+
+	installConnectivityCheck(ctx, t, log, client)
+
+	log.Info("Waiting for connectivity-check pods to get ready...")
+	err = waitForPods(ctx, t, log, client, canalTestNs, "name", []string{
+		"echo-a",
+		"echo-b",
+		"echo-b-host",
+		"host-to-b-multi-node-clusterip",
+		"host-to-b-multi-node-headless",
+		"pod-to-a",
+		"pod-to-a-allowed-knp",
+		"pod-to-a-denied-knp",
+		"pod-to-b-multi-node-clusterip",
+		"pod-to-b-multi-node-headless",
+		"pod-to-b-multi-node-nodeport",
+		"pod-to-b-intra-node-nodeport",
+		"pod-to-external-1111",
+		"pod-to-external-fqdn-google",
+	})
+	if err != nil {
+		t.Fatalf("connectivity-check pods never became ready: %v", err)
+	}
+
+	log.Info("Checking for the test nginx ApplicationInstallation...")
+	err = wait.PollLog(ctx, log, 2*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
+		app := &appskubermaticv1.ApplicationInstallation{}
+		if err := client.Get(context.Background(), types.NamespacedName{Namespace: metav1.NamespaceSystem, Name: nginxAppName}, app); err != nil {
+			return fmt.Errorf("failed to get nginx ApplicationInstallation in user cluster: %w", err), nil
+		}
+		if app.Status.ApplicationVersion == nil {
+			return fmt.Errorf("application not yet installed: %v", app.Status), nil
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Application observe test failed: %v", err)
+	}
+
+	log.Info("Canal cluster tests passed.")
+}
+
+// installConnectivityCheck deploys echo servers, client pods, and services
+// from the testdata manifests into the canal-test namespace.
+func installConnectivityCheck(ctx context.Context, t *testing.T, log *zap.SugaredLogger, client ctrlruntimeclient.Client) {
+	objs, err := resourcesFromYaml("./testdata/connectivity-check.yaml")
+	if err != nil {
+		t.Fatalf("failed to read connectivity-check manifests: %v", err)
+	}
+
+	for _, obj := range objs {
+		obj.SetNamespace(canalTestNs)
+		if err := client.Create(ctx, obj); err != nil {
+			t.Fatalf("failed to apply resource: %v", err)
+		}
+
+		log.Debugw("Created object", "kind", obj.GetObjectKind(), "name", obj.GetName())
+	}
+}
+
+// verifyKubeProxyConfigHash checks that the kube-proxy DaemonSet pod template
+// has the checksum/config annotation set (non-empty), which ensures pods will
+// be restarted when the kube-proxy ConfigMap changes.
+func verifyKubeProxyConfigHash(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client) error {
+	return wait.PollLog(ctx, log, 5*time.Second, 3*time.Minute, func(ctx context.Context) (error, error) {
+		ds := &appsv1.DaemonSet{}
+		if err := client.Get(ctx, types.NamespacedName{Name: "kube-proxy", Namespace: "kube-system"}, ds); err != nil {
+			return fmt.Errorf("failed to get kube-proxy DaemonSet: %w", err), nil
+		}
+
+		annotations := ds.Spec.Template.Annotations
+		if annotations == nil {
+			return errors.New("kube-proxy DaemonSet pod template has no annotations"), nil
+		}
+
+		hash, ok := annotations["checksum/config"]
+		if !ok {
+			return errors.New("kube-proxy DaemonSet pod template is missing checksum/config annotation"), nil
+		}
+
+		if hash == "" {
+			return errors.New("kube-proxy DaemonSet checksum/config annotation is empty"), nil
+		}
+
+		log.Infow("kube-proxy config hash verified", "hash", hash)
+		return nil, nil
+	})
+}
+
+func waitForPods(ctx context.Context, t *testing.T, log *zap.SugaredLogger, client ctrlruntimeclient.Client, namespace string, key string, names []string) error {
+	log = log.With("namespace", namespace)
+
+	r, err := labels.NewRequirement(key, selection.In, names)
+	if err != nil {
+		return fmt.Errorf("failed to build requirement: %w", err)
+	}
+	l := labels.NewSelector().Add(*r)
+
+	return wait.PollLog(ctx, log, 5*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
+		pods := corev1.PodList{}
+		err = client.List(ctx, &pods, ctrlruntimeclient.InNamespace(namespace), ctrlruntimeclient.MatchingLabelsSelector{Selector: l})
+		if err != nil {
+			return fmt.Errorf("failed to list Pods: %w", err), nil
+		}
+
+		if len(pods.Items) == 0 {
+			return errors.New("no Pods found"), nil
+		}
+
+		unready := sets.New[string]()
+		for _, pod := range pods.Items {
+			ready := false
+			for _, c := range pod.Status.Conditions {
+				if c.Type == corev1.ContainersReady {
+					ready = c.Status == corev1.ConditionTrue
+				}
+			}
+
+			if !ready {
+				unready.Insert(pod.Name)
+			}
+		}
+
+		if unready.Len() > 0 {
+			return fmt.Errorf("not all Pods are ready: %v", sets.List(unready)), nil
+		}
+
+		return nil, nil
+	})
+}
+
+func resourcesFromYaml(filename string) ([]ctrlruntimeclient.Object, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	manifests, err := yamlutil.ParseMultipleDocuments(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	var objs []ctrlruntimeclient.Object
+	for _, m := range manifests {
+		obj := &unstructured.Unstructured{}
+		if err := kyaml.NewYAMLOrJSONDecoder(bytes.NewReader(m.Raw), 1024).Decode(obj); err != nil {
+			return nil, err
+		}
+
+		objs = append(objs, obj)
+	}
+
+	return objs, nil
+}
+
+func getTestApplicationAnnotation(appName string) ([]byte, error) {
+	var values json.RawMessage
+	err := json.Unmarshal([]byte(`{"controller":{"ingressClass":"test-nginx"}}`), &values)
+	if err != nil {
+		return nil, err
+	}
+
+	app := apiv1.Application{
+		ObjectMeta: apiv1.ObjectMeta{
+			Name: appName,
+		},
+		Spec: apiv1.ApplicationSpec{
+			Namespace: apiv1.NamespaceSpec{
+				Name: metav1.NamespaceSystem,
+			},
+			ApplicationRef: apiv1.ApplicationRef{
+				Name:    appName,
+				Version: "1.8.1",
+			},
+			Values: values,
+		},
+	}
+	applications := []apiv1.Application{app}
+	data, err := json.Marshal(applications)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// createUserCluster creates a user cluster on AWS with Canal CNI.
+func createUserCluster(
+	ctx context.Context,
+	t *testing.T,
+	log *zap.SugaredLogger,
+	masterClient ctrlruntimeclient.Client,
+	proxyMode string,
+) (ctrlruntimeclient.Client, func(), *zap.SugaredLogger, error) {
+	testAppAnnotation, err := getTestApplicationAnnotation(nginxAppName)
+	if err != nil {
+		return nil, nil, log, fmt.Errorf("failed to prepare test application: %w", err)
+	}
+
+	testJig := jig.NewAWSCluster(masterClient, log, credentials, 2, nil)
+	testJig.ProjectJig.WithHumanReadableName(projectName)
+	testJig.ClusterJig.
+		WithTestName("canal").
+		WithProxyMode(proxyMode).
+		WithKonnectivity(true).
+		WithCNIPlugin(&kubermaticv1.CNIPluginSettings{
+			Type:    kubermaticv1.CNIPluginTypeCanal,
+			Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
+		}).
+		WithAnnotations(map[string]string{
+			kubermaticv1.InitialApplicationInstallationsRequestAnnotation: string(testAppAnnotation),
+		})
+
+	cleanup := func() {
+		testJig.Cleanup(ctx, t, true)
+	}
+
+	// let the magic happen
+	if _, _, err := testJig.Setup(ctx, jig.WaitForReadyPods); err != nil {
+		return nil, cleanup, log, fmt.Errorf("failed to setup test environment: %w", err)
+	}
+
+	clusterClient, err := testJig.ClusterClient(ctx)
+
+	return clusterClient, cleanup, log, err
+}

--- a/pkg/test/e2e/canal/testdata/connectivity-check.yaml
+++ b/pkg/test/e2e/canal/testdata/connectivity-check.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Canal connectivity check manifests.
 # Mirrors the Cilium connectivity-check coverage:
 #   - ClusterIP service   (pod-to-a, pod-to-b-multi-node-clusterip)
@@ -32,7 +46,7 @@ spec:
       - name: echo-a-container
         image: registry.k8s.io/e2e-test-images/agnhost:2.43
         imagePullPolicy: IfNotPresent
-        args: ["serve-hostname", "--port", "8080", "--tcp"]
+        args: ["serve-hostname", "--port", "8080"]
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -78,7 +92,7 @@ spec:
       - name: echo-b-container
         image: registry.k8s.io/e2e-test-images/agnhost:2.43
         imagePullPolicy: IfNotPresent
-        args: ["serve-hostname", "--port", "8080", "--tcp"]
+        args: ["serve-hostname", "--port", "8080"]
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -158,7 +172,7 @@ spec:
       - name: echo-b-host-container
         image: registry.k8s.io/e2e-test-images/agnhost:2.43
         imagePullPolicy: IfNotPresent
-        args: ["serve-hostname", "--port", "8180", "--tcp"]
+        args: ["serve-hostname", "--port", "8180"]
         ports:
         - containerPort: 8180
           hostPort: 8180
@@ -211,6 +225,7 @@ spec:
     metadata:
       labels:
         name: pod-to-a
+        allowed-to-echo-a: "true"
     spec:
       containers:
       - name: pod-to-a-container

--- a/pkg/test/e2e/canal/testdata/connectivity-check.yaml
+++ b/pkg/test/e2e/canal/testdata/connectivity-check.yaml
@@ -1,0 +1,744 @@
+# Canal connectivity check manifests.
+# Mirrors the Cilium connectivity-check coverage:
+#   - ClusterIP service   (pod-to-a, pod-to-b-multi-node-clusterip)
+#   - Headless service    (echo-b-headless, pod-to-b-multi-node-headless)
+#   - Host networking     (echo-b-host, echo-b-host-headless)
+#   - NodePort            (pod-to-b-intra-node-nodeport, pod-to-b-multi-node-nodeport)
+#   - Cross-node          (pod-to-b-multi-node-*)
+#   - Host-to-service     (host-to-b-multi-node-clusterip, host-to-b-multi-node-headless)
+#   - External            (pod-to-external-1111, pod-to-external-fqdn-google)
+#   - NetworkPolicy allow (pod-to-a-allowed-knp) — equivalent to Cilium's pod-to-a-allowed-cnp
+#   - NetworkPolicy deny  (pod-to-a-denied-knp)  — equivalent to Cilium's pod-to-a-denied-cnp
+---
+# echo-a: basic echo server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: echo-a
+  template:
+    metadata:
+      labels:
+        name: echo-a
+    spec:
+      containers:
+      - name: echo-a-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        args: ["serve-hostname", "--port", "8080", "--tcp"]
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-a
+  labels:
+    name: echo-a
+spec:
+  type: ClusterIP
+  selector:
+    name: echo-a
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+# echo-b: echo server with ClusterIP, headless, and NodePort services
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: echo-b
+  template:
+    metadata:
+      labels:
+        name: echo-b
+    spec:
+      containers:
+      - name: echo-b-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        args: ["serve-hostname", "--port", "8080", "--tcp"]
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          tcpSocket:
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-b
+  labels:
+    name: echo-b
+spec:
+  type: ClusterIP
+  selector:
+    name: echo-b
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+# echo-b-headless: headless service for echo-b
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-b-headless
+  labels:
+    name: echo-b-headless
+spec:
+  clusterIP: None
+  selector:
+    name: echo-b
+  ports:
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+# echo-b-nodeport: NodePort service for echo-b
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-b-nodeport
+  labels:
+    name: echo-b-nodeport
+spec:
+  type: NodePort
+  selector:
+    name: echo-b
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 31414
+    protocol: TCP
+---
+# echo-b-host: echo server running with host networking
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-b-host
+  labels:
+    name: echo-b-host
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: echo-b-host
+  template:
+    metadata:
+      labels:
+        name: echo-b-host
+    spec:
+      hostNetwork: true
+      containers:
+      - name: echo-b-host-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        args: ["serve-hostname", "--port", "8180", "--tcp"]
+        ports:
+        - containerPort: 8180
+          hostPort: 8180
+        readinessProbe:
+          tcpSocket:
+            port: 8180
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+---
+# echo-b-host-headless: headless service for echo-b-host
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo-b-host-headless
+  labels:
+    name: echo-b-host-headless
+spec:
+  clusterIP: None
+  selector:
+    name: echo-b-host
+  ports:
+  - port: 8180
+    targetPort: 8180
+    protocol: TCP
+---
+# pod-to-a: connects to echo-a via ClusterIP
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-a
+  labels:
+    name: pod-to-a
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-a
+  template:
+    metadata:
+      labels:
+        name: pod-to-a
+    spec:
+      containers:
+      - name: pod-to-a-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-a:8080
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-a:8080
+            - --timeout=5s
+            - --protocol=tcp
+---
+# pod-to-b-multi-node-clusterip: connects to echo-b via ClusterIP (scheduled on different node)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-multi-node-clusterip
+  labels:
+    name: pod-to-b-multi-node-clusterip
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-clusterip
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-clusterip
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: pod-to-b-multi-node-clusterip-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b:8080
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b:8080
+            - --timeout=5s
+            - --protocol=tcp
+---
+# pod-to-b-multi-node-headless: connects to echo-b via headless service (scheduled on different node)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-multi-node-headless
+  labels:
+    name: pod-to-b-multi-node-headless
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-headless
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-headless
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: pod-to-b-multi-node-headless-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-headless:8080
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-headless:8080
+            - --timeout=5s
+            - --protocol=tcp
+---
+# pod-to-b-multi-node-nodeport: connects to echo-b via NodePort (scheduled on different node)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-multi-node-nodeport
+  labels:
+    name: pod-to-b-multi-node-nodeport
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-multi-node-nodeport
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-multi-node-nodeport
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: pod-to-b-multi-node-nodeport-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-host-headless:31414
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-host-headless:31414
+            - --timeout=5s
+            - --protocol=tcp
+---
+# pod-to-b-intra-node-nodeport: connects to echo-b via NodePort (same node)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-b-intra-node-nodeport
+  labels:
+    name: pod-to-b-intra-node-nodeport
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-b-intra-node-nodeport
+  template:
+    metadata:
+      labels:
+        name: pod-to-b-intra-node-nodeport
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: pod-to-b-intra-node-nodeport-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-host-headless:31414
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-host-headless:31414
+            - --timeout=5s
+            - --protocol=tcp
+---
+# host-to-b-multi-node-clusterip: host-networked pod connecting to echo-b via ClusterIP
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host-to-b-multi-node-clusterip
+  labels:
+    name: host-to-b-multi-node-clusterip
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-clusterip
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-clusterip
+    spec:
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: host-to-b-multi-node-clusterip-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b.canal-test.svc.cluster.local:8080
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b.canal-test.svc.cluster.local:8080
+            - --timeout=5s
+            - --protocol=tcp
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+      - operator: Exists
+---
+# host-to-b-multi-node-headless: host-networked pod connecting to echo-b via headless service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host-to-b-multi-node-headless
+  labels:
+    name: host-to-b-multi-node-headless
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: host-to-b-multi-node-headless
+  template:
+    metadata:
+      labels:
+        name: host-to-b-multi-node-headless
+    spec:
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - echo-b
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: host-to-b-multi-node-headless-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-headless.canal-test.svc.cluster.local:8080
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-b-headless.canal-test.svc.cluster.local:8080
+            - --timeout=5s
+            - --protocol=tcp
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+      - operator: Exists
+---
+# pod-to-external-1111: verifies external connectivity
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-external-1111
+  labels:
+    name: pod-to-external-1111
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-external-1111
+  template:
+    metadata:
+      labels:
+        name: pod-to-external-1111
+    spec:
+      containers:
+      - name: pod-to-external-1111-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - 1.1.1.1:443
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - 1.1.1.1:443
+            - --timeout=5s
+            - --protocol=tcp
+---
+# pod-to-external-fqdn-google: verifies DNS resolution + external connectivity
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-external-fqdn-google
+  labels:
+    name: pod-to-external-fqdn-google
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-external-fqdn-google
+  template:
+    metadata:
+      labels:
+        name: pod-to-external-fqdn-google
+    spec:
+      containers:
+      - name: pod-to-external-fqdn-google-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - www.google.com:443
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - www.google.com:443
+            - --timeout=5s
+            - --protocol=tcp
+---
+# NetworkPolicy: restrict ingress to echo-a to only pods with label "allowed-to-echo-a: true"
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-echo-a
+spec:
+  podSelector:
+    matchLabels:
+      name: echo-a
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          allowed-to-echo-a: "true"
+    ports:
+    - port: 8080
+      protocol: TCP
+---
+# pod-to-a-allowed-knp: has the "allowed-to-echo-a: true" label — should succeed
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-a-allowed-knp
+  labels:
+    name: pod-to-a-allowed-knp
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-a-allowed-knp
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-allowed-knp
+        allowed-to-echo-a: "true"
+    spec:
+      containers:
+      - name: pod-to-a-allowed-knp-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-a:8080
+            - --timeout=5s
+            - --protocol=tcp
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /agnhost
+            - connect
+            - echo-a:8080
+            - --timeout=5s
+            - --protocol=tcp
+---
+# pod-to-a-denied-knp: does NOT have the label — connection should be denied.
+# Uses a negated probe: the pod becomes ready when the connection FAILS,
+# proving the NetworkPolicy deny is enforced. Same pattern as Cilium's pod-to-a-denied-cnp.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pod-to-a-denied-knp
+  labels:
+    name: pod-to-a-denied-knp
+    component: connectivity-check
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pod-to-a-denied-knp
+  template:
+    metadata:
+      labels:
+        name: pod-to-a-denied-knp
+    spec:
+      containers:
+      - name: pod-to-a-denied-knp-container
+        image: registry.k8s.io/e2e-test-images/agnhost:2.43
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "sleep 1000000000"]
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "! /agnhost connect echo-a:8080 --timeout=3s --protocol=tcp"
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "! /agnhost connect echo-a:8080 --timeout=3s --protocol=tcp"

--- a/pkg/test/e2e/canal/testdata/test-app-def.yaml
+++ b/pkg/test/e2e/canal/testdata/test-app-def.yaml
@@ -1,0 +1,31 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps.kubermatic.k8c.io/v1
+kind: ApplicationDefinition
+metadata:
+  name: nginx-canal-test
+spec:
+  description: Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.
+  method: helm
+  versions:
+  - template:
+      source:
+        helm:
+          chartName: ingress-nginx
+          chartVersion: 4.7.1
+          url: https://kubernetes.github.io/ingress-nginx
+    version: 1.8.1
+  defaultValues: {}
+


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets the default kube-proxy mode to `nftables` for Kubernetes clusters running version v1.35 and above.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default kube-proxy mode to nftables for Kubernetes clusters running version v1.35 and above.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
