### PR TITLE
Add disabledAuditWebhookBackendDCs option to KubermaticSetting

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -179,6 +179,13 @@ spec:
                 disableChangelogPopup:
                   description: DisableChangelogPopup disables the changelog popup in KKP dashboard.
                   type: boolean
+                disabledAuditWebhookBackendDCs:
+                  description: |-
+                    DisabledAuditWebhookBackendDCs is the list of datacenters for which the Audit Webhook Backend
+                    option is disabled in the dashboard.
+                  items:
+                    type: string
+                  type: array
                 displayAPIDocs:
                   description: DisplayDemoInfo controls whether a a link to the KKP API documentation is shown in the footer.
                   type: boolean

--- a/sdk/apis/kubermatic/v1/settings.go
+++ b/sdk/apis/kubermatic/v1/settings.go
@@ -87,6 +87,10 @@ type SettingSpec struct {
 	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
 	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
 
+	// DisabledAuditWebhookBackendDCs is the list of datacenters for which the Audit Webhook Backend
+	// option is disabled in the dashboard.
+	DisabledAuditWebhookBackendDCs []string `json:"disabledAuditWebhookBackendDCs,omitempty"`
+
 	// UserProjectsLimit is the maximum number of projects a user can create.
 	UserProjectsLimit           int64 `json:"userProjectsLimit"`
 	RestrictProjectCreation     bool  `json:"restrictProjectCreation"`

--- a/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -7779,6 +7779,11 @@ func (in *SettingSpec) DeepCopyInto(out *SettingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisabledAuditWebhookBackendDCs != nil {
+		in, out := &in.DisabledAuditWebhookBackendDCs, &out.DisabledAuditWebhookBackendDCs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.CleanupOptions = in.CleanupOptions
 	out.OpaOptions = in.OpaOptions
 	out.MlaOptions = in.MlaOptions


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `disabledAuditWebhookBackendDCs` option to the `KubermaticSetting` (global settings) CRD. It holds a list of datacenters for which the "Audit Webhook Backend" option should be disabled in the dashboard, so users in those DCs aren't shown an option they can't configure.

**Which issue(s) this PR fixes**:
Ref #14862

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `disabledAuditWebhookBackendDCs` setting to disable the Audit Webhook Backend option in the dashboard for specific datacenters.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
