### PR TITLE
webhook: reject duplicate GroupProjectBinding for the same group and project

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -233,7 +233,7 @@ func main() {
 	// /////////////////////////////////////////
 	// setup GroupProjectBinding webhook
 
-	groupProjectBindingValidator := groupprojectbinding.NewValidator()
+	groupProjectBindingValidator := groupprojectbinding.NewValidator(mgr.GetClient())
 	if err := builder.WebhookManagedBy(mgr, &kubermaticv1.GroupProjectBinding{}).WithValidator(groupProjectBindingValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup GroupProjectBinding validation webhook", zap.Error(err))
 	}

--- a/pkg/ee/validation/groupprojectbinding/groupprojectbinding.go
+++ b/pkg/ee/validation/groupprojectbinding/groupprojectbinding.go
@@ -25,10 +25,29 @@
 package groupprojectbinding
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func ValidateCreate(ctx context.Context, binding *kubermaticv1.GroupProjectBinding, client ctrlruntimeclient.Client) error {
+	existingBindings := &kubermaticv1.GroupProjectBindingList{}
+	if err := client.List(ctx, existingBindings); err != nil {
+		return fmt.Errorf("failed to list GroupProjectBindings: %w", err)
+	}
+
+	for _, existing := range existingBindings.Items {
+		if existing.Spec.Group == binding.Spec.Group && existing.Spec.ProjectID == binding.Spec.ProjectID {
+			return fmt.Errorf("group %q is already bound to project %q", binding.Spec.Group, binding.Spec.ProjectID)
+		}
+	}
+
+	return nil
+}
 
 func ValidateUpdate(oldGroupProjectBinding *kubermaticv1.GroupProjectBinding, newGroupProjectBinding *kubermaticv1.GroupProjectBinding) error {
 	if oldGroupProjectBinding.Spec.ProjectID != newGroupProjectBinding.Spec.ProjectID {

--- a/pkg/ee/validation/groupprojectbinding/groupprojectbinding_test.go
+++ b/pkg/ee/validation/groupprojectbinding/groupprojectbinding_test.go
@@ -25,6 +25,7 @@
 package groupprojectbinding_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -32,9 +33,80 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/ee/validation/groupprojectbinding"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestValidateCreate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		existingBinding *kubermaticv1.GroupProjectBinding
+		newBinding      *kubermaticv1.GroupProjectBinding
+		errExpected     bool
+	}{
+		{
+			name: "no existing binding, create succeeds",
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			errExpected: false,
+		},
+		{
+			name: "same group and project already bound, create fails",
+			existingBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "existing-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "editors"},
+			},
+			errExpected: true,
+		},
+		{
+			name: "same group different project, create succeeds",
+			existingBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "existing-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project2", Role: "viewers"},
+			},
+			errExpected: false,
+		},
+		{
+			name: "different group same project, create succeeds",
+			existingBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "existing-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group2", ProjectID: "project1", Role: "viewers"},
+			},
+			errExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []ctrlruntimeclient.Object
+			if tc.existingBinding != nil {
+				objs = append(objs, tc.existingBinding)
+			}
+			client := fake.NewClientBuilder().WithObjects(objs...).Build()
+
+			err := groupprojectbinding.ValidateCreate(context.Background(), tc.newBinding, client)
+			if (err != nil) != tc.errExpected {
+				t.Fatalf("expected error: %v, got: %v", tc.errExpected, err)
+			}
+		})
+	}
+}
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := []struct {

--- a/pkg/webhook/groupprojectbinding/validation/validation.go
+++ b/pkg/webhook/groupprojectbinding/validation/validation.go
@@ -21,22 +21,26 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // validator for validating GroupProjectBinding CRD.
 type validator struct {
+	client ctrlruntimeclient.Client
 }
 
 // NewValidator returns a new GroupProjectBinding validator.
-func NewValidator() *validator {
-	return &validator{}
+func NewValidator(client ctrlruntimeclient.Client) *validator {
+	return &validator{
+		client: client,
+	}
 }
 
 var _ admission.Validator[*kubermaticv1.GroupProjectBinding] = &validator{}
 
 func (v *validator) ValidateCreate(ctx context.Context, obj *kubermaticv1.GroupProjectBinding) (admission.Warnings, error) {
-	return nil, validateCreate(ctx, obj)
+	return nil, validateCreate(ctx, obj, v.client)
 }
 
 func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj *kubermaticv1.GroupProjectBinding) (admission.Warnings, error) {

--- a/pkg/webhook/groupprojectbinding/validation/wrappers_ce.go
+++ b/pkg/webhook/groupprojectbinding/validation/wrappers_ce.go
@@ -23,10 +23,13 @@ import (
 	"errors"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func validateCreate(_ context.Context,
 	_ *kubermaticv1.GroupProjectBinding,
+	_ ctrlruntimeclient.Client,
 ) error {
 	return errors.New("this resource is disabled for the Community Edition")
 }

--- a/pkg/webhook/groupprojectbinding/validation/wrappers_ee.go
+++ b/pkg/webhook/groupprojectbinding/validation/wrappers_ee.go
@@ -23,12 +23,15 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	eegroupprojectbindingvalidation "k8c.io/kubermatic/v2/pkg/ee/validation/groupprojectbinding"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateCreate(_ context.Context,
-	_ *kubermaticv1.GroupProjectBinding,
+func validateCreate(ctx context.Context,
+	obj *kubermaticv1.GroupProjectBinding,
+	client ctrlruntimeclient.Client,
 ) error {
-	return nil
+	return eegroupprojectbindingvalidation.ValidateCreate(ctx, obj, client)
 }
 
 func validateUpdate(_ context.Context,


### PR DESCRIPTION
**What this PR does / why we need it**:

The `GroupProjectBinding` admission webhook's `validateCreate` function was a no-op, allowing multiple bindings with the same group and `projectID` to be created. This PR adds a uniqueness check that rejects creation of a new `GroupProjectBinding` if one already exists for the same `group` and `projectID` combination, regardless of role.

**Which issue(s) this PR fixes**:
Fixes #15778

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

The uniqueness check is implemented in the EE validation layer (`pkg/ee/validation/groupprojectbinding`), following the same pattern used by `ResourceQuota` validation. The webhook struct now holds a `ctrlruntimeclient.Client` to list existing bindings at admission time. The CE wrapper is updated to match the new function signature (it still returns the CE-disabled error).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed a bug where multiple GroupProjectBindings with the same group and project could be created. The admission webhook now rejects duplicate bindings at creation time.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```