### PR TITLE
propagate upstream defaultValuesBlock changes on upgrade

### DIFF
--- a/pkg/applicationdefinitions/application_catalog.go
+++ b/pkg/applicationdefinitions/application_catalog.go
@@ -132,26 +132,39 @@ func systemApplicationDefinitionReconcilerFactory(
 				updateApplicationDefinition(fileAppDef, config)
 			}
 
-			// detect whether an admin has modified defaultValuesBlock.
-			// if so, preserve their override. otherwise, use the
-			// file-embedded value so upstream changes propagate on upgrade.
+			// Decide whether to keep the cluster's defaultValuesBlock or replace
+			// it with the one from the embedded YAML file.
+			//
+			// When we already have a hash annotation, we can compare: if the cluster
+			// value changed since we last wrote it, the admin must have edited it, so
+			// we keep their version. Otherwise we apply the file value.
+			//
+			// Without a hash annotation (upgrade from an older KKP), we can't tell
+			// whether a differing value is an admin edit or a stale file value. We
+			// preserve it by default to avoid overwriting admin customizations. If the
+			// admin wants upstream changes to propagate, they can opt in by adding the
+			// allow-default-values-overwrite annotation.
 			fileHash := sha1Hex(fileAppDef.Spec.DefaultValuesBlock)
 			clusterHash := sha1Hex(clusterAppDef.Spec.DefaultValuesBlock)
 
 			clusterHasValue := clusterAppDef.Spec.DefaultValuesBlock != "" &&
 				clusterAppDef.Spec.DefaultValuesBlock != "{}"
 
-			var adminModified bool
-			if storedHash == "" {
-				// no annotation means that upgrade from old controller or fresh install.
-				// if cluster has a value that differs from the file, treat as admin edit.
-				adminModified = clusterHasValue && clusterHash != fileHash
-			} else {
-				// annotation present, admin changed it if cluster hash drifted from stored hash.
-				adminModified = clusterHasValue && storedHash != clusterHash
+			_, allowOverwrite := clusterAppDef.Annotations[appskubermaticv1.ApplicationAllowDefaultValuesOverwriteAnnotation]
+
+			var keepAdminModifications bool
+			switch {
+			case storedHash != "" && clusterHasValue && storedHash != clusterHash:
+				// steady state, hash drifted from what we recorded -> admin edit
+				keepAdminModifications = true
+			case storedHash == "" && clusterHasValue && !allowOverwrite:
+				// upgrade from old controller, preserve by default
+				keepAdminModifications = true
 			}
 
-			if adminModified {
+			// if there is an admin modification on default values block, preserve admin modifications.
+			// This means that the whatever KKP stores in ApplicationDefinition YAML file would be ignored.
+			if keepAdminModifications {
 				fileAppDef.Spec.DefaultValuesBlock = clusterAppDef.Spec.DefaultValuesBlock
 			}
 

--- a/pkg/applicationdefinitions/application_catalog.go
+++ b/pkg/applicationdefinitions/application_catalog.go
@@ -17,6 +17,8 @@ limitations under the License.
 package applicationdefinitions
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"io"
 
@@ -127,16 +129,32 @@ func systemApplicationDefinitionReconcilerFactory(
 				updateApplicationDefinition(fileAppDef, config)
 			}
 
-			// Also, we need to ensure that the default values are set correctly. To do this:
-			// 1. Get the default values from the currently being reconciled application definition (clusterAppDef)
-			// 2. If it's empty, use `fileAppDef` default values as a source of truth - ensuring the values are never empty
-			// 3. If it's not empty, use the current values from the reconciled object, allowing users to override the default values
-			if clusterAppDef.Spec.DefaultValuesBlock != "" && clusterAppDef.Spec.DefaultValuesBlock != "{}" {
+			// detect whether an admin has modified defaultValuesBlock since our
+			// last apply. If so, preserve their override. Otherwise, use the
+			// file-embedded value so upstream changes propagate on upgrade.
+			fileHash := sha1Hex(fileAppDef.Spec.DefaultValuesBlock)
+			storedHash := clusterAppDef.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]
+			clusterHash := sha1Hex(clusterAppDef.Spec.DefaultValuesBlock)
+
+			if clusterAppDef.Spec.DefaultValuesBlock != "" &&
+				clusterAppDef.Spec.DefaultValuesBlock != "{}" &&
+				storedHash != "" &&
+				storedHash != clusterHash {
+				// admin modified the value since our last apply -- preserve it
 				fileAppDef.Spec.DefaultValuesBlock = clusterAppDef.Spec.DefaultValuesBlock
 			}
 
 			clusterAppDef.Name = fileAppDef.Name
 			clusterAppDef.Spec = fileAppDef.Spec
+
+			// record what file hash we applied so future reconciles can detect admin changes
+			annotations := clusterAppDef.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation] = fileHash
+			clusterAppDef.SetAnnotations(annotations)
+
 			return clusterAppDef, nil
 		}
 	}
@@ -168,4 +186,9 @@ func updateApplicationDefinition(appDef *appskubermaticv1.ApplicationDefinition,
 		appDef.Spec.Versions[i].Template.Source.Helm.Insecure = &config.Spec.UserCluster.SystemApplications.InsecureSkipTLSVerify
 		appDef.Spec.Versions[i].Template.Source.Helm.PlainHTTP = &config.Spec.UserCluster.SystemApplications.PlainHTTP
 	}
+}
+
+func sha1Hex(s string) string {
+	sum := sha1.Sum([]byte(s))
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/applicationdefinitions/application_catalog.go
+++ b/pkg/applicationdefinitions/application_catalog.go
@@ -101,7 +101,7 @@ func systemApplicationDefinitionReconcilerFactory(
 			fileAppDef.SetLabels(l)
 
 			// capture the stored hash before EnsureAnnotations potentially overwrites it
-			storedHash := clusterAppDef.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]
+			storedHash := clusterAppDef.Annotations[appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation]
 
 			// Labels and annotations specified in the ApplicationDefinition installed on the cluster are merged with the ones specified in the ApplicationDefinition
 			// that is generated from the system applications.
@@ -177,7 +177,7 @@ func systemApplicationDefinitionReconcilerFactory(
 				annotations = make(map[string]string)
 			}
 
-			annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation] = fileHash
+			annotations[appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation] = fileHash
 			clusterAppDef.SetAnnotations(annotations)
 
 			return clusterAppDef, nil

--- a/pkg/applicationdefinitions/application_catalog.go
+++ b/pkg/applicationdefinitions/application_catalog.go
@@ -100,6 +100,9 @@ func systemApplicationDefinitionReconcilerFactory(
 			l[appskubermaticv1.ApplicationManagedByLabel] = appskubermaticv1.ApplicationManagedByKKPValue
 			fileAppDef.SetLabels(l)
 
+			// capture the stored hash before EnsureAnnotations potentially overwrites it
+			storedHash := clusterAppDef.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]
+
 			// Labels and annotations specified in the ApplicationDefinition installed on the cluster are merged with the ones specified in the ApplicationDefinition
 			// that is generated from the system applications.
 			kubernetes.EnsureLabels(clusterAppDef, fileAppDef.Labels)
@@ -129,18 +132,26 @@ func systemApplicationDefinitionReconcilerFactory(
 				updateApplicationDefinition(fileAppDef, config)
 			}
 
-			// detect whether an admin has modified defaultValuesBlock since our
-			// last apply. If so, preserve their override. Otherwise, use the
+			// detect whether an admin has modified defaultValuesBlock.
+			// if so, preserve their override. otherwise, use the
 			// file-embedded value so upstream changes propagate on upgrade.
 			fileHash := sha1Hex(fileAppDef.Spec.DefaultValuesBlock)
-			storedHash := clusterAppDef.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]
 			clusterHash := sha1Hex(clusterAppDef.Spec.DefaultValuesBlock)
 
-			if clusterAppDef.Spec.DefaultValuesBlock != "" &&
-				clusterAppDef.Spec.DefaultValuesBlock != "{}" &&
-				storedHash != "" &&
-				storedHash != clusterHash {
-				// admin modified the value since our last apply -- preserve it
+			clusterHasValue := clusterAppDef.Spec.DefaultValuesBlock != "" &&
+				clusterAppDef.Spec.DefaultValuesBlock != "{}"
+
+			var adminModified bool
+			if storedHash == "" {
+				// no annotation means that upgrade from old controller or fresh install.
+				// if cluster has a value that differs from the file, treat as admin edit.
+				adminModified = clusterHasValue && clusterHash != fileHash
+			} else {
+				// annotation present, admin changed it if cluster hash drifted from stored hash.
+				adminModified = clusterHasValue && storedHash != clusterHash
+			}
+
+			if adminModified {
 				fileAppDef.Spec.DefaultValuesBlock = clusterAppDef.Spec.DefaultValuesBlock
 			}
 
@@ -152,6 +163,7 @@ func systemApplicationDefinitionReconcilerFactory(
 			if annotations == nil {
 				annotations = make(map[string]string)
 			}
+
 			annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation] = fileHash
 			clusterAppDef.SetAnnotations(annotations)
 

--- a/pkg/applicationdefinitions/application_catalog_test.go
+++ b/pkg/applicationdefinitions/application_catalog_test.go
@@ -27,11 +27,10 @@ import (
 )
 
 const (
-	testAppDefName       = "test-app"
-	testDefaultValues    = "key: value\n"
-	testUpdatedValues    = "key: updated-value\n"
-	testAdminValues      = "key: admin-override\n"
-	testValuesBlockEmpty = "{}"
+	testAppDefName    = "test-app"
+	testDefaultValues = "key: value\n"
+	testUpdatedValues = "key: updated-value\n"
+	testAdminValues   = "key: admin-override\n"
 )
 
 func makeAppDef(name, defaultValuesBlock string, annotations map[string]string) *appskubermaticv1.ApplicationDefinition {
@@ -66,208 +65,125 @@ func reconcile(fileAppDef, clusterAppDef *appskubermaticv1.ApplicationDefinition
 	return reconciler(clusterAppDef)
 }
 
-func TestFreshInstall(t *testing.T) {
-	// clusterAppDef has empty DefaultValuesBlock, no annotation
-	fileAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, "", nil)
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestDefaultValuesBlockReconciliation(t *testing.T) {
+	tests := []struct {
+		name               string
+		fileValues         string
+		clusterValues      string
+		clusterAnnotations map[string]string
+		wantValues         string
+		wantHashOf         string // the value whose sha1 should appear in the annotation
+	}{
+		{
+			name:          "fresh install, empty cluster",
+			fileValues:    testDefaultValues,
+			clusterValues: "",
+			wantValues:    testDefaultValues,
+			wantHashOf:    testDefaultValues,
+		},
+		{
+			name:          "fresh install, cluster has empty JSON",
+			fileValues:    testDefaultValues,
+			clusterValues: "{}",
+			wantValues:    testDefaultValues,
+			wantHashOf:    testDefaultValues,
+		},
+		{
+			name:          "upgrade, no admin edit (cluster matches file)",
+			fileValues:    testDefaultValues,
+			clusterValues: testDefaultValues,
+			wantValues:    testDefaultValues,
+			wantHashOf:    testDefaultValues,
+		},
+		{
+			name:          "upgrade, admin edited (cluster differs from file, no annotation)",
+			fileValues:    testUpdatedValues,
+			clusterValues: testAdminValues,
+			wantValues:    testAdminValues,
+			wantHashOf:    testUpdatedValues,
+		},
+		{
+			name:          "steady state, no admin edit (file changed, propagate upstream)",
+			fileValues:    testUpdatedValues,
+			clusterValues: testDefaultValues,
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+			},
+			wantValues: testUpdatedValues,
+			wantHashOf: testUpdatedValues,
+		},
+		{
+			name:          "steady state, admin edited",
+			fileValues:    testUpdatedValues,
+			clusterValues: testAdminValues,
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+			},
+			wantValues: testAdminValues,
+			wantHashOf: testUpdatedValues,
+		},
+		{
+			name:          "admin clears field (empty), annotation exists",
+			fileValues:    testUpdatedValues,
+			clusterValues: "",
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+			},
+			wantValues: testUpdatedValues,
+			wantHashOf: testUpdatedValues,
+		},
+		{
+			name:          "admin sets to empty JSON, annotation exists",
+			fileValues:    testUpdatedValues,
+			clusterValues: "{}",
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+			},
+			wantValues: testUpdatedValues,
+			wantHashOf: testUpdatedValues,
+		},
+		{
+			name:          "file becomes empty, no admin edit",
+			fileValues:    "",
+			clusterValues: testDefaultValues,
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+			},
+			wantValues: "",
+			wantHashOf: "",
+		},
+		{
+			name:          "file becomes empty, admin edited",
+			fileValues:    "",
+			clusterValues: testAdminValues,
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+			},
+			wantValues: testAdminValues,
+			wantHashOf: "",
+		},
 	}
 
-	if result.Spec.DefaultValuesBlock != testDefaultValues {
-		t.Errorf("expected DefaultValuesBlock %q, got %q", testDefaultValues, result.Spec.DefaultValuesBlock)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileAppDef := makeAppDef(testAppDefName, tt.fileValues, nil)
+			clusterAppDef := makeAppDef(testAppDefName, tt.clusterValues, tt.clusterAnnotations)
 
-	expectedHash := sha1Hex(testDefaultValues)
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
-	}
-}
+			result, err := reconcile(fileAppDef, clusterAppDef)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-func TestFirstUpgradeNoAnnotation(t *testing.T) {
-	// clusterAppDef has stale non-empty DefaultValuesBlock, no annotation.
-	// file value should overwrite the stale value.
-	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
+			if result.Spec.DefaultValuesBlock != tt.wantValues {
+				t.Errorf("DefaultValuesBlock: got %q, want %q", result.Spec.DefaultValuesBlock, tt.wantValues)
+			}
 
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testUpdatedValues {
-		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
-	}
-
-	expectedHash := sha1Hex(testUpdatedValues)
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
-	}
-}
-
-func TestReconcileNoAdminChange(t *testing.T) {
-	// clusterAppDef has DefaultValuesBlock matching stored hash annotation.
-	// file has a new value. expect new file value applied, annotation updated.
-	oldHash := sha1Hex(testDefaultValues)
-	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, testDefaultValues, map[string]string{
-		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
-	})
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testUpdatedValues {
-		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
-	}
-
-	expectedHash := sha1Hex(testUpdatedValues)
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
-	}
-}
-
-func TestAdminCustomizationPreserved(t *testing.T) {
-	// clusterAppDef has modified DefaultValuesBlock (hash differs from stored annotation).
-	// expect admin value preserved, annotation set to file hash.
-	oldHash := sha1Hex(testDefaultValues)
-	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, testAdminValues, map[string]string{
-		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
-	})
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testAdminValues {
-		t.Errorf("expected admin DefaultValuesBlock %q to be preserved, got %q", testAdminValues, result.Spec.DefaultValuesBlock)
-	}
-
-	// annotation should store the file hash, not the admin hash
-	expectedHash := sha1Hex(testUpdatedValues)
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q (file hash), got %q", expectedHash, got)
-	}
-}
-
-func TestAdminClearsField(t *testing.T) {
-	// clusterAppDef has empty DefaultValuesBlock, annotation exists.
-	// expect file value applied, annotation updated.
-	oldHash := sha1Hex(testDefaultValues)
-	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, "", map[string]string{
-		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
-	})
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testUpdatedValues {
-		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
-	}
-
-	expectedHash := sha1Hex(testUpdatedValues)
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
-	}
-}
-
-func TestAdminRevertsToSystemDefault(t *testing.T) {
-	// clusterAppDef has DefaultValuesBlock matching file value exactly,
-	// stored hash from previous file version.
-	// expect file value applied (same outcome either way).
-	oldHash := sha1Hex("old-value: something\n")
-	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, testUpdatedValues, map[string]string{
-		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
-	})
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testUpdatedValues {
-		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
-	}
-
-	expectedHash := sha1Hex(testUpdatedValues)
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
-	}
-}
-
-func TestFileBecomesEmpty(t *testing.T) {
-	// previous file had values, new file has empty DefaultValuesBlock.
-	// no admin override. expect empty value applied.
-	oldHash := sha1Hex(testDefaultValues)
-	fileAppDef := makeAppDef(testAppDefName, "", nil)
-	clusterAppDef := makeAppDef(testAppDefName, testDefaultValues, map[string]string{
-		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
-	})
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != "" {
-		t.Errorf("expected empty DefaultValuesBlock, got %q", result.Spec.DefaultValuesBlock)
-	}
-
-	// fileHash for empty string
-	expectedHash := sha1Hex("")
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
-	}
-}
-
-func TestFileBecomesEmptyWithAdminOverride(t *testing.T) {
-	// previous file had values, new file has empty DefaultValuesBlock.
-	// admin has custom value. expect admin value preserved.
-	oldHash := sha1Hex(testDefaultValues)
-	fileAppDef := makeAppDef(testAppDefName, "", nil)
-	clusterAppDef := makeAppDef(testAppDefName, testAdminValues, map[string]string{
-		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
-	})
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testAdminValues {
-		t.Errorf("expected admin DefaultValuesBlock %q to be preserved, got %q", testAdminValues, result.Spec.DefaultValuesBlock)
-	}
-
-	// annotation should store the file hash (empty), not the admin hash
-	expectedHash := sha1Hex("")
-	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
-		t.Errorf("expected hash annotation %q (file hash for empty), got %q", expectedHash, got)
-	}
-}
-
-func TestClusterValuesBlockEmptyJSONNoAnnotation(t *testing.T) {
-	// clusterAppDef has "{}" DefaultValuesBlock, no annotation.
-	// should be treated as empty, so file value applies.
-	fileAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
-	clusterAppDef := makeAppDef(testAppDefName, testValuesBlockEmpty, nil)
-
-	result, err := reconcile(fileAppDef, clusterAppDef)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Spec.DefaultValuesBlock != testDefaultValues {
-		t.Errorf("expected DefaultValuesBlock %q, got %q", testDefaultValues, result.Spec.DefaultValuesBlock)
+			expectedHash := sha1Hex(tt.wantHashOf)
+			gotHash := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]
+			if gotHash != expectedHash {
+				t.Errorf("hash annotation: got %q, want %q", gotHash, expectedHash)
+			}
+		})
 	}
 }
 

--- a/pkg/applicationdefinitions/application_catalog_test.go
+++ b/pkg/applicationdefinitions/application_catalog_test.go
@@ -96,7 +96,24 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			wantHashOf:    testDefaultValues,
 		},
 		{
-			name:          "upgrade, admin edited (cluster differs from file, no annotation)",
+			name:          "upgrade, file changed, cluster has stale value (no annotation, no opt-in)",
+			fileValues:    testUpdatedValues,
+			clusterValues: testDefaultValues,
+			wantValues:    testDefaultValues,
+			wantHashOf:    testUpdatedValues,
+		},
+		{
+			name:          "upgrade, file changed, cluster has stale value (no annotation, with opt-in)",
+			fileValues:    testUpdatedValues,
+			clusterValues: testDefaultValues,
+			clusterAnnotations: map[string]string{
+				appskubermaticv1.ApplicationAllowDefaultValuesOverwriteAnnotation: "true",
+			},
+			wantValues: testUpdatedValues,
+			wantHashOf: testUpdatedValues,
+		},
+		{
+			name:          "upgrade, admin edited (no annotation, no opt-in, preserved)",
 			fileValues:    testUpdatedValues,
 			clusterValues: testAdminValues,
 			wantValues:    testAdminValues,

--- a/pkg/applicationdefinitions/application_catalog_test.go
+++ b/pkg/applicationdefinitions/application_catalog_test.go
@@ -124,7 +124,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			fileValues:    testUpdatedValues,
 			clusterValues: testDefaultValues,
 			clusterAnnotations: map[string]string{
-				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+				appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
 			},
 			wantValues: testUpdatedValues,
 			wantHashOf: testUpdatedValues,
@@ -134,7 +134,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			fileValues:    testUpdatedValues,
 			clusterValues: testAdminValues,
 			clusterAnnotations: map[string]string{
-				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+				appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
 			},
 			wantValues: testAdminValues,
 			wantHashOf: testUpdatedValues,
@@ -144,7 +144,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			fileValues:    testUpdatedValues,
 			clusterValues: "",
 			clusterAnnotations: map[string]string{
-				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+				appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
 			},
 			wantValues: testUpdatedValues,
 			wantHashOf: testUpdatedValues,
@@ -154,7 +154,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			fileValues:    testUpdatedValues,
 			clusterValues: "{}",
 			clusterAnnotations: map[string]string{
-				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+				appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
 			},
 			wantValues: testUpdatedValues,
 			wantHashOf: testUpdatedValues,
@@ -164,7 +164,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			fileValues:    "",
 			clusterValues: testDefaultValues,
 			clusterAnnotations: map[string]string{
-				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+				appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
 			},
 			wantValues: "",
 			wantHashOf: "",
@@ -174,7 +174,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			fileValues:    "",
 			clusterValues: testAdminValues,
 			clusterAnnotations: map[string]string{
-				appskubermaticv1.ApplicationDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
+				appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation: sha1Hex(testDefaultValues),
 			},
 			wantValues: testAdminValues,
 			wantHashOf: "",
@@ -196,7 +196,7 @@ func TestDefaultValuesBlockReconciliation(t *testing.T) {
 			}
 
 			expectedHash := sha1Hex(tt.wantHashOf)
-			gotHash := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]
+			gotHash := result.Annotations[appskubermaticv1.ApplicationFileDefaultValuesHashAnnotation]
 			if gotHash != expectedHash {
 				t.Errorf("hash annotation: got %q, want %q", gotHash, expectedHash)
 			}

--- a/pkg/applicationdefinitions/application_catalog_test.go
+++ b/pkg/applicationdefinitions/application_catalog_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationdefinitions
+
+import (
+	"testing"
+
+	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testAppDefName       = "test-app"
+	testDefaultValues    = "key: value\n"
+	testUpdatedValues    = "key: updated-value\n"
+	testAdminValues      = "key: admin-override\n"
+	testValuesBlockEmpty = "{}"
+)
+
+func makeAppDef(name, defaultValuesBlock string, annotations map[string]string) *appskubermaticv1.ApplicationDefinition {
+	return &appskubermaticv1.ApplicationDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
+			DefaultValuesBlock: defaultValuesBlock,
+			Versions: []appskubermaticv1.ApplicationVersion{
+				{
+					Version: "v1.0.0",
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
+								URL:          "https://example.com/chart",
+								ChartName:    "test-chart",
+								ChartVersion: "1.0.0",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func reconcile(fileAppDef, clusterAppDef *appskubermaticv1.ApplicationDefinition) (*appskubermaticv1.ApplicationDefinition, error) {
+	factory := systemApplicationDefinitionReconcilerFactory(fileAppDef, nil, false)
+	_, reconciler := factory()
+	return reconciler(clusterAppDef)
+}
+
+func TestFreshInstall(t *testing.T) {
+	// clusterAppDef has empty DefaultValuesBlock, no annotation
+	fileAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, "", nil)
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testDefaultValues {
+		t.Errorf("expected DefaultValuesBlock %q, got %q", testDefaultValues, result.Spec.DefaultValuesBlock)
+	}
+
+	expectedHash := sha1Hex(testDefaultValues)
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
+	}
+}
+
+func TestFirstUpgradeNoAnnotation(t *testing.T) {
+	// clusterAppDef has stale non-empty DefaultValuesBlock, no annotation.
+	// file value should overwrite the stale value.
+	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testUpdatedValues {
+		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
+	}
+
+	expectedHash := sha1Hex(testUpdatedValues)
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
+	}
+}
+
+func TestReconcileNoAdminChange(t *testing.T) {
+	// clusterAppDef has DefaultValuesBlock matching stored hash annotation.
+	// file has a new value. expect new file value applied, annotation updated.
+	oldHash := sha1Hex(testDefaultValues)
+	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, testDefaultValues, map[string]string{
+		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testUpdatedValues {
+		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
+	}
+
+	expectedHash := sha1Hex(testUpdatedValues)
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
+	}
+}
+
+func TestAdminCustomizationPreserved(t *testing.T) {
+	// clusterAppDef has modified DefaultValuesBlock (hash differs from stored annotation).
+	// expect admin value preserved, annotation set to file hash.
+	oldHash := sha1Hex(testDefaultValues)
+	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, testAdminValues, map[string]string{
+		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testAdminValues {
+		t.Errorf("expected admin DefaultValuesBlock %q to be preserved, got %q", testAdminValues, result.Spec.DefaultValuesBlock)
+	}
+
+	// annotation should store the file hash, not the admin hash
+	expectedHash := sha1Hex(testUpdatedValues)
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q (file hash), got %q", expectedHash, got)
+	}
+}
+
+func TestAdminClearsField(t *testing.T) {
+	// clusterAppDef has empty DefaultValuesBlock, annotation exists.
+	// expect file value applied, annotation updated.
+	oldHash := sha1Hex(testDefaultValues)
+	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, "", map[string]string{
+		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testUpdatedValues {
+		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
+	}
+
+	expectedHash := sha1Hex(testUpdatedValues)
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
+	}
+}
+
+func TestAdminRevertsToSystemDefault(t *testing.T) {
+	// clusterAppDef has DefaultValuesBlock matching file value exactly,
+	// stored hash from previous file version.
+	// expect file value applied (same outcome either way).
+	oldHash := sha1Hex("old-value: something\n")
+	fileAppDef := makeAppDef(testAppDefName, testUpdatedValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, testUpdatedValues, map[string]string{
+		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testUpdatedValues {
+		t.Errorf("expected DefaultValuesBlock %q, got %q", testUpdatedValues, result.Spec.DefaultValuesBlock)
+	}
+
+	expectedHash := sha1Hex(testUpdatedValues)
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
+	}
+}
+
+func TestFileBecomesEmpty(t *testing.T) {
+	// previous file had values, new file has empty DefaultValuesBlock.
+	// no admin override. expect empty value applied.
+	oldHash := sha1Hex(testDefaultValues)
+	fileAppDef := makeAppDef(testAppDefName, "", nil)
+	clusterAppDef := makeAppDef(testAppDefName, testDefaultValues, map[string]string{
+		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != "" {
+		t.Errorf("expected empty DefaultValuesBlock, got %q", result.Spec.DefaultValuesBlock)
+	}
+
+	// fileHash for empty string
+	expectedHash := sha1Hex("")
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q, got %q", expectedHash, got)
+	}
+}
+
+func TestFileBecomesEmptyWithAdminOverride(t *testing.T) {
+	// previous file had values, new file has empty DefaultValuesBlock.
+	// admin has custom value. expect admin value preserved.
+	oldHash := sha1Hex(testDefaultValues)
+	fileAppDef := makeAppDef(testAppDefName, "", nil)
+	clusterAppDef := makeAppDef(testAppDefName, testAdminValues, map[string]string{
+		appskubermaticv1.ApplicationDefaultValuesHashAnnotation: oldHash,
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testAdminValues {
+		t.Errorf("expected admin DefaultValuesBlock %q to be preserved, got %q", testAdminValues, result.Spec.DefaultValuesBlock)
+	}
+
+	// annotation should store the file hash (empty), not the admin hash
+	expectedHash := sha1Hex("")
+	if got := result.Annotations[appskubermaticv1.ApplicationDefaultValuesHashAnnotation]; got != expectedHash {
+		t.Errorf("expected hash annotation %q (file hash for empty), got %q", expectedHash, got)
+	}
+}
+
+func TestClusterValuesBlockEmptyJSONNoAnnotation(t *testing.T) {
+	// clusterAppDef has "{}" DefaultValuesBlock, no annotation.
+	// should be treated as empty, so file value applies.
+	fileAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, testValuesBlockEmpty, nil)
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Spec.DefaultValuesBlock != testDefaultValues {
+		t.Errorf("expected DefaultValuesBlock %q, got %q", testDefaultValues, result.Spec.DefaultValuesBlock)
+	}
+}
+
+// TestSha1Hex verifies the helper produces correct hashes.
+func TestSha1Hex(t *testing.T) {
+	// known SHA1 of empty string
+	if got := sha1Hex(""); got != "da39a3ee5e6b4b0d3255bfef95601890afd80709" {
+		t.Errorf("sha1Hex(\"\") = %q, want known hash", got)
+	}
+
+	// SHA1 is deterministic
+	a := sha1Hex("test")
+	b := sha1Hex("test")
+	if a != b {
+		t.Errorf("sha1Hex not deterministic: %q != %q", a, b)
+	}
+
+	// different inputs produce different hashes
+	c := sha1Hex("other")
+	if a == c {
+		t.Errorf("sha1Hex(\"test\") == sha1Hex(\"other\")")
+	}
+}
+
+// TestReconcilePreservesExistingAnnotations ensures the reconciler does not
+// remove pre-existing annotations on the clusterAppDef.
+func TestReconcilePreservesExistingAnnotations(t *testing.T) {
+	fileAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
+	clusterAppDef := makeAppDef(testAppDefName, "", map[string]string{
+		"some-other-annotation": "should-survive",
+	})
+
+	result, err := reconcile(fileAppDef, clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := result.Annotations["some-other-annotation"]; got != "should-survive" {
+		t.Errorf("expected pre-existing annotation preserved, got %q", got)
+	}
+}
+
+// TestReconcileWithKubermaticConfig verifies the reconciler correctly applies
+// KubermaticConfiguration to the application definition when mirror is false.
+func TestReconcileWithKubermaticConfig(t *testing.T) {
+	fileAppDef := makeAppDef(testAppDefName, testDefaultValues, nil)
+	config := &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
+				SystemApplications: kubermaticv1.SystemApplicationsConfiguration{
+					HelmRegistryConfigFile: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+						Key: "config.json",
+					},
+				},
+			},
+		},
+	}
+	clusterAppDef := makeAppDef(testAppDefName, "", nil)
+
+	factory := systemApplicationDefinitionReconcilerFactory(fileAppDef, config, false)
+	_, reconciler := factory()
+	result, err := reconciler(clusterAppDef)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// verify credentials were applied
+	for _, v := range result.Spec.Versions {
+		if v.Template.Source.Helm == nil {
+			t.Fatal("expected Helm source to be set")
+		}
+		if v.Template.Source.Helm.Credentials == nil {
+			t.Fatal("expected Helm credentials to be set from config")
+		}
+	}
+}

--- a/sdk/apis/apps.kubermatic/v1/types.go
+++ b/sdk/apis/apps.kubermatic/v1/types.go
@@ -49,9 +49,9 @@ const (
 	// The value should be a valid Go duration string (e.g., "5m", "1h", "30s").
 	ApplicationReconciliationIntervalAnnotation = "apps.kubermatic.k8c.io/reconciliation-interval"
 
-	// ApplicationDefaultValuesHashAnnotation stores the SHA1 hash of the file-embedded
+	// ApplicationFileDefaultValuesHashAnnotation stores the SHA1 hash of the file-embedded
 	// defaultValuesBlock. Used to detect admin modifications to system ApplicationDefinitions.
-	ApplicationDefaultValuesHashAnnotation = "apps.kubermatic.k8c.io/default-values-hash"
+	ApplicationFileDefaultValuesHashAnnotation = "apps.kubermatic.k8c.io/file-default-values-hash"
 
 	// ApplicationAllowDefaultValuesOverwriteAnnotation signals that the admin allows KKP
 	// to overwrite defaultValuesBlock with upstream values during upgrade from an older

--- a/sdk/apis/apps.kubermatic/v1/types.go
+++ b/sdk/apis/apps.kubermatic/v1/types.go
@@ -52,4 +52,9 @@ const (
 	// ApplicationDefaultValuesHashAnnotation stores the SHA1 hash of the file-embedded
 	// defaultValuesBlock. Used to detect admin modifications to system ApplicationDefinitions.
 	ApplicationDefaultValuesHashAnnotation = "apps.kubermatic.k8c.io/default-values-hash"
+
+	// ApplicationAllowDefaultValuesOverwriteAnnotation signals that the admin allows KKP
+	// to overwrite defaultValuesBlock with upstream values during upgrade from an older
+	// controller that did not track the hash annotation.
+	ApplicationAllowDefaultValuesOverwriteAnnotation = "apps.kubermatic.k8c.io/allow-default-values-overwrite"
 )

--- a/sdk/apis/apps.kubermatic/v1/types.go
+++ b/sdk/apis/apps.kubermatic/v1/types.go
@@ -48,4 +48,8 @@ const (
 	// for ApplicationInstallations created from this ApplicationDefinition.
 	// The value should be a valid Go duration string (e.g., "5m", "1h", "30s").
 	ApplicationReconciliationIntervalAnnotation = "apps.kubermatic.k8c.io/reconciliation-interval"
+
+	// ApplicationDefaultValuesHashAnnotation stores the SHA1 hash of the file-embedded
+	// defaultValuesBlock. Used to detect admin modifications to system ApplicationDefinitions.
+	ApplicationDefaultValuesHashAnnotation = "apps.kubermatic.k8c.io/default-values-hash"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

The system ApplicationDefinition reconciler unconditionally preserved the cluster's existing `defaultValuesBlock` when non-empty, so upstream changes shipped in KKP upgrades never propagated to existing clusters. This PR adds SHA1 hash-based change detection via the `apps.kubermatic.k8c.io/default-values-hash` annotation to distinguish admin customizations from stale values, allowing upstream updates to propagate unless an admin has explicitly modified the field.

**Which issue(s) this PR fixes**:
Fixes #15619

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
System ApplicationDefinitions now receive upstream `defaultValuesBlock` changes during KKP upgrades. Admin customizations are preserved via hash-based detection.
```

**Documentation**:
```documentation
NONE
```
 
```test-issue
Prerequisites: KKP with seed and user cluster access.

Setup
1. Create KKP 2.29.1
2. Check the cluster-autoscaler ApplicationDefinition values. There will be no `patch` RBAC since the PR mentioned in the linked issue has not been shipped yet.
3. Upgrade KKP to replicate the issue (to v2.29.5, which should include the cluster-autoscaler fix on its defaultValuesBlock). See that cluster-autoscaler ApplicationDefinition does not contain the fix after upgrading.

Given: KKP upgraded with this fix
4. Deploy KKP with this fix and wait for reconciliation.
5. Verify defaultValuesBlock is updated to the file-embedded default.
6. Verify the hash annotation exists on the ApplicationDefinition
7. If KKP ships changes to values.yaml and customer did not modify it,
   the ApplicationInstallation in the user cluster should reflect the new defaults.

# example runs
#
# ###########################################
# after upgrading 2.29.1 to 2.29.3, which includes the fix
# ###########################################
$ k get kubermaticconfigurations -n kubermatic kubermatic -o yaml | yq .status.kubermaticVersion && echo "<->" && k get appdef cluster-autoscaler -o yaml | grep -i patch || echo "fix is not applied"
v2.29.3
<->
fix is not applied

# ###########################################
# after upgrading 2.29.1 to the custom image that includes this PR
# ###########################################
$ k get kubermaticconfigurations -n kubermatic kubermatic -o yaml | yq .status.kubermaticVersion && echo "<->" && k get appdef cluster-autoscaler -o yaml | grep -i patch || echo "fix is not applied"
v2.30.0-alpha.1-78-ge4db298e4
<->
        - patch
```

