### PR TITLE
[release/v2.28] Add support for k8s patch release v1.33.9/v1.32.13

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -73,7 +73,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -120,7 +120,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -165,7 +165,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -210,7 +210,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -255,7 +255,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -300,7 +300,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -345,7 +345,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -390,7 +390,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -435,7 +435,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -480,7 +480,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -525,7 +525,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -570,7 +570,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -615,7 +615,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -705,7 +705,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-application-definitions-e2e-test.sh"
           env:

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -582,7 +582,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-argocd-e2e-tests.sh"
           env:
@@ -342,7 +342,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-encryption-at-rest-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -159,7 +159,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -117,7 +117,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -161,7 +161,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -204,7 +204,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -248,7 +248,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -291,7 +291,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -330,7 +330,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -118,7 +118,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -206,7 +206,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-13
           command:
             - make
           args:
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - make
             - test-integration
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-13
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-13
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-13
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/release-utility-images.sh"
           env:
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-13
           command:
             - "./hack/ci/run-addons-integration-test.sh"
           resources:

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.24.12 AS builder
+FROM docker.io/golang:1.24.13 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.24.12 AS builder
+FROM docker.io/golang:1.24.13 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.24.12 AS builder
+FROM docker.io/golang:1.24.13 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -496,7 +496,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.32.12
+    default: v1.32.13
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -591,6 +591,7 @@ spec:
       - v1.32.9
       - v1.32.10
       - v1.32.12
+      - v1.32.13
       - v1.33.0
       - v1.33.2
       - v1.33.3
@@ -598,6 +599,7 @@ spec:
       - v1.33.6
       - v1.33.7
       - v1.33.8
+      - v1.33.9
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -496,7 +496,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.32.12
+    default: v1.32.13
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -591,6 +591,7 @@ spec:
       - v1.32.9
       - v1.32.10
       - v1.32.12
+      - v1.32.13
       - v1.33.0
       - v1.33.2
       - v1.33.3
@@ -598,6 +599,7 @@ spec:
       - v1.33.6
       - v1.33.7
       - v1.33.8
+      - v1.33.9
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-13 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-13 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-13 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-13 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-13 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -215,7 +215,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.32.12"),
+		Default: semver.NewSemverOrDie("v1.32.13"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -248,6 +248,7 @@ var (
 			newSemver("v1.32.9"),
 			newSemver("v1.32.10"),
 			newSemver("v1.32.12"),
+			newSemver("v1.32.13"),
 			// Kubernetes 1.33
 			newSemver("v1.33.0"),
 			newSemver("v1.33.2"),
@@ -256,6 +257,7 @@ var (
 			newSemver("v1.33.6"),
 			newSemver("v1.33.7"),
 			newSemver("v1.33.8"),
+			newSemver("v1.33.9"),
 		},
 		Updates: []kubermaticv1.Update{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add support for k8s patch release v1.33.9/v1.32.13 which includes CVE fixes. Also update default k8s to 1.32.13. 
Bump Go build image version. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for k8s patch release v1.33.9/v1.32.13
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
