### PR TITLE
 Fix KubeVirt CSI RBAC permissions for cluster

### DIFF
--- a/pkg/provider/cloud/kubevirt/csi.go
+++ b/pkg/provider/cloud/kubevirt/csi.go
@@ -87,11 +87,49 @@ func csiRoleReconciler(name string) reconciling.NamedRoleReconcilerFactory {
 				{
 					APIGroups: []string{""},
 					Resources: []string{"persistentvolumeclaims"},
+					Verbs:     []string{"get", "list", "watch", "update", "patch"},
+				},
+			}
+
+			return r, nil
+		}
+	}
+}
+
+func csiClusterRoleReconciler(name string) reconciling.NamedClusterRoleReconcilerFactory {
+	return func() (string, reconciling.ClusterRoleReconciler) {
+		return name, func(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			r.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"persistentvolumes"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			}
 
 			return r, nil
+		}
+	}
+}
+
+func csiClusterRoleBindingReconciler(name, namespace string) reconciling.NamedClusterRoleBindingReconcilerFactory {
+	return func() (string, reconciling.ClusterRoleBindingReconciler) {
+		return name, func(rb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			rb.Subjects = []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+
+			rb.RoleRef = rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     name,
+			}
+
+			return rb, nil
 		}
 	}
 }
@@ -118,7 +156,7 @@ func csiRoleBindingReconciler(name, namespace string) reconciling.NamedRoleBindi
 	}
 }
 
-// reconcileCSIRoleRoleBinding reconciles the Role and RoleBinding needed by CSI driver.
+// reconcileCSIRoleRoleBinding reconciles the Role, RoleBinding, ClusterRole and ClusterRoleBinding needed by CSI driver.
 func reconcileCSIRoleRoleBinding(ctx context.Context, namespace string, client ctrlruntimeclient.Client) error {
 	roleReconcilers := []reconciling.NamedRoleReconcilerFactory{
 		csiRoleReconciler(resources.KubeVirtCSIServiceAccountName),
@@ -131,6 +169,21 @@ func reconcileCSIRoleRoleBinding(ctx context.Context, namespace string, client c
 		csiRoleBindingReconciler(resources.KubeVirtCSIServiceAccountName, namespace),
 	}
 	if err := reconciling.ReconcileRoleBindings(ctx, roleBindingReconcilers, namespace, client); err != nil {
+		return err
+	}
+
+	// ClusterRole and ClusterRoleBinding for cluster-scoped resources (persistentvolumes)
+	clusterRoleReconcilers := []reconciling.NamedClusterRoleReconcilerFactory{
+		csiClusterRoleReconciler(resources.KubeVirtCSIServiceAccountName),
+	}
+	if err := reconciling.ReconcileClusterRoles(ctx, clusterRoleReconcilers, "", client); err != nil {
+		return err
+	}
+
+	clusterRoleBindingReconcilers := []reconciling.NamedClusterRoleBindingReconcilerFactory{
+		csiClusterRoleBindingReconciler(resources.KubeVirtCSIServiceAccountName, namespace),
+	}
+	if err := reconciling.ReconcileClusterRoleBindings(ctx, clusterRoleBindingReconcilers, "", client); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Added missing 'patch' verb to Role rules for `persistentvolumeclaims` resource.
- Add missing `ClusterRole` for persistent volumes with get, list and watch permissions.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix KubeVirt CSI RBAC permissions by adding the missing patch and update verbs for persistentvolumeclaims, and introducing a ClusterRole and ClusterRoleBinding for persistentvolumes with get, list, and watch permissions.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
