### PR TITLE
cleanup: remove deprecated OVDCNetwork field

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -170,9 +170,6 @@ linters:
         text: "SA1019: .*\\.Values is deprecated"
       - linters:
           - staticcheck
-        text: "SA1019: .*OVDCNetwork is deprecated"
-      - linters:
-          - staticcheck
         text: "SA1019: .*NodeportProxy\\.Annotations is deprecated"
       - linters:
           - staticcheck

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1672,12 +1672,6 @@ spec:
                         organization:
                           description: The name of organization to use.
                           type: string
-                        ovdcNetwork:
-                          description: |-
-                            The name of organizational virtual data center network that will be associated with the VMs and vApp.
-
-                            Deprecated: OVDCNetwork has been deprecated starting with KKP 2.25 and will be removed in KKP 2.27+. It is recommended to use OVDCNetworks instead.
-                          type: string
                         ovdcNetworks:
                           description: OVDCNetworks is the list of organizational virtual data center networks that will be attached to the vApp and can be consumed the VMs.
                           items:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1666,12 +1666,6 @@ spec:
                         organization:
                           description: The name of organization to use.
                           type: string
-                        ovdcNetwork:
-                          description: |-
-                            The name of organizational virtual data center network that will be associated with the VMs and vApp.
-
-                            Deprecated: OVDCNetwork has been deprecated starting with KKP 2.25 and will be removed in KKP 2.27+. It is recommended to use OVDCNetworks instead.
-                          type: string
                         ovdcNetworks:
                           description: OVDCNetworks is the list of organizational virtual data center networks that will be attached to the vApp and can be consumed the VMs.
                           items:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -609,12 +609,6 @@ spec:
                     organization:
                       description: The name of organization to use.
                       type: string
-                    ovdcNetwork:
-                      description: |-
-                        The name of organizational virtual data center network that will be associated with the VMs and vApp.
-
-                        Deprecated: OVDCNetwork has been deprecated starting with KKP 2.25 and will be removed in KKP 2.27+. It is recommended to use OVDCNetworks instead.
-                      type: string
                     ovdcNetworks:
                       description: OVDCNetworks is the list of organizational virtual data center networks that will be attached to the vApp and can be consumed the VMs.
                       items:

--- a/pkg/machine/provider/vmware_cloud_director.go
+++ b/pkg/machine/provider/vmware_cloud_director.go
@@ -115,13 +115,9 @@ func CompleteVMwareCloudDirectorProviderSpec(config *vmwareclouddirector.RawConf
 			config.VApp.Value = cluster.Spec.Cloud.VMwareCloudDirector.VApp
 		}
 
-		if config.Network.Value == "" {
-			if len(cluster.Spec.Cloud.VMwareCloudDirector.OVDCNetworks) > 0 {
-				// As a default, we attach the first network to the VMs.
-				config.Network.Value = cluster.Spec.Cloud.VMwareCloudDirector.OVDCNetworks[0]
-			} else if cluster.Spec.Cloud.VMwareCloudDirector.OVDCNetwork != "" {
-				config.Network.Value = cluster.Spec.Cloud.VMwareCloudDirector.OVDCNetwork
-			}
+		if config.Network.Value == "" && len(cluster.Spec.Cloud.VMwareCloudDirector.OVDCNetworks) > 0 {
+			// As a default, we attach the first network to the VMs.
+			config.Network.Value = cluster.Spec.Cloud.VMwareCloudDirector.OVDCNetworks[0]
 		}
 	}
 

--- a/pkg/provider/cloud/vmwareclouddirector/helper.go
+++ b/pkg/provider/cloud/vmwareclouddirector/helper.go
@@ -46,16 +46,8 @@ func deleteVApp(vdc *govcd.Vdc, vapp *govcd.VApp) error {
 }
 
 func getOrgVDCNetworks(vdc *govcd.Vdc, spec kubermaticv1.VMwareCloudDirectorCloudSpec) ([]*govcd.OrgVDCNetwork, error) {
-	var networks []string
-
-	if len(spec.OVDCNetworks) > 0 {
-		networks = spec.OVDCNetworks
-	} else {
-		networks = []string{spec.OVDCNetwork}
-	}
-
-	orgVDCNetworks := make([]*govcd.OrgVDCNetwork, 0, len(networks))
-	for _, network := range networks {
+	orgVDCNetworks := make([]*govcd.OrgVDCNetwork, 0, len(spec.OVDCNetworks))
+	for _, network := range spec.OVDCNetworks {
 		orgVDCNetwork, err := vdc.GetOrgVdcNetworkByNameOrId(network, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get OrgVDCNetwork '%s': %w", network, err)

--- a/pkg/provider/cloud/vmwareclouddirector/provider.go
+++ b/pkg/provider/cloud/vmwareclouddirector/provider.go
@@ -88,8 +88,8 @@ func (p *Provider) ValidateCloudSpec(_ context.Context, spec kubermaticv1.CloudS
 		return fmt.Errorf("failed to get organization VDC '%s': %w", client.Auth.VDC, err)
 	}
 
-	// Ensure that the network exists
-	if spec.VMwareCloudDirector.OVDCNetwork != "" || spec.VMwareCloudDirector.OVDCNetworks != nil {
+	// Ensure that the networks exist
+	if len(spec.VMwareCloudDirector.OVDCNetworks) > 0 {
 		_, err := getOrgVDCNetworks(vdc, *spec.VMwareCloudDirector)
 		if err != nil {
 			return fmt.Errorf("failed to get organization VDC networks '%s': %w", client.Auth.VDC, err)
@@ -161,10 +161,6 @@ func (p *Provider) CleanUpCloudProvider(ctx context.Context, cluster *kubermatic
 func (p *Provider) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error {
 	if oldSpec.VMwareCloudDirector == nil || newSpec.VMwareCloudDirector == nil {
 		return errors.New("'VMwareCloudDirector' spec is empty")
-	}
-
-	if oldSpec.VMwareCloudDirector.OVDCNetwork != newSpec.VMwareCloudDirector.OVDCNetwork {
-		return fmt.Errorf("updating VMware Cloud Director OVDCNetwork is not supported (was %s, updated to %s)", oldSpec.VMwareCloudDirector.OVDCNetwork, newSpec.VMwareCloudDirector.OVDCNetwork)
 	}
 
 	if oldSpec.VMwareCloudDirector.OVDCNetworks != nil && newSpec.VMwareCloudDirector.OVDCNetworks != nil {

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -172,7 +172,6 @@ var (
 				APIToken:     "vcd-api-token",
 				Organization: "vcd-organization",
 				VDC:          "vcd-vdc",
-				OVDCNetwork:  "vcd-ovdc-network",
 				OVDCNetworks: []string{"vcd-ovdc-network1", "vcd-ovdc-network2"},
 				VApp:         "vcd-vapp",
 			},

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -992,10 +992,8 @@ func validateVMwareCloudDirectorCloudSpec(spec *kubermaticv1.VMwareCloudDirector
 		}
 	}
 
-	if spec.OVDCNetwork == "" && len(spec.OVDCNetworks) == 0 {
-		return errors.New("one of ovdcNetwork or ovdcNetworks needs to be specified")
-	} else if spec.OVDCNetwork != "" && len(spec.OVDCNetworks) > 0 {
-		return errors.New("ovdcNetwork and ovdcNetworks cannot be set at the same time")
+	if len(spec.OVDCNetworks) == 0 {
+		return errors.New("ovdcNetworks must be specified")
 	}
 
 	return nil

--- a/sdk/apis/kubermatic/v1/cluster.go
+++ b/sdk/apis/kubermatic/v1/cluster.go
@@ -1368,11 +1368,6 @@ type VMwareCloudDirectorCloudSpec struct {
 	// +optional
 	VDC string `json:"vdc,omitempty"`
 
-	// The name of organizational virtual data center network that will be associated with the VMs and vApp.
-	//
-	// Deprecated: OVDCNetwork has been deprecated starting with KKP 2.25 and will be removed in KKP 2.27+. It is recommended to use OVDCNetworks instead.
-	OVDCNetwork string `json:"ovdcNetwork,omitempty"`
-
 	// OVDCNetworks is the list of organizational virtual data center networks that will be attached to the vApp and can be consumed the VMs.
 	OVDCNetworks []string `json:"ovdcNetworks,omitempty"`
 

--- a/sdk/apis/kubermatic/v1/preset.go
+++ b/sdk/apis/kubermatic/v1/preset.go
@@ -244,24 +244,18 @@ type VMwareCloudDirector struct {
 	VDC string `json:"vdc"`
 	// The name of organization to use.
 	Organization string `json:"organization"`
-	// The name of organizational virtual data center network that will be associated with the VMs and vApp.
-	//
-	// Deprecated: OVDCNetwork has been deprecated starting with KKP 2.25 and will be removed in KKP 2.27+. It is recommended to use OVDCNetworks instead.
-	OVDCNetwork string `json:"ovdcNetwork,omitempty"`
 	// OVDCNetworks is the list of organizational virtual data center networks that will be attached to the vApp and can be consumed the VMs.
 	OVDCNetworks []string `json:"ovdcNetworks,omitempty"`
 }
 
 func (s VMwareCloudDirector) IsValid() bool {
-	hasAnyNet := len(s.OVDCNetwork) > 0 || len(s.OVDCNetworks) > 0
-	hasBothNets := len(s.OVDCNetwork) > 0 && len(s.OVDCNetworks) > 0
 	hasCredentials := len(s.Username) > 0 && len(s.Password) > 0
 
 	return true &&
 		(hasCredentials || len(s.APIToken) > 0) &&
 		len(s.VDC) > 0 &&
 		len(s.Organization) > 0 &&
-		hasAnyNet && !hasBothNets
+		len(s.OVDCNetworks) > 0
 }
 
 type Baremetal struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the deprecated `OVDCNetwork` field from `VMwareCloudDirectorCloudSpec` and the `VMwareCloudDirector` preset, which was marked for removal since KKP 2.27. All validation, provider logic, and machine configuration now exclusively use OVDCNetworks.
CRD manifests and the golangci-lint suppression for the field are cleaned up accordingly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
