### PR TITLE
   Updates the kubectl image tag to `1.33.4` in the Velero Helm charts.

### DIFF
--- a/charts/backup/velero/test/default.yaml.out
+++ b/charts/backup/velero/test/default.yaml.out
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: kubectl
-          image: "quay.io/kubermatic-mirror/images/kubectl:1.33"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33.4"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ce.yaml.out
+++ b/charts/backup/velero/test/values.example.ce.yaml.out
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: kubectl
-          image: "quay.io/kubermatic-mirror/images/kubectl:1.33"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33.4"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/test/values.example.ee.yaml.out
+++ b/charts/backup/velero/test/values.example.ee.yaml.out
@@ -366,7 +366,7 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: kubectl
-          image: "quay.io/kubermatic-mirror/images/kubectl:1.33"
+          image: "quay.io/kubermatic-mirror/images/kubectl:1.33.4"
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/charts/backup/velero/values.yaml
+++ b/charts/backup/velero/values.yaml
@@ -108,4 +108,5 @@ velero:
   kubectl:
     image:
       repository: quay.io/kubermatic-mirror/images/kubectl
+      tag: 1.33.4
 


### PR DESCRIPTION
**What this PR does / why we need it**:

 Update kubectl image tag to 1.33.4 in Velero charts to resolve missing /bin/sh runtime error

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Updates the kubectl image tag to `1.33.4` to fix container startup failures referenced in Velero charts.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
