### PR TITLE
change label key to cluster-id for kubevirt infra netpols

### DIFF
--- a/pkg/ee/kubevirt-network-controller/controller.go
+++ b/pkg/ee/kubevirt-network-controller/controller.go
@@ -54,7 +54,7 @@ import (
 const (
 	ControllerName                = "kubevirt-network-controller"
 	WorkloadSubnetLabel           = "k8c.io/kubevirt-workload-subnet"
-	NetworkPolicyPodSelectorLabel = "cluster.x-k8s.io/cluster-name"
+	NetworkPolicyPodSelectorLabel = "cluster.x-k8s.io/cluster-id"
 	NetworkPolicyCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubevirt-infra-network-policy"
 )
 

--- a/pkg/ee/kubevirt-network-controller/controller.go
+++ b/pkg/ee/kubevirt-network-controller/controller.go
@@ -54,7 +54,7 @@ import (
 const (
 	ControllerName                = "kubevirt-network-controller"
 	WorkloadSubnetLabel           = "k8c.io/kubevirt-workload-subnet"
-	NetworkPolicyPodSelectorLabel = "cluster.x-k8s.io/cluster-id"
+	NetworkPolicyPodSelectorLabel = "kubermatic.k8c.io/cluster-id"
 	NetworkPolicyCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubevirt-infra-network-policy"
 )
 

--- a/pkg/ee/kubevirt-network-controller/controller_test.go
+++ b/pkg/ee/kubevirt-network-controller/controller_test.go
@@ -113,7 +113,7 @@ func TestReconcile(t *testing.T) {
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"cluster.x-k8s.io/cluster-name": clusterName,
+							NetworkPolicyPodSelectorLabel: clusterName,
 						},
 					},
 					Egress: []networkingv1.NetworkPolicyEgressRule{
@@ -123,7 +123,7 @@ func TestReconcile(t *testing.T) {
 								{
 									PodSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"cluster.x-k8s.io/cluster-name": clusterName,
+											NetworkPolicyPodSelectorLabel: clusterName,
 										},
 									},
 								},
@@ -221,7 +221,7 @@ func TestReconcile(t *testing.T) {
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"cluster.x-k8s.io/cluster-name": clusterName,
+							NetworkPolicyPodSelectorLabel: clusterName,
 						},
 					},
 					Egress: []networkingv1.NetworkPolicyEgressRule{
@@ -231,7 +231,7 @@ func TestReconcile(t *testing.T) {
 								{
 									PodSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"cluster.x-k8s.io/cluster-name": clusterName,
+											NetworkPolicyPodSelectorLabel: clusterName,
 										},
 									},
 								},
@@ -262,7 +262,7 @@ func TestReconcile(t *testing.T) {
 								{
 									PodSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"cluster.x-k8s.io/cluster-name": clusterName,
+											NetworkPolicyPodSelectorLabel: clusterName,
 										},
 									},
 								},

--- a/pkg/ee/kubevirt-network-controller/network_policy.go
+++ b/pkg/ee/kubevirt-network-controller/network_policy.go
@@ -143,7 +143,7 @@ func namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler(cluster *kuber
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"cluster.x-k8s.io/cluster-name": cluster.Name,
+										NetworkPolicyPodSelectorLabel: cluster.Name,
 									},
 								},
 							},

--- a/pkg/ee/kubevirt-network-controller/network_policy.go
+++ b/pkg/ee/kubevirt-network-controller/network_policy.go
@@ -71,7 +71,7 @@ func namespacedClusterIsolationNetworkPolicyDefaultAllowReconciler(clusterName s
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"cluster.x-k8s.io/cluster-name": clusterName,
+						NetworkPolicyPodSelectorLabel: clusterName,
 					},
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
@@ -81,7 +81,7 @@ func namespacedClusterIsolationNetworkPolicyDefaultAllowReconciler(clusterName s
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"cluster.x-k8s.io/cluster-name": clusterName,
+										NetworkPolicyPodSelectorLabel: clusterName,
 									},
 								},
 							},
@@ -107,7 +107,7 @@ func namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler(cluster *kuber
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"cluster.x-k8s.io/cluster-name": cluster.Name,
+						NetworkPolicyPodSelectorLabel: cluster.Name,
 					},
 				},
 				PolicyTypes: []networkingv1.PolicyType{
@@ -121,7 +121,7 @@ func namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler(cluster *kuber
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"cluster.x-k8s.io/cluster-name": cluster.Name,
+										NetworkPolicyPodSelectorLabel: cluster.Name,
 									},
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr changes the label key used for network policies in kubevirt infra cluster from `cluster.x-k8s.io/cluster-name` to `kubermatic.k8c.io/cluster-id`.

internal ref: 8896

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The label key used for network policies for kubevirt virtual machines changed from `cluster.x-k8s.io/cluster-name` to `kubermatic.k8c.io/cluster-id`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
