### PR TITLE
gateway-api: support existing TLS secret for default HTTPS listener

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -251,6 +251,11 @@ spec:
     gateway:
       # ClassName is the GatewayClass to use.
       className: kubermatic-envoy-gateway
+      # TLSSecretName is the name of an existing Kubernetes TLS secret in the KKP namespace
+      # to use for the default HTTPS listener on the Gateway. This allows operators to provide
+      # TLS without configuring a cert-manager CertificateIssuer. If both TLSSecretName and
+      # CertificateIssuer are set, CertificateIssuer takes precedence.
+      tlsSecretName: ""
     # NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
     namespaceOverride: ""
   # MasterController configures the master-controller-manager.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -251,6 +251,11 @@ spec:
     gateway:
       # ClassName is the GatewayClass to use.
       className: kubermatic-envoy-gateway
+      # TLSSecretName is the name of an existing Kubernetes TLS secret in the KKP namespace
+      # to use for the default HTTPS listener on the Gateway. This allows operators to provide
+      # TLS without configuring a cert-manager CertificateIssuer. If both TLSSecretName and
+      # CertificateIssuer are set, CertificateIssuer takes precedence.
+      tlsSecretName: ""
     # NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
     namespaceOverride: ""
   # MasterController configures the master-controller-manager.

--- a/pkg/controller/operator/master/resources/kubermatic/gateway.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway.go
@@ -135,6 +135,31 @@ func GatewayReconciler(
 						},
 					},
 				})
+			} else if cfg.Spec.Ingress.Gateway != nil && cfg.Spec.Ingress.Gateway.TLSSecretName != "" {
+				coreListeners = append(coreListeners, gatewayapiv1.Listener{
+					Name:     "https",
+					Hostname: ptr.To(gatewayapiv1.Hostname(cfg.Spec.Ingress.Domain)),
+					Protocol: gatewayapiv1.HTTPSProtocolType,
+					Port:     gatewayapiv1.PortNumber(443),
+					AllowedRoutes: &gatewayapiv1.AllowedRoutes{
+						Namespaces: &gatewayapiv1.RouteNamespaces{
+							From: ptr.To(gatewayapiv1.NamespacesFromSelector),
+							Selector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									common.GatewayAccessLabelKey: "true",
+								},
+							},
+						},
+					},
+					TLS: &gatewayapiv1.ListenerTLSConfig{
+						Mode: ptr.To(gatewayapiv1.TLSModeTerminate),
+						CertificateRefs: []gatewayapiv1.SecretObjectReference{
+							{
+								Name: gatewayapiv1.ObjectName(cfg.Spec.Ingress.Gateway.TLSSecretName),
+							},
+						},
+					},
+				})
 			}
 
 			// Merge core listeners with preserved non-core from existing (sorted)

--- a/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/gateway_test.go
@@ -288,6 +288,144 @@ func TestGatewayReconcilerPreservesNonCoreListeners(t *testing.T) {
 	}
 }
 
+func TestGatewayReconcilerTLSSecretName(t *testing.T) {
+	const tlsSecret = "kubermatic-tls"
+
+	cfg := &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			Ingress: kubermaticv1.KubermaticIngressConfiguration{
+				Domain: "example.com",
+				Gateway: &kubermaticv1.KubermaticGatewayConfiguration{
+					TLSSecretName: tlsSecret,
+				},
+			},
+		},
+	}
+
+	t.Run("HTTPS listener created from TLSSecretName when no CertificateIssuer", func(t *testing.T) {
+		creatorGetter := GatewayReconciler(cfg, "kubermatic", nil)
+		_, creator := creatorGetter()
+
+		gw, err := creator(&gatewayapiv1.Gateway{})
+		if err != nil {
+			t.Fatalf("GatewayReconciler failed: %v", err)
+		}
+
+		if len(gw.Spec.Listeners) != 2 {
+			t.Fatalf("expected 2 listeners (http + https), got %d: %v", len(gw.Spec.Listeners), listenerNames(gw.Spec.Listeners))
+		}
+
+		var httpsListener *gatewayapiv1.Listener
+		for i := range gw.Spec.Listeners {
+			if gw.Spec.Listeners[i].Name == "https" {
+				httpsListener = &gw.Spec.Listeners[i]
+				break
+			}
+		}
+		if httpsListener == nil {
+			t.Fatal("https listener not found")
+		}
+		if httpsListener.Protocol != gatewayapiv1.HTTPSProtocolType {
+			t.Errorf("expected HTTPS protocol, got %v", httpsListener.Protocol)
+		}
+		if httpsListener.TLS == nil {
+			t.Fatal("expected TLS config on https listener")
+		}
+		if len(httpsListener.TLS.CertificateRefs) != 1 {
+			t.Fatalf("expected 1 certificate ref, got %d", len(httpsListener.TLS.CertificateRefs))
+		}
+		if string(httpsListener.TLS.CertificateRefs[0].Name) != tlsSecret {
+			t.Errorf("expected certificate ref name %q, got %q", tlsSecret, httpsListener.TLS.CertificateRefs[0].Name)
+		}
+
+		// No cert-manager annotations should be set
+		for _, key := range []string{"cert-manager.io/issuer", "cert-manager.io/cluster-issuer"} {
+			if _, exists := gw.Annotations[key]; exists {
+				t.Errorf("annotation %q should not be set when using TLSSecretName", key)
+			}
+		}
+	})
+
+	t.Run("HTTPS listener survives reconciliation (idempotency)", func(t *testing.T) {
+		// First reconcile — no existing listeners
+		creatorGetter := GatewayReconciler(cfg, "kubermatic", nil)
+		_, creator := creatorGetter()
+		first, err := creator(&gatewayapiv1.Gateway{})
+		if err != nil {
+			t.Fatalf("first reconcile failed: %v", err)
+		}
+
+		// Second reconcile — pass the first result as existing listeners (simulates real reconcile loop)
+		creatorGetter2 := GatewayReconciler(cfg, "kubermatic", first.Spec.Listeners)
+		_, creator2 := creatorGetter2()
+		second, err := creator2(first.DeepCopy())
+		if err != nil {
+			t.Fatalf("second reconcile failed: %v", err)
+		}
+
+		if len(second.Spec.Listeners) != 2 {
+			t.Fatalf("after second reconcile: expected 2 listeners, got %d: %v", len(second.Spec.Listeners), listenerNames(second.Spec.Listeners))
+		}
+
+		var httpsListener *gatewayapiv1.Listener
+		for i := range second.Spec.Listeners {
+			if second.Spec.Listeners[i].Name == "https" {
+				httpsListener = &second.Spec.Listeners[i]
+				break
+			}
+		}
+		if httpsListener == nil {
+			t.Fatal("https listener was removed after second reconcile — bug reproduced")
+		}
+		if string(httpsListener.TLS.CertificateRefs[0].Name) != tlsSecret {
+			t.Errorf("certificate ref changed after reconcile: got %q, want %q",
+				httpsListener.TLS.CertificateRefs[0].Name, tlsSecret)
+		}
+	})
+
+	t.Run("CertificateIssuer takes precedence over TLSSecretName", func(t *testing.T) {
+		cfgBoth := &kubermaticv1.KubermaticConfiguration{
+			Spec: kubermaticv1.KubermaticConfigurationSpec{
+				Ingress: kubermaticv1.KubermaticIngressConfiguration{
+					Domain: "example.com",
+					CertificateIssuer: corev1.TypedLocalObjectReference{
+						Name: "letsencrypt-prod",
+						Kind: certmanagerv1.ClusterIssuerKind,
+					},
+					Gateway: &kubermaticv1.KubermaticGatewayConfiguration{
+						TLSSecretName: tlsSecret,
+					},
+				},
+			},
+		}
+
+		creatorGetter := GatewayReconciler(cfgBoth, "kubermatic", nil)
+		_, creator := creatorGetter()
+		gw, err := creator(&gatewayapiv1.Gateway{})
+		if err != nil {
+			t.Fatalf("GatewayReconciler failed: %v", err)
+		}
+
+		// Should use cert-manager path: certificateSecretName, not the tlsSecret
+		var httpsListener *gatewayapiv1.Listener
+		for i := range gw.Spec.Listeners {
+			if gw.Spec.Listeners[i].Name == "https" {
+				httpsListener = &gw.Spec.Listeners[i]
+				break
+			}
+		}
+		if httpsListener == nil {
+			t.Fatal("https listener not found")
+		}
+		if string(httpsListener.TLS.CertificateRefs[0].Name) != string(certificateSecretName) {
+			t.Errorf("expected cert-manager secret %q, got %q", certificateSecretName, httpsListener.TLS.CertificateRefs[0].Name)
+		}
+		if _, exists := gw.Annotations["cert-manager.io/cluster-issuer"]; !exists {
+			t.Error("expected cert-manager cluster-issuer annotation when CertificateIssuer is set")
+		}
+	})
+}
+
 func listenerNames(listeners []gatewayapiv1.Listener) []string {
 	names := make([]string, len(listeners))
 	for i, l := range listeners {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -674,6 +674,13 @@ spec:
                           default: kubermatic-envoy-gateway
                           description: ClassName is the GatewayClass to use.
                           type: string
+                        tlsSecretName:
+                          description: |-
+                            TLSSecretName is the name of an existing Kubernetes TLS secret in the KKP namespace
+                            to use for the default HTTPS listener on the Gateway. This allows operators to provide
+                            TLS without configuring a cert-manager CertificateIssuer. If both TLSSecretName and
+                            CertificateIssuer are set, CertificateIssuer takes precedence.
+                          type: string
                       type: object
                     namespaceOverride:
                       description: NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.

--- a/sdk/apis/kubermatic/v1/configuration.go
+++ b/sdk/apis/kubermatic/v1/configuration.go
@@ -483,6 +483,12 @@ type KubermaticGatewayConfiguration struct {
 	// ClassName is the GatewayClass to use.
 	// +kubebuilder:default:=kubermatic-envoy-gateway
 	ClassName string `json:"className,omitempty"`
+
+	// TLSSecretName is the name of an existing Kubernetes TLS secret in the KKP namespace
+	// to use for the default HTTPS listener on the Gateway. This allows operators to provide
+	// TLS without configuring a cert-manager CertificateIssuer. If both TLSSecretName and
+	// CertificateIssuer are set, CertificateIssuer takes precedence.
+	TLSSecretName string `json:"tlsSecretName,omitempty"`
 }
 
 // KubermaticMasterControllerConfiguration configures the Kubermatic master controller-manager.


### PR DESCRIPTION
## Summary

Fixes #15706

When `spec.ingress.certificateIssuer` is unset, the operator-managed default `Gateway` only contained an `http` listener. Any manually added `https` listener referencing an existing TLS secret was silently removed on every reconcile, because the reconciler treats `http` and `https` as core listener names and always replaces them with its own desired state.

- Add `spec.ingress.gateway.tlsSecretName` field to `KubermaticGatewayConfiguration` to allow operators to reference an existing Kubernetes TLS secret for the default HTTPS listener without a cert-manager `CertificateIssuer`
- When `tlsSecretName` is set and `certificateIssuer` is empty, the reconciler adds the `https` listener as a core listener referencing that secret — so it persists across reconciles
- If both `certificateIssuer` and `tlsSecretName` are set, `certificateIssuer` takes precedence
- CRD schema and generated docs updated to reflect the new field

## Test plan

- [ ] `go test ./pkg/controller/operator/master/resources/kubermatic/...` — existing tests pass, new `TestGatewayReconcilerTLSSecretName` covers:
  - HTTPS listener is created from `tlsSecretName` when no `certificateIssuer` is set
  - HTTPS listener survives a second reconcile (idempotency — directly reproduces the reported bug)
  - `certificateIssuer` takes precedence when both fields are set
- [ ] `go test ./pkg/controller/util/gateway/...` — all pass