### PR TITLE
validate ApplicationDefinitions in kubermatic-installer

### DIFF
--- a/pkg/applicationdefinitions/application_catalog.go
+++ b/pkg/applicationdefinitions/application_catalog.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
+	"k8c.io/kubermatic/v2/pkg/validation"
 
 	"sigs.k8s.io/yaml"
 )
@@ -41,7 +42,7 @@ func SystemApplicationDefinitionReconcilerFactories(
 		return nil, nil
 	}
 
-	sysAppDefFiles, err := GetSysAppDefFiles()
+	sysAppDefFiles, err := getSysAppDefFilesFunc()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get system application definition files: %w", err)
 	}
@@ -68,6 +69,10 @@ func SystemApplicationDefinitionReconcilerFactories(
 		err = yaml.Unmarshal(b, appDef)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse ApplicationDefinition: %w", err)
+		}
+
+		if errs := validation.ValidateApplicationDefinitionSpec(*appDef); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid ApplicationDefinition %q: %v", appDef.Name, errs.ToAggregate())
 		}
 
 		if filterApps {

--- a/pkg/applicationdefinitions/application_catalog_test.go
+++ b/pkg/applicationdefinitions/application_catalog_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationdefinitions
+
+import (
+	"io"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+)
+
+func testLogger(t *testing.T) *zap.SugaredLogger {
+	return zaptest.NewLogger(t).Sugar()
+}
+
+// invalidAppDefFile is an fs.File that returns an ApplicationDefinition with no versions,
+// which violates the validation rules.
+type invalidAppDefFile struct {
+	r io.Reader
+}
+
+func (f *invalidAppDefFile) Read(b []byte) (int, error)        { return f.r.Read(b) }
+func (f *invalidAppDefFile) Close() error                      { return nil }
+func (f *invalidAppDefFile) Stat() (fs.FileInfo, error)        { return nil, nil }
+
+func invalidAppDefFilesFunc() ([]fs.File, error) {
+	// A version with no source set triggers "no source provided" validation error.
+	yaml := `apiVersion: apps.kubermatic.k8c.io/v1
+kind: ApplicationDefinition
+metadata:
+  name: broken-app
+spec:
+  method: helm
+  versions:
+    - version: "v1.0.0"
+      template:
+        source: {}
+`
+	return []fs.File{&invalidAppDefFile{r: strings.NewReader(yaml)}}, nil
+}
+
+func TestSystemApplicationDefinitionReconcilerFactories_ValidEmbedded(t *testing.T) {
+	config := &kubermaticv1.KubermaticConfiguration{}
+
+	_, err := SystemApplicationDefinitionReconcilerFactories(testLogger(t), config, false)
+	if err != nil {
+		t.Fatalf("expected embedded system ApplicationDefinitions to be valid, got error: %v", err)
+	}
+}
+
+func TestSystemApplicationDefinitionReconcilerFactories_InvalidDefinition(t *testing.T) {
+	original := getSysAppDefFilesFunc
+	t.Cleanup(func() { getSysAppDefFilesFunc = original })
+	getSysAppDefFilesFunc = invalidAppDefFilesFunc
+
+	config := &kubermaticv1.KubermaticConfiguration{}
+	_, err := SystemApplicationDefinitionReconcilerFactories(testLogger(t), config, false)
+	if err == nil {
+		t.Fatal("expected error for invalid ApplicationDefinition, got nil")
+	}
+}

--- a/pkg/applicationdefinitions/embed.go
+++ b/pkg/applicationdefinitions/embed.go
@@ -28,6 +28,10 @@ const (
 //go:embed system-applications
 var f embed.FS
 
+// getSysAppDefFilesFunc is the function used to load system ApplicationDefinition files.
+// It can be overridden in tests to inject custom definitions.
+var getSysAppDefFilesFunc = GetSysAppDefFiles
+
 func GetSysAppDefFiles() ([]fs.File, error) {
 	files := []fs.File{}
 	entries, err := f.ReadDir(systemApplicationsDirectory)

--- a/pkg/ee/default-application-catalog/application_catalog.go
+++ b/pkg/ee/default-application-catalog/application_catalog.go
@@ -33,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
+	"k8c.io/kubermatic/v2/pkg/validation"
 
 	"sigs.k8s.io/yaml"
 )
@@ -73,6 +74,10 @@ func DefaultApplicationCatalogReconcilerFactories(
 		err = yaml.Unmarshal(b, appDef)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse ApplicationDefinition: %w", err)
+		}
+
+		if errs := validation.ValidateApplicationDefinitionSpec(*appDef); len(errs) > 0 {
+			return nil, fmt.Errorf("invalid ApplicationDefinition %q: %v", appDef.Name, errs.ToAggregate())
 		}
 
 		if filterApps {

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -30,6 +30,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	k8csemver "k8c.io/kubermatic/sdk/v2/semver"
+	"k8c.io/kubermatic/v2/pkg/applicationdefinitions"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
@@ -246,7 +247,22 @@ func (*MasterStack) ValidateConfiguration(config *kubermaticv1.KubermaticConfigu
 		helmFailures[idx] = prefixError("Helm values: ", e)
 	}
 
-	return config, helmValues, append(kubermaticFailures, helmFailures...)
+	appDefFailures := validateApplicationDefinitions(config, logger)
+
+	return config, helmValues, append(append(kubermaticFailures, helmFailures...), appDefFailures...)
+}
+
+func validateApplicationDefinitions(config *kubermaticv1.KubermaticConfiguration, logger logrus.FieldLogger) []error {
+	zapLogger, err := zap.NewProduction()
+	if err != nil {
+		return []error{fmt.Errorf("failed to create logger for ApplicationDefinition validation: %w", err)}
+	}
+
+	if _, err := applicationdefinitions.SystemApplicationDefinitionReconcilerFactories(zapLogger.Sugar(), config, false); err != nil {
+		return []error{prefixError("ApplicationDefinitions: ", err)}
+	}
+
+	return nil
 }
 
 func validateKubermaticConfiguration(config *kubermaticv1.KubermaticConfiguration) []error {


### PR DESCRIPTION
Closes #15649

Validate system and default ApplicationDefinitions during `kubermatic-installer deploy` and fail with a clear error if any are invalid, instead of silently ignoring them in the controller-manager.