### PR TITLE
kubermatic-installer: deploy ingress-controller or envoy gateway controller in separate seed

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -72,6 +72,7 @@ type DeployOptions struct {
 	StorageClass       string
 	DisableTelemetry   bool
 	AllowEditionChange bool
+	SeparateSeed       bool
 
 	MigrateCertManager         bool
 	MigrateUpstreamCertManager bool
@@ -151,6 +152,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermatic.Versions) *cobra.C
 	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", sets.List(common.SupportedStorageClassProviders())))
 	cmd.PersistentFlags().BoolVar(&opt.DisableTelemetry, "disable-telemetry", false, "disable telemetry agents")
 	cmd.PersistentFlags().BoolVar(&opt.AllowEditionChange, "allow-edition-change", false, "allow up- or downgrading between Community and Enterprise editions")
+	cmd.PersistentFlags().BoolVar(&opt.SeparateSeed, "separate-seed", false, "deploy the seed components to a separate cluster (only applies to kubermatic-seed stack)")
 
 	cmd.PersistentFlags().BoolVar(&opt.MigrateCertManager, "migrate-cert-manager", false, "enable the migration for cert-manager CRDs from v1alpha2 to v1")
 	cmd.PersistentFlags().BoolVar(&opt.MigrateUpstreamCertManager, "migrate-upstream-cert-manager", false, "enable the migration for cert-manager to chart version 2.1.0+")
@@ -215,6 +217,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 			ForceHelmReleaseUpgrade:            opt.Force,
 			ChartsDirectory:                    opt.ChartsDirectory,
 			EnableCertManagerV2Migration:       opt.MigrateCertManager,
+			SeparateSeed:                       opt.SeparateSeed,
 			EnableCertManagerUpstreamMigration: opt.MigrateUpstreamCertManager,
 			EnableNginxIngressMigration:        opt.MigrateNginx,
 			DisableTelemetry:                   opt.DisableTelemetry,

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -152,7 +152,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermatic.Versions) *cobra.C
 	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", sets.List(common.SupportedStorageClassProviders())))
 	cmd.PersistentFlags().BoolVar(&opt.DisableTelemetry, "disable-telemetry", false, "disable telemetry agents")
 	cmd.PersistentFlags().BoolVar(&opt.AllowEditionChange, "allow-edition-change", false, "allow up- or downgrading between Community and Enterprise editions")
-	cmd.PersistentFlags().BoolVar(&opt.SeparateSeed, "separate-seed", false, "deploy the seed components to a separate cluster (only applies to kubermatic-seed stack)")
+	cmd.PersistentFlags().BoolVar(&opt.SeparateSeed, "separate-seed", false, "deploy ingress or gateway-api master components to the seed (only applies to kubermatic-seed stack)")
 
 	cmd.PersistentFlags().BoolVar(&opt.MigrateCertManager, "migrate-cert-manager", false, "enable the migration for cert-manager CRDs from v1alpha2 to v1")
 	cmd.PersistentFlags().BoolVar(&opt.MigrateUpstreamCertManager, "migrate-upstream-cert-manager", false, "enable the migration for cert-manager to chart version 2.1.0+")

--- a/pkg/install/stack/common/envoygateway.go
+++ b/pkg/install/stack/common/envoygateway.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermaticmaster
+package common
 
 import (
 	"context"
@@ -44,9 +44,13 @@ const (
 	// created by the envoy-gateway-controller Helm chart. This must match
 	// the value set in the chart's values.yaml under gatewayClass.name.
 	GatewayClassName = "kubermatic-envoy-gateway"
+
+	EnvoyGatewayControllerChartName   = "envoy-gateway-controller"
+	EnvoyGatewayControllerReleaseName = EnvoyGatewayControllerChartName
+	EnvoyGatewayControllerNamespace   = EnvoyGatewayControllerChartName
 )
 
-func deployEnvoyGatewayController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+func DeployEnvoyGatewayController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
 	if slices.Contains(opt.SkipCharts, EnvoyGatewayControllerChartName) {
 		logger.Infof("⭕ Skipping %s deployment.", EnvoyGatewayControllerChartName)
 		return nil

--- a/pkg/install/stack/common/nginxingress.go
+++ b/pkg/install/stack/common/nginxingress.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubermaticmaster
+package common
 
 import (
 	"context"
@@ -42,7 +42,13 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+const (
+	NginxIngressControllerChartName   = "nginx-ingress-controller"
+	NginxIngressControllerReleaseName = NginxIngressControllerChartName
+	NginxIngressControllerNamespace   = NginxIngressControllerChartName
+)
+
+func DeployNginxIngressController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
 	if slices.Contains(opt.SkipCharts, NginxIngressControllerChartName) {
 		logger.Infof("⭕ Skipping %s deployment.", NginxIngressControllerChartName)
 		return nil

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -47,14 +47,6 @@ import (
 )
 
 const (
-	NginxIngressControllerChartName   = "nginx-ingress-controller"
-	NginxIngressControllerReleaseName = NginxIngressControllerChartName
-	NginxIngressControllerNamespace   = NginxIngressControllerChartName
-
-	EnvoyGatewayControllerChartName   = "envoy-gateway-controller"
-	EnvoyGatewayControllerReleaseName = EnvoyGatewayControllerChartName
-	EnvoyGatewayControllerNamespace   = EnvoyGatewayControllerChartName
-
 	CertManagerChartName   = "cert-manager"
 	CertManagerReleaseName = CertManagerChartName
 	CertManagerNamespace   = CertManagerChartName
@@ -98,12 +90,12 @@ func (s *MasterStack) Deploy(ctx context.Context, opt stack.DeployOptions) error
 	}
 
 	if opt.MigrateToGatewayAPI {
-		err := deployEnvoyGatewayController(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt)
+		err := common.DeployEnvoyGatewayController(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt)
 		if err != nil {
 			return fmt.Errorf("failed to deploy envoy-gateway-controller: %w", err)
 		}
 	} else {
-		err := deployNginxIngressController(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt)
+		err := common.DeployNginxIngressController(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt)
 		if err != nil {
 			return fmt.Errorf("failed to deploy nginx-ingress-controller: %w", err)
 		}

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -69,6 +69,18 @@ func (s *SeedStack) Deploy(ctx context.Context, opt stack.DeployOptions) error {
 		return fmt.Errorf("failed to deploy StorageClass: %w", err)
 	}
 
+	if opt.SeparateSeed {
+		if opt.MigrateToGatewayAPI {
+			if err := common.DeployEnvoyGatewayController(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
+				return fmt.Errorf("failed to deploy envoy-gateway-controller: %w", err)
+			}
+		} else {
+			if err := common.DeployNginxIngressController(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
+				return fmt.Errorf("failed to deploy nginx-ingress-controller: %w", err)
+			}
+		}
+	}
+
 	if err := deployMinio(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
 		return fmt.Errorf("failed to deploy Minio: %w", err)
 	}

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -48,8 +48,8 @@ type DeployOptions struct {
 
 	SeedsGetter      provider.SeedsGetter
 	SeedClientGetter provider.SeedClientGetter
-
-	Versions kubermaticversion.Versions
+	SeparateSeed     bool
+	Versions         kubermaticversion.Versions
 
 	Logger                             *logrus.Entry
 	EnableCertManagerV2Migration       bool

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/install/stack/common"
+	stackscommon "k8c.io/kubermatic/v2/pkg/install/stack/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -328,7 +328,7 @@ func ApiserverInternalAllowReconciler() reconciling.NamedNetworkPolicyReconciler
 // OIDCIssuerAllowReconciler returns a func to create/update the apiserver oidc-issuer-allow egress policy.
 func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
-		ingressNamespace := common.NginxIngressControllerNamespace
+		ingressNamespace := stackscommon.NginxIngressControllerNamespace
 		if namespaceOverride != "" {
 			ingressNamespace = namespaceOverride
 		}
@@ -336,7 +336,7 @@ func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) rec
 		return resources.NetworkPolicyOIDCIssuerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			// Allow egress to both nginx-ingress and envoy-gateway namespaces
 			// That helps for backward compatibility until we fully switch to envoy-gateway
-			ingressNamespaces := []string{ingressNamespace, common.EnvoyGatewayControllerNamespace}
+			ingressNamespaces := []string{ingressNamespace, stackscommon.EnvoyGatewayControllerNamespace}
 
 			egressRules := []networkingv1.NetworkPolicyEgressRule{
 				{

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
-	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
+	commond "k8c.io/kubermatic/v2/pkg/install/stack/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -328,7 +328,7 @@ func ApiserverInternalAllowReconciler() reconciling.NamedNetworkPolicyReconciler
 // OIDCIssuerAllowReconciler returns a func to create/update the apiserver oidc-issuer-allow egress policy.
 func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
-		ingressNamespace := kubermaticmaster.NginxIngressControllerNamespace
+		ingressNamespace := commond.NginxIngressControllerNamespace
 		if namespaceOverride != "" {
 			ingressNamespace = namespaceOverride
 		}
@@ -336,7 +336,7 @@ func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) rec
 		return resources.NetworkPolicyOIDCIssuerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			// Allow egress to both nginx-ingress and envoy-gateway namespaces
 			// That helps for backward compatibility until we fully switch to envoy-gateway
-			ingressNamespaces := []string{ingressNamespace, kubermaticmaster.EnvoyGatewayControllerNamespace}
+			ingressNamespaces := []string{ingressNamespace, commond.EnvoyGatewayControllerNamespace}
 
 			egressRules := []networkingv1.NetworkPolicyEgressRule{
 				{

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
-	commond "k8c.io/kubermatic/v2/pkg/install/stack/common"
+	common "k8c.io/kubermatic/v2/pkg/install/stack/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -328,7 +328,7 @@ func ApiserverInternalAllowReconciler() reconciling.NamedNetworkPolicyReconciler
 // OIDCIssuerAllowReconciler returns a func to create/update the apiserver oidc-issuer-allow egress policy.
 func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
-		ingressNamespace := commond.NginxIngressControllerNamespace
+		ingressNamespace := common.NginxIngressControllerNamespace
 		if namespaceOverride != "" {
 			ingressNamespace = namespaceOverride
 		}
@@ -336,7 +336,7 @@ func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) rec
 		return resources.NetworkPolicyOIDCIssuerAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			// Allow egress to both nginx-ingress and envoy-gateway namespaces
 			// That helps for backward compatibility until we fully switch to envoy-gateway
-			ingressNamespaces := []string{ingressNamespace, commond.EnvoyGatewayControllerNamespace}
+			ingressNamespaces := []string{ingressNamespace, common.EnvoyGatewayControllerNamespace}
 
 			egressRules := []networkingv1.NetworkPolicyEgressRule{
 				{

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
-	common "k8c.io/kubermatic/v2/pkg/install/stack/common"
+	"k8c.io/kubermatic/v2/pkg/install/stack/common"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the deployment logic for the NGINX Ingress Controller and Envoy Gateway Controller by moving the related functions into a shared package. This allows both **kubermatic-master** and **kubermatic-seed** to reuse the same implementation.
Additionally, the PR introduces a new `--separate-seed` flag to the `deploy seed` command, enabling the deployment of either the Ingress Controller or the Envoy Gateway when operating with a separate seed setup.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15517

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduced a new `--separate-seed` flag to the `deploy seed` command, enabling the deployment of either the Ingress Controller or the Envoy Gateway when operating with a separate seed setup
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
T.B.D
```
