### PR TITLE
add dependabot configuration for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot PRs on `kubermatic/kubermatic` cannot be merged because they lack the ```documentation```, ```test-issue```, and ```release-note``` code blocks required by the PR template. The prow plugins detect the missing blocks and apply blocking labels (`do-not-merge/docs-needed`, `do-not-merge/test-issue-needed`, `do-not-merge/release-note-label-needed`). This PR adds a `.github/dependabot.yml` that pre-labels dependabot PRs with the "resolved" variants of those labels, following the same pattern used by the `kubermatic/dashboard` repo.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
