### PR TITLE
fix: make local kind installer idempotent

### DIFF
--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -232,6 +232,9 @@ func localKind(logger *logrus.Logger, dir string) (ctrlruntimeclient.Client, con
 }
 
 func ensureResource(kubeClient ctrlruntimeclient.Client, logger *logrus.Logger, o ctrlruntimeclient.Object) {
+	if err := kubeClient.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(o), o); err == nil {
+		return
+	}
 	if err := kubeClient.Create(context.Background(), o); err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't attempt to create the `nodeport-proxy-kind` Service when it already exists. Check for its existance explicitly upfront instead of relying on the 409/AlreadyExists response handling since, in case of a NodePort Service, the k8s endpoint rejects the resource with a validation error if the port is already taken, even if it is taken by the same resource that is submitted.

Relates to #15185

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15539

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix idempotency of local kind installer
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
