### PR TITLE
chore: Specify Vault OIDC path within app chart mirror script

### DIFF
--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -124,19 +124,23 @@ resolve_chart_config() {
 
 # ─── Authenticate with Vault ──────────────────────────────────────────────────
 login_vault() {
+  if [ -z "${VAULT_ADDR:-}" ]; then
+    export VAULT_ADDR=https://vault.kubermatic.com/
+  fi
+
   if [ -n "${VAULT_TOKEN:-}" ] || vault token lookup &> /dev/null; then
     return 0 # already logged in
   fi
 
-  echo "Logging into Vault..."
-
   if [ -z "${VAULT_ROLE_ID:-}" ] || [ -z "${VAULT_SECRET_ID:-}" ]; then
     # Interactive user login outside the CI pipeline
-    vault login --method=oidc --path="$VAULT_OIDC_AUTH_PATH"
+    echo "🌐 Logging into Vault interactively using OIDC"
+    vault login --method=oidc --path="${VAULT_OIDC_AUTH_PATH:-loodse}"
     return 0
   fi
 
   # CI pipeline specific login (non-interactive)
+  echo "🌐 Logging into Vault using prow CI credentials"
   local token
   token=$(vault write --format=json auth/approle/login "role_id=$VAULT_ROLE_ID" "secret_id=$VAULT_SECRET_ID" | jq -r '.auth.client_token')
 
@@ -145,13 +149,9 @@ login_vault() {
 
 # ─── Authenticate to OCI registry ─────────────────────────────────────────────
 login_registry() {
-  echo "🌐 Authenticating to registry..."
-
-  if [ -z "${VAULT_ADDR:-}" ]; then
-    export VAULT_ADDR=https://vault.kubermatic.com/
-  fi
-
   login_vault
+
+  echo "🌐 Authenticating to registry..."
 
   REGISTRY_USER="${REGISTRY_USER:-$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
   REGISTRY_PASSWORD="${REGISTRY_PASSWORD:-$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Specify the default Vault OIDC path within the `mirror-application-charts.sh` script as opposed to relying on the user to set the `VAULT_OIDC_AUTH_PATH` env var.
This is not needed for CI (which is why it wasn't a problem so far) but in case we'd manually want to sync charts using the script at some point in the future eventually.

Also, the PR improves the Vault login log and moves the VAULT_ADDR defaulting into the `vault_login` method to improve coherence.

This is a follow-up of #15846

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
