### PR TITLE
Add support for k8s patch releases v1.35.3/v1.34.6/v1.33.10

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -649,7 +649,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.34.5
+    default: v1.34.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -732,14 +732,17 @@ spec:
       - v1.33.7
       - v1.33.8
       - v1.33.9
+      - v1.33.10
       - v1.34.1
       - v1.34.2
       - v1.34.3
       - v1.34.4
       - v1.34.5
+      - v1.34.6
       - v1.35.0
       - v1.35.1
       - v1.35.2
+      - v1.35.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -649,7 +649,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.34.5
+    default: v1.34.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -732,14 +732,17 @@ spec:
       - v1.33.7
       - v1.33.8
       - v1.33.9
+      - v1.33.10
       - v1.34.1
       - v1.34.2
       - v1.34.3
       - v1.34.4
       - v1.34.5
+      - v1.34.6
       - v1.35.0
       - v1.35.1
       - v1.35.2
+      - v1.35.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -223,7 +223,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.34.5"),
+		Default: semver.NewSemverOrDie("v1.34.6"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -251,16 +251,19 @@ var (
 			newSemver("v1.33.7"),
 			newSemver("v1.33.8"),
 			newSemver("v1.33.9"),
+			newSemver("v1.33.10"),
 			// Kubernetes 1.34
 			newSemver("v1.34.1"),
 			newSemver("v1.34.2"),
 			newSemver("v1.34.3"),
 			newSemver("v1.34.4"),
 			newSemver("v1.34.5"),
+			newSemver("v1.34.6"),
 			// Kubernetes 1.35
 			newSemver("v1.35.0"),
 			newSemver("v1.35.1"),
 			newSemver("v1.35.2"),
+			newSemver("v1.35.3"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.32 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add support for k8s patch releases v1.35.3/v1.34.6/v1.33.10. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for k8s patch releases v1.35.3/v1.34.6/v1.33.10
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
