### PR TITLE
Make Dex HTTPRoute path and pathType configurable

### DIFF
--- a/charts/dex/templates/httproute.yaml
+++ b/charts/dex/templates/httproute.yaml
@@ -31,8 +31,8 @@ spec:
   rules:
     - matches:
         - path:
-            type: PathPrefix
-            value: /dex
+            type: {{ .Values.httpRoute.pathType }}
+            value: {{ .Values.httpRoute.path }}
       backendRefs:
         - name: dex
           port: 5556

--- a/charts/dex/values.yaml
+++ b/charts/dex/values.yaml
@@ -27,6 +27,10 @@ httpRoute:
   domain: ""
   # Timeout for requests (matching nginx proxy-read-timeout annotation)
   timeout: 3600s
+  # Path for Dex route (default: /dex)
+  path: /dex
+  # Path match type: PathPrefix, Exact, or RegularExpression (default: PathPrefix)
+  pathType: PathPrefix
 
 dex:
   replicaCount: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the Dex HTTPRoute path and path type configurable via Helm values. Previously, the HTTPRoute template had hardcoded values (path: `/dex`, pathType: `PathPrefix`) that did not respect user configuration, preventing users from deploying Dex on a separate subdomain with root path (`/`).

The fix adds two new configurable values under `httpRoute`:
- `path`: Path for Dex route (default: `/dex`)
- `pathType`: Path match type - PathPrefix, Exact, or RegularExpression (default: `PathPrefix`)

This brings the HTTPRoute configuration in line with the existing Ingress configuration flexibility, where path and pathType are already configurable.

**Which issue(s) this PR fixes**:
Fixes #15610

**What type of PR is this?**:
/kind feature

**Special notes for your reviewer**:

Example use case - deploying Dex on a separate subdomain:
```yaml
# The following is a demonstration to show that fields are now configurable.
# Values, such as `domain: auth.example.com` or `pathType: Exact`, 
# depend on specific installations.
httpRoute:
  domain: auth.example.com
  path: /
  pathType: Exact
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Dex HTTPRoute path and pathType are now configurable via `httpRoute.path` and `httpRoute.pathType` values, allowing users to deploy Dex on a separate subdomain with root path instead of being limited to path-based routing.
```

**Documentation**:
```documentation
NONE
```
