### PR TITLE
resolve audit logging enforcement controller and webhook conflict

### DIFF
--- a/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller.go
@@ -370,15 +370,19 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		return nil
 	}
 
-	// Skip enforcement if seed has no audit logging configuration.
-	// This prevents accidentally removing audit logging from clusters when the seed config is empty.
-	seedAuditLogging := seed.Spec.AuditLogging
-	if seedAuditLogging == nil {
-		log.Debug("Seed has no audit logging configuration, skipping enforcement")
-		return nil
+	var desiredAuditLogging *kubermaticv1.AuditLoggingSettings
+	if seed.Spec.AuditLogging != nil {
+		desiredAuditLogging = seed.Spec.AuditLogging.DeepCopy()
+	} else {
+		desiredAuditLogging = &kubermaticv1.AuditLoggingSettings{}
 	}
+	desiredAuditLogging.Enabled = true
 
-	desiredAuditLogging := seedAuditLogging.DeepCopy()
+	// Also include enforced webhook backend if configured on the datacenter.
+	// This must match what the defaulting webhook does to avoid reconciliation loops.
+	if datacenter.Spec.EnforcedAuditWebhookSettings != nil {
+		desiredAuditLogging.WebhookBackend = datacenter.Spec.EnforcedAuditWebhookSettings
+	}
 
 	clusterAuditLogging := cluster.Spec.AuditLogging
 

--- a/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller.go
@@ -363,25 +363,22 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		return nil
 	}
 
-	// Skip enforcement if seed has no audit logging configuration
-	// This prevents accidentally removing audit logging from clusters when the seed config is empty
+	// When enforcement is off, the controller should not touch the cluster at all.
+	// A cluster might have audit logging enabled for its own reasons.
+	if !datacenter.Spec.EnforceAuditLogging {
+		log.Debug("Audit logging enforcement is disabled for datacenter, skipping")
+		return nil
+	}
+
+	// Skip enforcement if seed has no audit logging configuration.
+	// This prevents accidentally removing audit logging from clusters when the seed config is empty.
 	seedAuditLogging := seed.Spec.AuditLogging
 	if seedAuditLogging == nil {
 		log.Debug("Seed has no audit logging configuration, skipping enforcement")
 		return nil
 	}
 
-	// Determine the desired audit logging configuration based on enforcement flag
-	var desiredAuditLogging *kubermaticv1.AuditLoggingSettings
-	if datacenter.Spec.EnforceAuditLogging {
-		// When enforcement is enabled, copy the seed's audit logging configuration
-		desiredAuditLogging = seedAuditLogging.DeepCopy()
-	} else {
-		// When enforcement is disabled, explicitly disable audit logging
-		desiredAuditLogging = &kubermaticv1.AuditLoggingSettings{
-			Enabled: false,
-		}
-	}
+	desiredAuditLogging := seedAuditLogging.DeepCopy()
 
 	clusterAuditLogging := cluster.Spec.AuditLogging
 
@@ -391,11 +388,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	}
 
 	// Update cluster's audit logging configuration
-	if datacenter.Spec.EnforceAuditLogging {
-		log.Infow("Enforcing audit logging configuration from seed", "seed", seed.Name)
-	} else {
-		log.Infow("Disabling audit logging as enforcement is disabled for datacenter", "datacenter", cluster.Spec.Cloud.DatacenterName)
-	}
+	log.Infow("Enforcing audit logging configuration from seed", "seed", seed.Name)
 
 	oldCluster := cluster.DeepCopy()
 	cluster.Spec.AuditLogging = desiredAuditLogging
@@ -404,13 +397,12 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		return fmt.Errorf("failed to update cluster audit logging configuration: %w", err)
 	}
 
-	if datacenter.Spec.EnforceAuditLogging {
-		r.recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "AuditLoggingEnforced", "Reconciling",
-			"Audit logging configuration enforced from seed %s", seed.Name)
-	} else {
-		r.recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "AuditLoggingDisabled", "Reconciling",
-			"Audit logging disabled as enforcement is disabled for datacenter %s", cluster.Spec.Cloud.DatacenterName)
-	}
+	r.recorder.Eventf(cluster, nil,
+		corev1.EventTypeNormal,
+		"AuditLoggingEnforced",
+		"Reconciling",
+		"Audit logging configuration enforced from seed %s", seed.Name,
+	)
 
 	log.Info("Successfully updated audit logging configuration")
 	return nil

--- a/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller_test.go
@@ -18,6 +18,7 @@ package auditloggingenforcement
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -27,6 +28,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/generator"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -57,7 +60,6 @@ func TestReconcile(t *testing.T) {
 		cluster                  *kubermaticv1.Cluster
 		seed                     *kubermaticv1.Seed
 		expectedAuditLogging     *kubermaticv1.AuditLoggingSettings
-		expectUpdate             bool
 		shouldSkipReconciliation bool
 	}{
 		{
@@ -65,28 +67,24 @@ func TestReconcile(t *testing.T) {
 			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
 			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
-			expectUpdate:         true,
 		},
 		{
 			name:                 "scenario 2: skip enforcement when cluster has opt-out annotation",
 			cluster:              genClusterWithAuditLogging(datacenterName, nil, true),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
 			expectedAuditLogging: nil,
-			expectUpdate:         false,
 		},
 		{
 			name:                 "scenario 3: leave cluster unchanged when datacenter has EnforceAuditLogging disabled",
 			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
 			expectedAuditLogging: nil,
-			expectUpdate:         false,
 		},
 		{
 			name:                     "scenario 4: skip enforcement when cluster is paused",
 			cluster:                  genClusterWithAuditLogging(datacenterName, nil, false),
 			seed:                     genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
 			expectedAuditLogging:     nil,
-			expectUpdate:             false,
 			shouldSkipReconciliation: true,
 		},
 		{
@@ -94,42 +92,216 @@ func TestReconcile(t *testing.T) {
 			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
 			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
-			expectUpdate:         false,
 		},
 		{
 			name:                 "scenario 6: update audit logging policy when seed changes",
 			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyMetadata), false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
 			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
-			expectUpdate:         true,
 		},
 		{
-			name:                 "scenario 7: skip enforcement when seed has no audit logging config",
-			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
+			name:                 "scenario 7: enforce enabled even when seed has no audit logging config",
+			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
 			seed:                 genSeedWithAuditLogging(datacenterName, nil, true),
-			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
-			expectUpdate:         false,
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: true},
 		},
 		{
-			name:                 "scenario 8: enforce disabled state when seed explicitly disables audit logging",
+			name:                 "scenario 8: enforce enabled even when seed disables audit logging",
 			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(false, ""), true),
-			expectedAuditLogging: genAuditLoggingSettings(false, ""),
-			expectUpdate:         true,
+			expectedAuditLogging: genAuditLoggingSettings(true, ""),
 		},
 		{
-			name:                 "scenario 9: enforce disabled state with empty policy preset",
+			name:                 "scenario 9: enforce enabled with empty policy preset",
 			cluster:              genClusterWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
 			seed:                 genSeedWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{Enabled: false}, true),
-			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: false},
-			expectUpdate:         true,
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: true},
 		},
 		{
 			name:                 "scenario 10: enforce when seed has config and datacenter enforcement is enabled",
 			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
 			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
-			expectUpdate:         true,
+		},
+		{
+			name:    "scenario 11: enforce includes EnforcedAuditWebhookSettings from datacenter",
+			cluster: genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:    genSeedWithAuditLoggingAndWebhook(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "audit-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name:    "scenario 12: enforce=true, seed=nil, DC has EnforcedAuditWebhookSettings",
+			cluster: genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:    genSeedWithAuditLoggingAndWebhook(datacenterName, nil, true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "audit-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name:                 "scenario 13: enforce=false, DC has EnforcedAuditWebhookSettings are ignored",
+			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
+			seed:                 genSeedWithAuditLoggingAndWebhook(datacenterName, nil, false),
+			expectedAuditLogging: nil,
+		},
+		{
+			name: "scenario 14: no-op when cluster already matches including WebhookBackend",
+			cluster: genClusterWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "audit-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			}, false),
+			seed: genSeedWithAuditLoggingAndWebhook(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "audit-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name: "scenario 15: DC enforced webhook overrides cluster's existing webhook",
+			cluster: genClusterWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "old-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			}, false),
+			seed: genSeedWithAuditLoggingAndWebhook(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "audit-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name: "scenario 16: removing DC webhook settings clears cluster's WebhookBackend",
+			cluster: genClusterWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "old-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			}, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, nil, true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: true},
+		},
+		{
+			name:    "scenario 17: DC webhook overrides seed's own WebhookBackend",
+			cluster: genClusterWithAuditLogging(datacenterName, nil, false),
+			seed: genSeedWithDCWebhook(datacenterName, &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "seed-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			}, true, &kubermaticv1.AuditWebhookBackendSettings{
+				AuditWebhookConfig: &corev1.SecretReference{
+					Name:      "dc-webhook-secret",
+					Namespace: "kube-system",
+				},
+			}),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "dc-webhook-secret",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name:    "scenario 18: seed SidecarSettings are propagated to cluster",
+			cluster: genClusterWithAuditLogging(datacenterName, nil, false),
+			seed: genSeedWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				SidecarSettings: &kubermaticv1.AuditSidecarSettings{
+					ExtraEnvs: []corev1.EnvVar{
+						{Name: "TEST_VAR", Value: "test-value"},
+					},
+				},
+			}, true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				SidecarSettings: &kubermaticv1.AuditSidecarSettings{
+					ExtraEnvs: []corev1.EnvVar{
+						{Name: "TEST_VAR", Value: "test-value"},
+					},
+				},
+			},
+		},
+		{
+			name: "scenario 19: seed=nil replaces cluster's existing AuditLogging with bare Enabled=true",
+			cluster: genClusterWithAuditLogging(datacenterName, &kubermaticv1.AuditLoggingSettings{
+				Enabled:      false,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "old-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			}, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, nil, true),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: true},
+		},
+		{
+			name:                 "scenario 20: cluster with empty DatacenterName is skipped",
+			cluster:              genClusterWithAuditLogging("", nil, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: nil,
+		},
+		{
+			name:                 "scenario 21: cluster's datacenter not found in seed is skipped",
+			cluster:              genClusterWithAuditLogging("nonexistent-dc", nil, false),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: nil,
+		},
+		{
+			name:                 "scenario 22: opt-out annotation 'false' does not skip enforcement",
+			cluster:              genClusterWithAnnotationValue(datacenterName, nil, "false"),
+			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true),
+			expectedAuditLogging: genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended),
 		},
 	}
 
@@ -210,9 +382,139 @@ func genSeedWithAuditLogging(datacenterName string, auditLogging *kubermaticv1.A
 	return seed
 }
 
+func genSeedWithAuditLoggingAndWebhook(datacenterName string, auditLogging *kubermaticv1.AuditLoggingSettings, enforceAuditLogging bool) *kubermaticv1.Seed {
+	seed := genSeedWithAuditLogging(datacenterName, auditLogging, enforceAuditLogging)
+	dc := seed.Spec.Datacenters[datacenterName]
+	dc.Spec.EnforcedAuditWebhookSettings = &kubermaticv1.AuditWebhookBackendSettings{
+		AuditWebhookConfig: &corev1.SecretReference{
+			Name:      "audit-webhook-secret",
+			Namespace: "kube-system",
+		},
+	}
+	seed.Spec.Datacenters[datacenterName] = dc
+	return seed
+}
+
 func genAuditLoggingSettings(enabled bool, policyPreset kubermaticv1.AuditPolicyPreset) *kubermaticv1.AuditLoggingSettings {
 	return &kubermaticv1.AuditLoggingSettings{
 		Enabled:      enabled,
 		PolicyPreset: policyPreset,
+	}
+}
+
+func genSeedWithDCWebhook(datacenterName string, auditLogging *kubermaticv1.AuditLoggingSettings, enforceAuditLogging bool, dcWebhook *kubermaticv1.AuditWebhookBackendSettings) *kubermaticv1.Seed {
+	seed := genSeedWithAuditLogging(datacenterName, auditLogging, enforceAuditLogging)
+	if dcWebhook != nil {
+		dc := seed.Spec.Datacenters[datacenterName]
+		dc.Spec.EnforcedAuditWebhookSettings = dcWebhook
+		seed.Spec.Datacenters[datacenterName] = dc
+	}
+	return seed
+}
+
+func genClusterWithAnnotationValue(datacenterName string, auditLogging *kubermaticv1.AuditLoggingSettings, annotationValue string) *kubermaticv1.Cluster {
+	cluster := genClusterWithAuditLogging(datacenterName, auditLogging, false)
+	if cluster.Annotations == nil {
+		cluster.Annotations = make(map[string]string)
+	}
+	cluster.Annotations[kubermaticv1.SkipAuditLoggingEnforcementAnnotation] = annotationValue
+	return cluster
+}
+
+func TestReconcileDeletedCluster(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	cluster := genClusterWithAuditLogging(datacenterName, nil, false)
+	now := metav1.Now()
+	cluster.DeletionTimestamp = &now
+	cluster.Finalizers = []string{"test-finalizer"}
+
+	seed := genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true)
+
+	seedClient := fake.
+		NewClientBuilder().
+		WithObjects(cluster, seed).
+		Build()
+
+	r := &reconciler{
+		log:                     kubermaticlog.Logger,
+		workerNameLabelSelector: workerSelector,
+		recorder:                &events.FakeRecorder{},
+		seedGetter:              func() (*kubermaticv1.Seed, error) { return seed, nil },
+		seedClient:              seedClient,
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: cluster.Name}}
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatalf("reconciling failed: %v", err)
+	}
+
+	updatedCluster := &kubermaticv1.Cluster{}
+	if err := seedClient.Get(context.Background(), types.NamespacedName{Name: cluster.Name}, updatedCluster); err != nil {
+		t.Fatalf("failed to get cluster: %v", err)
+	}
+
+	if updatedCluster.Spec.AuditLogging != nil {
+		t.Fatalf("expected nil AuditLogging for deleted cluster, got: %v", updatedCluster.Spec.AuditLogging)
+	}
+}
+
+func TestReconcileSeedGetterError(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	cluster := genClusterWithAuditLogging(datacenterName, nil, false)
+	seed := genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true)
+
+	seedClient := fake.
+		NewClientBuilder().
+		WithObjects(cluster, seed).
+		Build()
+
+	r := &reconciler{
+		log:                     kubermaticlog.Logger,
+		workerNameLabelSelector: workerSelector,
+		recorder:                &events.FakeRecorder{},
+		seedGetter:              func() (*kubermaticv1.Seed, error) { return nil, fmt.Errorf("seed getter error") },
+		seedClient:              seedClient,
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: cluster.Name}}
+	_, err = r.Reconcile(context.Background(), request)
+	if err == nil {
+		t.Fatal("expected error from seedGetter, got nil")
+	}
+}
+
+func TestReconcileClusterNotFound(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	seed := genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), true)
+
+	seedClient := fake.
+		NewClientBuilder().
+		WithObjects(seed).
+		Build()
+
+	r := &reconciler{
+		log:                     kubermaticlog.Logger,
+		workerNameLabelSelector: workerSelector,
+		recorder:                &events.FakeRecorder{},
+		seedGetter:              func() (*kubermaticv1.Seed, error) { return seed, nil },
+		seedClient:              seedClient,
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: "nonexistent-cluster"}}
+	_, err = r.Reconcile(context.Background(), request)
+	if err != nil {
+		t.Fatalf("expected no error for not-found cluster, got: %v", err)
 	}
 }

--- a/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/audit-logging-enforcement-controller/controller_test.go
@@ -75,11 +75,11 @@ func TestReconcile(t *testing.T) {
 			expectUpdate:         false,
 		},
 		{
-			name:                 "scenario 3: disable audit logging when datacenter has EnforceAuditLogging disabled",
+			name:                 "scenario 3: leave cluster unchanged when datacenter has EnforceAuditLogging disabled",
 			cluster:              genClusterWithAuditLogging(datacenterName, nil, false),
 			seed:                 genSeedWithAuditLogging(datacenterName, genAuditLoggingSettings(true, kubermaticv1.AuditPolicyRecommended), false),
-			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{Enabled: false},
-			expectUpdate:         true,
+			expectedAuditLogging: nil,
+			expectUpdate:         false,
 		},
 		{
 			name:                     "scenario 4: skip enforcement when cluster is paused",

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -105,14 +105,14 @@ func DefaultClusterSpec(
 
 	// Set the audit logging settings (skip if cluster has opt-out annotation)
 	if clusterAnnotations[kubermaticv1.SkipAuditLoggingEnforcementAnnotation] != "true" {
-		if seed.Spec.AuditLogging != nil {
-			spec.AuditLogging = new(kubermaticv1.AuditLoggingSettings)
-			(*seed.Spec.AuditLogging).DeepCopyInto(spec.AuditLogging)
-		}
-
-		// Enforce audit logging
+		// Only apply seed/datacenter audit logging when enforcement is enabled.
+		// Without this guard, the webhook would overwrite changes made by the
+		// audit-logging-enforcement controller when enforcement is off.
 		if datacenter.Spec.EnforceAuditLogging {
-			if spec.AuditLogging == nil {
+			if seed.Spec.AuditLogging != nil {
+				spec.AuditLogging = new(kubermaticv1.AuditLoggingSettings)
+				(*seed.Spec.AuditLogging).DeepCopyInto(spec.AuditLogging)
+			} else if spec.AuditLogging == nil {
 				spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
 			}
 			spec.AuditLogging.Enabled = true
@@ -120,6 +120,9 @@ func DefaultClusterSpec(
 
 		// Enforce audit webhook backend
 		if datacenter.Spec.EnforcedAuditWebhookSettings != nil {
+			if spec.AuditLogging == nil {
+				spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
+			}
 			spec.AuditLogging.WebhookBackend = datacenter.Spec.EnforcedAuditWebhookSettings
 		}
 	}

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -116,14 +116,10 @@ func DefaultClusterSpec(
 				spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
 			}
 			spec.AuditLogging.Enabled = true
-		}
 
-		// Enforce audit webhook backend
-		if datacenter.Spec.EnforcedAuditWebhookSettings != nil {
-			if spec.AuditLogging == nil {
-				spec.AuditLogging = &kubermaticv1.AuditLoggingSettings{}
+			if datacenter.Spec.EnforcedAuditWebhookSettings != nil {
+				spec.AuditLogging.WebhookBackend = datacenter.Spec.EnforcedAuditWebhookSettings
 			}
-			spec.AuditLogging.WebhookBackend = datacenter.Spec.EnforcedAuditWebhookSettings
 		}
 	}
 

--- a/pkg/defaulting/cluster_test.go
+++ b/pkg/defaulting/cluster_test.go
@@ -596,11 +596,21 @@ func TestDefaultAuditLogging(t *testing.T) {
 			expectedAuditLogging: nil,
 		},
 		{
-			name: "EnforcedAuditWebhookSettings with nil spec.AuditLogging: no nil dereference",
-			spec: makeSpec(nil),
-			seed: makeSeed(nil, false, webhookSettings),
+			name:                 "EnforcedAuditWebhookSettings ignored when enforcement is off",
+			spec:                 makeSpec(nil),
+			seed:                 makeSeed(nil, false, webhookSettings),
+			expectedAuditLogging: nil,
+		},
+		{
+			name: "enforcement off with webhook settings: cluster's own audit logging preserved",
+			spec: makeSpec(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+			}),
+			seed: makeSeed(seedAuditConfig, false, webhookSettings),
 			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
-				WebhookBackend: webhookSettings,
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
 			},
 		},
 		{
@@ -611,6 +621,164 @@ func TestDefaultAuditLogging(t *testing.T) {
 				Enabled:        true,
 				PolicyPreset:   kubermaticv1.AuditPolicyRecommended,
 				WebhookBackend: webhookSettings,
+			},
+		},
+		{
+			name: "enforcement on, seed.Enabled=false: Enabled overridden to true",
+			spec: makeSpec(nil),
+			seed: makeSeed(&kubermaticv1.AuditLoggingSettings{Enabled: false}, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+			},
+		},
+		{
+			name: "enforcement on, seed=nil, DC has webhook: both Enabled and webhook applied",
+			spec: makeSpec(nil),
+			seed: makeSeed(nil, true, webhookSettings),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:        true,
+				WebhookBackend: webhookSettings,
+			},
+		},
+		{
+			name: "enforcement on, seed=nil, spec has AuditLogging: Enabled set, other fields preserved",
+			spec: makeSpec(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      false,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "cluster-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			}),
+			seed: makeSeed(nil, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "cluster-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name: "enforcement on, seed has webhook, DC has different webhook: DC webhook wins",
+			spec: makeSpec(nil),
+			seed: makeSeed(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "seed-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			}, true, &kubermaticv1.AuditWebhookBackendSettings{
+				AuditWebhookConfig: &corev1.SecretReference{
+					Name:      "dc-webhook",
+					Namespace: "kube-system",
+				},
+			}),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "dc-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			},
+		},
+		{
+			name: "enforcement on, spec and seed both non-nil: seed config replaces spec entirely",
+			spec: makeSpec(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+			}),
+			seed: makeSeed(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      false,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+			}, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+			},
+		},
+		{
+			name: "opt-out annotation prevents EnforcedAuditWebhookSettings from being applied",
+			spec: makeSpec(nil),
+			seed: makeSeed(seedAuditConfig, true, webhookSettings),
+			annotations: map[string]string{
+				kubermaticv1.SkipAuditLoggingEnforcementAnnotation: "true",
+			},
+			expectedAuditLogging: nil,
+		},
+		{
+			name: "enforcement on, seed has SidecarSettings: propagated to cluster",
+			spec: makeSpec(nil),
+			seed: makeSeed(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				SidecarSettings: &kubermaticv1.AuditSidecarSettings{
+					ExtraEnvs: []corev1.EnvVar{
+						{Name: "TEST_VAR", Value: "test-value"},
+					},
+				},
+			}, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+				SidecarSettings: &kubermaticv1.AuditSidecarSettings{
+					ExtraEnvs: []corev1.EnvVar{
+						{Name: "TEST_VAR", Value: "test-value"},
+					},
+				},
+			},
+		},
+		{
+			name: "annotation 'false' does not trigger opt-out, enforcement proceeds",
+			spec: makeSpec(nil),
+			seed: makeSeed(seedAuditConfig, true, nil),
+			annotations: map[string]string{
+				kubermaticv1.SkipAuditLoggingEnforcementAnnotation: "false",
+			},
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+			},
+		},
+		{
+			name: "enforcement on, spec has old webhook, seed has new webhook: seed replaces spec",
+			spec: makeSpec(&kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "old-cluster-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			}),
+			seed: makeSeed(&kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "new-seed-webhook",
+						Namespace: "kube-system",
+					},
+				},
+			}, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+				WebhookBackend: &kubermaticv1.AuditWebhookBackendSettings{
+					AuditWebhookConfig: &corev1.SecretReference{
+						Name:      "new-seed-webhook",
+						Namespace: "kube-system",
+					},
+				},
 			},
 		},
 	}

--- a/pkg/defaulting/cluster_test.go
+++ b/pkg/defaulting/cluster_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package defaulting
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -488,6 +491,141 @@ func TestDefaultEventRateLimitPlugin(t *testing.T) {
 			assert.Equal(t, tc.expectedUseEventRateLimitAdmissionPlugin, tc.spec.UseEventRateLimitAdmissionPlugin)
 			assert.Equal(t, tc.expectedAdmissionPlugins, tc.spec.AdmissionPlugins)
 			assert.Equal(t, tc.expectedConfig, tc.spec.EventRateLimitConfig)
+		})
+	}
+}
+
+func TestDefaultAuditLogging(t *testing.T) {
+	const dcName = "audit-test-dc"
+
+	seedAuditConfig := &kubermaticv1.AuditLoggingSettings{
+		Enabled:      true,
+		PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+	}
+
+	webhookSettings := &kubermaticv1.AuditWebhookBackendSettings{
+		AuditWebhookConfig: &corev1.SecretReference{
+			Name:      "audit-webhook-secret",
+			Namespace: "kube-system",
+		},
+	}
+
+	makeSeed := func(auditLogging *kubermaticv1.AuditLoggingSettings, enforce bool, webhookBackend *kubermaticv1.AuditWebhookBackendSettings) *kubermaticv1.Seed {
+		return &kubermaticv1.Seed{
+			Spec: kubermaticv1.SeedSpec{
+				AuditLogging: auditLogging,
+				Datacenters: map[string]kubermaticv1.Datacenter{
+					dcName: {
+						Spec: kubermaticv1.DatacenterSpec{
+							Fake:                         &kubermaticv1.DatacenterSpecFake{},
+							EnforceAuditLogging:          enforce,
+							EnforcedAuditWebhookSettings: webhookBackend,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	makeSpec := func(auditLogging *kubermaticv1.AuditLoggingSettings) *kubermaticv1.ClusterSpec {
+		return &kubermaticv1.ClusterSpec{
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: dcName,
+				ProviderName:   string(kubermaticv1.FakeCloudProvider),
+				Fake:           &kubermaticv1.FakeCloudSpec{Token: "test"},
+			},
+			AuditLogging: auditLogging,
+		}
+	}
+
+	testCases := []struct {
+		name                 string
+		spec                 *kubermaticv1.ClusterSpec
+		seed                 *kubermaticv1.Seed
+		annotations          map[string]string
+		expectedAuditLogging *kubermaticv1.AuditLoggingSettings
+	}{
+		{
+			name: "enforcement on with seed config: cluster gets seed config with Enabled=true",
+			spec: makeSpec(nil),
+			seed: makeSeed(seedAuditConfig, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyRecommended,
+			},
+		},
+		{
+			name: "enforcement on with nil seed config: cluster gets bare Enabled=true",
+			spec: makeSpec(nil),
+			seed: makeSeed(nil, true, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled: true,
+			},
+		},
+		{
+			name:                 "enforcement off with seed config: cluster audit logging untouched",
+			spec:                 makeSpec(nil),
+			seed:                 makeSeed(seedAuditConfig, false, nil),
+			expectedAuditLogging: nil,
+		},
+		{
+			name:                 "enforcement off without seed config: cluster audit logging untouched",
+			spec:                 makeSpec(nil),
+			seed:                 makeSeed(nil, false, nil),
+			expectedAuditLogging: nil,
+		},
+		{
+			name: "enforcement off, cluster has own audit logging: preserved",
+			spec: makeSpec(&kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+			}),
+			seed: makeSeed(seedAuditConfig, false, nil),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:      true,
+				PolicyPreset: kubermaticv1.AuditPolicyMinimal,
+			},
+		},
+		{
+			name: "opt-out annotation set: cluster audit logging untouched despite enforcement",
+			spec: makeSpec(nil),
+			seed: makeSeed(seedAuditConfig, true, nil),
+			annotations: map[string]string{
+				kubermaticv1.SkipAuditLoggingEnforcementAnnotation: "true",
+			},
+			expectedAuditLogging: nil,
+		},
+		{
+			name: "EnforcedAuditWebhookSettings with nil spec.AuditLogging: no nil dereference",
+			spec: makeSpec(nil),
+			seed: makeSeed(nil, false, webhookSettings),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				WebhookBackend: webhookSettings,
+			},
+		},
+		{
+			name: "enforcement on with EnforcedAuditWebhookSettings: both applied",
+			spec: makeSpec(nil),
+			seed: makeSeed(seedAuditConfig, true, webhookSettings),
+			expectedAuditLogging: &kubermaticv1.AuditLoggingSettings{
+				Enabled:        true,
+				PolicyPreset:   kubermaticv1.AuditPolicyRecommended,
+				WebhookBackend: webhookSettings,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config, err := DefaultConfiguration(&kubermaticv1.KubermaticConfiguration{}, zap.NewNop().Sugar())
+			if err != nil {
+				t.Fatalf("DefaultConfiguration returned error: %v", err)
+			}
+			err = DefaultClusterSpec(context.Background(), tc.spec, tc.annotations, nil, tc.seed, config, nil)
+			if err != nil {
+				t.Fatalf("DefaultClusterSpec returned error: %v", err)
+			}
+			assert.Equal(t, tc.expectedAuditLogging, tc.spec.AuditLogging)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a conflict between the audit logging enforcement controller and the cluster defaulting webhook that caused an infinite reconciliation loop when `enforceAuditLogging=false` but the seed has audit logging configured.

The webhook was unconditionally copying `seed.Spec.AuditLogging` to clusters on every update, regardless of the `enforceAuditLogging` flag. This overwrote the controller's changes, causing the controller to re-patch indefinitely.

Changes:
- **Webhook (`pkg/defaulting/cluster.go`)**: Gate the audit logging defaulting on `datacenter.Spec.EnforceAuditLogging`. When enforcement is off, the webhook no longer touches cluster audit logging settings.
- **Controller (`audit-logging-enforcement-controller`)**: Return early when enforcement is disabled, allowing clusters to have independent audit logging configuration.

Also fixes a pre-existing nil dereference bug when `EnforcedAuditWebhookSettings` was set but audit logging was nil.

**Which issue(s) this PR fixes**:
Fixes #15524

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

The behavioral change: seed audit logging config is now only applied when `EnforceAuditLogging=true`. Previously, it was applied as a soft default to all clusters. Admins who relied on this must enable enforcement or use cluster templates. This is consistent with the enforcement controller's behavior.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

> NONE here because the initial PR is merged for the next release, so no need for a release note for the unreleased feature.

**Documentation**:
```documentation
NONE
```
