### PR TITLE
envoy-gateway: allow separate image repository and tag overrides

### DIFF
--- a/charts/envoy-gateway-controller/templates/envoyproxy.yaml
+++ b/charts/envoy-gateway-controller/templates/envoyproxy.yaml
@@ -36,7 +36,11 @@ spec:
           {{ toYaml . | nindent 10 }}
         {{- end }}
         container:
+          {{- if kindIs "string" .Values.envoyProxy.deployment.container.image }}
           image: {{ .Values.envoyProxy.deployment.container.image }}
+          {{- else }}
+          image: '{{ .Values.envoyProxy.deployment.container.image.repository }}:{{ .Values.envoyProxy.deployment.container.image.tag }}'
+          {{- end }}
           {{- with .Values.envoyProxy.deployment.container.resources }}
           resources:
             {{ toYaml . | nindent 12 }}

--- a/charts/envoy-gateway-controller/test/default.yaml
+++ b/charts/envoy-gateway-controller/test/default.yaml
@@ -1,0 +1,1 @@
+../values.yaml

--- a/charts/envoy-gateway-controller/test/default.yaml.out
+++ b/charts/envoy-gateway-controller/test/default.yaml.out
@@ -1,0 +1,920 @@
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy-gateway
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-gateway-config
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+data:
+  envoy-gateway.yaml: |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: EnvoyGateway
+    extensionApis: {}
+    gateway:
+      controllerName: gateway.k8c.io/envoy-gateway
+    logging:
+      level:
+        default: info
+    provider:
+      kubernetes:
+        rateLimitDeployment:
+          container:
+            image: docker.io/envoyproxy/ratelimit:99d85510
+          patch:
+            type: StrategicMerge
+            value:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - imagePullPolicy: IfNotPresent
+                      name: envoy-ratelimit
+        shutdownManager:
+          image: docker.io/envoyproxy/gateway:v1.6.1
+      type: Kubernetes
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: release-name-gateway-envoy-gateway-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - envoyproxies
+  - envoypatchpolicies
+  - clienttrafficpolicies
+  - backendtrafficpolicies
+  - securitypolicies
+  - envoyextensionpolicies
+  - backends
+  - httproutefilters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - envoypatchpolicies/status
+  - clienttrafficpolicies/status
+  - backendtrafficpolicies/status
+  - securitypolicies/status
+  - envoyextensionpolicies/status
+  - backends/status
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  - backendtlspolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - tcproutes/status
+  - tlsroutes/status
+  - udproutes/status
+  - backendtlspolicies/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/binding
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-gateway-envoy-gateway-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-gateway-envoy-gateway-role
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/infra-manager-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-gateway-infra-manager
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - autoscaling
+  - policy
+  resources:
+  - horizontalpodautoscalers
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - list
+  - get
+  - watch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-gateway-leader-election-role
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/infra-manager-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-gateway-infra-manager
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'release-name-gateway-infra-manager'
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-gateway-leader-election-rolebinding
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'release-name-gateway-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-gateway
+  namespace: 'default'
+  labels:
+    control-plane: envoy-gateway
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: envoy-gateway
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+  ports:
+  - name: grpc
+    port: 18000
+    targetPort: 18000
+  - name: ratelimit
+    port: 18001
+    targetPort: 18001
+  - name: wasm
+    port: 18002
+    targetPort: 18002
+  - name: metrics
+    port: 19001
+    targetPort: 19001
+  - name: webhook
+    port: 9443
+    targetPort: 9443
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-gateway
+  namespace: 'default'
+  labels:
+    control-plane: envoy-gateway
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway
+      app.kubernetes.io/name: gateway
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "19001"
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: envoy-gateway
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/instance: release-name
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubermatic.io/type
+                operator: In
+                values:
+                - stable
+            weight: 100
+      tolerations:
+      - effect: NoSchedule
+        key: only_critical
+        operator: Equal
+        value: "true"
+      containers:
+      - args:
+        - server
+        - --config-path=/config/envoy-gateway.yaml
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: docker.io/envoyproxy/gateway:v1.6.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: envoy-gateway
+        ports:
+        - containerPort: 18000
+          name: grpc
+        - containerPort: 18001
+          name: ratelimit
+        - containerPort: 18002
+          name: wasm
+        - containerPort: 19001
+          name: metrics
+        - name: webhook
+          containerPort: 9443
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /config
+          name: envoy-gateway-config
+          readOnly: true
+        - mountPath: /certs
+          name: certs
+          readOnly: true
+      imagePullSecrets: []
+      serviceAccountName: envoy-gateway
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: envoy-gateway-config
+        name: envoy-gateway-config
+      - name: certs
+        secret:
+          secretName: envoy-gateway
+---
+# Source: envoy-gateway-controller/templates/clienttrafficpolicy.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: envoy-gateway-controller/templates/backendtrafficpolicy.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: kubermatic-backend-policy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: backend-traffic-policy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kubermatic
+  requestBuffer:
+    limit: "100Mi"
+---
+# Source: envoy-gateway-controller/templates/clienttrafficpolicy.yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: kubermatic-client-policy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: client-traffic-policy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kubermatic
+  connection:
+    bufferLimit: "256Ki"
+---
+# Source: envoy-gateway-controller/templates/envoyproxy.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: kubermatic-default-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: envoy-proxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 3
+        strategy:
+          
+          rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 1
+          type: RollingUpdate
+        container:
+          image: 'envoyproxy/envoy:distroless-v1.36.3'
+          resources:
+            
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+        pod:
+          annotations:
+            
+            prometheus.io/port: "19001"
+            prometheus.io/scrape: "true"
+          affinity:
+            
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: kubermatic.io/type
+                    operator: In
+                    values:
+                    - stable
+                weight: 100
+          tolerations:
+            
+            - effect: NoSchedule
+              key: only_critical
+              operator: Equal
+              value: "true"
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  securityContext:
+                    
+                      runAsGroup: 65534
+                      runAsNonRoot: true
+                      runAsUser: 65534
+                      seccompProfile:
+                        type: RuntimeDefault
+                  containers:
+                  - name: envoy
+                    securityContext:
+                      
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                        - ALL
+                      readOnlyRootFilesystem: true
+                  - name: shutdown-manager
+                    resources:
+                      
+                      limits:
+                        cpu: 100m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 32Mi
+                    securityContext:
+                      
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                        - ALL
+                      readOnlyRootFilesystem: true
+      envoyService:
+        annotations:
+          
+          helm.sh/resource-policy: keep
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+  ipFamily: IPv4
+---
+# Source: envoy-gateway-controller/templates/gatewayclass.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kubermatic-envoy-gateway
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  controllerName: gateway.k8c.io/envoy-gateway
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: kubermatic-default-proxy
+    namespace: default
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'release-name-gateway-certgen:default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+rules:
+  - apiGroups:
+    - admissionregistration.k8s.io
+    resources:
+    - mutatingwebhookconfigurations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    resourceNames:
+      - 'envoy-gateway-topology-injector.default'
+    verbs:
+      - update
+      - patch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: 'release-name-gateway-certgen:default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'release-name-gateway-certgen:default'
+subjects:
+  - kind: ServiceAccount
+    name: 'release-name-gateway-certgen'
+    namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'release-name-gateway-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'release-name-gateway-certgen'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: certgen
+    spec:
+      containers:
+      - command:
+        - envoy-gateway
+        - certgen
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: docker.io/envoyproxy/gateway:v1.6.1
+        imagePullPolicy: IfNotPresent
+        name: envoy-gateway-certgen
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+      imagePullSecrets: []
+      restartPolicy: Never
+      serviceAccountName: release-name-gateway-certgen
+  ttlSecondsAfterFinished: 30
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-proxy-topology-injector-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: 'envoy-gateway-topology-injector.default'
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"
+  labels:
+    app.kubernetes.io/component: topology-injector
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: topology.webhook.gateway.envoyproxy.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    clientConfig:
+      service:
+        name: envoy-gateway
+        namespace: 'default'
+        path: "/inject-pod-topology"
+        port: 9443
+    failurePolicy: Ignore
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/binding"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - default

--- a/charts/envoy-gateway-controller/test/legacy-string-image.yaml
+++ b/charts/envoy-gateway-controller/test/legacy-string-image.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test backward compatibility with legacy string image format.
+# Users who previously set image as a single string should continue to work.
+envoyProxy:
+  deployment:
+    container:
+      image: "my-registry.io/envoy:custom-tag"

--- a/charts/envoy-gateway-controller/test/legacy-string-image.yaml.out
+++ b/charts/envoy-gateway-controller/test/legacy-string-image.yaml.out
@@ -1,0 +1,920 @@
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy-gateway
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: envoy-gateway-config
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+data:
+  envoy-gateway.yaml: |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: EnvoyGateway
+    extensionApis: {}
+    gateway:
+      controllerName: gateway.k8c.io/envoy-gateway
+    logging:
+      level:
+        default: info
+    provider:
+      kubernetes:
+        rateLimitDeployment:
+          container:
+            image: docker.io/envoyproxy/ratelimit:99d85510
+          patch:
+            type: StrategicMerge
+            value:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - imagePullPolicy: IfNotPresent
+                      name: envoy-ratelimit
+        shutdownManager:
+          image: docker.io/envoyproxy/gateway:v1.6.1
+      type: Kubernetes
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: release-name-gateway-envoy-gateway-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - envoyproxies
+  - envoypatchpolicies
+  - clienttrafficpolicies
+  - backendtrafficpolicies
+  - securitypolicies
+  - envoyextensionpolicies
+  - backends
+  - httproutefilters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - envoypatchpolicies/status
+  - clienttrafficpolicies/status
+  - backendtrafficpolicies/status
+  - securitypolicies/status
+  - envoyextensionpolicies/status
+  - backends/status
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  - backendtlspolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - tcproutes/status
+  - tlsroutes/status
+  - udproutes/status
+  - backendtlspolicies/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/binding
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-gateway-envoy-gateway-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-gateway-envoy-gateway-role
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/infra-manager-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-gateway-infra-manager
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - autoscaling
+  - policy
+  resources:
+  - horizontalpodautoscalers
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - deletecollection
+  - patch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - clustertrustbundles
+  verbs:
+  - list
+  - get
+  - watch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-gateway-leader-election-role
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/infra-manager-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-gateway-infra-manager
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'release-name-gateway-infra-manager'
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/leader-election-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-gateway-leader-election-rolebinding
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'release-name-gateway-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: 'envoy-gateway'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-gateway
+  namespace: 'default'
+  labels:
+    control-plane: envoy-gateway
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    control-plane: envoy-gateway
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+  ports:
+  - name: grpc
+    port: 18000
+    targetPort: 18000
+  - name: ratelimit
+    port: 18001
+    targetPort: 18001
+  - name: wasm
+    port: 18002
+    targetPort: 18002
+  - name: metrics
+    port: 19001
+    targetPort: 19001
+  - name: webhook
+    port: 9443
+    targetPort: 9443
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-gateway-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy-gateway
+  namespace: 'default'
+  labels:
+    control-plane: envoy-gateway
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: envoy-gateway
+      app.kubernetes.io/name: gateway
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "19001"
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: envoy-gateway
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/instance: release-name
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubermatic.io/type
+                operator: In
+                values:
+                - stable
+            weight: 100
+      tolerations:
+      - effect: NoSchedule
+        key: only_critical
+        operator: Equal
+        value: "true"
+      containers:
+      - args:
+        - server
+        - --config-path=/config/envoy-gateway.yaml
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: docker.io/envoyproxy/gateway:v1.6.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: envoy-gateway
+        ports:
+        - containerPort: 18000
+          name: grpc
+        - containerPort: 18001
+          name: ratelimit
+        - containerPort: 18002
+          name: wasm
+        - containerPort: 19001
+          name: metrics
+        - name: webhook
+          containerPort: 9443
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /config
+          name: envoy-gateway-config
+          readOnly: true
+        - mountPath: /certs
+          name: certs
+          readOnly: true
+      imagePullSecrets: []
+      serviceAccountName: envoy-gateway
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: envoy-gateway-config
+        name: envoy-gateway-config
+      - name: certs
+        secret:
+          secretName: envoy-gateway
+---
+# Source: envoy-gateway-controller/templates/clienttrafficpolicy.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: envoy-gateway-controller/templates/backendtrafficpolicy.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: kubermatic-backend-policy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: backend-traffic-policy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kubermatic
+  requestBuffer:
+    limit: "100Mi"
+---
+# Source: envoy-gateway-controller/templates/clienttrafficpolicy.yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: kubermatic-client-policy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: client-traffic-policy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kubermatic
+  connection:
+    bufferLimit: "256Ki"
+---
+# Source: envoy-gateway-controller/templates/envoyproxy.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: kubermatic-default-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: envoy-proxy
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: helm
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 3
+        strategy:
+          
+          rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 1
+          type: RollingUpdate
+        container:
+          image: my-registry.io/envoy:custom-tag
+          resources:
+            
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+        pod:
+          annotations:
+            
+            prometheus.io/port: "19001"
+            prometheus.io/scrape: "true"
+          affinity:
+            
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: kubermatic.io/type
+                    operator: In
+                    values:
+                    - stable
+                weight: 100
+          tolerations:
+            
+            - effect: NoSchedule
+              key: only_critical
+              operator: Equal
+              value: "true"
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  securityContext:
+                    
+                      runAsGroup: 65534
+                      runAsNonRoot: true
+                      runAsUser: 65534
+                      seccompProfile:
+                        type: RuntimeDefault
+                  containers:
+                  - name: envoy
+                    securityContext:
+                      
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                        - ALL
+                      readOnlyRootFilesystem: true
+                  - name: shutdown-manager
+                    resources:
+                      
+                      limits:
+                        cpu: 100m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 32Mi
+                    securityContext:
+                      
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                        - ALL
+                      readOnlyRootFilesystem: true
+      envoyService:
+        annotations:
+          
+          helm.sh/resource-policy: keep
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+  ipFamily: IPv4
+---
+# Source: envoy-gateway-controller/templates/gatewayclass.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kubermatic-envoy-gateway
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  controllerName: gateway.k8c.io/envoy-gateway
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: kubermatic-default-proxy
+    namespace: default
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: 'release-name-gateway-certgen:default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+rules:
+  - apiGroups:
+    - admissionregistration.k8s.io
+    resources:
+    - mutatingwebhookconfigurations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    resourceNames:
+      - 'envoy-gateway-topology-injector.default'
+    verbs:
+      - update
+      - patch
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: 'release-name-gateway-certgen:default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'release-name-gateway-certgen:default'
+subjects:
+  - kind: ServiceAccount
+    name: 'release-name-gateway-certgen'
+    namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"   # Ensure rbac is created before the certgen job when using ArgoCD.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: 'release-name-gateway-certgen'
+subjects:
+- kind: ServiceAccount
+  name: 'release-name-gateway-certgen'
+  namespace: 'default'
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/certgen.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: release-name-gateway-certgen
+  namespace: 'default'
+  labels:
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: certgen
+    spec:
+      containers:
+      - command:
+        - envoy-gateway
+        - certgen
+        env:
+        - name: ENVOY_GATEWAY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: cluster.local
+        image: docker.io/envoyproxy/gateway:v1.6.1
+        imagePullPolicy: IfNotPresent
+        name: envoy-gateway-certgen
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+      imagePullSecrets: []
+      restartPolicy: Never
+      serviceAccountName: release-name-gateway-certgen
+  ttlSecondsAfterFinished: 30
+---
+# Source: envoy-gateway-controller/charts/gateway/templates/envoy-proxy-topology-injector-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: 'envoy-gateway-topology-injector.default'
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-weight": "-1"
+  labels:
+    app.kubernetes.io/component: topology-injector
+    helm.sh/chart: gateway-v1.6.1
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.6.1"
+    app.kubernetes.io/managed-by: Helm
+webhooks:
+  - name: topology.webhook.gateway.envoyproxy.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    clientConfig:
+      service:
+        name: envoy-gateway
+        namespace: 'default'
+        path: "/inject-pod-topology"
+        port: 9443
+    failurePolicy: Ignore
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods/binding"]
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+            - default

--- a/charts/envoy-gateway-controller/test/test.sh
+++ b/charts/envoy-gateway-controller/test/test.sh
@@ -1,0 +1,1 @@
+../../../hack/test-chart-rendering.sh

--- a/charts/envoy-gateway-controller/values.yaml
+++ b/charts/envoy-gateway-controller/values.yaml
@@ -57,7 +57,12 @@ envoyProxy:
         maxUnavailable: 1
         maxSurge: 1
     container:
-      image: "envoyproxy/envoy:distroless-v1.36.3"
+      # Image can be specified in two ways:
+      # 1. Map format (recommended): image.repository and image.tag separately
+      # 2. String format (legacy): image as a single string "repo:tag"
+      image:
+        repository: "envoyproxy/envoy"
+        tag: "distroless-v1.36.3"
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the envoyProxy image configuration in the envoy-gateway-controller Helm chart to use separate `repository` and `tag` fields instead of a single string. This matches the pattern used by other KKP Helm charts (like kubermatic-operator) and enables users to override the image repository while preserving the official tag, which is essential for air-gapped environments and private registries.

The implementation maintains full backward compatibility using Helm's `kindIs` function to detect the value type at template rendering time.

**Which issue(s) this PR fixes**:
Fixes #15594

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
envoy-gateway-controller: The envoyProxy image configuration now supports separate repository and tag fields for easier image mirroring. The legacy single-string format continues to work for backward compatibility.
```

**Documentation**:
```documentation
NONE
```

> The values.yaml file includes inline comments explaining both formats.
