### PR TITLE
[release/v2.30] Add ownership to kubermatic-operator's Gateway resources

### DIFF
--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -616,11 +616,11 @@ func (r *Reconciler) reconcileGatewayAPIResources(ctx context.Context, config *k
 		return fmt.Errorf("failed to label namespace for Gateway access: %w", err)
 	}
 
-	if err := kubermatic.EnsureGateway(ctx, r.Client, logger, config, config.Namespace); err != nil {
+	if err := kubermatic.EnsureGateway(ctx, r.Client, logger, config, config.Namespace, r.scheme); err != nil {
 		return fmt.Errorf("failed to reconcile Gateway: %w", err)
 	}
 
-	if err := kubermatic.EnsureHTTPRoute(ctx, r.Client, logger, config, config.Namespace); err != nil {
+	if err := kubermatic.EnsureHTTPRoute(ctx, r.Client, logger, config, config.Namespace, r.scheme); err != nil {
 		return fmt.Errorf("failed to reconcile HTTPRoute: %w", err)
 	}
 

--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -18,6 +18,7 @@ package kubermatic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -236,6 +237,12 @@ func HTTPRouteReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace st
 	}
 }
 
+// gatewayComparable holds the fields used to detect meaningful changes between
+// existing and desired Gateway state. OwnerReferences are intentionally excluded:
+// the managed-by label difference triggers the first update on upgrade, which
+// applies the ownerReference as a side effect. After that initial reconciliation,
+// OwnerReferences stay stable. Including them would cause unnecessary updates if
+// external tools modify ownership metadata.
 type gatewayComparable struct {
 	Spec        gatewayapiv1.GatewaySpec
 	Labels      map[string]string
@@ -250,6 +257,12 @@ func comparableGateway(gw *gatewayapiv1.Gateway) gatewayComparable {
 	}
 }
 
+// httpRouteComparable holds the fields used to detect meaningful changes between
+// existing and desired HTTPRoute state. OwnerReferences are intentionally excluded:
+// the managed-by label difference triggers the first update on upgrade, which
+// applies the ownerReference as a side effect. After that initial reconciliation,
+// OwnerReferences stay stable. Including them would cause unnecessary updates if
+// external tools modify ownership metadata.
 type httpRouteComparable struct {
 	Spec        gatewayapiv1.HTTPRouteSpec
 	Labels      map[string]string
@@ -262,6 +275,19 @@ func comparableHTTPRoute(hr *gatewayapiv1.HTTPRoute) httpRouteComparable {
 		Labels:      hr.Labels,
 		Annotations: hr.Annotations,
 	}
+}
+
+// setControllerReference sets a controller owner reference on the object,
+// ignoring AlreadyOwnedError when the object already has a different
+// controller owner. Matches the pattern in modifier.Ownership().
+func setControllerReference(owner metav1.Object, controlled ctrlruntimeclient.Object, scheme *runtime.Scheme) error {
+	if err := controllerutil.SetControllerReference(owner, controlled, scheme); err != nil {
+		var alreadyOwned *controllerutil.AlreadyOwnedError
+		if !errors.As(err, &alreadyOwned) {
+			return fmt.Errorf("failed to set owner reference: %w", err)
+		}
+	}
+	return nil
 }
 
 // EnsureGateway creates or updates the Gateway. Uses direct client operations instead of the standard reconciling
@@ -294,7 +320,7 @@ func EnsureGateway(
 		return fmt.Errorf("failed to build desired Gateway: %w", err)
 	}
 
-	if err := controllerutil.SetControllerReference(cfg, desired, scheme); err != nil {
+	if err := setControllerReference(cfg, desired, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on Gateway: %w", err)
 	}
 	kubernetes.EnsureLabels(desired, map[string]string{
@@ -311,7 +337,7 @@ func EnsureGateway(
 	kubernetes.EnsureLabels(updated, desired.Labels)
 	kubernetes.EnsureAnnotations(updated, desired.Annotations)
 
-	if err := controllerutil.SetControllerReference(cfg, updated, scheme); err != nil {
+	if err := setControllerReference(cfg, updated, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on Gateway: %w", err)
 	}
 
@@ -345,7 +371,7 @@ func EnsureHTTPRoute(
 		return fmt.Errorf("failed to build desired HTTPRoute: %w", err)
 	}
 
-	if err := controllerutil.SetControllerReference(cfg, desired, scheme); err != nil {
+	if err := setControllerReference(cfg, desired, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on HTTPRoute: %w", err)
 	}
 	kubernetes.EnsureLabels(desired, map[string]string{
@@ -373,7 +399,7 @@ func EnsureHTTPRoute(
 	kubernetes.EnsureLabels(updated, desired.Labels)
 	kubernetes.EnsureAnnotations(updated, desired.Annotations)
 
-	if err := controllerutil.SetControllerReference(cfg, updated, scheme); err != nil {
+	if err := setControllerReference(cfg, updated, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on HTTPRoute: %w", err)
 	}
 

--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -306,26 +306,20 @@ func EnsureGateway(
 		return client.Create(ctx, desired)
 	}
 
-	// compare only Spec/Labels/Annotations (ignore Status to avoid update loops)
-	if equality.Semantic.DeepEqual(comparableGateway(&existing), comparableGateway(desired)) {
-		log.Debugw("Gateway unchanged, skipping update", "name", gatewayName)
-
-		return nil
-	}
-
 	updated := existing.DeepCopy()
 	updated.Spec = desired.Spec
-	updated.Labels = desired.Labels
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-
-	for k, v := range desired.Annotations {
-		updated.Annotations[k] = v
-	}
+	kubernetes.EnsureLabels(updated, desired.Labels)
+	kubernetes.EnsureAnnotations(updated, desired.Annotations)
 
 	if err := controllerutil.SetControllerReference(cfg, updated, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on Gateway: %w", err)
+	}
+
+	// compare only Spec/Labels/Annotations (ignore Status to avoid update loops)
+	if equality.Semantic.DeepEqual(comparableGateway(&existing), comparableGateway(updated)) {
+		log.Debugw("Gateway unchanged, skipping update", "name", gatewayName)
+
+		return nil
 	}
 
 	log.Debugw("Updating Gateway", "name", gatewayName)
@@ -371,25 +365,23 @@ func EnsureHTTPRoute(
 		return fmt.Errorf("failed to get HTTPRoute %s/%s: %w", namespace, routeName, err)
 	}
 
-	// compare only Spec/Labels/Annotations (ignore Status to avoid update loops)
-	if equality.Semantic.DeepEqual(comparableHTTPRoute(&existing), comparableHTTPRoute(desired)) {
-		log.Debugw("HTTPRoute unchanged, skipping update", "name", routeName)
-
-		return nil
-	}
-
+	// Build the merged state: desired labels/annotations on top of existing ones.
+	// This preserves user-added metadata (e.g. external-dns annotations) while
+	// ensuring operator-managed fields are up to date.
 	updated := existing.DeepCopy()
 	updated.Spec = desired.Spec
-	updated.Labels = desired.Labels
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-	for k, v := range desired.Annotations {
-		updated.Annotations[k] = v
-	}
+	kubernetes.EnsureLabels(updated, desired.Labels)
+	kubernetes.EnsureAnnotations(updated, desired.Annotations)
 
 	if err := controllerutil.SetControllerReference(cfg, updated, scheme); err != nil {
 		return fmt.Errorf("failed to set owner reference on HTTPRoute: %w", err)
+	}
+
+	// compare only Spec/Labels/Annotations (ignore Status to avoid update loops)
+	if equality.Semantic.DeepEqual(comparableHTTPRoute(&existing), comparableHTTPRoute(updated)) {
+		log.Debugw("HTTPRoute unchanged, skipping update", "name", routeName)
+
+		return nil
 	}
 
 	log.Debugw("Updating HTTPRoute", "name", routeName)

--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -27,14 +27,18 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	gatewayutil "k8c.io/kubermatic/v2/pkg/controller/util/gateway"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling/modifier"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -269,6 +273,7 @@ func EnsureGateway(
 	log *zap.SugaredLogger,
 	cfg *kubermaticv1.KubermaticConfiguration,
 	namespace string,
+	scheme *runtime.Scheme,
 ) error {
 	key := types.NamespacedName{Namespace: namespace, Name: gatewayName}
 
@@ -288,6 +293,13 @@ func EnsureGateway(
 	if _, err := reconciler(desired); err != nil {
 		return fmt.Errorf("failed to build desired Gateway: %w", err)
 	}
+
+	if err := controllerutil.SetControllerReference(cfg, desired, scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on Gateway: %w", err)
+	}
+	kubernetes.EnsureLabels(desired, map[string]string{
+		modifier.ManagedByLabel: common.OperatorName,
+	})
 
 	if apierrors.IsNotFound(err) {
 		log.Debugw("Creating Gateway", "name", gatewayName, "namespace", namespace)
@@ -312,6 +324,10 @@ func EnsureGateway(
 		updated.Annotations[k] = v
 	}
 
+	if err := controllerutil.SetControllerReference(cfg, updated, scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on Gateway: %w", err)
+	}
+
 	log.Debugw("Updating Gateway", "name", gatewayName)
 	return client.Update(ctx, updated)
 }
@@ -325,6 +341,7 @@ func EnsureHTTPRoute(
 	log *zap.SugaredLogger,
 	cfg *kubermaticv1.KubermaticConfiguration,
 	namespace string,
+	scheme *runtime.Scheme,
 ) error {
 	factory := HTTPRouteReconciler(cfg, namespace)
 	routeName, reconciler := factory()
@@ -333,6 +350,13 @@ func EnsureHTTPRoute(
 	if _, err := reconciler(desired); err != nil {
 		return fmt.Errorf("failed to build desired HTTPRoute: %w", err)
 	}
+
+	if err := controllerutil.SetControllerReference(cfg, desired, scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on HTTPRoute: %w", err)
+	}
+	kubernetes.EnsureLabels(desired, map[string]string{
+		modifier.ManagedByLabel: common.OperatorName,
+	})
 
 	key := types.NamespacedName{Namespace: namespace, Name: routeName}
 
@@ -362,6 +386,10 @@ func EnsureHTTPRoute(
 	}
 	for k, v := range desired.Annotations {
 		updated.Annotations[k] = v
+	}
+
+	if err := controllerutil.SetControllerReference(cfg, updated, scheme); err != nil {
+		return fmt.Errorf("failed to set owner reference on HTTPRoute: %w", err)
 	}
 
 	log.Debugw("Updating HTTPRoute", "name", routeName)

--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -238,42 +238,38 @@ func HTTPRouteReconciler(cfg *kubermaticv1.KubermaticConfiguration, namespace st
 }
 
 // gatewayComparable holds the fields used to detect meaningful changes between
-// existing and desired Gateway state. OwnerReferences are intentionally excluded:
-// the managed-by label difference triggers the first update on upgrade, which
-// applies the ownerReference as a side effect. After that initial reconciliation,
-// OwnerReferences stay stable. Including them would cause unnecessary updates if
-// external tools modify ownership metadata.
+// existing and desired Gateway state.
 type gatewayComparable struct {
-	Spec        gatewayapiv1.GatewaySpec
-	Labels      map[string]string
-	Annotations map[string]string
+	Spec            gatewayapiv1.GatewaySpec
+	Labels          map[string]string
+	Annotations     map[string]string
+	OwnerReferences []metav1.OwnerReference
 }
 
 func comparableGateway(gw *gatewayapiv1.Gateway) gatewayComparable {
 	return gatewayComparable{
-		Spec:        gw.Spec,
-		Labels:      gw.Labels,
-		Annotations: gw.Annotations,
+		Spec:            gw.Spec,
+		Labels:          gw.Labels,
+		Annotations:     gw.Annotations,
+		OwnerReferences: gw.OwnerReferences,
 	}
 }
 
 // httpRouteComparable holds the fields used to detect meaningful changes between
-// existing and desired HTTPRoute state. OwnerReferences are intentionally excluded:
-// the managed-by label difference triggers the first update on upgrade, which
-// applies the ownerReference as a side effect. After that initial reconciliation,
-// OwnerReferences stay stable. Including them would cause unnecessary updates if
-// external tools modify ownership metadata.
+// existing and desired HTTPRoute state.
 type httpRouteComparable struct {
-	Spec        gatewayapiv1.HTTPRouteSpec
-	Labels      map[string]string
-	Annotations map[string]string
+	Spec            gatewayapiv1.HTTPRouteSpec
+	Labels          map[string]string
+	Annotations     map[string]string
+	OwnerReferences []metav1.OwnerReference
 }
 
 func comparableHTTPRoute(hr *gatewayapiv1.HTTPRoute) httpRouteComparable {
 	return httpRouteComparable{
-		Spec:        hr.Spec,
-		Labels:      hr.Labels,
-		Annotations: hr.Annotations,
+		Spec:            hr.Spec,
+		Labels:          hr.Labels,
+		Annotations:     hr.Annotations,
+		OwnerReferences: hr.OwnerReferences,
 	}
 }
 

--- a/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
@@ -26,13 +26,27 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling/modifier"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+func testKubermaticConfiguration(spec kubermaticv1.KubermaticConfigurationSpec) *kubermaticv1.KubermaticConfiguration {
+	return &kubermaticv1.KubermaticConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubermatic",
+			Namespace: "kubermatic",
+			UID:       types.UID("test-uid"),
+		},
+		Spec: spec,
+	}
+}
 
 func TestGatewayReconciler(t *testing.T) {
 	testCases := []struct {
@@ -493,18 +507,17 @@ func TestHTTPRouteReconciler(t *testing.T) {
 
 func TestEnsureGatewayCreatesNew(t *testing.T) {
 	ctx := context.Background()
-	cfg := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			Ingress: kubermaticv1.KubermaticIngressConfiguration{
-				Domain: "kubermatic.example.com",
-			},
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
 		},
-	}
+	})
 	namespace := "kubermatic"
+	scheme := fake.NewScheme()
 
-	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -535,11 +548,29 @@ func TestEnsureGatewayCreatesNew(t *testing.T) {
 	if httpListener.Protocol != gatewayapiv1.HTTPProtocolType {
 		t.Errorf("expected protocol HTTP, got %s", httpListener.Protocol)
 	}
+
+	if len(created.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(created.OwnerReferences))
+	}
+	ownerRef := created.OwnerReferences[0]
+	if ownerRef.Kind != "KubermaticConfiguration" {
+		t.Errorf("expected owner kind KubermaticConfiguration, got %s", ownerRef.Kind)
+	}
+	if ownerRef.Name != "kubermatic" {
+		t.Errorf("expected owner name kubermatic, got %s", ownerRef.Name)
+	}
+	if ownerRef.UID != "test-uid" {
+		t.Errorf("expected owner UID test-uid, got %s", ownerRef.UID)
+	}
+	if created.Labels[modifier.ManagedByLabel] != common.OperatorName {
+		t.Errorf("expected managed-by label %q, got %q", common.OperatorName, created.Labels[modifier.ManagedByLabel])
+	}
 }
 
 func TestEnsureGatewayUpdatesExisting(t *testing.T) {
 	ctx := context.Background()
 	namespace := "kubermatic"
+	scheme := fake.NewScheme()
 
 	existing := &gatewayapiv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
@@ -561,20 +592,18 @@ func TestEnsureGatewayUpdatesExisting(t *testing.T) {
 		},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).WithObjects(existing).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 
-	cfg := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			Ingress: kubermaticv1.KubermaticIngressConfiguration{
-				Domain: "kubermatic.example.com",
-				Gateway: &kubermaticv1.KubermaticGatewayConfiguration{
-					ClassName: defaulting.DefaultGatewayClassName,
-				},
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
+			Gateway: &kubermaticv1.KubermaticGatewayConfiguration{
+				ClassName: defaulting.DefaultGatewayClassName,
 			},
 		},
-	}
+	})
 
-	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -588,22 +617,32 @@ func TestEnsureGatewayUpdatesExisting(t *testing.T) {
 	if updated.Spec.GatewayClassName != gatewayapiv1.ObjectName(defaulting.DefaultGatewayClassName) {
 		t.Errorf("expected GatewayClassName %s, got %s", defaulting.DefaultGatewayClassName, updated.Spec.GatewayClassName)
 	}
+
+	if len(updated.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(updated.OwnerReferences))
+	}
+	if updated.OwnerReferences[0].Kind != "KubermaticConfiguration" {
+		t.Errorf("expected owner kind KubermaticConfiguration, got %s", updated.OwnerReferences[0].Kind)
+	}
+	if updated.Labels[modifier.ManagedByLabel] != common.OperatorName {
+		t.Errorf("expected managed-by label %q, got %q", common.OperatorName, updated.Labels[modifier.ManagedByLabel])
+	}
 }
 
 func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {
 	ctx := context.Background()
 	namespace := "kubermatic"
+	scheme := fake.NewScheme()
 
-	cfg := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			Ingress: kubermaticv1.KubermaticIngressConfiguration{
-				Domain: "kubermatic.example.com",
-				Gateway: &kubermaticv1.KubermaticGatewayConfiguration{
-					ClassName: defaulting.DefaultGatewayClassName,
-				},
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
+			Gateway: &kubermaticv1.KubermaticGatewayConfiguration{
+				ClassName: defaulting.DefaultGatewayClassName,
 			},
 		},
-	}
+	})
+
 	factory := GatewayReconciler(cfg, namespace, nil)
 	_, reconciler := factory()
 
@@ -611,6 +650,14 @@ func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {
 	if _, err := reconciler(desired); err != nil {
 		t.Fatalf("failed to build desired Gateway: %v", err)
 	}
+
+	// set ownership on desired so existing (DeepCopy) matches what EnsureGateway produces
+	if err := controllerutil.SetControllerReference(cfg, desired, scheme); err != nil {
+		t.Fatalf("failed to set owner reference: %v", err)
+	}
+	kubernetes.EnsureLabels(desired, map[string]string{
+		modifier.ManagedByLabel: common.OperatorName,
+	})
 
 	existing := desired.DeepCopy()
 	existing.Status = gatewayapiv1.GatewayStatus{
@@ -625,9 +672,9 @@ func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {
 		},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).WithObjects(existing).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 
-	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -646,26 +693,28 @@ func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {
 func TestEnsureGatewayPreservesDynamicListeners(t *testing.T) {
 	ctx := context.Background()
 	namespace := "kubermatic"
+	scheme := fake.NewScheme()
 
-	cfg := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			Ingress: kubermaticv1.KubermaticIngressConfiguration{
-				Domain: "example.com",
-				CertificateIssuer: corev1.TypedLocalObjectReference{
-					Name: "letsencrypt-prod",
-					Kind: certmanagerv1.ClusterIssuerKind,
-				},
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "example.com",
+			CertificateIssuer: corev1.TypedLocalObjectReference{
+				Name: "letsencrypt-prod",
+				Kind: certmanagerv1.ClusterIssuerKind,
 			},
 		},
-	}
+	})
 
-	// Simulate Gateway with dynamic listener added by httproute-gateway-sync
+	// Simulate Gateway with dynamic listener added by httproute-gateway-sync.
+	// Pre-set ownership so that the only potential diff is in listeners/spec,
+	// keeping this test focused on listener preservation.
 	existing := &gatewayapiv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gatewayName,
 			Namespace: namespace,
 			Labels: map[string]string{
-				common.NameLabel: defaulting.DefaultGatewayName,
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
 			},
 			Annotations: map[string]string{
 				certmanagerv1.IngressClusterIssuerNameAnnotationKey: "letsencrypt-prod",
@@ -680,10 +729,13 @@ func TestEnsureGatewayPreservesDynamicListeners(t *testing.T) {
 			},
 		},
 	}
+	if err := controllerutil.SetControllerReference(cfg, existing, scheme); err != nil {
+		t.Fatalf("failed to set owner reference on existing: %v", err)
+	}
 
-	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).WithObjects(existing).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 
-	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -714,18 +766,17 @@ func TestEnsureGatewayPreservesDynamicListeners(t *testing.T) {
 
 func TestEnsureHTTPRouteCreatesNew(t *testing.T) {
 	ctx := context.Background()
-	cfg := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			Ingress: kubermaticv1.KubermaticIngressConfiguration{
-				Domain: "kubermatic.example.com",
-			},
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
 		},
-	}
+	})
 	namespace := "kubermatic"
+	scheme := fake.NewScheme()
 
-	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	err := EnsureHTTPRoute(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	err := EnsureHTTPRoute(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -754,19 +805,28 @@ func TestEnsureHTTPRouteCreatesNew(t *testing.T) {
 	if apiRule.BackendRefs[0].Name != APIDeploymentName {
 		t.Errorf("expected backend %s, got %s", APIDeploymentName, apiRule.BackendRefs[0].Name)
 	}
+
+	if len(created.OwnerReferences) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(created.OwnerReferences))
+	}
+	if created.OwnerReferences[0].Kind != "KubermaticConfiguration" {
+		t.Errorf("expected owner kind KubermaticConfiguration, got %s", created.OwnerReferences[0].Kind)
+	}
+	if created.Labels[modifier.ManagedByLabel] != common.OperatorName {
+		t.Errorf("expected managed-by label %q, got %q", common.OperatorName, created.Labels[modifier.ManagedByLabel])
+	}
 }
 
 func TestEnsureHTTPRouteSkipsWhenUnchanged(t *testing.T) {
 	ctx := context.Background()
 	namespace := "kubermatic"
+	scheme := fake.NewScheme()
 
-	cfg := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			Ingress: kubermaticv1.KubermaticIngressConfiguration{
-				Domain: "kubermatic.example.com",
-			},
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
 		},
-	}
+	})
 
 	factory := HTTPRouteReconciler(cfg, namespace)
 	_, reconciler := factory()
@@ -775,6 +835,14 @@ func TestEnsureHTTPRouteSkipsWhenUnchanged(t *testing.T) {
 	if _, err := reconciler(desired); err != nil {
 		t.Fatalf("failed to build desired HTTPRoute: %v", err)
 	}
+
+	// set ownership on desired so existing (DeepCopy) matches what EnsureHTTPRoute produces
+	if err := controllerutil.SetControllerReference(cfg, desired, scheme); err != nil {
+		t.Fatalf("failed to set owner reference: %v", err)
+	}
+	kubernetes.EnsureLabels(desired, map[string]string{
+		modifier.ManagedByLabel: common.OperatorName,
+	})
 
 	existing := desired.DeepCopy()
 	existing.Status.RouteStatus = gatewayapiv1.RouteStatus{
@@ -791,9 +859,9 @@ func TestEnsureHTTPRouteSkipsWhenUnchanged(t *testing.T) {
 		},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(fake.NewScheme()).WithObjects(existing).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
 
-	err := EnsureHTTPRoute(ctx, client, zap.NewNop().Sugar(), cfg, namespace)
+	err := EnsureHTTPRoute(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}

--- a/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
@@ -627,6 +627,357 @@ func TestEnsureGatewayUpdatesExisting(t *testing.T) {
 	if updated.Labels[modifier.ManagedByLabel] != common.OperatorName {
 		t.Errorf("expected managed-by label %q, got %q", common.OperatorName, updated.Labels[modifier.ManagedByLabel])
 	}
+	if updated.Labels["old-label"] != "old-value" {
+		t.Errorf("expected user label 'old-label' to be preserved, got %q", updated.Labels["old-label"])
+	}
+}
+
+func TestEnsureGatewayPreservesUserMetadata(t *testing.T) {
+	namespace := "kubermatic"
+	scheme := fake.NewScheme()
+
+	testCases := []struct {
+		name                string
+		cfg                 *kubermaticv1.KubermaticConfiguration
+		existingLabels      map[string]string
+		existingAnnotations map[string]string
+		wantLabels          map[string]string
+		wantAnnotations     map[string]string
+	}{
+		{
+			name: "user labels and annotations preserved without cert-manager",
+			cfg: testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+				},
+			}),
+			existingLabels: map[string]string{
+				"team": "platform",
+			},
+			existingAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+			},
+			wantLabels: map[string]string{
+				"team":                  "platform",
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+			},
+		},
+		{
+			name: "user annotations coexist with cert-manager ClusterIssuer annotation",
+			cfg: testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+					CertificateIssuer: corev1.TypedLocalObjectReference{
+						Name: "letsencrypt-prod",
+						Kind: certmanagerv1.ClusterIssuerKind,
+					},
+				},
+			}),
+			existingLabels: map[string]string{
+				"environment": "production",
+			},
+			existingAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+			},
+			wantLabels: map[string]string{
+				"environment":           "production",
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname":         "example.kubermatic.com",
+				certmanagerv1.IngressClusterIssuerNameAnnotationKey: "letsencrypt-prod",
+			},
+		},
+		{
+			name: "user annotations coexist with cert-manager Issuer annotation",
+			cfg: testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+					CertificateIssuer: corev1.TypedLocalObjectReference{
+						Name: "my-issuer",
+						Kind: certmanagerv1.IssuerKind,
+					},
+				},
+			}),
+			existingLabels: map[string]string{},
+			existingAnnotations: map[string]string{
+				"custom.io/note": "managed-externally",
+			},
+			wantLabels: map[string]string{
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{
+				"custom.io/note": "managed-externally",
+				certmanagerv1.IngressIssuerNameAnnotationKey: "my-issuer",
+			},
+		},
+		{
+			name: "no user metadata, only operator metadata present",
+			cfg: testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+				},
+			}),
+			existingLabels:      map[string]string{},
+			existingAnnotations: map[string]string{},
+			wantLabels: map[string]string{
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{},
+		},
+		{
+			name: "multiple user labels and annotations at once",
+			cfg: testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+					CertificateIssuer: corev1.TypedLocalObjectReference{
+						Name: "letsencrypt-prod",
+						Kind: certmanagerv1.ClusterIssuerKind,
+					},
+				},
+			}),
+			existingLabels: map[string]string{
+				"team":        "platform",
+				"environment": "staging",
+				"cost-center": "engineering",
+			},
+			existingAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+				"external-dns.alpha.kubernetes.io/ttl":      "60",
+				"custom.io/owner":                           "team-alpha",
+			},
+			wantLabels: map[string]string{
+				"team":                  "platform",
+				"environment":           "staging",
+				"cost-center":           "engineering",
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname":         "example.kubermatic.com",
+				"external-dns.alpha.kubernetes.io/ttl":              "60",
+				"custom.io/owner":                                   "team-alpha",
+				certmanagerv1.IngressClusterIssuerNameAnnotationKey: "letsencrypt-prod",
+			},
+		},
+		{
+			name: "operator overwrites stale managed label value",
+			cfg: testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+				},
+			}),
+			existingLabels: map[string]string{
+				common.NameLabel: "stale-value",
+				"team":           "platform",
+			},
+			existingAnnotations: map[string]string{},
+			wantLabels: map[string]string{
+				common.NameLabel:        defaulting.DefaultGatewayName,
+				modifier.ManagedByLabel: common.OperatorName,
+				"team":                  "platform",
+			},
+			wantAnnotations: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// build existing Gateway with the correct spec so only metadata differs
+			factory := GatewayReconciler(tc.cfg, namespace, nil)
+			_, reconciler := factory()
+			base := &gatewayapiv1.Gateway{}
+			if _, err := reconciler(base); err != nil {
+				t.Fatalf("failed to build base Gateway: %v", err)
+			}
+
+			// apply operator ownership so the test starts from a stable state
+			if err := controllerutil.SetControllerReference(tc.cfg, base, scheme); err != nil {
+				t.Fatalf("failed to set owner reference: %v", err)
+			}
+			kubernetes.EnsureLabels(base, map[string]string{
+				modifier.ManagedByLabel: common.OperatorName,
+			})
+
+			// layer on user-provided metadata (may overwrite operator labels to simulate stale state)
+			kubernetes.EnsureLabels(base, tc.existingLabels)
+			kubernetes.EnsureAnnotations(base, tc.existingAnnotations)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(base).Build()
+
+			if err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), tc.cfg, namespace, scheme); err != nil {
+				t.Fatalf("EnsureGateway failed: %v", err)
+			}
+
+			var updated gatewayapiv1.Gateway
+			if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: gatewayName}, &updated); err != nil {
+				t.Fatalf("Gateway should exist: %v", err)
+			}
+
+			if len(updated.Labels) != len(tc.wantLabels) {
+				t.Errorf("expected %d labels, got %d: %v", len(tc.wantLabels), len(updated.Labels), updated.Labels)
+			}
+			for k, v := range tc.wantLabels {
+				if updated.Labels[k] != v {
+					t.Errorf("expected label %q=%q, got %q", k, v, updated.Labels[k])
+				}
+			}
+			if len(updated.Annotations) != len(tc.wantAnnotations) {
+				t.Errorf("expected %d annotations, got %d: %v", len(tc.wantAnnotations), len(updated.Annotations), updated.Annotations)
+			}
+			for k, v := range tc.wantAnnotations {
+				if updated.Annotations[k] != v {
+					t.Errorf("expected annotation %q=%q, got %q", k, v, updated.Annotations[k])
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureHTTPRoutePreservesUserMetadata(t *testing.T) {
+	namespace := "kubermatic"
+	scheme := fake.NewScheme()
+
+	testCases := []struct {
+		name                string
+		existingLabels      map[string]string
+		existingAnnotations map[string]string
+		wantLabels          map[string]string
+		wantAnnotations     map[string]string
+	}{
+		{
+			name: "user labels and annotations preserved",
+			existingLabels: map[string]string{
+				"team": "platform",
+			},
+			existingAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+			},
+			wantLabels: map[string]string{
+				"team":                  "platform",
+				common.NameLabel:        "kubermatic",
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+			},
+		},
+		{
+			name:                "no user metadata, only operator metadata",
+			existingLabels:      map[string]string{},
+			existingAnnotations: map[string]string{},
+			wantLabels: map[string]string{
+				common.NameLabel:        "kubermatic",
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{},
+		},
+		{
+			name: "multiple user labels and annotations at once",
+			existingLabels: map[string]string{
+				"team":        "platform",
+				"environment": "staging",
+			},
+			existingAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+				"external-dns.alpha.kubernetes.io/ttl":      "60",
+				"custom.io/owner":                           "team-alpha",
+			},
+			wantLabels: map[string]string{
+				"team":                  "platform",
+				"environment":           "staging",
+				common.NameLabel:        "kubermatic",
+				modifier.ManagedByLabel: common.OperatorName,
+			},
+			wantAnnotations: map[string]string{
+				"external-dns.alpha.kubernetes.io/hostname": "example.kubermatic.com",
+				"external-dns.alpha.kubernetes.io/ttl":      "60",
+				"custom.io/owner":                           "team-alpha",
+			},
+		},
+		{
+			name: "operator overwrites stale managed label value",
+			existingLabels: map[string]string{
+				common.NameLabel: "stale-value",
+				"team":           "platform",
+			},
+			existingAnnotations: map[string]string{},
+			wantLabels: map[string]string{
+				common.NameLabel:        "kubermatic",
+				modifier.ManagedByLabel: common.OperatorName,
+				"team":                  "platform",
+			},
+			wantAnnotations: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "kubermatic.example.com",
+				},
+			})
+
+			// build existing HTTPRoute with correct spec so only metadata differs
+			factory := HTTPRouteReconciler(cfg, namespace)
+			_, reconciler := factory()
+			base := &gatewayapiv1.HTTPRoute{}
+			if _, err := reconciler(base); err != nil {
+				t.Fatalf("failed to build base HTTPRoute: %v", err)
+			}
+
+			if err := controllerutil.SetControllerReference(cfg, base, scheme); err != nil {
+				t.Fatalf("failed to set owner reference: %v", err)
+			}
+			kubernetes.EnsureLabels(base, map[string]string{
+				modifier.ManagedByLabel: common.OperatorName,
+			})
+
+			// layer on user-provided metadata (may overwrite operator labels to simulate stale state)
+			kubernetes.EnsureLabels(base, tc.existingLabels)
+			kubernetes.EnsureAnnotations(base, tc.existingAnnotations)
+
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(base).Build()
+
+			if err := EnsureHTTPRoute(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme); err != nil {
+				t.Fatalf("EnsureHTTPRoute failed: %v", err)
+			}
+
+			var updated gatewayapiv1.HTTPRoute
+			if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: httpRouteName}, &updated); err != nil {
+				t.Fatalf("HTTPRoute should exist: %v", err)
+			}
+
+			if len(updated.Labels) != len(tc.wantLabels) {
+				t.Errorf("expected %d labels, got %d: %v", len(tc.wantLabels), len(updated.Labels), updated.Labels)
+			}
+			for k, v := range tc.wantLabels {
+				if updated.Labels[k] != v {
+					t.Errorf("expected label %q=%q, got %q", k, v, updated.Labels[k])
+				}
+			}
+			if len(updated.Annotations) != len(tc.wantAnnotations) {
+				t.Errorf("expected %d annotations, got %d: %v", len(tc.wantAnnotations), len(updated.Annotations), updated.Annotations)
+			}
+			for k, v := range tc.wantAnnotations {
+				if updated.Annotations[k] != v {
+					t.Errorf("expected annotation %q=%q, got %q", k, v, updated.Annotations[k])
+				}
+			}
+		})
+	}
 }
 
 func TestEnsureGatewaySkipsWhenUnchanged(t *testing.T) {

--- a/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -1226,5 +1227,120 @@ func TestEnsureHTTPRouteSkipsWhenUnchanged(t *testing.T) {
 
 	if len(fetched.Status.Parents) == 0 {
 		t.Error("Expected Status Parents to be preserved, but they were cleared (Update was called when it shouldn't have been)")
+	}
+}
+
+func TestEnsureGatewayToleratesExistingOwner(t *testing.T) {
+	ctx := context.Background()
+	namespace := "kubermatic"
+	scheme := fake.NewScheme()
+
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
+		},
+	})
+
+	// pre-existing Gateway with a different controller owner
+	existing := &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaulting.DefaultGatewayName,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "ConfigMap",
+					Name:               "other-owner",
+					UID:                types.UID("other-uid"),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+			Labels: map[string]string{
+				common.NameLabel: defaulting.DefaultGatewayName,
+			},
+		},
+		Spec: gatewayapiv1.GatewaySpec{
+			GatewayClassName: "old-class",
+			Listeners: []gatewayapiv1.Listener{
+				{
+					Name:     "http",
+					Protocol: gatewayapiv1.HTTPProtocolType,
+					Port:     80,
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	err := EnsureGateway(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
+	if err != nil {
+		t.Fatalf("expected no error when Gateway has different controller owner, got: %v", err)
+	}
+}
+
+func TestEnsureHTTPRouteToleratesExistingOwner(t *testing.T) {
+	ctx := context.Background()
+	namespace := "kubermatic"
+	scheme := fake.NewScheme()
+
+	cfg := testKubermaticConfiguration(kubermaticv1.KubermaticConfigurationSpec{
+		Ingress: kubermaticv1.KubermaticIngressConfiguration{
+			Domain: "kubermatic.example.com",
+		},
+	})
+
+	// pre-existing HTTPRoute with a different controller owner
+	existing := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaulting.DefaultHTTPRouteName,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "ConfigMap",
+					Name:               "other-owner",
+					UID:                types.UID("other-uid"),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+			Labels: map[string]string{
+				common.NameLabel: "kubermatic",
+			},
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1.ParentReference{
+					{
+						Name:      "default-gateway",
+						Namespace: (*gatewayapiv1.Namespace)(&namespace),
+					},
+				},
+			},
+			Hostnames: []gatewayapiv1.Hostname{"kubermatic.example.com"},
+			Rules: []gatewayapiv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayapiv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapiv1.BackendRef{
+								BackendObjectReference: gatewayapiv1.BackendObjectReference{
+									Name: APIDeploymentName,
+									Port: ptr.To(gatewayapiv1.PortNumber(80)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+	err := EnsureHTTPRoute(ctx, client, zap.NewNop().Sugar(), cfg, namespace, scheme)
+	if err != nil {
+		t.Fatalf("expected no error when HTTPRoute has different controller owner, got: %v", err)
 	}
 }


### PR DESCRIPTION
Manual cherry pick of https://github.com/kubermatic/kubermatic/pull/15642

```release-note
Gateway and HTTPRoute resources are now properly owned by KubermaticConfiguration and will be garbage collected on deletion. User-added labels and annotations on these resources are no longer overwritten during reconciliation.
```

