### PR TITLE
Fix dual-stack CI failures by using quay.io for Canal Calico images

### DIFF
--- a/addons/canal/canal_v3.30.yaml
+++ b/addons/canal/canal_v3.30.yaml
@@ -9924,7 +9924,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Image "docker.io/calico/cni:v3.30.3" }}'
+          image: '{{ Image "quay.io/calico/cni:v3.30.3" }}'
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -9973,7 +9973,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: '{{ Image "docker.io/calico/node:v3.30.3" }}'
+          image: '{{ Image "quay.io/calico/node:v3.30.3" }}'
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -9999,7 +9999,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Image "docker.io/calico/node:v3.30.3" }}'
+          image: '{{ Image "quay.io/calico/node:v3.30.3" }}'
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -10250,7 +10250,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: '{{ Image "docker.io/calico/kube-controllers:v3.30.3" }}'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.30.3" }}'
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.

--- a/addons/canal/canal_v3.31.yaml
+++ b/addons/canal/canal_v3.31.yaml
@@ -7100,7 +7100,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Image "docker.io/calico/cni:v3.31.3" }}'
+          image: '{{ Image "quay.io/calico/cni:v3.31.3" }}'
           imagePullPolicy: IfNotPresent
           command: ["/opt/cni/bin/install"]
           envFrom:
@@ -7149,7 +7149,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: '{{ Image "docker.io/calico/node:v3.31.3" }}'
+          image: '{{ Image "quay.io/calico/node:v3.31.3" }}'
           imagePullPolicy: IfNotPresent
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
@@ -7175,7 +7175,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Image "docker.io/calico/node:v3.31.3" }}'
+          image: '{{ Image "quay.io/calico/node:v3.31.3" }}'
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -7426,7 +7426,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: '{{ Image "docker.io/calico/kube-controllers:v3.31.3" }}'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.31.3" }}'
           imagePullPolicy: IfNotPresent
           env:
             # Choose which controllers to run.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Canal v3.30 and v3.31 manifests to pull Calico images from `quay.io` instead of `docker.io`.

We need this because AWS dual-stack CI jobs using Canal are failing when the canal DaemonSet init container tries to pull `docker.io/calico/cni:v3.30.3` and hits Docker Hub's unauthenticated rate limit `(429 Too Many Requests)`. When that happens, CNI never initializes, all worker nodes stay NotReady, and the test times out waiting for ready nodes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind failing-test
/kind regression

**Special notes for your reviewer**:
- flannel still uses docker.io/flannel/flannel:v0.24.4 and is not changed here, because there is no verified equivalent registry change for that exact image/version in this PR.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Canal v3.30 and v3.31 now pull Calico images from quay.io instead of docker.io to avoid Docker Hub rate limits that could block cluster bootstrap.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
