### PR TITLE
Fix seed-controller-manager cache sync timeout issue on large kkp instance clusters

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -29,6 +29,7 @@ import (
 	k8cuserclusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	"k8c.io/kubermatic/v2/pkg/clusterdeletion"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
+	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
@@ -225,7 +226,7 @@ func Add(
 		For(&kubermaticv1.Cluster{})
 
 	for _, t := range typesToWatch {
-		bldr.Watches(t, inNamespaceHandler)
+		bldr.Watches(t, inNamespaceHandler, builder.WithPredicates(predicateutil.SkipCreateEvents()))
 	}
 
 	_, err := bldr.Build(reconciler)

--- a/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
+++ b/pkg/controller/seed-controller-manager/monitoring/monitoring_controller.go
@@ -26,6 +26,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	k8cuserclusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
+	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -137,7 +138,7 @@ func Add(
 		&autoscalingv1.VerticalPodAutoscaler{},
 		&corev1.Service{},
 	} {
-		bldr.Watches(t, controllerutil.EnqueueClusterForNamespacedObject(mgr.GetClient()))
+		bldr.Watches(t, controllerutil.EnqueueClusterForNamespacedObject(mgr.GetClient()), builder.WithPredicates(predicateutil.SkipCreateEvents()))
 	}
 
 	_, err := bldr.Build(reconciler)

--- a/pkg/controller/util/predicate/predicate.go
+++ b/pkg/controller/util/predicate/predicate.go
@@ -130,6 +130,19 @@ func ByAnnotation(key, value string, checkValue bool) predicate.Funcs {
 	})
 }
 
+// SkipCreateEvents returns a predicate that filters out Create events.
+// This is useful for secondary watches where the initial informer cache fill
+// generates synthetic Create events for all existing objects. With thousands
+// of objects, the expensive mapper calls during cache fill can exceed the
+// controller-runtime CacheSyncTimeout (2 minutes).
+func SkipCreateEvents() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+	}
+}
+
 // TrueFilter is a helper filter implementation that always returns true, e.g. for use with MultiFactory.
 func TrueFilter(_ ctrlruntimeclient.Object) bool {
 	return true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a predicate to skip create events for secondary watches in the `kubernetes-controller` and `monitoring-controller`. By skipping create events during the initial cache population, we prevent the expensive mapper from being triggered for every existing resource under those watches. 

This is caused by a regression introduced in controller-runtime v0.23.1 (https://github.com/kubernetes-sigs/controller-runtime/pull/3406) where the cache is considered ready only after all event handler mapping functions have completed for the initial set of events.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15663

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix seed-controller-manager cache sync timeout issue on large kkp instance clusters.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
