### PR TITLE
Mirror the missing cluster-autoscaler images

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -382,7 +382,7 @@ func mirrorImages(ctx context.Context, logger *logrus.Logger, versions kubermati
 	imageSet.Insert(sets.List(helmChartImages)...)
 
 	// get images from system and default applications
-	applicationImages, err := collectApplicationImages(logger, kubermaticConfig, options, clusterVersions)
+	applicationImages, err := collectApplicationImages(logger, kubermaticConfig, options)
 	if err != nil {
 		return err
 	}
@@ -436,7 +436,7 @@ func collectHelmChartImages(ctx context.Context, logger *logrus.Logger, kubermat
 	return imageSet, nil
 }
 
-func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, options *MirrorImagesOptions, clusterVersions []*version.Version) (sets.Set[string], error) {
+func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, options *MirrorImagesOptions) (sets.Set[string], error) {
 	imageSet := sets.New[string]()
 
 	helmClient, err := helm.NewCLI(options.HelmBinary, "", "", options.HelmTimeout, logger)

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -382,7 +382,7 @@ func mirrorImages(ctx context.Context, logger *logrus.Logger, versions kubermati
 	imageSet.Insert(sets.List(helmChartImages)...)
 
 	// get images from system and default applications
-	applicationImages, err := collectApplicationImages(logger, kubermaticConfig, options)
+	applicationImages, err := collectApplicationImages(logger, kubermaticConfig, options, clusterVersions)
 	if err != nil {
 		return err
 	}
@@ -436,7 +436,7 @@ func collectHelmChartImages(ctx context.Context, logger *logrus.Logger, kubermat
 	return imageSet, nil
 }
 
-func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, options *MirrorImagesOptions) (sets.Set[string], error) {
+func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, options *MirrorImagesOptions, clusterVersions []*version.Version) (sets.Set[string], error) {
 	imageSet := sets.New[string]()
 
 	helmClient, err := helm.NewCLI(options.HelmBinary, "", "", options.HelmTimeout, logger)

--- a/pkg/applications/providers/template/util.go
+++ b/pkg/applications/providers/template/util.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"sort"
 	"strconv"
 
 	semverlib "github.com/Masterminds/semver/v3"
@@ -162,18 +163,32 @@ func RenderValueTemplate(applicationValues map[string]interface{}, templateData 
 	return parsedMap, nil
 }
 
+// autoscalerImageTags maps Kubernetes major.minor versions to the corresponding
+// cluster-autoscaler image tag that should be used for that version.
+var autoscalerImageTags = map[string]string{
+	"1.31": "v1.31.1",
+	"1.32": "v1.32.1",
+	"1.33": "v1.33.3",
+	"1.34": "v1.34.2",
+	"1.35": "v1.34.2",
+}
+
+// GetAutoscalerImageTag returns the cluster-autoscaler image tag for the given
+// Kubernetes major.minor version (e.g. "1.32").
 func GetAutoscalerImageTag(majorMinorVersion string) (string, error) {
-	switch majorMinorVersion {
-	case "1.31":
-		return "v1.31.1", nil
-	case "1.32":
-		return "v1.32.1", nil
-	case "1.33":
-		return "v1.33.3", nil
-	case "1.34":
-		return "v1.34.2", nil
-	case "1.35":
-		return "v1.34.2", nil
+	if tag, ok := autoscalerImageTags[majorMinorVersion]; ok {
+		return tag, nil
 	}
 	return "", fmt.Errorf("could not find cluster autoscaler tag for cluster minor-major version %v", majorMinorVersion)
+}
+
+// SupportedAutoscalerMinorVersions returns the sorted list of Kubernetes major.minor
+// versions for which a cluster-autoscaler image tag is known.
+func SupportedAutoscalerMinorVersions() []string {
+	versions := make([]string, 0, len(autoscalerImageTags))
+	for v := range autoscalerImageTags {
+		versions = append(versions, v)
+	}
+	sort.Strings(versions)
+	return versions
 }

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -22,6 +22,7 @@ import (
 	"iter"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -148,6 +149,10 @@ func getHelmChartRenderFunc(config *kubermaticv1.KubermaticConfiguration,
 				return
 			}
 
+			// Save original (unrendered) values so that apps needing per-version
+			// rendering (e.g. cluster-autoscaler) can re-render them per K8s version.
+			originalValues := values
+
 			// Render the ApplicationDefinition values to inject template variables
 			values, err = renderApplicationDefinitionValues(values, defaultKubernetesVersion)
 			if err != nil {
@@ -196,6 +201,44 @@ func getHelmChartRenderFunc(config *kubermaticv1.KubermaticConfiguration,
 					yield(nil, fmt.Errorf("failed to pull app chart: %w", err))
 
 					return
+				}
+
+				// cluster-autoscaler image tags are Kubernetes-version-specific, so we render
+				// the chart once per supported K8s minor version (as known to GetAutoscalerImageTag).
+				if appName == "cluster-autoscaler" {
+					for _, majorMinor := range template.SupportedAutoscalerMinorVersions() {
+						sv, err := semver.NewSemver(majorMinor + ".0")
+						if err != nil {
+							yield(nil, fmt.Errorf("failed to parse autoscaler minor version %s: %w", majorMinor, err))
+							return
+						}
+
+						renderedValues, err := renderApplicationDefinitionValues(originalValues, sv)
+						if err != nil {
+							yield(nil, fmt.Errorf("failed to render values for cluster-autoscaler (k8s %s): %w", majorMinor, err))
+							return
+						}
+
+						versionValuesFile := ""
+						if renderedValues != nil {
+							versionValuesFile = path.Join(tmpDir, fmt.Sprintf("values-%s.yaml", strings.ReplaceAll(majorMinor, ".", "-")))
+							if err := os.WriteFile(versionValuesFile, renderedValues, 0o644); err != nil {
+								yield(nil, fmt.Errorf("failed to write values file for k8s %s: %w", majorMinor, err))
+								return
+							}
+						}
+
+						chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, versionValuesFile, registryPrefix, "")
+						if err != nil {
+							yield(nil, fmt.Errorf("failed to get images for cluster-autoscaler (k8s %s): %w", majorMinor, err))
+							return
+						}
+
+						if !yield(&AppsHelmChart{ChartArchive: chartPath, WorkloadImages: chartImages, ApplicationVersion: appVer}, nil) {
+							return
+						}
+					}
+					continue
 				}
 
 				// get images


### PR DESCRIPTION
**What this PR does / why we need it**:

We deleted the cluster-autoscaler addon in KKP 2.30. So the installer is not able to mirror all the supported images correctly anymore. This PR introduces a fix by iterating through all the supporting versions when we render and extract the images of cluster-autoscaler from our system application definition

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

Internal Reference: INC-8911

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mirror the missing cluster-autoscaler images
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
