### PR TITLE
chore: update pre-kubermatic-canal-e2e build image

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-6
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
           command:
             - "./hack/ci/run-canal-e2e-test.sh"
           env:

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -57,16 +57,19 @@ useful as part of another script to setup KKP for testing.
 
 ## run-addons-integration-test.sh
 
-TBD
+Tests addon upgrade compatibility by verifying that addons can be successfully upgraded across versions.
+
+## run-canal-e2e-test.sh
+
+Runs Canal CNI e2e tests, verifying Canal networking and kube-proxy proxy mode handling.
 
 ## run-cilium-e2e-test.sh
 
-This script is used as a postsubmit job and updates the dev master
-cluster after every commit to main.
+Runs Cilium CNI e2e tests, verifying Cilium networking, eBPF proxy mode, and Hubble observability.
 
 ## run-cluster-backup-e2e-tests.sh
 
-TBD
+Runs cluster backup e2e tests, verifying Velero-based backup and restore functionality.
 
 ## run-conformance-tests.sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update pre-kubermatic-canal-e2e build image to `quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8`
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
