### PR TITLE
skip per-listener check in Gateway API installer wait

### DIFF
--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -448,6 +448,7 @@ func showGatewayDNSSettings(ctx context.Context, logger *logrus.Entry, kubeClien
 		logger.Warn("reconfigure the envoy-gateway-controller Helm chart. Re-run the installer")
 		logger.Warn("to apply updated configuration afterwards.")
 		logger.Warn(err.Error())
+		return "", ""
 	}
 
 	logger.Info("The main Gateway is ready.")
@@ -558,6 +559,10 @@ func cleanupIngress(ctx context.Context, l *logrus.Entry, c ctrlruntimeclient.Cl
 	return nil
 }
 
+// waitForGateway waits for the Gateway to have an address and be Programmed.
+// Per-listener conditions are not checked because HTTPS listeners depend on
+// TLS certificates that require DNS to be configured first, which only happens
+// after the installer finishes.
 func waitForGateway(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, config *kubermaticv1.KubermaticConfiguration) (*gatewayapiv1.Gateway, error) {
 	if config == nil {
 		return nil, fmt.Errorf("Invalid KubermaticConfiguration provided")
@@ -597,17 +602,6 @@ func waitForGateway(ctx context.Context, logger *logrus.Entry, kubeClient ctrlru
 
 			l.Debugf("Gateway not yet programmed: %s - %s", reason, message)
 			return false, nil
-		}
-
-		for _, listener := range gw.Status.Listeners {
-			listenerProgrammed := meta.IsStatusConditionTrue(
-				listener.Conditions,
-				string(gatewayapiv1.ListenerConditionProgrammed),
-			)
-			if !listenerProgrammed {
-				l.Debugf("Gateway listener %s not yet programmed", listener.Name)
-				return false, nil
-			}
 		}
 
 		l.Infof("Gateway is ready with %d address(es) and %d listener(s)",


### PR DESCRIPTION
HTTPS listeners cannot be programmed until TLS certificates are issued, which requires DNS to be configured first. This chicken-and-egg problem causes the installer to timeout on fresh installations with CertificateIssuer configured. The installer now only waits for Gateway to have addresses and be in Programmed state, allowing DNS configuration to happen post-install.

**What this PR does / why we need it**:

In fresh KKP installations with Gateway API enabled and a `CertificateIssuer` configured, the installer times out waiting for the Gateway's HTTPS listener to become programmed. This happens because:

1. The HTTPS listener requires a valid TLS certificate (stored in `kubermatic-tls` secret)
2. Cert-manager needs to issue the certificate via ACME (e.g., Let's Encrypt)
3. ACME HTTP-01 challenge requires DNS to resolve to the Gateway's address
4. DNS cannot be configured until the user knows the Gateway's LoadBalancer address
5. The installer waits for ALL listeners to be programmed before showing DNS settings

This chicken-and-egg problem prevents fresh installations from completing.

The fix removes the per-listener programming check from `waitForGateway()`, allowing the installer to complete once the Gateway has addresses and is in `Programmed` state. Users can then configure DNS and certificates will be issued afterwards.

**Which issue(s) this PR fixes**:
<!-- Fixes # -->
xref #15441

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

- Migration scenarios should be verified to ensure old Ingress is not deleted prematurely.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
