### PR TITLE
Fix ineffective anti-affinity for seed nodeport-proxy-envoy

### DIFF
--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -179,10 +179,10 @@ func EnvoyDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, seed *
 					Resources: seed.Spec.NodeportProxy.Envoy.Resources,
 				},
 			}
-			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(EnvoyDeploymentName, kubermaticv1.AntiAffinityTypePreferred)
+			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinityForLabel(common.NameLabel, EnvoyDeploymentName, kubermaticv1.AntiAffinityTypePreferred)
 
 			if supportsFailureDomainZoneAntiAffinity {
-				failureDomainZoneAntiAffinity := resources.FailureDomainZoneAntiAffinity(EnvoyDeploymentName, kubermaticv1.AntiAffinityTypePreferred)
+				failureDomainZoneAntiAffinity := resources.FailureDomainZoneAntiAffinityForLabel(common.NameLabel, EnvoyDeploymentName, kubermaticv1.AntiAffinityTypePreferred)
 				d.Spec.Template.Spec.Affinity = resources.MergeAffinities(d.Spec.Template.Spec.Affinity, failureDomainZoneAntiAffinity)
 			}
 

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments_test.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -70,5 +71,36 @@ func TestEnvoyDeploymentReconcilerReplicas(t *testing.T) {
 				t.Fatalf("unexpected replica count: got %d, want %d", *reconciled.Spec.Replicas, tc.expectedReplicas)
 			}
 		})
+	}
+}
+
+func TestEnvoyDeploymentReconcilerAffinityUsesNameLabel(t *testing.T) {
+	t.Parallel()
+
+	seed := &kubermaticv1.Seed{}
+
+	_, reconcile := EnvoyDeploymentReconciler(&kubermaticv1.KubermaticConfiguration{}, seed, true, kubermatic.Versions{
+		KubermaticContainerTag: "v0.0.0-test",
+	})()
+
+	reconciled, err := reconcile(&appsv1.Deployment{})
+	if err != nil {
+		t.Fatalf("failed to reconcile deployment: %v", err)
+	}
+
+	if reconciled.Spec.Template.Spec.Affinity == nil || reconciled.Spec.Template.Spec.Affinity.PodAntiAffinity == nil {
+		t.Fatal("expected pod anti-affinity to be set")
+	}
+
+	terms := reconciled.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 2 {
+		t.Fatalf("expected 2 preferred anti-affinity terms, got %d", len(terms))
+	}
+
+	for _, term := range terms {
+		matchLabels := term.PodAffinityTerm.LabelSelector.MatchLabels
+		if matchLabels[common.NameLabel] != EnvoyDeploymentName {
+			t.Fatalf("expected anti-affinity to match %q=%q, got %#v", common.NameLabel, EnvoyDeploymentName, matchLabels)
+		}
 	}
 }

--- a/pkg/resources/antiaffinity.go
+++ b/pkg/resources/antiaffinity.go
@@ -26,12 +26,23 @@ import (
 // HostnameAntiAffinity returns a simple Affinity rule to prevent* scheduling of same kind pods on the same node.
 // *if scheduling is not possible with this rule, it will be ignored.
 func HostnameAntiAffinity(app string, antiAffinityType kubermaticv1.AntiAffinityType) *corev1.Affinity {
-	return antiAffinity(app, antiAffinityType, TopologyKeyHostname)
+	return antiAffinity(AppLabelKey, app, antiAffinityType, TopologyKeyHostname)
+}
+
+// HostnameAntiAffinityForLabel returns a simple Affinity rule to prevent* scheduling of same kind pods on the same node.
+// *if scheduling is not possible with this rule, it will be ignored.
+func HostnameAntiAffinityForLabel(labelKey, labelValue string, antiAffinityType kubermaticv1.AntiAffinityType) *corev1.Affinity {
+	return antiAffinity(labelKey, labelValue, antiAffinityType, TopologyKeyHostname)
 }
 
 // FailureDomainZoneAntiAffinity ensures that same-kind pods are spread across different availability zones.
 func FailureDomainZoneAntiAffinity(app string, antiAffinityType kubermaticv1.AntiAffinityType) *corev1.Affinity {
-	return antiAffinity(app, antiAffinityType, TopologyKeyZone)
+	return antiAffinity(AppLabelKey, app, antiAffinityType, TopologyKeyZone)
+}
+
+// FailureDomainZoneAntiAffinityForLabel ensures that same-kind pods are spread across different availability zones.
+func FailureDomainZoneAntiAffinityForLabel(labelKey, labelValue string, antiAffinityType kubermaticv1.AntiAffinityType) *corev1.Affinity {
+	return antiAffinity(labelKey, labelValue, antiAffinityType, TopologyKeyZone)
 }
 
 func MergeAffinities(a *corev1.Affinity, b *corev1.Affinity) *corev1.Affinity {
@@ -55,23 +66,23 @@ func MergeAffinities(a *corev1.Affinity, b *corev1.Affinity) *corev1.Affinity {
 	return a
 }
 
-func antiAffinity(app string, antiAffinity kubermaticv1.AntiAffinityType, topologyKey string) *corev1.Affinity {
+func antiAffinity(labelKey, labelValue string, antiAffinity kubermaticv1.AntiAffinityType, topologyKey string) *corev1.Affinity {
 	if antiAffinity == kubermaticv1.AntiAffinityTypeRequired {
 		return &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: podAffinityTerm(app, topologyKey),
+				RequiredDuringSchedulingIgnoredDuringExecution: podAffinityTerm(labelKey, labelValue, topologyKey),
 			},
 		}
 	}
 
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm(app, topologyKey),
+			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm(labelKey, labelValue, topologyKey),
 		},
 	}
 }
 
-func weightedPodAffinityTerm(app string, topologyKey string) []corev1.WeightedPodAffinityTerm {
+func weightedPodAffinityTerm(labelKey, labelValue string, topologyKey string) []corev1.WeightedPodAffinityTerm {
 	return []corev1.WeightedPodAffinityTerm{
 		// Avoid that we schedule multiple same-kind pods within the same namespace on a single node.
 		{
@@ -79,7 +90,7 @@ func weightedPodAffinityTerm(app string, topologyKey string) []corev1.WeightedPo
 			PodAffinityTerm: corev1.PodAffinityTerm{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						AppLabelKey: app,
+						labelKey: labelValue,
 					},
 				},
 				TopologyKey: topologyKey,
@@ -88,13 +99,13 @@ func weightedPodAffinityTerm(app string, topologyKey string) []corev1.WeightedPo
 	}
 }
 
-func podAffinityTerm(app string, topologyKey string) []corev1.PodAffinityTerm {
+func podAffinityTerm(labelKey, labelValue string, topologyKey string) []corev1.PodAffinityTerm {
 	return []corev1.PodAffinityTerm{
 		// Avoid that we schedule multiple same-kind pods within the same namespace on a single node.
 		{
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					AppLabelKey: app,
+					labelKey: labelValue,
 				},
 			},
 			TopologyKey: topologyKey,

--- a/pkg/resources/antiaffinity_test.go
+++ b/pkg/resources/antiaffinity_test.go
@@ -19,20 +19,22 @@ package resources
 import (
 	"testing"
 
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestMerge(t *testing.T) {
 	a := &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution:  podAffinityTerm("app", "zone"),
-			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm("app", "zone"),
+			RequiredDuringSchedulingIgnoredDuringExecution:  podAffinityTerm(AppLabelKey, "app", "zone"),
+			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm(AppLabelKey, "app", "zone"),
 		},
 	}
 	b := &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution:  podAffinityTerm("app", "zone"),
-			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm("app", "zone"),
+			RequiredDuringSchedulingIgnoredDuringExecution:  podAffinityTerm(AppLabelKey, "app", "zone"),
+			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm(AppLabelKey, "app", "zone"),
 		},
 	}
 	c := MergeAffinities(a, b)
@@ -42,5 +44,23 @@ func TestMerge(t *testing.T) {
 	}
 	if len(c.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 2 {
 		t.Errorf("Merge failed, expected length of RequiredDuringSchedulingIgnoredDuringExecution to be 2, got %d", len(a.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	}
+}
+
+func TestHostnameAntiAffinityForLabel(t *testing.T) {
+	t.Parallel()
+
+	affinity := HostnameAntiAffinityForLabel("app.kubernetes.io/name", "nodeport-proxy-envoy", kubermaticv1.AntiAffinityTypePreferred)
+	terms := affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	if len(terms) != 1 {
+		t.Fatalf("expected 1 preferred anti-affinity term, got %d", len(terms))
+	}
+
+	got := terms[0].PodAffinityTerm.LabelSelector.MatchLabels
+	if got["app.kubernetes.io/name"] != "nodeport-proxy-envoy" {
+		t.Fatalf("unexpected label selector: got %#v", got)
+	}
+	if _, exists := got[AppLabelKey]; exists {
+		t.Fatalf("expected custom label key to be used, got %#v", got)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an anti-affinity label selector mismatch for the seed-side `nodeport-proxy-envoy` Deployment. The Deployment labels/selects pods via `app.kubernetes.io/name=nodeport-proxy-envoy`, but its anti-affinity matched `app=nodeport-proxy-envoy`. Because the pods do not carry the `app` label, the anti-affinity rule never matched the deployment's own pods, making the intended hostname/zone spreading ineffective.
This change makes the seed `nodeport-proxy-envoy` anti-affinity match the actual pod label key while preserving the existing `app`-based behavior for other workloads.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15600

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
- This change is intentionally scoped only to the seed `nodeport-proxy-envoy` Deployment. Existing callers that rely on `app`-based anti-affinity are unchanged.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed ineffective anti-affinity for the seed nodeport-proxy-envoy Deployment by aligning its anti-affinity selector with the pod labels actually used by the Deployment.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
