### PR TITLE
Add KubeVirt v1.7.1 to application catalog

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/kubevirt-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/kubevirt-app.yaml
@@ -25,6 +25,7 @@ metadata:
 spec:
   description: KubeVirt with Containerized Data Importer
   displayName: KubeVirt
+  defaultVersion: v1.7.1
   method: helm
   versions:
     - template:
@@ -34,6 +35,13 @@ spec:
             chartVersion: v1.1.0
             url: oci://quay.io/kubermatic/helm-charts
       version: v1.1.0
+    - template:
+        source:
+          helm:
+            chartName: kubevirt
+            chartVersion: v1.7.1
+            url: oci://quay.io/kubermatic/helm-charts
+      version: v1.7.1
   documentationURL: https://kubevirt.io/
   sourceURL: https://github.com/kubevirt/kubevirt
   logo: |+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds KubeVirt v1.7.1 as a new version in the application catalog and sets it as the default. The existing v1.1.0 chart has broken VM creation due to `/dev/kvm` permission issues and a `guest-console-log` sidecar crash. v1.7.1 fixes both issues.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/15392

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
- Only the ApplicationDefinition is changed in this PR. The chart source (`charts/local-kubevirt/`) improvements to `update.sh` and `upload-chart.sh` are not included.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update KubeVirt application catalog entry to v1.7.1, fixing VM creation failures in v1.1.0.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
