### PR TITLE
chore: fix run-kubermatic-kind script

### DIFF
--- a/hack/local/data/metallb-ipaddresspool.yaml
+++ b/hack/local/data/metallb-ipaddresspool.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: ConfigMap
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
 metadata:
+  name: local-ip-pool
   namespace: metallb-system
-  name: config
-data:
-  config: |
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
-      - 172.18.255.200-172.18.255.204
+spec:
+  addresses:
+  - 172.18.255.200/32

--- a/hack/local/run-kubermatic-kind.sh
+++ b/hack/local/run-kubermatic-kind.sh
@@ -215,10 +215,11 @@ retry 9 check_all_deployments_ready kube-system
 echodate "VPA is ready."
 
 echodate "Installing metallb"
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+METALLB_VERSION="v0.14.9"
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/$METALLB_VERSION/config/manifests/metallb-native.yaml
 kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
 echodate "Waiting for load balancer to be ready..."
 retry 10 check_all_deployments_ready metallb-system
 echodate "Load balancer is ready."
-kubectl apply -f "$DATA_FILE"/metallb-configmap.yaml
+kubectl wait --for condition=established --timeout 20s crd ipaddresspools.metallb.io
+kubectl apply -f "$DATA_FILE"/metallb-ipaddresspool.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Make the `hack/local/run-kubermatic-kind.sh` script install a newer MetalLB version (0.14.9; aligned with the [ApplicationDefinition](https://github.com/kubermatic/kubermatic/blob/v2.30.0/pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml#L48)) since the old MetalLB version attempted to install a `PodSecurityPolicy` which isn't supported in k8s >1.25 anymore.
Also, the newer MetalLB version requires the IP pool to be configured within a corresponding custom resource as opposed to a ConfigMap.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

Relates to #14935

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
