### PR TITLE
fix: prevent ApplicationInstallation from getting permanently stuck

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -70,6 +70,17 @@ const (
 
 	// initialRequeueDuration is the time interval which is used until a node object to schedule workloads is registered in the cluster.
 	initialRequeueDuration = 10 * time.Second
+
+	// transientErrorMessage is the error message returned by Helm when another operation is in progress.
+	// This is a transient error that should not count toward the failure limit.
+	transientErrorMessage = "another operation (install/upgrade/rollback) is in progress"
+
+	// transientErrorRequeueDuration is the duration to wait before retrying when a transient error occurs.
+	transientErrorRequeueDuration = 30 * time.Second
+
+	// failureResetDuration is the duration after which the failure counter is reset if no new failures occur.
+	// This allows the application to recover from transient issues after a cooldown period.
+	failureResetDuration = 1 * time.Hour
 )
 
 type reconciler struct {
@@ -149,6 +160,22 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, log, appInstallation)
 	if err != nil {
+		// Check if this is a transient error (e.g., "another operation in progress")
+		// For transient errors, we don't want to trigger the default exponential backoff
+		// which can exhaust retries too quickly. Instead, we requeue with a longer delay.
+		if isTransientError(err) {
+			log.Infow("Transient error detected, requeuing with longer delay",
+				"error", err.Error(),
+				"requeueAfter", transientErrorRequeueDuration)
+			// Update the condition to reflect the transient error, but don't increment failures
+			oldAppInstallation := appInstallation.DeepCopy()
+			appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, "TransientError", err.Error())
+			if patchErr := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); patchErr != nil {
+				log.Errorw("Failed to update status for transient error", "error", patchErr)
+			}
+			return reconcile.Result{RequeueAfter: transientErrorRequeueDuration}, nil
+		}
+
 		r.userRecorder.Eventf(appInstallation, nil, corev1.EventTypeWarning, applicationInstallationReconcileFailedEvent, "Reconciling", err.Error())
 		return reconcile.Result{}, err
 	}
@@ -163,6 +190,8 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, appI
 		if err := r.handleDeletion(ctx, log, appInstallation); err != nil {
 			return fmt.Errorf("handling deletion of application installation: %w", err)
 		}
+		// Clean up metrics when the application is deleted
+		deleteMetrics(appInstallation.Namespace, appInstallation.Name, appInstallation.Spec.ApplicationRef.Name)
 		return nil
 	}
 
@@ -273,20 +302,15 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return err
 	}
 
-	// Install or upgrade application only if max number of retries is not exceeded.
-	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
-		oldAppInstallation := appInstallation.DeepCopy()
-		appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, "InstallationFailedRetriesExceeded", "Max number of retries was exceeded. Last error: "+oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message)
-
-		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
-			return fmt.Errorf("failed to update status: %w", err)
-		}
-		log.Infow("Max number of retries was exceeded. Do not reconcile application", "failures", appInstallation.Status.Failures, "maxRetries", maxRetries)
-		return nil
+	// Reset failures if enough time has passed since the last failure (time-based recovery).
+	// This allows the application to recover from transient issues after a cooldown period.
+	if err := r.resetFailuresIfCooldownPassed(ctx, log, appInstallation); err != nil {
+		return err
 	}
 
+	// Check if the release is stuck BEFORE checking maxRetries.
+	// This ensures we can recover stuck releases even after hitting the retry limit.
 	// Because some upstream tools are not completely idempotent, we need a check to make sure a release is not stuck.
-	// This should be run before we make any changes to the status field, so we can use it in our analysis
 	stuck, err := r.appInstaller.IsStuck(ctx, log, r.seedClient, r.userClient, appInstallation)
 	if err != nil {
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
@@ -297,6 +321,26 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 			return fmt.Errorf("failed to rollback release: %w", err)
 		}
 		log.Infof("Release for ApplicationInstallation has been rolled back successfully")
+
+		// Reset failures after successful rollback to give the application another chance
+		oldAppInstallation := appInstallation.DeepCopy()
+		appInstallation.Status.Failures = 0
+		appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionUnknown, "RollbackSuccessful", "Release was stuck and has been rolled back, retrying installation")
+		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+			return fmt.Errorf("failed to update status after rollback: %w", err)
+		}
+	}
+
+	// Install or upgrade application only if max number of retries is not exceeded.
+	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
+		oldAppInstallation := appInstallation.DeepCopy()
+		appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, "InstallationFailedRetriesExceeded", "Max number of retries was exceeded. Last error: "+oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message)
+
+		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+			return fmt.Errorf("failed to update status: %w", err)
+		}
+		log.Infow("Max number of retries was exceeded. Do not reconcile application", "failures", appInstallation.Status.Failures, "maxRetries", maxRetries)
+		return nil
 	}
 
 	downloadDest, err := os.MkdirTemp(r.appInstaller.GetAppCache(), appInstallation.Namespace+"-"+appInstallation.Name)
@@ -337,7 +381,45 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to update status: %w", err)
 	}
 
+	// Update Prometheus metrics
+	r.updateApplicationMetrics(appInstallation, appDefinition)
+
 	return installErr
+}
+
+// updateApplicationMetrics updates the Prometheus metrics for an ApplicationInstallation.
+func (r *reconciler) updateApplicationMetrics(appInstallation *appskubermaticv1.ApplicationInstallation, appDefinition *appskubermaticv1.ApplicationDefinition) {
+	readyCondition, exists := appInstallation.Status.Conditions[appskubermaticv1.Ready]
+
+	// Determine ready status: 1=ready, 0=not ready, -1=unknown
+	readyStatus := -1
+	if exists {
+		switch readyCondition.Status {
+		case corev1.ConditionTrue:
+			readyStatus = 1
+		case corev1.ConditionFalse:
+			readyStatus = 0
+		}
+	}
+
+	// Determine if the application is stuck (failures > maxRetries and has limited retries)
+	isStuck := appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation)
+
+	// Get last success timestamp (when Ready condition became True)
+	var lastSuccessTime float64
+	if exists && readyCondition.Status == corev1.ConditionTrue && !readyCondition.LastTransitionTime.IsZero() {
+		lastSuccessTime = float64(readyCondition.LastTransitionTime.Unix())
+	}
+
+	updateMetrics(
+		appInstallation.Namespace,
+		appInstallation.Name,
+		appInstallation.Spec.ApplicationRef.Name,
+		appInstallation.Status.Failures,
+		isStuck,
+		readyStatus,
+		lastSuccessTime,
+	)
 }
 
 func hasLimitedRetries(appDefinition *appskubermaticv1.ApplicationDefinition, appInstallation *appskubermaticv1.ApplicationInstallation) bool {
@@ -364,6 +446,57 @@ func (r reconciler) resetFailuresIfSpecHasChanged(ctx context.Context, appInstal
 		}
 	}
 	return nil
+}
+
+// resetFailuresIfCooldownPassed resets the failure counter if enough time has passed since the last failure.
+// This allows the application to recover from transient issues after a cooldown period.
+// We use the LastHeartbeatTime of the Ready condition as a proxy for the last failure time.
+func (r reconciler) resetFailuresIfCooldownPassed(ctx context.Context, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+	// Only reset if there are failures to reset
+	if appInstallation.Status.Failures == 0 {
+		return nil
+	}
+
+	// Check if the Ready condition exists and has a LastHeartbeatTime
+	readyCondition, exists := appInstallation.Status.Conditions[appskubermaticv1.Ready]
+	if !exists || readyCondition.LastHeartbeatTime.IsZero() {
+		return nil
+	}
+
+	// Only reset if the condition indicates a failure (not successful)
+	if readyCondition.Status == corev1.ConditionTrue {
+		return nil
+	}
+
+	// Check if enough time has passed since the last failure
+	timeSinceLastFailure := time.Since(readyCondition.LastHeartbeatTime.Time)
+	if timeSinceLastFailure < failureResetDuration {
+		return nil
+	}
+
+	log.Infow("Resetting failure counter after cooldown period",
+		"failures", appInstallation.Status.Failures,
+		"timeSinceLastFailure", timeSinceLastFailure,
+		"cooldownDuration", failureResetDuration)
+
+	oldAppInstallation := appInstallation.DeepCopy()
+	appInstallation.Status.Failures = 0
+	appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionUnknown, "CooldownReset", "Failure counter reset after cooldown period, retrying installation")
+
+	if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+		return fmt.Errorf("failed to update status after cooldown reset: %w", err)
+	}
+
+	return nil
+}
+
+// isTransientError checks if the error is a transient error that should not count toward the failure limit.
+// Transient errors are temporary conditions that are expected to resolve on their own.
+func isTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), transientErrorMessage)
 }
 
 // handleDeletion uninstalls the application in the user cluster.

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -587,3 +587,169 @@ func TestSyncReconciliationInterval(t *testing.T) {
 		})
 	}
 }
+
+func TestIsTransientError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error is not transient",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "another operation in progress is transient",
+			err:      errors.New("another operation (install/upgrade/rollback) is in progress"),
+			expected: true,
+		},
+		{
+			name:     "wrapped transient error is detected",
+			err:      fmt.Errorf("handling installation: %w", errors.New("another operation (install/upgrade/rollback) is in progress")),
+			expected: true,
+		},
+		{
+			name:     "regular error is not transient",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "timeout error is not transient",
+			err:      errors.New("context deadline exceeded"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isTransientError(tc.err)
+			if result != tc.expected {
+				t.Errorf("isTransientError(%v) = %v, expected %v", tc.err, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestResetFailuresIfCooldownPassed(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		applicationInstallation *appskubermaticv1.ApplicationInstallation
+		expectedFailures        int
+		expectReset             bool
+	}{
+		{
+			name: "no failures to reset",
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Status.Failures = 0
+				return appInstall
+			}(),
+			expectedFailures: 0,
+			expectReset:      false,
+		},
+		{
+			name: "failures exist but no Ready condition",
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Status.Failures = 3
+				appInstall.Status.Conditions = nil
+				return appInstall
+			}(),
+			expectedFailures: 3,
+			expectReset:      false,
+		},
+		{
+			name: "failures exist but Ready condition is True (success)",
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Status.Failures = 3
+				appInstall.Status.Conditions = map[appskubermaticv1.ApplicationInstallationConditionType]appskubermaticv1.ApplicationInstallationCondition{
+					appskubermaticv1.Ready: {
+						Status:            corev1.ConditionTrue,
+						LastHeartbeatTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+					},
+				}
+				return appInstall
+			}(),
+			expectedFailures: 3,
+			expectReset:      false,
+		},
+		{
+			name: "failures exist, Ready is False, but cooldown not passed",
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Status.Failures = 3
+				appInstall.Status.Conditions = map[appskubermaticv1.ApplicationInstallationConditionType]appskubermaticv1.ApplicationInstallationCondition{
+					appskubermaticv1.Ready: {
+						Status:            corev1.ConditionFalse,
+						LastHeartbeatTime: metav1.NewTime(time.Now().Add(-30 * time.Minute)), // Only 30 minutes ago
+					},
+				}
+				return appInstall
+			}(),
+			expectedFailures: 3,
+			expectReset:      false,
+		},
+		{
+			name: "failures exist, Ready is False, cooldown passed - should reset",
+			applicationInstallation: func() *appskubermaticv1.ApplicationInstallation {
+				appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 0)
+				appInstall.Status.Failures = 6
+				appInstall.Status.Conditions = map[appskubermaticv1.ApplicationInstallationConditionType]appskubermaticv1.ApplicationInstallationCondition{
+					appskubermaticv1.Ready: {
+						Status:            corev1.ConditionFalse,
+						LastHeartbeatTime: metav1.NewTime(time.Now().Add(-2 * time.Hour)), // 2 hours ago, exceeds 1 hour cooldown
+					},
+				}
+				return appInstall
+			}(),
+			expectedFailures: 0,
+			expectReset:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+			userClient := kubermaticfake.
+				NewClientBuilder().
+				WithObjects(tc.applicationInstallation).
+				WithStatusSubresource(tc.applicationInstallation).
+				Build()
+
+			r := reconciler{
+				log:        kubermaticlog.Logger,
+				seedClient: userClient,
+				userClient: userClient,
+			}
+
+			err := r.resetFailuresIfCooldownPassed(ctx, kubermaticlog.Logger, tc.applicationInstallation)
+			if err != nil {
+				t.Fatalf("resetFailuresIfCooldownPassed returned error: %v", err)
+			}
+
+			// Fetch the updated application installation
+			updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+			if err := userClient.Get(ctx, types.NamespacedName{Name: tc.applicationInstallation.Name, Namespace: tc.applicationInstallation.Namespace}, updatedAppInstall); err != nil {
+				t.Fatalf("failed to get application installation: %v", err)
+			}
+
+			if updatedAppInstall.Status.Failures != tc.expectedFailures {
+				t.Errorf("expected failures %d, got %d", tc.expectedFailures, updatedAppInstall.Status.Failures)
+			}
+
+			if tc.expectReset {
+				// Check that the condition was updated
+				readyCondition, exists := updatedAppInstall.Status.Conditions[appskubermaticv1.Ready]
+				if !exists {
+					t.Error("expected Ready condition to exist after reset")
+				} else if readyCondition.Reason != "CooldownReset" {
+					t.Errorf("expected Ready condition reason to be 'CooldownReset', got '%s'", readyCondition.Reason)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricsNamespace = "kkp"
+	metricsSubsystem = "application_installation"
+)
+
+var (
+	// applicationInstallationFailures tracks the number of failures for each ApplicationInstallation.
+	// This metric can be used to alert when an application is approaching or has exceeded the retry limit.
+	applicationInstallationFailures = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "failures",
+			Help:      "Number of installation/upgrade failures for an ApplicationInstallation",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+
+	// applicationInstallationStuck indicates whether an ApplicationInstallation is stuck (1) or not (0).
+	// An application is considered stuck when it has exceeded the maximum retry limit.
+	applicationInstallationStuck = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "stuck",
+			Help:      "Whether an ApplicationInstallation is stuck (1=stuck, 0=ok). An application is stuck when it has exceeded the maximum retry limit.",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+
+	// applicationInstallationReady indicates the ready status of an ApplicationInstallation.
+	// Values: 1 = ready (successfully installed), 0 = not ready (failed or in progress), -1 = unknown.
+	applicationInstallationReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "ready",
+			Help:      "Ready status of an ApplicationInstallation (1=ready, 0=not ready, -1=unknown)",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+
+	// applicationInstallationLastSuccessTimestamp records the timestamp of the last successful installation/upgrade.
+	applicationInstallationLastSuccessTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "last_success_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful installation/upgrade",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+)
+
+func init() {
+	// Register metrics with the controller-runtime metrics registry
+	metrics.Registry.MustRegister(
+		applicationInstallationFailures,
+		applicationInstallationStuck,
+		applicationInstallationReady,
+		applicationInstallationLastSuccessTimestamp,
+	)
+}
+
+// updateMetrics updates the Prometheus metrics for an ApplicationInstallation.
+func updateMetrics(namespace, name, application string, failures int, isStuck bool, readyStatus int, lastSuccessTime float64) {
+	applicationInstallationFailures.WithLabelValues(namespace, name, application).Set(float64(failures))
+
+	stuckValue := 0.0
+	if isStuck {
+		stuckValue = 1.0
+	}
+	applicationInstallationStuck.WithLabelValues(namespace, name, application).Set(stuckValue)
+
+	applicationInstallationReady.WithLabelValues(namespace, name, application).Set(float64(readyStatus))
+
+	if lastSuccessTime > 0 {
+		applicationInstallationLastSuccessTimestamp.WithLabelValues(namespace, name, application).Set(lastSuccessTime)
+	}
+}
+
+// deleteMetrics removes the Prometheus metrics for an ApplicationInstallation when it's deleted.
+func deleteMetrics(namespace, name, application string) {
+	applicationInstallationFailures.DeleteLabelValues(namespace, name, application)
+	applicationInstallationStuck.DeleteLabelValues(namespace, name, application)
+	applicationInstallationReady.DeleteLabelValues(namespace, name, application)
+	applicationInstallationLastSuccessTimestamp.DeleteLabelValues(namespace, name, application)
+}


### PR DESCRIPTION
- Move IsStuck() check before maxRetries check to recover stuck releases
- Handle transient errors (another operation in progress) without counting toward failures
- Add time-based failure reset after 1 hour cooldown period
- Add Prometheus metrics for monitoring stuck applications
- Add unit tests for new functionality

Fixes stuck ApplicationInstallation when Helm release gets into pending state and rapid retries exhaust the maxRetries limit before recovery can occur.

**What this PR does / why we need it**:

This PR fixes the issue where ApplicationInstallation gets permanently stuck when Helm releases enter a pending state (e.g., `pending-upgrade`) and rapid retries exhaust the `maxRetries` limit before recovery can occur.

**Root Cause:** When Helm gets stuck in a `pending-upgrade` state (often due to API server unavailability or etcd leader changes), subsequent reconciliation attempts fail with `"another operation in progress"`. Each failure increments the `status.failures` counter, and since the controller retries quickly with exponential backoff starting at ~1 second, all 5 retries can be exhausted in under 10 seconds. Once `failures > maxRetries`, the controller returns early without checking `IsStuck()`, leaving the application permanently stuck.

**Solution:**
- Move `IsStuck()` check before `maxRetries` check to recover stuck releases even after hitting the retry limit
- Handle transient errors ("another operation in progress") without counting toward failures
- Add time-based failure reset after 1 hour cooldown period
- Add Prometheus metrics for monitoring stuck applications
- Add unit tests for new functionality

**Which issue(s) this PR fixes**:
Fixes #15833

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

The key changes are:
1. Reordering the `IsStuck()` check to run before the `maxRetries` check in `handleInstallation()`
2. New `isTransientError()` function to detect Helm's "another operation in progress" error
3. New `resetFailuresIfCooldownPassed()` function for time-based recovery
4. New Prometheus metrics in `metrics.go` for observability

All existing tests pass, and new unit tests have been added for the new functionality.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed ApplicationInstallation getting permanently stuck when Helm releases enter pending state. The controller now handles transient errors gracefully, can recover stuck releases even after hitting the retry limit, and automatically resets the failure counter after a 1-hour cooldown period. New Prometheus metrics (kkp_application_installation_failures, kkp_application_installation_stuck, kkp_application_installation_ready) are now available for monitoring. 
```

**Documentation:**
```documentation
NONE
```

**Test issue:**
```test-issue
NONE
```

