### PR TITLE
Add EventRateLimit enforcement controller for existing clusters

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -39,6 +39,7 @@ import (
 	encryptionatrestcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/encryption-at-rest-controller"
 	etcdbackupcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdbackup"
 	etcdrestorecontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdrestore"
+	eventratelimitenforcement "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller"
 	initialapplicationinstallationcontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/initial-application-installation-controller"
 	initialmachinedeployment "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/initial-machinedeployment-controller"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/ipam"
@@ -89,6 +90,7 @@ var AllControllers = map[string]controllerCreator{
 	clustercredentialscontroller.ControllerName:             createClusterCredentialsController,
 	applicationsecretclustercontroller.ControllerName:       createApplicationSecretClusterController,
 	auditloggingenforcement.ControllerName:                  createAuditLoggingEnforcementController,
+	eventratelimitenforcement.ControllerName:                createEventRateLimitEnforcementController,
 }
 
 type controllerCreator func(*controllerContext) error
@@ -511,6 +513,16 @@ func createAuditLoggingEnforcementController(ctrlCtx *controllerContext) error {
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerName,
 		ctrlCtx.seedGetter,
+		ctrlCtx.runOptions.workerCount,
+	)
+}
+
+func createEventRateLimitEnforcementController(ctrlCtx *controllerContext) error {
+	return eventratelimitenforcement.Add(
+		ctrlCtx.mgr,
+		ctrlCtx.log,
+		ctrlCtx.runOptions.workerName,
+		ctrlCtx.configGetter,
 		ctrlCtx.runOptions.workerCount,
 	)
 }

--- a/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller/controller.go
@@ -76,9 +76,7 @@ func Add(
 	}
 
 	// Handler to enqueue all clusters when a KubermaticConfiguration is updated
-	configHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
-		log.Debugw("KubermaticConfiguration handler triggered", "config", obj.GetName())
-
+	configHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, _ ctrlruntimeclient.Object) []reconcile.Request {
 		clusterList := &kubermaticv1.ClusterList{}
 		if err := reconciler.seedClient.List(ctx, clusterList, &ctrlruntimeclient.ListOptions{LabelSelector: workerSelector}); err != nil {
 			log.Errorw("Failed to list clusters for config update", zap.Error(err))
@@ -93,7 +91,6 @@ func Add(
 			})
 		}
 
-		log.Debugw("Total clusters enqueued for reconciliation", "count", len(requests))
 		return requests
 	})
 

--- a/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller/controller.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventratelimitenforcement
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// ControllerName is the name of this controller.
+	ControllerName = "kkp-event-rate-limit-enforcement-controller"
+)
+
+type reconciler struct {
+	log                     *zap.SugaredLogger
+	workerNameLabelSelector labels.Selector
+	recorder                events.EventRecorder
+	configGetter            provider.KubermaticConfigurationGetter
+	seedClient              ctrlruntimeclient.Client
+}
+
+// Add creates a new event rate limit enforcement controller.
+func Add(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	workerName string,
+	configGetter provider.KubermaticConfigurationGetter,
+	numWorkers int,
+) error {
+	workerSelector, err := workerlabel.LabelSelector(workerName)
+	if err != nil {
+		return fmt.Errorf("failed to build worker-name selector: %w", err)
+	}
+
+	reconciler := &reconciler{
+		log:                     log.Named(ControllerName),
+		workerNameLabelSelector: workerSelector,
+		recorder:                mgr.GetEventRecorder(ControllerName),
+		configGetter:            configGetter,
+		seedClient:              mgr.GetClient(),
+	}
+
+	// Handler to enqueue all clusters when a KubermaticConfiguration is updated
+	configHandler := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+		log.Debugw("KubermaticConfiguration handler triggered", "config", obj.GetName())
+
+		clusterList := &kubermaticv1.ClusterList{}
+		if err := reconciler.seedClient.List(ctx, clusterList, &ctrlruntimeclient.ListOptions{LabelSelector: workerSelector}); err != nil {
+			log.Errorw("Failed to list clusters for config update", zap.Error(err))
+			utilruntime.HandleError(fmt.Errorf("failed to list clusters: %w", err))
+			return nil
+		}
+
+		requests := make([]reconcile.Request, 0, len(clusterList.Items))
+		for _, cluster := range clusterList.Items {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(&cluster),
+			})
+		}
+
+		log.Debugw("Total clusters enqueued for reconciliation", "count", len(requests))
+		return requests
+	})
+
+	_, err = builder.ControllerManagedBy(mgr).
+		Named(ControllerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: numWorkers,
+		}).
+		For(&kubermaticv1.Cluster{}, builder.WithPredicates(workerlabel.Predicate(workerName), clusterEventRateLimitPredicate())).
+		Watches(&kubermaticv1.KubermaticConfiguration{}, configHandler, builder.WithPredicates(configEventRateLimitPredicate())).
+		Build(reconciler)
+
+	return err
+}
+
+// clusterEventRateLimitPredicate filters cluster events to only trigger on relevant changes.
+func clusterEventRateLimitPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCluster, ok := e.ObjectOld.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+			newCluster, ok := e.ObjectNew.(*kubermaticv1.Cluster)
+			if !ok {
+				return false
+			}
+
+			// Reconcile if UseEventRateLimitAdmissionPlugin changed
+			if oldCluster.Spec.UseEventRateLimitAdmissionPlugin != newCluster.Spec.UseEventRateLimitAdmissionPlugin {
+				return true
+			}
+
+			// Reconcile if EventRateLimitConfig changed
+			if !equality.Semantic.DeepEqual(oldCluster.Spec.EventRateLimitConfig, newCluster.Spec.EventRateLimitConfig) {
+				return true
+			}
+
+			// Reconcile if pause status changed
+			if oldCluster.Spec.Pause != newCluster.Spec.Pause {
+				return true
+			}
+
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// configEventRateLimitPredicate filters KubermaticConfiguration events to only trigger on EventRateLimit changes.
+func configEventRateLimitPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			config, ok := e.Object.(*kubermaticv1.KubermaticConfiguration)
+			if !ok {
+				return false
+			}
+			return config.Spec.UserCluster.AdmissionPlugins != nil && config.Spec.UserCluster.AdmissionPlugins.EventRateLimit != nil
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldConfig, ok := e.ObjectOld.(*kubermaticv1.KubermaticConfiguration)
+			if !ok {
+				return false
+			}
+			newConfig, ok := e.ObjectNew.(*kubermaticv1.KubermaticConfiguration)
+			if !ok {
+				return false
+			}
+
+			return !equality.Semantic.DeepEqual(
+				getEventRateLimitConfig(oldConfig),
+				getEventRateLimitConfig(newConfig),
+			)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func getEventRateLimitConfig(config *kubermaticv1.KubermaticConfiguration) *kubermaticv1.EventRateLimitPluginConfiguration {
+	if config.Spec.UserCluster.AdmissionPlugins == nil {
+		return nil
+	}
+	return config.Spec.UserCluster.AdmissionPlugins.EventRateLimit
+}
+
+// Reconcile enforces EventRateLimit configuration from KubermaticConfiguration to User Clusters.
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("cluster", request.Name)
+	log.Debug("Reconciling")
+
+	cluster := &kubermaticv1.Cluster{}
+	if err := r.seedClient.Get(ctx, request.NamespacedName, cluster); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	err := r.reconcile(ctx, log, cluster)
+	if err != nil {
+		log.Errorw("Reconciling failed", zap.Error(err))
+		r.recorder.Eventf(cluster, nil, corev1.EventTypeWarning, "EventRateLimitEnforcementError", "Reconciling", err.Error())
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
+	// Skip if cluster is being deleted
+	if !cluster.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	// Skip if cluster is paused
+	if cluster.Spec.Pause {
+		return nil
+	}
+
+	config, err := r.configGetter(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
+	}
+
+	eventRateLimitConfig := getEventRateLimitConfig(config)
+	if eventRateLimitConfig == nil || eventRateLimitConfig.Enforced == nil || !*eventRateLimitConfig.Enforced {
+		return nil
+	}
+
+	// Enforcement is active: check if plugin is already in desired state
+	needsPluginEnabled := !cluster.Spec.UseEventRateLimitAdmissionPlugin
+	needsConfigUpdate := eventRateLimitConfig.DefaultConfig != nil &&
+		!equality.Semantic.DeepEqual(cluster.Spec.EventRateLimitConfig, eventRateLimitConfig.DefaultConfig)
+
+	if !needsPluginEnabled && !needsConfigUpdate {
+		return nil
+	}
+
+	oldCluster := cluster.DeepCopy()
+
+	if needsPluginEnabled {
+		cluster.Spec.UseEventRateLimitAdmissionPlugin = true
+	}
+
+	if needsConfigUpdate {
+		cluster.Spec.EventRateLimitConfig = eventRateLimitConfig.DefaultConfig.DeepCopy()
+	}
+
+	if err := r.seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+		return fmt.Errorf("failed to update cluster EventRateLimit configuration: %w", err)
+	}
+
+	log.Info("EventRateLimit configuration enforced from KubermaticConfiguration")
+	r.recorder.Eventf(cluster, nil, corev1.EventTypeNormal, "EventRateLimitEnforced", "Reconciling",
+		"EventRateLimit configuration enforced from KubermaticConfiguration")
+
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/event-rate-limit-enforcement-controller/controller_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eventratelimitenforcement
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/test/diff"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+	"k8c.io/kubermatic/v2/pkg/test/generator"
+	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcile(t *testing.T) {
+	workerSelector, err := workerlabel.LabelSelector("")
+	if err != nil {
+		t.Fatalf("failed to build worker-name selector: %v", err)
+	}
+
+	defaultConfig := &kubermaticv1.EventRateLimitConfig{
+		Server: &kubermaticv1.EventRateLimitConfigItem{
+			QPS:       50,
+			Burst:     100,
+			CacheSize: 2000,
+		},
+	}
+
+	testCases := []struct {
+		name                         string
+		cluster                      *kubermaticv1.Cluster
+		config                       *kubermaticv1.KubermaticConfiguration
+		expectedUseEventRateLimit    bool
+		expectedEventRateLimitConfig *kubermaticv1.EventRateLimitConfig
+	}{
+		{
+			name:                         "enforce EventRateLimit on cluster without it",
+			cluster:                      genCluster(false, nil, false),
+			config:                       genConfig(true, defaultConfig),
+			expectedUseEventRateLimit:    true,
+			expectedEventRateLimitConfig: defaultConfig,
+		},
+		{
+			name:                         "skip enforcement when cluster is paused",
+			cluster:                      genCluster(false, nil, true),
+			config:                       genConfig(true, defaultConfig),
+			expectedUseEventRateLimit:    false,
+			expectedEventRateLimitConfig: nil,
+		},
+		{
+			name:                         "no update when cluster already matches enforced state",
+			cluster:                      genCluster(true, defaultConfig, false),
+			config:                       genConfig(true, defaultConfig),
+			expectedUseEventRateLimit:    true,
+			expectedEventRateLimitConfig: defaultConfig,
+		},
+		{
+			name:                         "no-op when enforcement is not enabled",
+			cluster:                      genCluster(false, nil, false),
+			config:                       genConfig(false, defaultConfig),
+			expectedUseEventRateLimit:    false,
+			expectedEventRateLimitConfig: nil,
+		},
+		{
+			name:                         "no-op when EventRateLimit config is nil",
+			cluster:                      genCluster(false, nil, false),
+			config:                       genConfigNilEventRateLimit(),
+			expectedUseEventRateLimit:    false,
+			expectedEventRateLimitConfig: nil,
+		},
+		{
+			name:                         "no-op when Enforced field is nil",
+			cluster:                      genCluster(false, nil, false),
+			config:                       genConfigEnforcedNil(defaultConfig),
+			expectedUseEventRateLimit:    false,
+			expectedEventRateLimitConfig: nil,
+		},
+		{
+			name:                         "skip enforcement when cluster is being deleted",
+			cluster:                      genDeletedCluster(),
+			config:                       genConfig(true, defaultConfig),
+			expectedUseEventRateLimit:    false,
+			expectedEventRateLimitConfig: nil,
+		},
+		{
+			name:                         "enforce enables plugin even without default config",
+			cluster:                      genCluster(false, nil, false),
+			config:                       genConfig(true, nil),
+			expectedUseEventRateLimit:    true,
+			expectedEventRateLimitConfig: nil,
+		},
+		{
+			name: "enforce overwrites existing cluster config with default config",
+			cluster: genCluster(true, &kubermaticv1.EventRateLimitConfig{
+				Server: &kubermaticv1.EventRateLimitConfigItem{
+					QPS:       10,
+					Burst:     20,
+					CacheSize: 500,
+				},
+			}, false),
+			config:                       genConfig(true, defaultConfig),
+			expectedUseEventRateLimit:    true,
+			expectedEventRateLimitConfig: defaultConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			seedClient := fake.
+				NewClientBuilder().
+				WithObjects(tc.cluster).
+				Build()
+
+			configGetter := func(_ context.Context) (*kubermaticv1.KubermaticConfiguration, error) {
+				return tc.config, nil
+			}
+
+			r := &reconciler{
+				log:                     kubermaticlog.Logger,
+				workerNameLabelSelector: workerSelector,
+				recorder:                &events.FakeRecorder{},
+				configGetter:            configGetter,
+				seedClient:              seedClient,
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.cluster.Name}}
+			if _, err := r.Reconcile(ctx, request); err != nil {
+				t.Fatalf("reconciling failed: %v", err)
+			}
+
+			updatedCluster := &kubermaticv1.Cluster{}
+			if err := seedClient.Get(ctx, types.NamespacedName{Name: tc.cluster.Name}, updatedCluster); err != nil {
+				t.Fatalf("failed to get cluster: %v", err)
+			}
+
+			if updatedCluster.Spec.UseEventRateLimitAdmissionPlugin != tc.expectedUseEventRateLimit {
+				t.Errorf("UseEventRateLimitAdmissionPlugin: got %v, want %v",
+					updatedCluster.Spec.UseEventRateLimitAdmissionPlugin, tc.expectedUseEventRateLimit)
+			}
+
+			if !diff.SemanticallyEqual(tc.expectedEventRateLimitConfig, updatedCluster.Spec.EventRateLimitConfig) {
+				t.Fatalf("EventRateLimitConfig mismatch:\n%v", diff.ObjectDiff(tc.expectedEventRateLimitConfig, updatedCluster.Spec.EventRateLimitConfig))
+			}
+		})
+	}
+}
+
+func genCluster(useEventRateLimit bool, eventRateLimitConfig *kubermaticv1.EventRateLimitConfig, paused bool) *kubermaticv1.Cluster {
+	cluster := generator.GenDefaultCluster()
+	cluster.Spec.UseEventRateLimitAdmissionPlugin = useEventRateLimit
+	cluster.Spec.EventRateLimitConfig = eventRateLimitConfig
+	cluster.Spec.Pause = paused
+
+	return cluster
+}
+
+func genConfig(enforced bool, defaultConfig *kubermaticv1.EventRateLimitConfig) *kubermaticv1.KubermaticConfiguration {
+	return &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
+				AdmissionPlugins: &kubermaticv1.AdmissionPluginsConfiguration{
+					EventRateLimit: &kubermaticv1.EventRateLimitPluginConfiguration{
+						Enforced:      ptr.To(enforced),
+						DefaultConfig: defaultConfig,
+					},
+				},
+			},
+		},
+	}
+}
+
+func genConfigNilEventRateLimit() *kubermaticv1.KubermaticConfiguration {
+	return &kubermaticv1.KubermaticConfiguration{}
+}
+
+func genConfigEnforcedNil(defaultConfig *kubermaticv1.EventRateLimitConfig) *kubermaticv1.KubermaticConfiguration {
+	return &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
+				AdmissionPlugins: &kubermaticv1.AdmissionPluginsConfiguration{
+					EventRateLimit: &kubermaticv1.EventRateLimitPluginConfiguration{
+						DefaultConfig: defaultConfig,
+					},
+				},
+			},
+		},
+	}
+}
+
+func genDeletedCluster() *kubermaticv1.Cluster {
+	cluster := generator.GenDefaultCluster()
+	now := metav1.Now()
+	cluster.DeletionTimestamp = &now
+	cluster.Finalizers = []string{"test-finalizer"}
+	return cluster
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an EventRateLimit enforcement controller to the seed-controller-manager. When `KubermaticConfiguration.spec.userCluster.admissionPlugins.eventRateLimit.enforced=true`, the existing webhook-based enforcement only applies to new or edited clusters. This controller actively reconciles all existing clusters to enable the EventRateLimit admission plugin and apply the default configuration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15559

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
