### PR TITLE
Fix app helm chart sync CI job

### DIFF
--- a/hack/ci/mirror-new-application-charts.sh
+++ b/hack/ci/mirror-new-application-charts.sh
@@ -23,12 +23,13 @@
 ###   2. Version bumps in CHART_VERSIONS for existing charts
 ### Then calls mirror-application-charts.sh for each affected chart.
 ###
-### Detection works by sourcing the current and previous (HEAD~1) versions of
+### Detection works by sourcing the current and previous versions of
 ### mirror-application-charts.sh in a subshell. This relies only on the file
 ### being valid bash with the two associative arrays - no formatting assumptions.
 ###
 ### Environment variables:
 ### * `DRY_RUN=true` - skip actual mirroring, only print charts that would be mirrored
+### * `MAX_HISTORY` - how many commits back to look for a valid previous version of the script (default: 5)
 
 set -euo pipefail
 
@@ -36,12 +37,13 @@ cd "$(dirname "$0")/../.."
 source hack/lib.sh
 
 SCRIPT_PATH="hack/mirror-application-charts.sh"
-DRY_RUN="${DRY_RUN:-false}"
+: "${DRY_RUN:=false}"
+: "${MAX_HISTORY:=5}" # how many commits back to look for a valid previous version of the script
 
-# temp file holding HEAD~1's version of the mirror script. declared at file
-# scope (not inside main) so the EXIT trap can resolve $OLD_SCRIPT at trigger
-# time -- if this were `local` inside main, the variable would be out of scope
-# by the time the trap fires and the temp file would leak.
+# temp file holding a previous commit's version of the mirror script. declared
+# at file scope (not inside main) so the EXIT trap can resolve $OLD_SCRIPT at
+# trigger time -- if this were `local` inside main, the variable would be out
+# of scope by the time the trap fires and the temp file would leak.
 OLD_SCRIPT=$(mktemp)
 trap 'rm -f "$OLD_SCRIPT"' EXIT
 
@@ -49,7 +51,7 @@ trap 'rm -f "$OLD_SCRIPT"' EXIT
 # lines from its CHART_VERSIONS array. the subshell isolates the source from
 # our environment so set -u, traps, and any other side effects don't leak.
 # returns empty output (exit 0) if the file is missing, unreadable, or doesn't
-# define CHART_VERSIONS (e.g. truncated HEAD~1, totally unrelated file).
+# define CHART_VERSIONS (e.g. truncated, totally unrelated file).
 read_chart_versions_from() {
   local script_file="$1"
   [[ -f "$script_file" ]] || return 0
@@ -71,14 +73,11 @@ read_chart_versions_from() {
 main() {
   echodate "Detecting changes in ${SCRIPT_PATH}..."
 
-  # write HEAD~1's version of the script (with the bare main "$@" stripped, in
-  # case HEAD~1 predates the sourcing guard) so read_chart_versions_from can
-  # source it. source(1) reads from a file path, not stdin.
-  if ! git show "HEAD~1:${SCRIPT_PATH}" 2> /dev/null | sed '/^main "\$@"$/d' > "$OLD_SCRIPT"; then
-    # no HEAD~1 (e.g. shallow clone, first commit) -- treat old as empty, which
-    # means every current chart shows up as "added". the chart_exists_in_registry
-    # check in the inner script makes that idempotent.
-    : > "$OLD_SCRIPT"
+  # Get a previous version of the script from git history for comparison and write it to the temp file.
+  # Remove the main function invocation from the old script to prevent side effects when sourcing it subsequently.
+  # ($SCRIPT_PATH is idempotent, not overwriting already synced chart versions subsequently.)
+  if ! git show "HEAD~${MAX_HISTORY}:${SCRIPT_PATH}" 2> /dev/null | sed '/^main "\$@"$/d' > "$OLD_SCRIPT"; then
+    echo "WARNING: No previous version of ${SCRIPT_PATH} found in the last ${MAX_HISTORY} commits. Treating all charts as new." >&2
   fi
 
   local old_pairs new_pairs

--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -122,6 +122,27 @@ resolve_chart_config() {
   CHART_PACKAGE="${CHART_NAME}-${CHART_VERSION}.tgz"
 }
 
+# ─── Authenticate with Vault ──────────────────────────────────────────────────
+login_vault() {
+  if [ -n "${VAULT_TOKEN:-}" ] || vault token lookup &> /dev/null; then
+    return 0 # already logged in
+  fi
+
+  echo "Logging into Vault..."
+
+  if [ -z "${VAULT_ROLE_ID:-}" ] || [ -z "${VAULT_SECRET_ID:-}" ]; then
+    # Interactive user login outside the CI pipeline
+    vault login --method=oidc --path="$VAULT_OIDC_AUTH_PATH"
+    return 0
+  fi
+
+  # CI pipeline specific login (non-interactive)
+  local token
+  token=$(vault write --format=json auth/approle/login "role_id=$VAULT_ROLE_ID" "secret_id=$VAULT_SECRET_ID" | jq -r '.auth.client_token')
+
+  export VAULT_TOKEN="$token"
+}
+
 # ─── Authenticate to OCI registry ─────────────────────────────────────────────
 login_registry() {
   echo "🌐 Authenticating to registry..."
@@ -129,6 +150,8 @@ login_registry() {
   if [ -z "${VAULT_ADDR:-}" ]; then
     export VAULT_ADDR=https://vault.kubermatic.com/
   fi
+
+  login_vault
 
   REGISTRY_USER="${REGISTRY_USER:-$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
   REGISTRY_PASSWORD="${REGISTRY_PASSWORD:-$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up of #15839:
* Let the CI job log into Vault before syncing app helm chart images.
* Look 5 commits in the history back for an old version of the `mirror-application-charts.sh` script in order to take the previous chart update in that script into account that wasn't applied to the Kubermatic registry due to the CI job failing previously due to the missing Vault login.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Relates to:
* #15684
* #15693

**What type of PR is this?**
/kind bug
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
