### PR TITLE
Auto-mirror new charts and version bumps when mirror-application-charts.sh changes

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -262,3 +262,38 @@ presubmits:
             limits:
               memory: 4Gi
               cpu: 2
+
+  - name: pre-kubermatic-lint-mirror-application-charts
+    run_if_changed: "hack/mirror-application-charts.sh"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+          command:
+            - "./hack/ci/lint-mirror-application-charts.sh"
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 256Mi
+
+postsubmits:
+  - name: post-kubermatic-mirror-new-application-charts
+    run_if_changed: "hack/mirror-application-charts.sh"
+    branches:
+      - ^main$
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vault: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+          command:
+            - "./hack/ci/mirror-new-application-charts.sh"
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 200m

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -49,6 +49,34 @@ tweaked by setting a number of environment variables, most importantly:
 Whenever this is changed, run the optional `pre-kubermatic-simulate-github-release`
 job to (mostly) ensure that the changes will work.
 
+## lint-mirror-application-charts.sh
+
+Lints hack/mirror-application-charts.sh by sourcing it and asserting
+CHART_URLS and CHART_VERSIONS have identical key sets.
+
+Catches the most common contributor mistake: adding a chart to one
+array but forgetting the other. Also serves as a smoke test that
+mirror-application-charts.sh remains sourceable (which the post-submit
+detection wrapper relies on).
+
+## mirror-new-application-charts.sh
+
+Detects newly added charts and version bumps in hack/mirror-application-charts.sh
+and mirrors them to the OCI registry.
+
+Runs as a Prow post-submit job when mirror-application-charts.sh changes.
+Detects two types of changes:
+  1. New chart entries added to CHART_URLS / CHART_VERSIONS
+  2. Version bumps in CHART_VERSIONS for existing charts
+Then calls mirror-application-charts.sh for each affected chart.
+
+Detection works by sourcing the current and previous (HEAD~1) versions of
+mirror-application-charts.sh in a subshell. This relies only on the file
+being valid bash with the two associative arrays - no formatting assumptions.
+
+Environment variables:
+* `DRY_RUN=true` - skip actual mirroring, only print charts that would be mirrored
+
 ## release-images.sh
 
 This script compiles the KKP binaries and then builds and pushes all
@@ -57,19 +85,36 @@ useful as part of another script to setup KKP for testing.
 
 ## run-addons-integration-test.sh
 
-Tests addon upgrade compatibility by verifying that addons can be successfully upgraded across versions.
+TBD
+
+## run-appcatalog-manager-e2e-tests.sh
+
+This script sets up a local KKP installation in kind and runs the
+Application Catalog Manager E2E tests.
+
+## run-application-definitions-e2e-test.sh
+
+This script is used as a postsubmit job and updates the dev master
+cluster after every commit to main.
+
+## run-argocd-e2e-tests.sh
+
+This script sets a multi-seed Kubermatic installation in AWS, deploys various applications on it via ArgoCD
+and then runs validation e2e tests using chainsaw
 
 ## run-canal-e2e-test.sh
 
-Runs Canal CNI e2e tests, verifying Canal networking and kube-proxy proxy mode handling.
+This script runs Canal CNI e2e tests, verifying Canal networking
+and kube-proxy proxy mode handling.
 
 ## run-cilium-e2e-test.sh
 
-Runs Cilium CNI e2e tests, verifying Cilium networking, eBPF proxy mode, and Hubble observability.
+This script is used as a postsubmit job and updates the dev master
+cluster after every commit to main.
 
 ## run-cluster-backup-e2e-tests.sh
 
-Runs cluster backup e2e tests, verifying Velero-based backup and restore functionality.
+TBD
 
 ## run-conformance-tests.sh
 
@@ -78,8 +123,7 @@ used to run the conformance-tester for a given cloud provider.
 
 ## run-default-application-e2e-test.sh
 
-This script is used as a postsubmit job and updates the dev master
-cluster after every commit to main.
+TBD
 
 ## run-dualstack-e2e-test.sh
 
@@ -99,6 +143,15 @@ TBD
 
 This script sets up a local KKP installation in kind, deploys a
 couple of test Presets and Users and then runs the etcd-launcher tests.
+
+## run-gateway-api-e2e-tests.sh
+
+This script sets up a local KKP installation in kind with Gateway API enabled
+from the start (fresh install) and runs the Gateway API e2e tests.
+
+## run-gateway-api-migration-e2e.sh
+
+This script tests the migration from nginx-ingress-controller to Gateway API.
 
 ## run-ipam-e2e-tests.sh
 
@@ -210,14 +263,14 @@ Go cache again.
 This that when we're in a PR targeting a release branch, the minimum
 Go version used to build KKP is not bumped to a different minor version.
 
+## verify-user-cluster-prometheus-configs.sh
+
+This ensures that the Prometheus rules deployed into userclusters
+are valid Prometheus rules.
+
 ## verify.sh
 
 This script is used as a presubmit to check that Helm chart versions
 have been updated if charts have been modified. Without the Prow env
 vars, this script won't run properly.
-
-## verify-user-cluster-prometheus-configs.sh
-
-This ensures that the Prometheus rules deployed into userclusters
-are valid Prometheus rules.
 

--- a/hack/ci/lint-mirror-application-charts.sh
+++ b/hack/ci/lint-mirror-application-charts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Lints hack/mirror-application-charts.sh by sourcing it and asserting
+### CHART_URLS and CHART_VERSIONS have identical key sets.
+###
+### Catches the most common contributor mistake: adding a chart to one
+### array but forgetting the other. Also serves as a smoke test that
+### mirror-application-charts.sh remains sourceable (which the post-submit
+### detection wrapper relies on).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+SCRIPT="hack/mirror-application-charts.sh"
+
+# strip main "$@" so sourcing only loads arrays/functions without side effects.
+# this handles both the old bare call and the new sourcing guard.
+stripped=$(mktemp)
+trap 'rm -f "$stripped"' EXIT
+sed '/^main "\$@"$/d' "$SCRIPT" > "$stripped"
+
+# source in a subshell to keep our env clean, then print sorted key lists
+# from both arrays. awk compares the two key sets and prints mismatches.
+mismatch=$(
+  (
+    # shellcheck disable=SC1090
+    source "$stripped" >/dev/null 2>&1
+    {
+      printf 'urls\n'
+      for k in "${!CHART_URLS[@]}"; do printf '%s\n' "$k"; done | sort
+      printf 'versions\n'
+      for k in "${!CHART_VERSIONS[@]}"; do printf '%s\n' "$k"; done | sort
+    }
+  ) | awk '
+    /^urls$/     { mode="urls"; next }
+    /^versions$/ { mode="versions"; next }
+    mode=="urls"     { urls[$0]=1 }
+    mode=="versions" { versions[$0]=1 }
+    END {
+      for (k in urls)     if (!(k in versions)) print "missing in CHART_VERSIONS: " k
+      for (k in versions) if (!(k in urls))     print "missing in CHART_URLS: "    k
+    }
+  '
+)
+
+if [[ -n "$mismatch" ]]; then
+  echo "FAIL: ${SCRIPT} has inconsistent CHART_URLS / CHART_VERSIONS keys:"
+  echo "$mismatch" | sed 's/^/  /'
+  echo
+  echo "Both arrays must contain the same set of chart names."
+  exit 1
+fi
+
+count=$(
+  (
+    # shellcheck disable=SC1090
+    source "$stripped" >/dev/null 2>&1
+    echo "${#CHART_URLS[@]}"
+  )
+)
+echo "OK: ${SCRIPT}: ${count} charts, CHART_URLS and CHART_VERSIONS keys match."

--- a/hack/ci/lint-mirror-application-charts.sh
+++ b/hack/ci/lint-mirror-application-charts.sh
@@ -39,7 +39,7 @@ sed '/^main "\$@"$/d' "$SCRIPT" > "$stripped"
 mismatch=$(
   (
     # shellcheck disable=SC1090
-    source "$stripped" >/dev/null 2>&1
+    source "$stripped" > /dev/null 2>&1
     {
       printf 'urls\n'
       for k in "${!CHART_URLS[@]}"; do printf '%s\n' "$k"; done | sort
@@ -69,7 +69,7 @@ fi
 count=$(
   (
     # shellcheck disable=SC1090
-    source "$stripped" >/dev/null 2>&1
+    source "$stripped" > /dev/null 2>&1
     echo "${#CHART_URLS[@]}"
   )
 )

--- a/hack/ci/mirror-new-application-charts.sh
+++ b/hack/ci/mirror-new-application-charts.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Detects newly added charts and version bumps in hack/mirror-application-charts.sh
+### and mirrors them to the OCI registry.
+###
+### Runs as a Prow post-submit job when mirror-application-charts.sh changes.
+### Detects two types of changes:
+###   1. New chart entries added to CHART_URLS / CHART_VERSIONS
+###   2. Version bumps in CHART_VERSIONS for existing charts
+### Then calls mirror-application-charts.sh for each affected chart.
+###
+### Detection works by sourcing the current and previous (HEAD~1) versions of
+### mirror-application-charts.sh in a subshell. This relies only on the file
+### being valid bash with the two associative arrays - no formatting assumptions.
+###
+### Environment variables:
+### * `DRY_RUN=true` - skip actual mirroring, only print charts that would be mirrored
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
+
+SCRIPT_PATH="hack/mirror-application-charts.sh"
+DRY_RUN="${DRY_RUN:-false}"
+
+# temp file holding HEAD~1's version of the mirror script. declared at file
+# scope (not inside main) so the EXIT trap can resolve $OLD_SCRIPT at trigger
+# time -- if this were `local` inside main, the variable would be out of scope
+# by the time the trap fires and the temp file would leak.
+OLD_SCRIPT=$(mktemp)
+trap 'rm -f "$OLD_SCRIPT"' EXIT
+
+# sources the given script file in a subshell and prints sorted "name=version"
+# lines from its CHART_VERSIONS array. the subshell isolates the source from
+# our environment so set -u, traps, and any other side effects don't leak.
+# returns empty output (exit 0) if the file is missing, unreadable, or doesn't
+# define CHART_VERSIONS (e.g. truncated HEAD~1, totally unrelated file).
+read_chart_versions_from() {
+  local script_file="$1"
+  [[ -f "$script_file" ]] || return 0
+
+  (
+    # shellcheck disable=SC1090
+    source "$script_file" >/dev/null 2>&1 || exit 0
+    # guard against the sourced file not defining CHART_VERSIONS. without
+    # this, set -u would cause "${!CHART_VERSIONS[@]}" to abort the subshell
+    # and we'd silently lose pairs we should have read.
+    [[ "$(declare -p CHART_VERSIONS 2>/dev/null)" == "declare -A"* ]] || exit 0
+    for key in "${!CHART_VERSIONS[@]}"; do
+      printf '%s=%s\n' "$key" "${CHART_VERSIONS[$key]}"
+    done
+  ) | sort
+}
+
+# --- Main ----------------------------------------------------------------------
+main() {
+  echodate "Detecting changes in ${SCRIPT_PATH}..."
+
+  # write HEAD~1's version of the script (with the bare main "$@" stripped, in
+  # case HEAD~1 predates the sourcing guard) so read_chart_versions_from can
+  # source it. source(1) reads from a file path, not stdin.
+  if ! git show "HEAD~1:${SCRIPT_PATH}" 2>/dev/null | sed '/^main "\$@"$/d' > "$OLD_SCRIPT"; then
+    # no HEAD~1 (e.g. shallow clone, first commit) -- treat old as empty, which
+    # means every current chart shows up as "added". the chart_exists_in_registry
+    # check in the inner script makes that idempotent.
+    : > "$OLD_SCRIPT"
+  fi
+
+  local old_pairs new_pairs
+  old_pairs=$(read_chart_versions_from "$OLD_SCRIPT")
+  new_pairs=$(read_chart_versions_from "$SCRIPT_PATH")
+
+  # any "name=version" line in new but not old is either a newly added chart
+  # OR a version bump on an existing chart. both should trigger a mirror.
+  local changed_pairs
+  changed_pairs=$(comm -13 <(echo "$old_pairs") <(echo "$new_pairs"))
+
+  if [[ -z "$changed_pairs" ]]; then
+    echodate "No new charts or version changes detected."
+    return 0
+  fi
+
+  # extract just the chart names for the loop. the inner script reads the
+  # version from CHART_VERSIONS itself when no version arg is passed, so we
+  # don't need to forward the version explicitly.
+  local charts_to_mirror
+  charts_to_mirror=$(echo "$changed_pairs" | cut -d= -f1 | sort -u)
+
+  echodate "Charts to mirror:"
+  echo "$changed_pairs" | sed 's/^/  - /'
+
+  local chart version
+  while IFS= read -r chart; do
+    version=$(echo "$new_pairs" | grep "^${chart}=" | cut -d= -f2)
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echodate "[DRY-RUN] Would mirror: ${chart} @ ${version}"
+    else
+      echodate "Mirroring: ${chart} @ ${version}"
+      ./"${SCRIPT_PATH}" "${chart}"
+    fi
+  done <<< "$charts_to_mirror"
+
+  echodate "Done."
+}
+
+main "$@"

--- a/hack/ci/mirror-new-application-charts.sh
+++ b/hack/ci/mirror-new-application-charts.sh
@@ -56,11 +56,11 @@ read_chart_versions_from() {
 
   (
     # shellcheck disable=SC1090
-    source "$script_file" >/dev/null 2>&1 || exit 0
+    source "$script_file" > /dev/null 2>&1 || exit 0
     # guard against the sourced file not defining CHART_VERSIONS. without
     # this, set -u would cause "${!CHART_VERSIONS[@]}" to abort the subshell
     # and we'd silently lose pairs we should have read.
-    [[ "$(declare -p CHART_VERSIONS 2>/dev/null)" == "declare -A"* ]] || exit 0
+    [[ "$(declare -p CHART_VERSIONS 2> /dev/null)" == "declare -A"* ]] || exit 0
     for key in "${!CHART_VERSIONS[@]}"; do
       printf '%s=%s\n' "$key" "${CHART_VERSIONS[$key]}"
     done
@@ -74,7 +74,7 @@ main() {
   # write HEAD~1's version of the script (with the bare main "$@" stripped, in
   # case HEAD~1 predates the sourcing guard) so read_chart_versions_from can
   # source it. source(1) reads from a file path, not stdin.
-  if ! git show "HEAD~1:${SCRIPT_PATH}" 2>/dev/null | sed '/^main "\$@"$/d' > "$OLD_SCRIPT"; then
+  if ! git show "HEAD~1:${SCRIPT_PATH}" 2> /dev/null | sed '/^main "\$@"$/d' > "$OLD_SCRIPT"; then
     # no HEAD~1 (e.g. shallow clone, first commit) -- treat old as empty, which
     # means every current chart shows up as "added". the chart_exists_in_registry
     # check in the inner script makes that idempotent.

--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -63,7 +63,7 @@ declare -A CHART_VERSIONS=(
   ["flux2"]="2.15.0"
   ["k8sgpt-operator"]="0.2.17"
   ["kube-vip"]="0.6.6"
-  ["metallb"]="0.14.9"
+  ["metallb"]="0.15.3"
   ["ingress-nginx"]="4.14.3"
   ["gpu-operator"]="v25.3.0"
   ["trivy"]="0.14.1"
@@ -193,4 +193,10 @@ main() {
 
 }
 
-main "$@"
+# only run main when this script is executed directly. when sourced
+# (e.g. by hack/ci/mirror-new-application-charts.sh to read CHART_URLS
+# and CHART_VERSIONS), skip main so the caller can inspect the arrays
+# without triggering registry login or mirroring.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Prow postsubmit that automatically mirrors new charts and version bumps to the OCI registry when `hack/mirror-application-charts.sh` changes. Detection works by sourcing the current and previous (HEAD~1) versions of the script in a subshell, reading `CHART_VERSIONS` via the bash interpreter rather than text parsing - so it's immune to formatting changes. Also adds a presubmit lint that asserts `CHART_URLS` and `CHART_VERSIONS` have matching keys, and restricts the postsubmit to the `main` branch only.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

- Wrapper DRY_RUN: `docker run --rm -v $(pwd):/go/src/k8c.io/kubermatic -w /go/src/k8c.io/kubermatic quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8 bash -c 'DRY_RUN=true ./hack/ci/mirror-new-application-charts.sh'`


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
