### PR TITLE
preserve dynamic Gateway listeners in operator reconciliation

### DIFF
--- a/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/httproute-gateway-sync/reconciler.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	gatewayutil "k8c.io/kubermatic/v2/pkg/controller/util/gateway"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -156,12 +157,10 @@ func (r *Reconciler) desiredListeners(
 	gateway *gatewayapiv1.Gateway,
 	httpRoutes []gatewayapiv1.HTTPRoute,
 ) []gatewayapiv1.Listener {
-	// preserve the core HTTP and HTTPs listeners.
+	// preserve the core HTTP and HTTPS listeners.
 	listeners := make([]gatewayapiv1.Listener, 0)
 	for _, l := range gateway.Spec.Listeners {
-		if l.Protocol == gatewayapiv1.HTTPProtocolType && l.Name == "http" {
-			listeners = append(listeners, l)
-		} else if l.Protocol == gatewayapiv1.HTTPSProtocolType && l.Name == "https" {
+		if _, isCore := gatewayutil.CoreListenerNames[l.Name]; isCore {
 			listeners = append(listeners, l)
 		}
 	}
@@ -231,6 +230,7 @@ func (r *Reconciler) desiredListeners(
 		listeners = append(listeners, listener)
 	}
 
+	gatewayutil.SortListenersByName(listeners)
 	return listeners
 }
 

--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -25,6 +25,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	gatewayutil "k8c.io/kubermatic/v2/pkg/controller/util/gateway"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -43,7 +44,13 @@ const (
 )
 
 // GatewayReconciler returns a reconciler for the main Gateway resource.
-func GatewayReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace string) kkpreconciling.NamedGatewayAPIGatewayReconcilerFactory {
+// existingListeners contains the current listeners from the Gateway (empty for new Gateways).
+// Non-core listeners (not http/https) from existingListeners are preserved.
+func GatewayReconciler(
+	cfg *kubermaticv1.KubermaticConfiguration,
+	namespace string,
+	existingListeners []gatewayapiv1.Listener,
+) kkpreconciling.NamedGatewayAPIGatewayReconcilerFactory {
 	return func() (string, kkpreconciling.GatewayAPIGatewayReconciler) {
 		return gatewayName, func(g *gatewayapiv1.Gateway) (*gatewayapiv1.Gateway, error) {
 			g.Name = gatewayName
@@ -64,9 +71,9 @@ func GatewayReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace stri
 			}
 			g.Spec.GatewayClassName = gatewayapiv1.ObjectName(gatewayClassName)
 
-			// Build the listeners slice. HTTP is always present.
-			// HTTPs is only added when a CertificateIssuer is configured.
-			listeners := []gatewayapiv1.Listener{
+			// Build core listeners. HTTP is always present.
+			// HTTPS is only added when a CertificateIssuer is configured.
+			coreListeners := []gatewayapiv1.Listener{
 				{
 					Name:     "http",
 					Protocol: gatewayapiv1.HTTPProtocolType,
@@ -99,7 +106,7 @@ func GatewayReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace stri
 				case certmanagerv1.ClusterIssuerKind:
 					g.Annotations[certmanagerv1.IngressClusterIssuerNameAnnotationKey] = issuer.Name
 				}
-				listeners = append(listeners, gatewayapiv1.Listener{
+				coreListeners = append(coreListeners, gatewayapiv1.Listener{
 					Name:     "https",
 					Hostname: ptr.To(gatewayapiv1.Hostname(cfg.Spec.Ingress.Domain)),
 					Protocol: gatewayapiv1.HTTPSProtocolType,
@@ -125,7 +132,8 @@ func GatewayReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace stri
 				})
 			}
 
-			g.Spec.Listeners = listeners
+			// Merge core listeners with preserved non-core from existing (sorted)
+			g.Spec.Listeners = gatewayutil.MergeListeners(coreListeners, existingListeners)
 
 			return g, nil
 		}
@@ -262,24 +270,28 @@ func EnsureGateway(
 	cfg *kubermaticv1.KubermaticConfiguration,
 	namespace string,
 ) error {
-	factory := GatewayReconciler(cfg, namespace)
-	gatewayName, reconciler := factory()
+	key := types.NamespacedName{Namespace: namespace, Name: gatewayName}
+
+	var existing gatewayapiv1.Gateway
+	existingListeners := []gatewayapiv1.Listener{}
+
+	err := client.Get(ctx, key, &existing)
+	if err == nil {
+		existingListeners = existing.Spec.Listeners
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get Gateway %q: %w", key.String(), err)
+	}
+
+	_, reconciler := GatewayReconciler(cfg, namespace, existingListeners)()
 
 	desired := &gatewayapiv1.Gateway{}
 	if _, err := reconciler(desired); err != nil {
 		return fmt.Errorf("failed to build desired Gateway: %w", err)
 	}
 
-	key := types.NamespacedName{Namespace: namespace, Name: gatewayName}
-
-	var existing gatewayapiv1.Gateway
-	if err := client.Get(ctx, key, &existing); err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Debugw("Creating Gateway", "name", gatewayName, "namespace", namespace)
-			return client.Create(ctx, desired)
-		}
-
-		return fmt.Errorf("failed to get Gateway %s/%s: %w", namespace, gatewayName, err)
+	if apierrors.IsNotFound(err) {
+		log.Debugw("Creating Gateway", "name", gatewayName, "namespace", namespace)
+		return client.Create(ctx, desired)
 	}
 
 	// compare only Spec/Labels/Annotations (ignore Status to avoid update loops)

--- a/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
@@ -204,7 +204,7 @@ func TestGatewayReconciler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			creatorGetter := GatewayReconciler(tc.config, "kubermatic")
+			creatorGetter := GatewayReconciler(tc.config, "kubermatic", nil)
 			_, creator := creatorGetter()
 
 			reconciled, err := creator(&gatewayapiv1.Gateway{})
@@ -219,6 +219,68 @@ func TestGatewayReconciler(t *testing.T) {
 	}
 }
 
+func TestGatewayReconcilerPreservesNonCoreListeners(t *testing.T) {
+	cfg := &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			Ingress: kubermaticv1.KubermaticIngressConfiguration{
+				Domain: "example.com",
+				CertificateIssuer: corev1.TypedLocalObjectReference{
+					Name: "letsencrypt-prod",
+					Kind: certmanagerv1.ClusterIssuerKind,
+				},
+			},
+		},
+	}
+
+	existingListeners := []gatewayapiv1.Listener{
+		{Name: "http", Port: 80, Protocol: gatewayapiv1.HTTPProtocolType},
+		{Name: "https", Port: 443, Protocol: gatewayapiv1.HTTPSProtocolType},
+		{Name: "dex-example-com", Port: 443, Protocol: gatewayapiv1.HTTPSProtocolType},
+	}
+
+	creatorGetter := GatewayReconciler(cfg, "kubermatic", existingListeners)
+	_, creator := creatorGetter()
+
+	reconciled, err := creator(&gatewayapiv1.Gateway{})
+	if err != nil {
+		t.Fatalf("GatewayReconciler failed: %v", err)
+	}
+
+	// should have 3 listeners: http, https, dex-example-com
+	if len(reconciled.Spec.Listeners) != 3 {
+		t.Fatalf("expected 3 listeners, got %d: %v", len(reconciled.Spec.Listeners), listenerNames(reconciled.Spec.Listeners))
+	}
+
+	// verify dex listener is preserved
+	var found bool
+	for _, l := range reconciled.Spec.Listeners {
+		if l.Name == "dex-example-com" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("dex-example-com listener should be preserved")
+	}
+
+	// verify listeners are sorted
+	names := listenerNames(reconciled.Spec.Listeners)
+	expected := []string{"dex-example-com", "http", "https"}
+	for i, name := range expected {
+		if names[i] != name {
+			t.Errorf("listener %d: expected %q, got %q", i, name, names[i])
+		}
+	}
+}
+
+func listenerNames(listeners []gatewayapiv1.Listener) []string {
+	names := make([]string, len(listeners))
+	for i, l := range listeners {
+		names[i] = string(l.Name)
+	}
+	return names
+}
+
 func TestGatewayReconcilerKeepsAnnotations(t *testing.T) {
 	// Test that custom annotations are preserved (similar to IngressReconcilerKeepsAnnotations)
 	cfg := &kubermaticv1.KubermaticConfiguration{
@@ -228,7 +290,7 @@ func TestGatewayReconcilerKeepsAnnotations(t *testing.T) {
 			},
 		},
 	}
-	creatorGetter := GatewayReconciler(cfg, "kubermatic")
+	creatorGetter := GatewayReconciler(cfg, "kubermatic", nil)
 	_, creator := creatorGetter()
 
 	testCases := []struct {
@@ -542,7 +604,7 @@ func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {
 			},
 		},
 	}
-	factory := GatewayReconciler(cfg, namespace)
+	factory := GatewayReconciler(cfg, namespace, nil)
 	_, reconciler := factory()
 
 	desired := &gatewayapiv1.Gateway{}
@@ -578,6 +640,75 @@ func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {
 
 	if len(fetched.Status.Conditions) == 0 {
 		t.Error("Expected Status conditions to be preserved, but they were cleared (Update was called when it shouldn't have been)")
+	}
+}
+
+func TestEnsureGatewayPreservesDynamicListeners(t *testing.T) {
+	ctx := context.Background()
+	namespace := "kubermatic"
+
+	cfg := &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			Ingress: kubermaticv1.KubermaticIngressConfiguration{
+				Domain: "example.com",
+				CertificateIssuer: corev1.TypedLocalObjectReference{
+					Name: "letsencrypt-prod",
+					Kind: certmanagerv1.ClusterIssuerKind,
+				},
+			},
+		},
+	}
+
+	// Simulate Gateway with dynamic listener added by httproute-gateway-sync
+	existing := &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				common.NameLabel: defaulting.DefaultGatewayName,
+			},
+			Annotations: map[string]string{
+				certmanagerv1.IngressClusterIssuerNameAnnotationKey: "letsencrypt-prod",
+			},
+		},
+		Spec: gatewayapiv1.GatewaySpec{
+			GatewayClassName: gatewayapiv1.ObjectName(defaulting.DefaultGatewayClassName),
+			Listeners: []gatewayapiv1.Listener{
+				{Name: "dex-example-com", Port: 443, Protocol: gatewayapiv1.HTTPSProtocolType},
+				{Name: "http", Port: 80, Protocol: gatewayapiv1.HTTPProtocolType},
+				{Name: "https", Port: 443, Protocol: gatewayapiv1.HTTPSProtocolType},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).WithObjects(existing).Build()
+
+	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var updated gatewayapiv1.Gateway
+	err = client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: gatewayName}, &updated)
+	if err != nil {
+		t.Fatalf("Gateway should exist: %v", err)
+	}
+
+	// Verify dynamic listener is preserved
+	var foundDex bool
+	for _, l := range updated.Spec.Listeners {
+		if l.Name == "dex-example-com" {
+			foundDex = true
+			break
+		}
+	}
+	if !foundDex {
+		t.Error("dex-example-com listener should be preserved after EnsureGateway")
+	}
+
+	// Verify we have exactly 3 listeners
+	if len(updated.Spec.Listeners) != 3 {
+		t.Errorf("expected 3 listeners, got %d", len(updated.Spec.Listeners))
 	}
 }
 

--- a/pkg/controller/util/gateway/listeners.go
+++ b/pkg/controller/util/gateway/listeners.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package gateway provides utilities for working with Gateway API resources.
+package gateway
+
+import (
+	"slices"
+	"strings"
+
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	// CoreListenerHTTP is the name of the HTTP listener managed by kubermatic-operator.
+	CoreListenerHTTP gatewayapiv1.SectionName = "http"
+	// CoreListenerHTTPS is the name of the HTTPS listener managed by kubermatic-operator.
+	CoreListenerHTTPS gatewayapiv1.SectionName = "https"
+)
+
+// CoreListenerNames defines the listener names managed by kubermatic-operator.
+// These are always replaced with the operator's desired state.
+var CoreListenerNames = map[gatewayapiv1.SectionName]struct{}{
+	CoreListenerHTTP:  {},
+	CoreListenerHTTPS: {},
+}
+
+// MergeListeners combines core listeners with preserved non-core listeners from existing.
+// Core listeners (http, https) come from the operator's desired state.
+// Non-core listeners (hostname-based) are preserved from existing state.
+// Returns sorted slice for deterministic comparison.
+func MergeListeners(core, existing []gatewayapiv1.Listener) []gatewayapiv1.Listener {
+	result := make([]gatewayapiv1.Listener, 0, len(core)+len(existing))
+	result = append(result, core...)
+
+	for _, l := range existing {
+		if _, isCoreListener := CoreListenerNames[l.Name]; !isCoreListener {
+			result = append(result, l)
+		}
+	}
+
+	SortListenersByName(result)
+	return result
+}
+
+// SortListenersByName sorts listeners alphabetically by name for deterministic ordering.
+func SortListenersByName(listeners []gatewayapiv1.Listener) {
+	slices.SortFunc(listeners, func(a, b gatewayapiv1.Listener) int {
+		return strings.Compare(string(a.Name), string(b.Name))
+	})
+}

--- a/pkg/controller/util/gateway/listeners_test.go
+++ b/pkg/controller/util/gateway/listeners_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"testing"
+
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestMergeListeners(t *testing.T) {
+	tests := []struct {
+		name      string
+		core      []gatewayapiv1.Listener
+		existing  []gatewayapiv1.Listener
+		want      []string                  // expected listener names in order
+		wantPorts []gatewayapiv1.PortNumber // expected ports in same order as want
+	}{
+		{
+			name: "core only, no existing",
+			core: []gatewayapiv1.Listener{
+				{Name: "http", Port: 80},
+				{Name: "https", Port: 443},
+			},
+			existing:  nil,
+			want:      []string{"http", "https"},
+			wantPorts: []gatewayapiv1.PortNumber{80, 443},
+		},
+		{
+			name: "preserves non-core from existing",
+			core: []gatewayapiv1.Listener{
+				{Name: "http", Port: 80},
+				{Name: "https", Port: 443},
+			},
+			existing: []gatewayapiv1.Listener{
+				{Name: "http", Port: 80},
+				{Name: "https", Port: 443},
+				{Name: "dex-example-com", Port: 8443},
+			},
+			want:      []string{"dex-example-com", "http", "https"},
+			wantPorts: []gatewayapiv1.PortNumber{8443, 80, 443},
+		},
+		{
+			name: "sorts alphabetically",
+			core: []gatewayapiv1.Listener{
+				{Name: "https", Port: 443},
+				{Name: "http", Port: 80},
+			},
+			existing: []gatewayapiv1.Listener{
+				{Name: "zebra-host", Port: 9443},
+				{Name: "alpha-host", Port: 8443},
+			},
+			want:      []string{"alpha-host", "http", "https", "zebra-host"},
+			wantPorts: []gatewayapiv1.PortNumber{8443, 80, 443, 9443},
+		},
+		{
+			name: "uses core version of http/https, not existing",
+			core: []gatewayapiv1.Listener{
+				{Name: "http", Port: 8080},
+				{Name: "https", Port: 8443},
+			},
+			existing: []gatewayapiv1.Listener{
+				{Name: "http", Port: 80},
+				{Name: "https", Port: 443},
+			},
+			want:      []string{"http", "https"},
+			wantPorts: []gatewayapiv1.PortNumber{8080, 8443},
+		},
+		{
+			name:      "empty core and existing",
+			core:      nil,
+			existing:  nil,
+			want:      []string{},
+			wantPorts: []gatewayapiv1.PortNumber{},
+		},
+		{
+			name: "only non-core in existing",
+			core: []gatewayapiv1.Listener{
+				{Name: "http", Port: 80},
+			},
+			existing: []gatewayapiv1.Listener{
+				{Name: "custom-listener", Port: 9000},
+			},
+			want:      []string{"custom-listener", "http"},
+			wantPorts: []gatewayapiv1.PortNumber{9000, 80},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeListeners(tt.core, tt.existing)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("MergeListeners() returned %d listeners, want %d", len(got), len(tt.want))
+			}
+
+			for i, name := range tt.want {
+				if string(got[i].Name) != name {
+					t.Errorf("MergeListeners()[%d].Name = %q, want %q", i, got[i].Name, name)
+				}
+				if got[i].Port != tt.wantPorts[i] {
+					t.Errorf("MergeListeners()[%d].Port = %d, want %d", i, got[i].Port, tt.wantPorts[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMergeListenersPreservesFields(t *testing.T) {
+	core := []gatewayapiv1.Listener{
+		{
+			Name:     "http",
+			Port:     80,
+			Protocol: gatewayapiv1.HTTPProtocolType,
+		},
+	}
+
+	const (
+		dexListenerName = "dex-example-com"
+		dexHostname     = "dex.example.com"
+	)
+
+	existing := []gatewayapiv1.Listener{
+		{
+			Name:     dexListenerName,
+			Port:     443,
+			Protocol: gatewayapiv1.HTTPSProtocolType,
+			Hostname: ptr.To(gatewayapiv1.Hostname(dexHostname)),
+			TLS: &gatewayapiv1.ListenerTLSConfig{
+				Mode: ptr.To(gatewayapiv1.TLSModeTerminate),
+			},
+		},
+	}
+
+	got := MergeListeners(core, existing)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 listeners, got %d", len(got))
+	}
+
+	var dexListener *gatewayapiv1.Listener
+	for i := range got {
+		if got[i].Name == dexListenerName {
+			dexListener = &got[i]
+			break
+		}
+	}
+
+	if dexListener == nil {
+		t.Fatalf("%q listener not found", dexListenerName)
+	}
+
+	if dexListener.Port != 443 {
+		t.Errorf("expected port 443, got %d", dexListener.Port)
+	}
+
+	if dexListener.Hostname == nil || *dexListener.Hostname != dexHostname {
+		t.Errorf("expected hostname %q, got %v", dexHostname, dexListener.Hostname)
+	}
+
+	if dexListener.TLS == nil {
+		t.Error("expected TLS config to be preserved")
+	}
+}
+
+func TestSortListenersByName(t *testing.T) {
+	listeners := []gatewayapiv1.Listener{
+		{Name: "zebra"},
+		{Name: "alpha"},
+		{Name: "http"},
+		{Name: "https"},
+		{Name: "beta"},
+	}
+
+	SortListenersByName(listeners)
+
+	expected := []string{"alpha", "beta", "http", "https", "zebra"}
+	for i, name := range expected {
+		if string(listeners[i].Name) != name {
+			t.Errorf("SortListenersByName()[%d].Name = %q, want %q", i, listeners[i].Name, name)
+		}
+	}
+}
+
+func TestSortListenersByNameDeterministic(t *testing.T) {
+	for run := 0; run < 10; run++ {
+		listeners := []gatewayapiv1.Listener{
+			{Name: "c"},
+			{Name: "a"},
+			{Name: "b"},
+		}
+
+		SortListenersByName(listeners)
+
+		if listeners[0].Name != "a" || listeners[1].Name != "b" || listeners[2].Name != "c" {
+			t.Errorf("run %d: non-deterministic sort result", run)
+		}
+	}
+}

--- a/pkg/controller/util/gateway/listeners_test.go
+++ b/pkg/controller/util/gateway/listeners_test.go
@@ -197,7 +197,7 @@ func TestSortListenersByName(t *testing.T) {
 }
 
 func TestSortListenersByNameDeterministic(t *testing.T) {
-	for run := 0; run < 10; run++ {
+	for run := range 10 {
 		listeners := []gatewayapiv1.Listener{
 			{Name: "c"},
 			{Name: "a"},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes Gateway API listener churn that occurs during kubermatic-operator reconciliation.

Previously, kubermatic-operator and httproute-gateway-sync controller were in conflict over Gateway listeners. The operator would overwrite all listeners with its core listeners (http, https), removing dynamic hostname-based listeners added by the httproute-gateway-sync controller. This caused a reconciliation loop where:
1. httproute-gateway-sync adds a listener for a hostname (e.g., mla.example.com)
2. kubermatic-operator reconciles and removes that listener
3. httproute-gateway-sync detects the missing listener and adds it again
4. Repeat

The fix introduces:
- A shared `pkg/controller/util/gateway` package with common listener definitions
- `MergeListeners()` function that preserves non-core listeners during operator reconciliation
- `SortListenersByName()` for deterministic listener ordering
- Shared `CoreListenerNames` constant used by both controllers

**Which issue(s) this PR fixes**:
Fixes #15626

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

Reproduction steps:
1. Deploy KKP with Gateway API enabled
2. Create an HTTPRoute in the watched namespace (e.g., mla) with a different hostname
3. Observe the dynamic listener added to the Gateway
4. Trigger operator reconciliation (annotate KubermaticConfiguration)
5. Verify dynamic listener is preserved and no generation churn

Test cases that i covered (observe metadata.generation during tests):
- Operator restart
- master-controller-manager restart
- HTTPRoute deletion
- Simultaneous restart
- Rapid create/delete

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix Gateway API listener churn where kubermatic-operator would cyclically remove and re-add dynamic listeners during reconciliation. Dynamic listeners added by httproute-gateway-sync controller are now preserved.
```

**Documentation**:
```documentation
NONE
```
