### PR TITLE
Update Velero and kubectl repo referenced in the Velero chart

### DIFF
--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -168,7 +168,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: velero
-          image: "velero/velero:v1.17.1"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.17.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnamilegacy/kubectl:1.33"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -378,7 +378,7 @@ spec:
               name: crds
       containers:
         - name: velero
-          image: "velero/velero:v1.17.1"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /tmp/sh

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -168,7 +168,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: velero
-          image: "velero/velero:v1.17.1"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.17.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnamilegacy/kubectl:1.33"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -378,7 +378,7 @@ spec:
               name: crds
       containers:
         - name: velero
-          image: "velero/velero:v1.17.1"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /tmp/sh

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -168,7 +168,7 @@ spec:
       terminationGracePeriodSeconds: 3600
       containers:
         - name: velero
-          image: "velero/velero:v1.17.1"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.17.1"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-monitoring
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: kubectl
-          image: "docker.io/bitnamilegacy/kubectl:1.33"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -378,7 +378,7 @@ spec:
               name: crds
       containers:
         - name: velero
-          image: "velero/velero:v1.17.1"
+          image: "quay.io/kubermatic-mirror/images/velero:v1.17.1"
           imagePullPolicy: IfNotPresent
           command:
             - /tmp/sh

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 velero:
+  image:
+    repository: quay.io/kubermatic-mirror/images/velero
+
   # whether to enable etcd backups?
   # if you set this as true, you must provide valid configuration for velero.configuration.backupStorageLocation[0]
   backupsEnabled: false
@@ -101,4 +104,8 @@ velero:
   # Only kube2iam: change the AWS_ACCOUNT_ID and HEPTIO_VELERO_ROLE_NAME
   annotations: {}
   # iam.amazonaws.com/role: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<HEPTIO_VELERO_ROLE_NAME>
+
+  kubectl:
+    image:
+      repository: quay.io/kubermatic-mirror/images/kubectl
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where kubermatic-installer attempts to mirror the kubectl image from `docker.io/bitnamilegacy` for  version 1.35, where the image does not exist.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix kubermatic-installer attempting to mirror a non-existent kubectl image from docker.io/bitnamilegacy for v1.35.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
