### PR TITLE
[release/v2.30] Set Cilium v1.18.6 and Canal v3.31 as default version

### DIFF
--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -28,8 +28,8 @@ import (
 
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
-		kubermaticv1.CNIPluginTypeCanal:  "v3.30",
-		kubermaticv1.CNIPluginTypeCilium: "1.18.2",
+		kubermaticv1.CNIPluginTypeCanal:  "v3.31",
+		kubermaticv1.CNIPluginTypeCilium: "1.18.6",
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to set the default cilium version to v1.18.6 and canal version to v3.31 during the user cluster provisioning. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set Cilium v1.18.6 as the default Cilium CNI version
Set Canal v3.31 as the default Canal CNI version
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
