### PR TITLE
Bump OSM to support containerd v2

### DIFF
--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -55,7 +55,7 @@ var controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
 }
 
 const (
-	Tag = "25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12"
+	Tag = "bae446bf033b69feb9840566e18913f8123c1740"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:25cc076a2e28ae3ecdc7e4facec4ac73f4f4cc12
+        image: quay.io/kubermatic/operating-system-manager:bae446bf033b69feb9840566e18913f8123c1740
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump OSM(https://github.com/kubermatic/operating-system-manager/commit/bae446bf033b69feb9840566e18913f8123c1740) to support containerd v2 for machines.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #15225

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
