### PR TITLE
Add kyverno-enabled flag to user-cluster controller-manager helper

### DIFF
--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -73,6 +73,10 @@ if echo $CLUSTER_RAW | grep -i kubevirt -q; then
   ARGS="$ARGS -kv-infra-kubeconfig=${KUBEVIRT_INFRA_KUBECONFIG}"
 fi
 
+if [[ "$(echo "${CLUSTER_RAW}" | jq -r '.spec.kyverno.enabled // false')" == "true" ]]; then
+  ARGS="$ARGS -kyverno-enabled"
+fi
+
 if $(echo ${CLUSTER_RAW} | jq -r '.spec.clusterNetwork.konnectivityEnabled'); then
   KONNECTIVITY_SERVER_SERVICE_RAW="$(kubectl --namespace "$NAMESPACE" get service konnectivity-server -o json)"
   if $(echo ${KONNECTIVITY_SERVER_SERVICE_RAW} | jq --exit-status '.spec.ports[0].nodePort' > /dev/null); then


### PR DESCRIPTION
**What this PR does / why we need it**:
Small helper-script update to enable local runs of the user-cluster-controller-manager policy binding controller when Kyverno is enabled in the cluster spec.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
