### PR TITLE
Pin Flatcar AMI in AWS dualstack e2e tests for 4593.2.0 regression

### DIFF
--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -34,6 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
+	awstypes "k8c.io/machine-controller/sdk/cloudprovider/aws"
 	"k8c.io/machine-controller/sdk/net"
 	"k8c.io/machine-controller/sdk/providerconfig"
 	"k8c.io/operating-system-manager/pkg/providerconfig/flatcar"
@@ -577,6 +578,20 @@ func TestNewClusters(t *testing.T) {
 					WithNetworkConfig(&providerconfig.NetworkConfig{
 						IPFamily: net.IPFamilyIPv4IPv6,
 					})
+
+				// pin Flatcar AMI on AWS to a pre-4593.2.0 build until OSM ships a fix.
+				// Flatcar Stable 4593.2.0 made /etc/environment a symlink to read-only
+				// /usr/lib/pam/environment, which makes the OSP bootstrap's `tee -a /etc/environment`
+				// fail and bootstrap.service loop forever.
+				if test.cloudProvider == kubermaticv1.AWSCloudProvider && osName == providerconfig.OperatingSystemFlatcar {
+					osMachineJig.WithCloudProviderSpecPatch(func(spec interface{}) interface{} {
+						awsSpec := spec.(awstypes.RawConfig)
+						awsSpec.AMI = providerconfig.ConfigVarString{Value: "ami-07a16a557a7b240e3"} // Flatcar 4459.2.4, eu-west-1
+						return awsSpec
+					})
+
+					osMachineJig.WithOSSpec(flatcar.Config{DisableAutoUpdate: true})
+				}
 
 				// no need to keep track of machine cleanups, as KKP will delete all machines in the
 				// cluster when the cluster itself is being deleted


### PR DESCRIPTION
**What this PR does / why we need it**:
Flatcar Stable 4593.2.0 changed `/etc/environment` from a regular file to a symlink pointing to read-only `/usr/lib/pam/environment`. The OSM Flatcar bootstrap script uses `tee -a /etc/environment`, which now fails with "Read-only file system" and causes `bootstrap.service` to retry forever. This prevents Flatcar nodes from joining in AWS dualstack e2e tests (`pre-kubermatic-dualstack-e2e-aws-cilium` and `pre-kubermatic-dualstack-e2e-aws-canal`).

This PR pins the Flatcar AMI to a known-good build (4459.2.4, `ami-07a16a557a7b240e3`, eu-west-1) and disables Flatcar auto-updates for AWS Flatcar test nodes only. Other cloud providers and operating systems are unaffected.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind regression
/kind failing-test

**Special notes for your reviewer**:
This is a temporary CI unblock/


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
