### PR TITLE
reconcile Gateway API resources before Deployments

### DIFF
--- a/hack/ci/run-gateway-api-e2e-tests.sh
+++ b/hack/ci/run-gateway-api-e2e-tests.sh
@@ -107,3 +107,63 @@ go_test gateway_api_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/gateway-api \
   -test.run "TestGatewayAPIFreshInstall"
 
 echodate "Gateway API fresh install tests completed successfully!"
+
+# Reproduce issue #15711: patch KubermaticConfiguration with a missing ConfigMap
+# reference, then redeploy from scratch. The fix ensures Gateway is created
+# before Deployments, so the installer succeeds despite the broken volume ref.
+
+echodate "=============== Starting deployment failure tolerance test phase ==============="
+echodate "Uninstalling kubermatic-operator Helm release..."
+if ! helm uninstall kubermatic-operator -n kubermatic; then
+  echodate "WARNING: failed to uninstall kubermatic-operator Helm release (may already be gone)"
+fi
+
+echodate "Cleaning up operator-managed resources..."
+if ! kubectl delete gateway -n kubermatic --all --ignore-not-found=true; then
+  echodate "ERROR: failed to delete Gateway resources"
+  exit 1
+fi
+if ! kubectl delete httproute -n kubermatic --all --ignore-not-found=true; then
+  echodate "ERROR: failed to delete HTTPRoute resources"
+  exit 1
+fi
+if ! kubectl delete deploy kubermatic-dashboard -n kubermatic --ignore-not-found=true; then
+  echodate "ERROR: failed to delete kubermatic-dashboard Deployment"
+  exit 1
+fi
+
+echodate "Patching KubermaticConfiguration with missing ConfigMap reference..."
+if ! kubectl patch kubermaticconfiguration -n kubermatic e2e --type merge -p '
+spec:
+  ui:
+    extraVolumeMounts:
+      - name: themes
+        mountPath: /dist/light.css
+        subPath: light
+    extraVolumes:
+      - name: themes
+        configMap:
+          name: kubermatic-dashboard-themes
+'; then
+  echodate "ERROR: failed to patch KubermaticConfiguration with missing ConfigMap reference"
+  exit 1
+fi
+
+echodate "Re-deploying KKP with broken dashboard ConfigMap reference..."
+if ! _build/kubermatic-installer --verbose deploy kubermatic-master \
+  --helm-values "$HELM_VALUES_FILE" \
+  --skip-seed-validation=kubermatic \
+  --migrate-gateway-api; then
+  echodate "ERROR: kubermatic-installer failed during re-deploy with broken ConfigMap (this is the core of issue #15711)"
+  exit 1
+fi
+
+echodate "Running Gateway API deployment failure tolerance tests..."
+
+if ! go_test gateway_api_deployment_failure_tolerance_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/gateway-api \
+  -test.run "TestGatewayAPIDeploymentFailureTolerance"; then
+  echodate "ERROR: Gateway API deployment failure tolerance test failed"
+  exit 1
+fi
+
+echodate "Gateway API deployment failure tolerance tests completed successfully!"

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -140,6 +140,10 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		return err
 	}
 
+	if err := r.reconcileGatewayAPIResources(ctx, defaulted, logger); err != nil {
+		return err
+	}
+
 	if err := r.reconcileSecrets(ctx, defaulted, logger); err != nil {
 		return err
 	}
@@ -161,10 +165,6 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 	}
 
 	if err := r.reconcileIngresses(ctx, defaulted, logger); err != nil {
-		return err
-	}
-
-	if err := r.reconcileGatewayAPIResources(ctx, defaulted, logger); err != nil {
 		return err
 	}
 

--- a/pkg/test/e2e/gateway-api/fresh_install_test.go
+++ b/pkg/test/e2e/gateway-api/fresh_install_test.go
@@ -56,3 +56,22 @@ func TestGatewayAPIFreshInstall(t *testing.T) {
 		t.Fatalf("Gateway HTTP connectivity verification failed: %v", err)
 	}
 }
+
+func TestGatewayAPIDeploymentFailureTolerance(t *testing.T) {
+	ctx := context.Background()
+	rawLogger := log.NewFromOptions(logOptions)
+	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLogger.WithOptions(zap.AddCallerSkip(1))))
+	logger := rawLogger.Sugar()
+
+	seedClient, _, err := utils.GetClients()
+	if err != nil {
+		t.Fatalf("Failed to build client: %v", err)
+	}
+
+	logger.Info("Verifying Gateway API resources exist despite Deployment reconciliation failure...")
+
+	err = verifyGatewayExistsRegardlessOfDeploymentHealth(ctx, t, seedClient, logger)
+	if err != nil {
+		t.Fatalf("Gateway API deployment failure tolerance verification failed: %v", err)
+	}
+}

--- a/pkg/test/e2e/gateway-api/fresh_install_test.go
+++ b/pkg/test/e2e/gateway-api/fresh_install_test.go
@@ -58,7 +58,7 @@ func TestGatewayAPIFreshInstall(t *testing.T) {
 }
 
 func TestGatewayAPIDeploymentFailureTolerance(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	rawLogger := log.NewFromOptions(logOptions)
 	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLogger.WithOptions(zap.AddCallerSkip(1))))
 	logger := rawLogger.Sugar()

--- a/pkg/test/e2e/gateway-api/helpers.go
+++ b/pkg/test/e2e/gateway-api/helpers.go
@@ -440,3 +440,70 @@ func verifyGatewayHTTPConnectivity(ctx context.Context, t *testing.T, c ctrlrunt
 	l.Infof("Dex health check endpoint /dex/healthz returned 200 OK")
 	return nil
 }
+
+// verifyGatewayExistsRegardlessOfDeploymentHealth verifies that Gateway API resources
+// exist and are functional even when some Deployments are unhealthy due to missing
+// volumes (like ConfigMaps). This validates the resilience fix for issue
+// https://github.com/kubermatic/kubermatic/issues/15711 where a missing ConfigMap blocked
+// Gateway creation because Deployments were reconciled first.
+func verifyGatewayExistsRegardlessOfDeploymentHealth(ctx context.Context, t *testing.T, c ctrlruntimeclient.Client, l *zap.SugaredLogger) error {
+	t.Helper()
+	ns := jig.KubermaticNamespace()
+
+	gtwName := types.NamespacedName{Namespace: ns, Name: defaulting.DefaultGatewayName}
+	gtw := &gatewayapiv1.Gateway{}
+	err := wait.PollImmediateLog(ctx, l, defaultInterval, defaultTimeout, func(ctx context.Context) (transient error, terminal error) {
+		if err := c.Get(ctx, gtwName, gtw); err != nil {
+			return fmt.Errorf("Gateway not found: %w", err), nil
+		}
+
+		programmed := meta.IsStatusConditionTrue(gtw.Status.Conditions, string(gatewayapiv1.GatewayConditionProgrammed))
+		if !programmed {
+			return fmt.Errorf("Gateway %q not programmed", gtwName.String()), nil
+		}
+
+		return nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Gateway not found/programmed: %w", err)
+	}
+
+	l.Infof("Gateway %q exists and is programmed (despite broken Deployment)", gtwName.String())
+
+	hrName := types.NamespacedName{Namespace: ns, Name: defaulting.DefaultHTTPRouteName}
+	hr := &gatewayapiv1.HTTPRoute{}
+	err = wait.PollImmediateLog(ctx, l, defaultInterval, defaultTimeout, func(ctx context.Context) (transient error, terminal error) {
+		if err := c.Get(ctx, hrName, hr); err != nil {
+			return fmt.Errorf("HTTPRoute not found: %w", err), nil
+		}
+
+		if len(hr.Status.Parents) == 0 {
+			return fmt.Errorf("HTTPRoute has no parents"), nil
+		}
+
+		accepted := meta.IsStatusConditionTrue(hr.Status.Parents[0].Conditions, string(gatewayapiv1.RouteConditionAccepted))
+		if !accepted {
+			return fmt.Errorf("HTTPRoute not accepted"), nil
+		}
+
+		return nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("HTTPRoute not found/accepted: %w", err)
+	}
+
+	l.Infof("HTTPRoute %q exists and is accepted", hrName.String())
+
+	l.Info("kubermatic-api Deployment is healthy (unaffected by missing ConfigMap)")
+
+	// verify the ConfigMap referenced by the dashboard does not exist
+	cmName := types.NamespacedName{Namespace: ns, Name: "kubermatic-dashboard-themes"}
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, cmName, cm); !apierrors.IsNotFound(err) {
+		return fmt.Errorf("ConfigMap kubermatic-dashboard-themes should not exist for this test")
+	}
+
+	l.Info("ConfigMap kubermatic-dashboard-themes correctly absent (test precondition)")
+
+	return nil
+}

--- a/pkg/test/e2e/gateway-api/helpers.go
+++ b/pkg/test/e2e/gateway-api/helpers.go
@@ -494,16 +494,15 @@ func verifyGatewayExistsRegardlessOfDeploymentHealth(ctx context.Context, t *tes
 
 	l.Infof("HTTPRoute %q exists and is accepted", hrName.String())
 
-	l.Info("kubermatic-api Deployment is healthy (unaffected by missing ConfigMap)")
-
 	// verify the ConfigMap referenced by the dashboard does not exist
 	cmName := types.NamespacedName{Namespace: ns, Name: "kubermatic-dashboard-themes"}
 	cm := &corev1.ConfigMap{}
-	if err := c.Get(ctx, cmName, cm); !apierrors.IsNotFound(err) {
+
+	err := c.Get(ctx, cmName, cm)
+	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("ConfigMap kubermatic-dashboard-themes should not exist for this test")
 	}
 
 	l.Info("ConfigMap kubermatic-dashboard-themes correctly absent (test precondition)")
-
 	return nil
 }

--- a/pkg/test/e2e/gateway-api/helpers.go
+++ b/pkg/test/e2e/gateway-api/helpers.go
@@ -498,7 +498,7 @@ func verifyGatewayExistsRegardlessOfDeploymentHealth(ctx context.Context, t *tes
 	cmName := types.NamespacedName{Namespace: ns, Name: "kubermatic-dashboard-themes"}
 	cm := &corev1.ConfigMap{}
 
-	err := c.Get(ctx, cmName, cm)
+	err = c.Get(ctx, cmName, cm)
 	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("ConfigMap kubermatic-dashboard-themes should not exist for this test")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
A missing ConfigMap referenced by `spec.ui.extraVolumes` caused the `RelatedRevisionsLabels` modifier in `reconcileDeployments()` to fail. Because `reconcile()` uses fail-fast error handling, `reconcileGatewayAPIResources()` was never reached and the Gateway was never created. This blocked `kubermatic-installer` from completing.

The fix moves `reconcileGatewayAPIResources()` before `reconcileDeployments()` so Gateway and HTTPRoute are created regardless of Deployment health.

**Which issue(s) this PR fixes**:
Fixes #15711

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
kubermatic-operator now reconciles Gateway API resources before Deployments, preventing missing ConfigMaps from blocking Gateway creation.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
Prerequisites: A kind cluster with KKP installed via hack/ci/run-gateway-api-e2e-tests.sh

Setup
1. Deploy KKP with Gateway API enabled using the existing CI script.

Reproduce (without this fix)
2. Patch KubermaticConfiguration to add extraVolumes referencing a non-existent ConfigMap:

  kubectl patch kubermaticconfiguration -n kubermatic e2e --type merge -p '
  spec:
    ui:
      extraVolumes:
        - name: themes
          configMap:
            name: kubermatic-dashboard-themes
      extraVolumeMounts:
        - name: themes
          mountPath: /dist/light.css
          subPath: light
  '
3. Observe that the installer hangs/times out because the Gateway is never created.

Given: this fix applied
4. Delete the kubermatic-operator helm chart, HTTPRoute and Gateway,
5. Re-run kubermatic-installer to verify it passes
```
