### PR TITLE
Remove the clusterrole and clusterrolebinding from KubeVirt provider

### DIFF
--- a/pkg/provider/cloud/kubevirt/csi.go
+++ b/pkg/provider/cloud/kubevirt/csi.go
@@ -96,44 +96,6 @@ func csiRoleReconciler(name string) reconciling.NamedRoleReconcilerFactory {
 	}
 }
 
-func csiClusterRoleReconciler(name string) reconciling.NamedClusterRoleReconcilerFactory {
-	return func() (string, reconciling.ClusterRoleReconciler) {
-		return name, func(r *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-			r.Rules = []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"persistentvolumes"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-			}
-
-			return r, nil
-		}
-	}
-}
-
-func csiClusterRoleBindingReconciler(name, namespace string) reconciling.NamedClusterRoleBindingReconcilerFactory {
-	return func() (string, reconciling.ClusterRoleBindingReconciler) {
-		return name, func(rb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
-			rb.Subjects = []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      name,
-					Namespace: namespace,
-				},
-			}
-
-			rb.RoleRef = rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "ClusterRole",
-				Name:     name,
-			}
-
-			return rb, nil
-		}
-	}
-}
-
 func csiRoleBindingReconciler(name, namespace string) reconciling.NamedRoleBindingReconcilerFactory {
 	return func() (string, reconciling.RoleBindingReconciler) {
 		return name, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
@@ -169,21 +131,6 @@ func reconcileCSIRoleRoleBinding(ctx context.Context, namespace string, client c
 		csiRoleBindingReconciler(resources.KubeVirtCSIServiceAccountName, namespace),
 	}
 	if err := reconciling.ReconcileRoleBindings(ctx, roleBindingReconcilers, namespace, client); err != nil {
-		return err
-	}
-
-	// ClusterRole and ClusterRoleBinding for cluster-scoped resources (persistentvolumes)
-	clusterRoleReconcilers := []reconciling.NamedClusterRoleReconcilerFactory{
-		csiClusterRoleReconciler(resources.KubeVirtCSIServiceAccountName),
-	}
-	if err := reconciling.ReconcileClusterRoles(ctx, clusterRoleReconcilers, "", client); err != nil {
-		return err
-	}
-
-	clusterRoleBindingReconcilers := []reconciling.NamedClusterRoleBindingReconcilerFactory{
-		csiClusterRoleBindingReconciler(resources.KubeVirtCSIServiceAccountName, namespace),
-	}
-	if err := reconciling.ReconcileClusterRoleBindings(ctx, clusterRoleBindingReconcilers, "", client); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In a previous patch release, we offloaded the functionality of creating cluster scoped RBAC resources to KKP. This has introduced a permission deadlock problem as KKP shouldn't have the permission to create cluster scoped resources such cluster role. 

 This PR removes this functionality and offload the  creation and exiting of cluster scope resources to the KubeV administrators, where they should take care of the creation and assignment of these resources. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove the creation of cluster scope resources from KubeVirt provider and offload that functionality to the platform admin. 
Needed permissions to be created in the cluster:
PersistentVolumes: "get", "list", "watch"  
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/2168
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
None
```
