### PR TITLE
Add toleration validation for cluster componentsOverride

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -140,6 +140,31 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 	allErrs = append(allErrs, ValidateLeaderElectionSettings(&spec.ComponentsOverride.ControllerManager.LeaderElectionSettings, parentFieldPath.Child("componentsOverride", "controllerManager", "leaderElection"))...)
 	allErrs = append(allErrs, ValidateLeaderElectionSettings(&spec.ComponentsOverride.Scheduler.LeaderElectionSettings, parentFieldPath.Child("componentsOverride", "scheduler", "leaderElection"))...)
 
+	componentsOverridePath := parentFieldPath.Child("componentsOverride")
+	allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.Apiserver.Tolerations, componentsOverridePath.Child("apiserver", "tolerations"))...)
+	allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.ControllerManager.Tolerations, componentsOverridePath.Child("controllerManager", "tolerations"))...)
+	allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.Scheduler.Tolerations, componentsOverridePath.Child("scheduler", "tolerations"))...)
+	allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.Etcd.Tolerations, componentsOverridePath.Child("etcd", "tolerations"))...)
+	allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.Prometheus.Tolerations, componentsOverridePath.Child("prometheus", "tolerations"))...)
+	if spec.ComponentsOverride.UserClusterController != nil {
+		allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.UserClusterController.Tolerations, componentsOverridePath.Child("userClusterController", "tolerations"))...)
+	}
+	if spec.ComponentsOverride.OperatingSystemManager != nil {
+		allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.OperatingSystemManager.Tolerations, componentsOverridePath.Child("operatingSystemManager", "tolerations"))...)
+	}
+	if spec.ComponentsOverride.CoreDNS != nil {
+		allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.CoreDNS.Tolerations, componentsOverridePath.Child("coreDNS", "tolerations"))...)
+	}
+	if spec.ComponentsOverride.KubeStateMetrics != nil {
+		allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.KubeStateMetrics.Tolerations, componentsOverridePath.Child("kubeStateMetrics", "tolerations"))...)
+	}
+	if spec.ComponentsOverride.MachineController != nil {
+		allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.MachineController.Tolerations, componentsOverridePath.Child("machineController", "tolerations"))...)
+	}
+	if spec.ComponentsOverride.EnvoyAgent != nil {
+		allErrs = append(allErrs, validateTolerations(spec.ComponentsOverride.EnvoyAgent.Tolerations, componentsOverridePath.Child("envoyAgent", "tolerations"))...)
+	}
+
 	externalCCM := false
 	if val, ok := spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; ok {
 		externalCCM = val
@@ -1197,6 +1222,39 @@ func ValidateContainerRuntime(spec *kubermaticv1.ClusterSpec) error {
 	}
 
 	return nil
+}
+
+func validateTolerations(tolerations []corev1.Toleration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, toleration := range tolerations {
+		idxPath := fldPath.Index(i)
+
+		if toleration.Operator == corev1.TolerationOpExists && toleration.Value != "" {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("value"), toleration.Value, "value must be empty when `operator` is 'Exists'"))
+		}
+
+		if toleration.Effect != "" &&
+			toleration.Effect != corev1.TaintEffectNoSchedule &&
+			toleration.Effect != corev1.TaintEffectPreferNoSchedule &&
+			toleration.Effect != corev1.TaintEffectNoExecute {
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("effect"), toleration.Effect,
+				[]string{string(corev1.TaintEffectNoSchedule), string(corev1.TaintEffectPreferNoSchedule), string(corev1.TaintEffectNoExecute)}))
+		}
+
+		if toleration.TolerationSeconds != nil && toleration.Effect != corev1.TaintEffectNoExecute {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("tolerationSeconds"), toleration.TolerationSeconds, "tolerationSeconds can only be set for effect 'NoExecute'"))
+		}
+
+		if toleration.Operator != "" &&
+			toleration.Operator != corev1.TolerationOpEqual &&
+			toleration.Operator != corev1.TolerationOpExists {
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("operator"), toleration.Operator,
+				[]string{string(corev1.TolerationOpEqual), string(corev1.TolerationOpExists)}))
+		}
+	}
+
+	return allErrs
 }
 
 func ValidateLeaderElectionSettings(l *kubermaticv1.LeaderElectionSettings, fldPath *field.Path) field.ErrorList {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -33,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/version"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 )
@@ -1605,6 +1606,100 @@ func TestValidateEventRateLimitConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			errs := ValidateEventRateLimitConfig(test.spec, field.NewPath("spec", "eventRateLimitConfig"))
+			if test.wantErr == (len(errs) == 0) {
+				t.Errorf("Want error: %t, but got: %v", test.wantErr, errs)
+			}
+		})
+	}
+}
+
+func TestValidateTolerations(t *testing.T) {
+	tests := []struct {
+		name        string
+		tolerations []corev1.Toleration
+		wantErr     bool
+	}{
+		{
+			name:        "empty tolerations",
+			tolerations: nil,
+			wantErr:     false,
+		},
+		{
+			name: "valid Equal operator with value",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpEqual, Value: "val", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid Exists operator without value",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid NoExecute with tolerationSeconds",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute, TolerationSeconds: ptr.To[int64](30)},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid wildcard toleration",
+			tolerations: []corev1.Toleration{
+				{Operator: corev1.TolerationOpExists},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Exists operator with non-empty value",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpExists, Value: "val", Effect: corev1.TaintEffectNoExecute},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid effect",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpEqual, Value: "val", Effect: "InvalidEffect"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tolerationSeconds with non-NoExecute effect",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule, TolerationSeconds: ptr.To[int64](30)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "tolerationSeconds without effect",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: corev1.TolerationOpExists, TolerationSeconds: ptr.To[int64](30)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid operator",
+			tolerations: []corev1.Toleration{
+				{Key: "key", Operator: "InvalidOperator", Effect: corev1.TaintEffectNoSchedule},
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple tolerations, one invalid",
+			tolerations: []corev1.Toleration{
+				{Key: "key1", Operator: corev1.TolerationOpEqual, Value: "val", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Operator: corev1.TolerationOpExists, Value: "val"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := validateTolerations(test.tolerations, field.NewPath("spec", "componentsOverride", "userClusterController", "tolerations"))
 			if test.wantErr == (len(errs) == 0) {
 				t.Errorf("Want error: %t, but got: %v", test.wantErr, errs)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds toleration validation for `Cluster.spec.componentsOverride` in the cluster validating webhook. Without this, invalid tolerations are silently accepted by the KKP API and only rejected later by kube-apiserver when the controller tries to reconcile the Deployment, resulting in a confusing `ReconcilingError` warning event instead of immediate feedback.

Applies the same validation rules as kube-apiserver uses for pod tolerations:
- `operator: Exists` requires empty `value`
- `tolerationSeconds` only valid with `effect: NoExecute`
- `effect` must be one of `NoSchedule`, `PreferNoSchedule`, `NoExecute`
- `operator` must be `Equal` or `Exists`

**Which issue(s) this PR fixes**:
Implements #12395

**What type of PR is this?**
feature

**Special notes for your reviewer**:
Validation is added to `ValidateClusterSpec()` in `pkg/validation/cluster.go`, which is called by both `ValidateCreate` and `ValidateUpdate` in the webhook. All components that expose a `Tolerations` field are covered.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Invalid tolerations in `Cluster.spec.componentsOverride` are now rejected immediately by the validating webhook with a descriptive error message, instead of causing a `ReconcilingError` event during reconciliation.
```

**Documentation**:
```documentation
NONE
```