### PR TITLE
Use kkp-e2e-ubuntu-24.04 source VM for vSphere CI

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -111,7 +111,7 @@ spec:
           templates:
             flatcar: kkp-flatcar-3033.2.2
             rhel: kkp-rhel-8.6
-            ubuntu: kubeone-ubuntu-22.04-template
+            ubuntu: kkp-ubuntu-noble-amd64
             rockylinux: kkp-rockylinux-8
     azure-westeurope:
       location: "Azure West europe"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -111,7 +111,7 @@ spec:
           templates:
             flatcar: kkp-flatcar-3033.2.2
             rhel: kkp-rhel-8.6
-            ubuntu: kkp-ubuntu-24.04
+            ubuntu: kubeone-ubuntu-22.04-template
             rockylinux: kkp-rockylinux-8
     azure-westeurope:
       location: "Azure West europe"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -111,7 +111,7 @@ spec:
           templates:
             flatcar: kkp-flatcar-3033.2.2
             rhel: kkp-rhel-8.6
-            ubuntu: kkp-ubuntu-24.04-old
+            ubuntu: kkp-e2e-ubuntu-24.04
             rockylinux: kkp-rockylinux-8
     azure-westeurope:
       location: "Azure West europe"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -111,7 +111,7 @@ spec:
           templates:
             flatcar: kkp-flatcar-3033.2.2
             rhel: kkp-rhel-8.6
-            ubuntu: kkp-ubuntu-noble-amd64
+            ubuntu: kkp-ubuntu-24.04-old
             rockylinux: kkp-rockylinux-8
     azure-westeurope:
       location: "Azure West europe"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the vSphere CI seed test data to use `kkp-e2e-ubuntu-24.04` for Ubuntu-based vSphere scenarios.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
