### PR TITLE
[release/v2.28] update app catalog to include the new nvidia gpu operator

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
@@ -48,6 +48,16 @@ spec:
             chartVersion: v25.3.0
             url: oci://quay.io/kubermatic-mirror/helm-charts
       version: v25.3.0
+    - template:
+        source:
+          helm:
+            chartName: nvidia/gpu-operator
+            chartVersion: v26.3.0
+            url: oci://quay.io/kubermatic-mirror/helm-charts
+      version: v26.3.0
+  defaultDeployOptions:
+    helm:
+      wait: true
   defaultValuesBlock: |
     node-feature-discovery:
       fullnameOverride: gpu-operator-node-feature-discovery


### PR DESCRIPTION
This is a manual cherry-pick of #15739

/assign buraksekili

```release-note
Update gpu-operator application to v26.3.0
```