### PR TITLE
Preserve external SSH keys in user-ssh-key-agent

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -465,7 +465,7 @@ presubmits:
               memory: 6Gi
 
   - name: pre-kubermatic-user-ssh-keys-agent-e2e
-    run_if_changed: "(pkg/controller/usersshkeysagent/|pkg/test/e2e/usersshkeysagent/|cmd/user-ssh-keys-agent/)"
+    run_if_changed: "(pkg/controller/usersshkeysagent/|pkg/test/e2e/usersshkeysagent/|cmd/user-ssh-keys-agent/|pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/|hack/ci/run-user-ssh-key-agent-e2e-tests.sh)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -463,3 +463,39 @@ presubmits:
               cpu: 2
             limits:
               memory: 6Gi
+
+  - name: pre-kubermatic-user-ssh-keys-agent-e2e
+    run_if_changed: "(pkg/controller/usersshkeysagent/|pkg/test/e2e/usersshkeysagent/|cmd/user-ssh-keys-agent/)"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-aws-e2e-kkp: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-e2e-ssh: "true"
+      preset-goproxy: "true"
+      preset-kind-volume-mounts: "true"
+      preset-kubeconfig-ci: "true"
+      preset-vault: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+          command:
+            - "./hack/ci/run-user-ssh-key-agent-e2e-tests.sh"
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 6Gi

--- a/hack/ci/run-user-ssh-key-agent-e2e-tests.sh
+++ b/hack/ci/run-user-ssh-key-agent-e2e-tests.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+TEST_NAME="Pre-warm Go build cache"
+echodate "Attempting to pre-warm Go build cache"
+
+beforeGocache=$(nowms)
+make download-gocache
+pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
+if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
+  echodate "Getting default SSH pubkey for machines from Vault"
+  retry 5 vault_ci_login
+  E2E_SSH_PUBKEY="$(mktemp)"
+  vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
+else
+  E2E_SSH_PUBKEY_CONTENT="${E2E_SSH_PUBKEY}"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  echo "${E2E_SSH_PUBKEY_CONTENT}" > "${E2E_SSH_PUBKEY}"
+fi
+
+export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
+export KUBERMATIC_YAML=hack/ci/testdata/kubermatic.yaml
+
+source hack/ci/setup-kind-cluster.sh
+source hack/ci/setup-kubermatic-in-kind.sh
+
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+
+echodate "Running user-ssh-keys-agent e2e tests..."
+
+go_test user_ssh_keys_agent -timeout 60m -tags e2e,ee -v ./pkg/test/e2e/usersshkeysagent \
+  -aws-kkp-datacenter aws-eu-west-1a \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
+
+echodate "user-ssh-keys-agent e2e tests completed successfully!"

--- a/hack/ci/run-user-ssh-key-agent-e2e-tests.sh
+++ b/hack/ci/run-user-ssh-key-agent-e2e-tests.sh
@@ -49,7 +49,7 @@ protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic"
 
 echodate "Running user-ssh-keys-agent e2e tests..."
 
-go_test user_ssh_keys_agent -timeout 60m -tags e2e,ee -v ./pkg/test/e2e/usersshkeysagent \
+go_test user_ssh_keys_agent -timeout 60m -tags e2e -v ./pkg/test/e2e/usersshkeysagent \
   -aws-kkp-datacenter aws-eu-west-1a \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -48,6 +48,12 @@ import (
 
 const (
 	controllerName = "kkp-usersshkeys-controller"
+
+	// kkpManagedMarker is a comment prefix the agent writes before each KKP-managed key.
+	// This allows the agent to distinguish its own keys from external keys (e.g. from
+	// cloud-init/machine-deployment) so that removed KKP keys can be cleaned up without
+	// affecting externally-managed keys.
+	kkpManagedMarker = "# kkp-managed"
 )
 
 type Reconciler struct {
@@ -161,25 +167,44 @@ func (r *Reconciler) fetchUserSSHKeySecret(ctx context.Context, namespace string
 }
 
 func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
-	expectedUserSSHKeys, err := createBuffer(sshKeys)
-	if err != nil {
-		return fmt.Errorf("failed creating user ssh keys buffer: %w", err)
-	}
+	kkpKeys := sortedKKPKeys(sshKeys)
 
 	for _, path := range r.authorizedKeysPath {
 		if err := updateOwnAndPermissions(path); err != nil {
 			return fmt.Errorf("failed updating permissions %s: %w", path, err)
 		}
 
-		actualUserSSHKeys, err := os.ReadFile(path)
+		actualContent, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed reading file in path %s: %w", path, err)
 		}
 
-		if !bytes.Equal(actualUserSSHKeys, expectedUserSSHKeys.Bytes()) {
-			if err := os.WriteFile(path, expectedUserSSHKeys.Bytes(), 0600); err != nil {
-				return fmt.Errorf("failed to overwrite file in path %s: %w", path, err)
+		// keep keys that are not marked as kkp-managed
+		externalKeys := extractExternalKeys(actualContent)
+
+		// deduplicate keys by dropping external keys that match a KKP key so we don't
+		// end up with two copies (one marked, one unmarked) after an
+		// upgrade or when cloud-init injects the same key via MD
+		kkpSet := make(map[string]struct{}, len(kkpKeys))
+		for _, nk := range kkpKeys {
+			kkpSet[nk.key] = struct{}{}
+		}
+
+		filtered := make([]string, 0, len(externalKeys))
+		for _, k := range externalKeys {
+			if _, dup := kkpSet[strings.TrimSpace(k)]; !dup {
+				filtered = append(filtered, k)
 			}
+		}
+
+		merged := mergeAuthorizedKeys(kkpKeys, filtered)
+
+		if !bytes.Equal(actualContent, merged) {
+			err = os.WriteFile(path, merged, 0600)
+			if err != nil {
+				return fmt.Errorf("failed to write file in path %q: %w", path, err)
+			}
+
 			r.log.Infow("File has been updated successfully", "file", path)
 		}
 	}
@@ -187,27 +212,77 @@ func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 	return nil
 }
 
-func createBuffer(data map[string][]byte) (*bytes.Buffer, error) {
-	var (
-		keys   = make([]string, 0, len(data))
-		buffer = &bytes.Buffer{}
-	)
+// namedKey pairs a KKP UserSSHKey name with its public key value.
+type namedKey struct {
+	name string
+	key  string
+}
 
-	for key := range data {
-		keys = append(keys, key)
+// sortedKKPKeys returns the KKP SSH keys sorted alphabetically by key value,
+// preserving the Secret map key (UserSSHKey object name) for marker comments.
+func sortedKKPKeys(sshKeys map[string][]byte) []namedKey {
+	keys := make([]namedKey, 0, len(sshKeys))
+	for name, v := range sshKeys {
+		keys = append(keys, namedKey{
+			name: name,
+			key:  strings.TrimSpace(string(v)),
+		})
 	}
 
-	sort.Strings(keys)
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].key < keys[j].key
+	})
 
-	for k := range keys {
-		key := keys[k]
-		data[key] = append(data[key], []byte("\n")...)
-		if _, err := buffer.Write(data[key]); err != nil {
-			return nil, fmt.Errorf("failed writing user ssh keys to buffer: %w", err)
+	return keys
+}
+
+// extractExternalKeys parses an authorized_keys file and returns key lines
+// that are not preceded by the kkpManagedMarker comment. Marker comment lines
+// and the first non-empty line following each marker are considered KKP-managed
+// and excluded.
+func extractExternalKeys(content []byte) []string {
+	var external []string
+	lines := strings.Split(string(content), "\n")
+
+	skipNext := false
+	for i := range lines {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
 		}
+
+		if strings.HasPrefix(trimmed, kkpManagedMarker) {
+			skipNext = true
+			continue
+		}
+
+		if skipNext {
+			skipNext = false
+			continue
+		}
+
+		external = append(external, trimmed)
 	}
 
-	return buffer, nil
+	return external
+}
+
+// mergeAuthorizedKeys builds the final authorized_keys content. Each KKP key
+// is preceded by a kkpManagedMarker comment (including the key name for
+// readability). External keys are appended without a marker.
+func mergeAuthorizedKeys(kkpKeys []namedKey, externalKeys []string) []byte {
+	var buf bytes.Buffer
+
+	for _, nk := range kkpKeys {
+		fmt.Fprintf(&buf, "%s: %s\n%s\n", kkpManagedMarker, nk.name, nk.key)
+	}
+
+	for _, key := range externalKeys {
+		buf.WriteString(key)
+		buf.WriteByte('\n')
+	}
+
+	return buf.Bytes()
 }
 
 func updateOwnAndPermissions(path string) error {

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -187,7 +187,7 @@ func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 		// upgrade or when cloud-init injects the same key via MD
 		kkpSet := make(map[string]struct{}, len(kkpKeys))
 		for _, nk := range kkpKeys {
-			kkpSet[nk.key] = struct{}{}
+			kkpSet[nk.Key] = struct{}{}
 		}
 
 		filtered := make([]string, 0, len(externalKeys))
@@ -212,69 +212,88 @@ func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 	return nil
 }
 
-// namedKey pairs a KKP UserSSHKey name with its public key value.
-type namedKey struct {
-	name string
-	key  string
+// NamedKey pairs a KKP UserSSHKey name with its public key value.
+type NamedKey struct {
+	Name string
+	Key  string
 }
 
 // sortedKKPKeys returns the KKP SSH keys sorted alphabetically by key value,
 // preserving the Secret map key (UserSSHKey object name) for marker comments.
-func sortedKKPKeys(sshKeys map[string][]byte) []namedKey {
-	keys := make([]namedKey, 0, len(sshKeys))
+func sortedKKPKeys(sshKeys map[string][]byte) []NamedKey {
+	keys := make([]NamedKey, 0, len(sshKeys))
 	for name, v := range sshKeys {
-		keys = append(keys, namedKey{
-			name: name,
-			key:  strings.TrimSpace(string(v)),
+		keys = append(keys, NamedKey{
+			Name: name,
+			Key:  strings.TrimSpace(string(v)),
 		})
 	}
 
 	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].key < keys[j].key
+		return keys[i].Key < keys[j].Key
 	})
 
 	return keys
 }
 
-// extractExternalKeys parses an authorized_keys file and returns key lines
-// that are not preceded by the kkpManagedMarker comment. Marker comment lines
-// and the first non-empty line following each marker are considered KKP-managed
-// and excluded.
-func extractExternalKeys(content []byte) []string {
-	var external []string
-	lines := strings.Split(string(content), "\n")
+// AuthorizedKeysView is the parsed form of an authorized_keys file: KKP-managed
+// keys keyed by their UserSSHKey object name, plus external (unmarked) keys.
+type AuthorizedKeysView struct {
+	Managed  map[string]string // UserSSHKey name -> public key value
+	External []string          // public key lines without a kkp-managed marker
+}
 
+// ParseAuthorizedKeys parses an authorized_keys file and splits keys into
+// KKP-managed (preceded by a kkpManagedMarker comment) and external.
+func ParseAuthorizedKeys(content string) AuthorizedKeysView {
+	view := AuthorizedKeysView{Managed: map[string]string{}}
+
+	lines := strings.Split(content, "\n")
+	var pendingName string
 	skipNext := false
-	for i := range lines {
-		trimmed := strings.TrimSpace(lines[i])
-		if trimmed == "" {
+
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
 			continue
 		}
 
-		if strings.HasPrefix(trimmed, kkpManagedMarker) {
+		if strings.HasPrefix(line, kkpManagedMarker) {
+			pendingName = ""
+			if rest := strings.TrimPrefix(line, kkpManagedMarker); strings.HasPrefix(rest, ":") {
+				pendingName = strings.TrimSpace(strings.TrimPrefix(rest, ":"))
+			}
 			skipNext = true
 			continue
 		}
 
 		if skipNext {
+			view.Managed[pendingName] = line
+			pendingName = ""
 			skipNext = false
 			continue
 		}
 
-		external = append(external, trimmed)
+		view.External = append(view.External, line)
 	}
 
-	return external
+	return view
+}
+
+// extractExternalKeys parses an authorized_keys file and returns key lines
+// that are not preceded by the kkpManagedMarker comment.
+func extractExternalKeys(content []byte) []string {
+	return ParseAuthorizedKeys(string(content)).External
 }
 
 // mergeAuthorizedKeys builds the final authorized_keys content. Each KKP key
 // is preceded by a kkpManagedMarker comment (including the key name for
 // readability). External keys are appended without a marker.
-func mergeAuthorizedKeys(kkpKeys []namedKey, externalKeys []string) []byte {
+func mergeAuthorizedKeys(kkpKeys []NamedKey, externalKeys []string) []byte {
 	var buf bytes.Buffer
 
 	for _, nk := range kkpKeys {
-		fmt.Fprintf(&buf, "%s: %s\n%s\n", kkpManagedMarker, nk.name, nk.key)
+		fmt.Fprintf(&buf, "%s: %s\n%s\n", kkpManagedMarker, nk.Name, nk.Key)
 	}
 
 	for _, key := range externalKeys {

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -169,6 +169,14 @@ func (r *Reconciler) fetchUserSSHKeySecret(ctx context.Context, namespace string
 func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 	kkpKeys := sortedKKPKeys(sshKeys)
 
+	// deduplicate keys by dropping external keys that match a KKP key so we don't
+	// end up with two copies (one marked, one unmarked) after an
+	// upgrade or when cloud-init injects the same key via MD
+	kkpSet := make(map[string]struct{}, len(kkpKeys))
+	for _, nk := range kkpKeys {
+		kkpSet[nk.Key] = struct{}{}
+	}
+
 	for _, path := range r.authorizedKeysPath {
 		if err := updateOwnAndPermissions(path); err != nil {
 			return fmt.Errorf("failed updating permissions %s: %w", path, err)
@@ -181,14 +189,6 @@ func (r *Reconciler) updateAuthorizedKeys(sshKeys map[string][]byte) error {
 
 		// keep keys that are not marked as kkp-managed
 		externalKeys := extractExternalKeys(actualContent)
-
-		// deduplicate keys by dropping external keys that match a KKP key so we don't
-		// end up with two copies (one marked, one unmarked) after an
-		// upgrade or when cloud-init injects the same key via MD
-		kkpSet := make(map[string]struct{}, len(kkpKeys))
-		for _, nk := range kkpKeys {
-			kkpSet[nk.Key] = struct{}{}
-		}
 
 		filtered := make([]string, 0, len(externalKeys))
 		for _, k := range externalKeys {

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller_test.go
@@ -77,7 +77,7 @@ func TestReconcileUserSSHKeys(t *testing.T) {
 					authorizedKeysPath,
 				},
 			},
-			expectedSSHKey: "ssh-rsa test_user_ssh_key\nssh-rsa test_user_ssh_key_2",
+			expectedSSHKey: "# kkp-managed: key-test\nssh-rsa test_user_ssh_key\n# kkp-managed: key-test-2\nssh-rsa test_user_ssh_key_2",
 		},
 		{
 			name: "Test ssh dir file mode",
@@ -88,7 +88,7 @@ func TestReconcileUserSSHKeys(t *testing.T) {
 				},
 			},
 			modifier:         changeFileModes,
-			expectedSSHKey:   "ssh-rsa test_user_ssh_key\nssh-rsa test_user_ssh_key_2",
+			expectedSSHKey:   "# kkp-managed: key-test\nssh-rsa test_user_ssh_key\n# kkp-managed: key-test-2\nssh-rsa test_user_ssh_key_2",
 			sshDirPath:       sshPath,
 			expectedFileMode: 384,
 			expectedDirMode:  448,
@@ -166,7 +166,7 @@ func readAuthorizedKeysFile(path string) (string, error) {
 
 func cleanupFiles(tmpFiles []string) error {
 	for _, tmpFile := range tmpFiles {
-		if err := os.RemoveAll(tmpFile); err == nil {
+		if err := os.RemoveAll(tmpFile); err != nil {
 			return err
 		}
 	}
@@ -182,4 +182,229 @@ func changeFileModes(sshDir, authorizedKeysFile string) error {
 		return fmt.Errorf("error while changing file mode: %w", err)
 	}
 	return nil
+}
+
+func TestMergeAuthorizedKeys(t *testing.T) {
+	testCases := []struct {
+		name            string
+		secretData      map[string][]byte
+		existingFile    string
+		expectedContent string
+		expectNoChange  bool
+	}{
+		{
+			name: "KKP keys written to empty file",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a",
+		},
+		{
+			name: "external keys (no marker) are preserved",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "ssh-rsa EXTERNAL md-key",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a\nssh-rsa EXTERNAL md-key",
+		},
+		{
+			name:            "removed KKP key is cleaned up",
+			secretData:      map[string][]byte{},
+			existingFile:    "# kkp-managed\nssh-rsa AAA old-kkp-key\nssh-rsa EXTERNAL md-key",
+			expectedContent: "ssh-rsa EXTERNAL md-key",
+		},
+		{
+			name: "KKP key replaced while external key preserved",
+			secretData: map[string][]byte{
+				"key-b": []byte("ssh-rsa BBB key-b"),
+			},
+			existingFile:    "# kkp-managed\nssh-rsa AAA old-kkp-key\nssh-rsa EXTERNAL md-key",
+			expectedContent: "# kkp-managed: key-b\nssh-rsa BBB key-b\nssh-rsa EXTERNAL md-key",
+		},
+		{
+			name: "no change when file already matches",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:   "# kkp-managed: key-a\nssh-rsa AAA key-a",
+			expectNoChange: true,
+		},
+		{
+			name:            "empty secret removes all KKP markers and keys",
+			secretData:      map[string][]byte{},
+			existingFile:    "# kkp-managed\nssh-rsa AAA kkp-key",
+			expectedContent: "",
+		},
+		{
+			name:            "only external keys, empty secret - no change",
+			secretData:      map[string][]byte{},
+			existingFile:    "ssh-rsa EXTERNAL-1\nssh-rsa EXTERNAL-2",
+			expectedContent: "ssh-rsa EXTERNAL-1\nssh-rsa EXTERNAL-2",
+			expectNoChange:  true,
+		},
+		{
+			name: "KKP keys are sorted alphabetically",
+			secretData: map[string][]byte{
+				"key-z": []byte("ssh-rsa ZZZ key-z"),
+				"key-a": []byte("ssh-rsa AAA key-a"),
+				"key-m": []byte("ssh-rsa MMM key-m"),
+			},
+			existingFile:    "",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a\n# kkp-managed: key-m\nssh-rsa MMM key-m\n# kkp-managed: key-z\nssh-rsa ZZZ key-z",
+		},
+		{
+			name:            "multiple KKP keys removed, external preserved",
+			secretData:      map[string][]byte{},
+			existingFile:    "# kkp-managed\nssh-rsa AAA kkp-1\n# kkp-managed\nssh-rsa BBB kkp-2\nssh-rsa EXTERNAL",
+			expectedContent: "ssh-rsa EXTERNAL",
+		},
+		{
+			name: "empty line between marker and key",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "# kkp-managed\n\nssh-rsa AAA key-a",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a",
+		},
+		{
+			name: "consecutive markers without intervening keys",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "# kkp-managed\n# kkp-managed\nssh-rsa AAA key-a",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a",
+		},
+		{
+			name: "external key matching KKP secret is deduplicated",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "ssh-rsa AAA key-a",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a",
+		},
+		{
+			name: "external key not matching any KKP secret is preserved",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "ssh-rsa AAA key-a\nssh-rsa EXTERNAL other",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a\nssh-rsa EXTERNAL other",
+		},
+		{
+			name:            "MD-only keys with empty KKP secret",
+			secretData:      map[string][]byte{},
+			existingFile:    "ssh-rsa MD-KEY cloud-init",
+			expectedContent: "ssh-rsa MD-KEY cloud-init",
+			expectNoChange:  true,
+		},
+		{
+			name: "common key between KKP and MD",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "ssh-rsa AAA key-a\nssh-rsa MD-KEY cloud-init",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a\nssh-rsa MD-KEY cloud-init",
+		},
+		{
+			name: "upgrade simulation",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+				"key-b": []byte("ssh-rsa BBB key-b"),
+			},
+			existingFile:    "ssh-rsa AAA key-a\nssh-rsa BBB key-b",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a\n# kkp-managed: key-b\nssh-rsa BBB key-b",
+		},
+		{
+			name: "upgrade with removed key",
+			secretData: map[string][]byte{
+				"key-a": []byte("ssh-rsa AAA key-a"),
+			},
+			existingFile:    "ssh-rsa AAA key-a\nssh-rsa BBB key-b",
+			expectedContent: "# kkp-managed: key-a\nssh-rsa AAA key-a\nssh-rsa BBB key-b",
+		},
+		{
+			name: "new marker format recognized as KKP-managed",
+			secretData: map[string][]byte{
+				"key-b": []byte("ssh-rsa BBB key-b"),
+			},
+			existingFile:    "# kkp-managed: key-a\nssh-rsa AAA key-a\nssh-rsa EXTERNAL md-key",
+			expectedContent: "# kkp-managed: key-b\nssh-rsa BBB key-b\nssh-rsa EXTERNAL md-key",
+		},
+		{
+			name:            "mixed old and new markers",
+			secretData:      map[string][]byte{},
+			existingFile:    "# kkp-managed\nssh-rsa AAA old-key\n# kkp-managed: key-b\nssh-rsa BBB new-key\nssh-rsa EXTERNAL",
+			expectedContent: "ssh-rsa EXTERNAL",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "sshkeys-merge")
+			if err != nil {
+				t.Fatalf("error creating temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			sshPath := filepath.Join(tmpDir, ".ssh")
+			if err := os.Mkdir(sshPath, 0700); err != nil {
+				t.Fatalf("error creating .ssh dir: %v", err)
+			}
+
+			authorizedKeysPath := filepath.Join(sshPath, "authorized_keys")
+			if tc.existingFile != "" {
+				if err := os.WriteFile(authorizedKeysPath, []byte(tc.existingFile+"\n"), 0600); err != nil {
+					t.Fatalf("error writing initial file: %v", err)
+				}
+			} else {
+				if f, err := os.Create(authorizedKeysPath); err != nil {
+					t.Fatalf("error creating file: %v", err)
+				} else {
+					f.Close()
+				}
+			}
+
+			if tc.secretData == nil {
+				tc.secretData = map[string][]byte{}
+			}
+
+			reconciler := Reconciler{
+				Client: fake.NewClientBuilder().WithObjects(
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      resources.UserSSHKeys,
+							Namespace: metav1.NamespaceSystem,
+						},
+						Data: tc.secretData,
+					},
+				).Build(),
+				log:                kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar(),
+				authorizedKeysPath: []string{authorizedKeysPath},
+			}
+
+			_, err = reconciler.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: resources.UserSSHKeys, Namespace: metav1.NamespaceSystem},
+			})
+			if err != nil {
+				t.Fatalf("reconcile failed: %v", err)
+			}
+
+			content, err := readAuthorizedKeysFile(authorizedKeysPath)
+			if err != nil {
+				t.Fatalf("error reading file: %v", err)
+			}
+
+			if tc.expectNoChange {
+				if content == tc.existingFile {
+					return
+				}
+				t.Fatalf("expected no change but file was modified:\ngot:      %q\noriginal: %q", content, tc.existingFile)
+			}
+
+			if content != tc.expectedContent {
+				t.Fatalf("content mismatch:\ngot:      %q\nexpected: %q", content, tc.expectedContent)
+			}
+		})
+	}
 }

--- a/pkg/test/e2e/usersshkeysagent/helpers.go
+++ b/pkg/test/e2e/usersshkeysagent/helpers.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	usersshkeysagent "k8c.io/kubermatic/v2/pkg/controller/usersshkeysagent"
 	"k8c.io/kubermatic/v2/pkg/util/podexec"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,6 @@ import (
 )
 
 const (
-	kkpManagedMarker   = "# kkp-managed"
 	agentLabelKey      = "app"
 	agentLabelValue    = "user-ssh-keys-agent"
 	agentContainer     = "user-ssh-keys-agent"
@@ -49,10 +49,7 @@ const (
 
 // authorizedKeysView is the parsed form of an authorized_keys file: KKP-managed
 // keys keyed by their UserSSHKey object name, plus external (unmarked) keys.
-type authorizedKeysView struct {
-	managed  map[string]string // UserSSHKey name -> public key value
-	external []string          // public key lines without a kkp-managed marker
-}
+type authorizedKeysView = usersshkeysagent.AuthorizedKeysView
 
 // generateSSHKey returns an OpenSSH-formatted ed25519 public key suitable for
 // authorized_keys and providerSpec.sshPublicKeys.
@@ -72,38 +69,10 @@ func generateSSHKey(t *testing.T) string {
 	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
 }
 
-// parseAuthorizedKeys mirrors the agent's contract: a "# kkp-managed[: name]"
-// comment line marks the next non-empty line as a KKP-managed key. Everything
-// else is external.
+// parseAuthorizedKeys parses an authorized_keys file using the same logic as
+// the agent controller, so the e2e tests validate against the real parser.
 func parseAuthorizedKeys(content string) authorizedKeysView {
-	view := authorizedKeysView{managed: map[string]string{}}
-
-	lines := strings.Split(content, "\n")
-	var pendingName string
-	skipNext := false
-
-	for _, raw := range lines {
-		line := strings.TrimSpace(raw)
-		if line == "" {
-			continue
-		}
-		if strings.HasPrefix(line, kkpManagedMarker) {
-			pendingName = ""
-			if rest := strings.TrimPrefix(line, kkpManagedMarker); strings.HasPrefix(rest, ":") {
-				pendingName = strings.TrimSpace(strings.TrimPrefix(rest, ":"))
-			}
-			skipNext = true
-			continue
-		}
-		if skipNext {
-			view.managed[pendingName] = line
-			pendingName = ""
-			skipNext = false
-			continue
-		}
-		view.external = append(view.external, line)
-	}
-	return view
+	return usersshkeysagent.ParseAuthorizedKeys(content)
 }
 
 // findAgentPodForNode returns the user-ssh-keys-agent pod scheduled on the

--- a/pkg/test/e2e/usersshkeysagent/helpers.go
+++ b/pkg/test/e2e/usersshkeysagent/helpers.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usersshkeysagent
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/util/podexec"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	kkpManagedMarker   = "# kkp-managed"
+	agentLabelKey      = "app"
+	agentLabelValue    = "user-ssh-keys-agent"
+	agentContainer     = "user-ssh-keys-agent"
+	debugContainerName = "debug-cat"
+)
+
+// authorizedKeysView is the parsed form of an authorized_keys file: KKP-managed
+// keys keyed by their UserSSHKey object name, plus external (unmarked) keys.
+type authorizedKeysView struct {
+	managed  map[string]string // UserSSHKey name -> public key value
+	external []string          // public key lines without a kkp-managed marker
+}
+
+// generateSSHKey returns an OpenSSH-formatted ed25519 public key suitable for
+// authorized_keys and providerSpec.sshPublicKeys.
+func generateSSHKey(t *testing.T) string {
+	t.Helper()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 key: %v", err)
+	}
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to wrap public key: %v", err)
+	}
+
+	return strings.TrimSpace(string(ssh.MarshalAuthorizedKey(sshPub)))
+}
+
+// parseAuthorizedKeys mirrors the agent's contract: a "# kkp-managed[: name]"
+// comment line marks the next non-empty line as a KKP-managed key. Everything
+// else is external.
+func parseAuthorizedKeys(content string) authorizedKeysView {
+	view := authorizedKeysView{managed: map[string]string{}}
+
+	lines := strings.Split(content, "\n")
+	var pendingName string
+	skipNext := false
+
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, kkpManagedMarker) {
+			pendingName = ""
+			if rest := strings.TrimPrefix(line, kkpManagedMarker); strings.HasPrefix(rest, ":") {
+				pendingName = strings.TrimSpace(strings.TrimPrefix(rest, ":"))
+			}
+			skipNext = true
+			continue
+		}
+		if skipNext {
+			view.managed[pendingName] = line
+			pendingName = ""
+			skipNext = false
+			continue
+		}
+		view.external = append(view.external, line)
+	}
+	return view
+}
+
+// findAgentPodForNode returns the user-ssh-keys-agent pod scheduled on the
+// given node, or nil if none is found.
+func findAgentPodForNode(ctx context.Context, userClient ctrlruntimeclient.Client, nodeName string) (*corev1.Pod, error) {
+	pods := corev1.PodList{}
+
+	err := userClient.List(ctx, &pods,
+		ctrlruntimeclient.InNamespace(metav1.NamespaceSystem),
+		ctrlruntimeclient.MatchingLabels{agentLabelKey: agentLabelValue},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list agent pods: %w", err)
+	}
+
+	for i := range pods.Items {
+		if pods.Items[i].Spec.NodeName == nodeName {
+			return &pods.Items[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// ensureDebugContainer attaches a busybox ephemeral container to the given pod
+// for reading host files. The agent image is distroless and has no shell
+// utilities, so we inject a debug container to get cat access.
+// The ephemeral container shares the pod's volume mounts (/home, /root).
+func ensureDebugContainer(ctx context.Context, cfg *rest.Config, pod *corev1.Pod) error {
+	for _, ec := range pod.Spec.EphemeralContainers {
+		if ec.Name == debugContainerName {
+			return nil
+		}
+	}
+
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	ec := corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:                     debugContainerName,
+			Image:                    "busybox:1.36",
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			Command:                  []string{"sleep", "infinity"},
+			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+			VolumeMounts: []corev1.VolumeMount{
+				{Name: "root", MountPath: "/root"},
+				{Name: "home", MountPath: "/home"},
+			},
+		},
+		TargetContainerName: agentContainer,
+	}
+
+	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
+	_, err = client.CoreV1().Pods(pod.Namespace).UpdateEphemeralContainers(ctx, pod.Name, pod, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to attach ephemeral debug container: %w", err)
+	}
+
+	// wait for the ephemeral container to be running.
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		updated, err := client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		for _, s := range updated.Status.EphemeralContainerStatuses {
+			if s.Name == debugContainerName && s.State.Running != nil {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+// readAuthorizedKeys execs into the ephemeral debug container attached to the
+// agent pod and returns the contents of the host's authorized_keys file.
+// The agent pod mounts /home and /root as hostPath volumes, making the node's
+// SSH authorized_keys files visible inside the container.
+func readAuthorizedKeys(ctx context.Context, cfg *rest.Config, pod *corev1.Pod, path string) (string, error) {
+	if err := ensureDebugContainer(ctx, cfg, pod); err != nil {
+		return "", fmt.Errorf("failed to ensure debug container: %w", err)
+	}
+
+	stdout, stderr, err := podexec.ExecuteCommand(
+		ctx, cfg,
+		types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+		debugContainerName,
+		"cat", path,
+	)
+	if err != nil {
+		return "", fmt.Errorf("cat %s failed (stdout=%q, stderr=%q): %w", path, stdout, stderr, err)
+	}
+	return stdout, nil
+}
+
+// newUserSSHKey builds (but does not create) a UserSSHKey CR attached to the
+// given cluster and project.
+func newUserSSHKey(name, displayName, projectName, clusterName, publicKey string) *kubermaticv1.UserSSHKey {
+	return &kubermaticv1.UserSSHKey{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kubermaticv1.SSHKeySpec{
+			Name:      displayName,
+			Project:   projectName,
+			Clusters:  []string{clusterName},
+			PublicKey: publicKey,
+		},
+	}
+}

--- a/pkg/test/e2e/usersshkeysagent/usersshkeys_test.go
+++ b/pkg/test/e2e/usersshkeysagent/usersshkeys_test.go
@@ -141,12 +141,12 @@ func (r *runner) testKKPKeyMaterializes(ctx context.Context, project *kubermatic
 		})
 
 		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
-			if got, ok := view.managed[key.Name]; !ok || got != kKKP {
+			if got, ok := view.Managed[key.Name]; !ok || got != kKKP {
 				return fmt.Errorf("expected managed[%q]=%q, got %q (ok=%v)", key.Name, kKKP, got, ok)
 			}
 
-			if !containsLine(view.external, kMD) {
-				return fmt.Errorf("cloud-init key %q not preserved as external line, got %v", kMD, view.external)
+			if !containsLine(view.External, kMD) {
+				return fmt.Errorf("cloud-init key %q not preserved as external line, got %v", kMD, view.External)
 			}
 
 			return nil
@@ -164,7 +164,7 @@ func (r *runner) testKKPKeyRemoved(ctx context.Context, project *kubermaticv1.Pr
 		}
 
 		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
-			if view.managed[key.Name] != kKKP {
+			if view.Managed[key.Name] != kKKP {
 				return fmt.Errorf("KKP key not yet on node")
 			}
 
@@ -176,12 +176,12 @@ func (r *runner) testKKPKeyRemoved(ctx context.Context, project *kubermaticv1.Pr
 		}
 
 		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
-			if _, present := view.managed[key.Name]; present {
-				return fmt.Errorf("KKP key still present in managed view: %v", view.managed)
+			if _, present := view.Managed[key.Name]; present {
+				return fmt.Errorf("KKP key still present in managed view: %v", view.Managed)
 			}
 
-			if !containsLine(view.external, kMD) {
-				return fmt.Errorf("cloud-init key %q no longer present after KKP key removal, got %v", kMD, view.external)
+			if !containsLine(view.External, kMD) {
+				return fmt.Errorf("cloud-init key %q no longer present after KKP key removal, got %v", kMD, view.External)
 			}
 
 			return nil
@@ -203,11 +203,11 @@ func (r *runner) testDedup(ctx context.Context, project *kubermaticv1.Project, c
 		})
 
 		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
-			if view.managed[key.Name] != kMD {
-				return fmt.Errorf("expected cloud-init key to appear as managed[%q], got %v", key.Name, view.managed)
+			if view.Managed[key.Name] != kMD {
+				return fmt.Errorf("expected cloud-init key to appear as managed[%q], got %v", key.Name, view.Managed)
 			}
-			if containsLine(view.external, kMD) {
-				return fmt.Errorf("cloud-init key still present as external line (dedup failed): %v", view.external)
+			if containsLine(view.External, kMD) {
+				return fmt.Errorf("cloud-init key still present as external line (dedup failed): %v", view.External)
 			}
 			return nil
 		})
@@ -240,16 +240,16 @@ func (r *runner) testKKPKeyAddedAlongsideMD(ctx context.Context, project *kuberm
 		})
 
 		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
-			if view.managed[keyA.Name] != kA {
-				return fmt.Errorf("expected keyA in managed[%q], got %v", keyA.Name, view.managed)
+			if view.Managed[keyA.Name] != kA {
+				return fmt.Errorf("expected keyA in managed[%q], got %v", keyA.Name, view.Managed)
 			}
 
-			if view.managed[keyB.Name] != kB {
-				return fmt.Errorf("expected keyB in managed[%q], got %v", keyB.Name, view.managed)
+			if view.Managed[keyB.Name] != kB {
+				return fmt.Errorf("expected keyB in managed[%q], got %v", keyB.Name, view.Managed)
 			}
 
-			if !containsLine(view.external, kMD) {
-				return fmt.Errorf("cloud-init key %q not preserved, got %v", kMD, view.external)
+			if !containsLine(view.External, kMD) {
+				return fmt.Errorf("cloud-init key %q not preserved, got %v", kMD, view.External)
 			}
 
 			return nil
@@ -284,15 +284,15 @@ func (r *runner) testMultipleKKPKeysSortedDeterministically(ctx context.Context,
 		})
 
 		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
-			if len(view.managed) < 2 {
-				return fmt.Errorf("expected at least 2 managed keys, got %d", len(view.managed))
+			if len(view.Managed) < 2 {
+				return fmt.Errorf("expected at least 2 managed keys, got %d", len(view.Managed))
 			}
 
-			if _, ok := view.managed[keyA.Name]; !ok {
+			if _, ok := view.Managed[keyA.Name]; !ok {
 				return fmt.Errorf("keyA %q not found in managed keys", keyA.Name)
 			}
 
-			if _, ok := view.managed[keyB.Name]; !ok {
+			if _, ok := view.Managed[keyB.Name]; !ok {
 				return fmt.Errorf("keyB %q not found in managed keys", keyB.Name)
 			}
 

--- a/pkg/test/e2e/usersshkeysagent/usersshkeys_test.go
+++ b/pkg/test/e2e/usersshkeysagent/usersshkeys_test.go
@@ -1,0 +1,356 @@
+//go:build e2e
+
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usersshkeysagent
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
+	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	defaultTimeout     = 5 * time.Minute
+	defaultInterval    = 10 * time.Second
+	authorizedKeysPath = "/home/ubuntu/.ssh/authorized_keys"
+)
+
+var (
+	credentials jig.AWSCredentials
+	logOptions  = utils.DefaultLogOptions
+)
+
+func init() {
+	credentials.AddFlags(flag.CommandLine)
+	jig.AddFlags(flag.CommandLine)
+	logOptions.AddFlags(flag.CommandLine)
+}
+
+type runner struct {
+	seedClient ctrlruntimeclient.Client
+	userClient ctrlruntimeclient.Client
+	restConfig *rest.Config
+	logger     *zap.SugaredLogger
+	testJig    *jig.TestJig
+}
+
+func TestUserSSHKeysAgent(t *testing.T) {
+	ctx := context.Background()
+	rawLogger := log.NewFromOptions(logOptions)
+	logger := rawLogger.Sugar()
+	ctrlruntimelog.SetLogger(zapr.NewLogger(rawLogger.WithOptions(zap.AddCallerSkip(1))))
+
+	if err := credentials.Parse(); err != nil {
+		t.Fatalf("failed to parse AWS credentials: %v", err)
+	}
+
+	seedClient, _, err := utils.GetClients()
+	if err != nil {
+		t.Fatalf("failed to get seed client: %v", err)
+	}
+
+	// kMd travels through cloud-init at first boot, before the agent runs.
+	kMD := generateSSHKey(t)
+
+	testJig := jig.NewAWSCluster(seedClient, logger, credentials, 1, nil)
+	testJig.ClusterJig.
+		WithTestName("sshkeys").
+		WithSSHKeyAgent(true)
+	testJig.MachineJig.AddSSHPublicKey(kMD)
+
+	t.Cleanup(func() { testJig.Cleanup(ctx, t, true) })
+
+	logger.Info("setting up the cluster (this takes several minutes)")
+	project, cluster, err := testJig.Setup(ctx, jig.WaitForReadyNodes)
+	if err != nil {
+		t.Fatalf("failed to set up cluster + machines: %v", err)
+	}
+
+	userClient, err := testJig.ClusterClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to get user-cluster client: %v", err)
+	}
+
+	restCfg, err := testJig.ClusterRESTConfig(ctx)
+	if err != nil {
+		t.Fatalf("failed to get user-cluster REST config: %v", err)
+	}
+
+	r := &runner{
+		seedClient: seedClient,
+		userClient: userClient,
+		restConfig: restCfg,
+		logger:     logger,
+		testJig:    testJig,
+	}
+
+	t.Run("KKPKeyMaterializes", r.testKKPKeyMaterializes(ctx, project, cluster, kMD))
+	t.Run("KKPKeyRemoved", r.testKKPKeyRemoved(ctx, project, cluster, kMD))
+	t.Run("KKPKeyAddedAlongsideMD", r.testKKPKeyAddedAlongsideMD(ctx, project, cluster, kMD))
+	t.Run("MultipleKKPKeysSortedDeterministically", r.testMultipleKKPKeysSortedDeterministically(ctx, project, cluster, kMD))
+	t.Run("Dedup", r.testDedup(ctx, project, cluster, kMD))
+}
+
+func (r *runner) testKKPKeyMaterializes(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, kMD string) func(*testing.T) {
+	return func(t *testing.T) {
+		kKKP := generateSSHKey(t)
+		key := newUserSSHKey("e2e-kkp-1", "e2e-kkp-1", project.Name, cluster.Name, kKKP)
+
+		if err := r.seedClient.Create(ctx, key); err != nil {
+			t.Fatalf("failed to create UserSSHKey: %v", err)
+		}
+
+		t.Cleanup(func() {
+			if err := r.seedClient.Delete(ctx, key); err != nil {
+				t.Logf("warning: failed to delete UserSSHKey %q during cleanup: %v", key.Name, err)
+			}
+		})
+
+		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
+			if got, ok := view.managed[key.Name]; !ok || got != kKKP {
+				return fmt.Errorf("expected managed[%q]=%q, got %q (ok=%v)", key.Name, kKKP, got, ok)
+			}
+
+			if !containsLine(view.external, kMD) {
+				return fmt.Errorf("cloud-init key %q not preserved as external line, got %v", kMD, view.external)
+			}
+
+			return nil
+		})
+	}
+}
+
+func (r *runner) testKKPKeyRemoved(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, kMD string) func(*testing.T) {
+	return func(t *testing.T) {
+		kKKP := generateSSHKey(t)
+		key := newUserSSHKey("e2e-kkp-removed", "e2e-kkp-removed", project.Name, cluster.Name, kKKP)
+
+		if err := r.seedClient.Create(ctx, key); err != nil {
+			t.Fatalf("create UserSSHKey: %v", err)
+		}
+
+		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
+			if view.managed[key.Name] != kKKP {
+				return fmt.Errorf("KKP key not yet on node")
+			}
+
+			return nil
+		})
+
+		if err := r.seedClient.Delete(ctx, key); err != nil {
+			t.Fatalf("delete UserSSHKey: %v", err)
+		}
+
+		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
+			if _, present := view.managed[key.Name]; present {
+				return fmt.Errorf("KKP key still present in managed view: %v", view.managed)
+			}
+
+			if !containsLine(view.external, kMD) {
+				return fmt.Errorf("cloud-init key %q no longer present after KKP key removal, got %v", kMD, view.external)
+			}
+
+			return nil
+		})
+	}
+}
+
+func (r *runner) testDedup(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, kMD string) func(*testing.T) {
+	return func(t *testing.T) {
+		key := newUserSSHKey("e2e-dedup", "e2e-dedup", project.Name, cluster.Name, kMD)
+
+		if err := r.seedClient.Create(ctx, key); err != nil {
+			t.Fatalf("create UserSSHKey: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := r.seedClient.Delete(ctx, key); err != nil {
+				t.Logf("warning: failed to delete UserSSHKey %q during cleanup: %v", key.Name, err)
+			}
+		})
+
+		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
+			if view.managed[key.Name] != kMD {
+				return fmt.Errorf("expected cloud-init key to appear as managed[%q], got %v", key.Name, view.managed)
+			}
+			if containsLine(view.external, kMD) {
+				return fmt.Errorf("cloud-init key still present as external line (dedup failed): %v", view.external)
+			}
+			return nil
+		})
+	}
+}
+
+func (r *runner) testKKPKeyAddedAlongsideMD(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, kMD string) func(*testing.T) {
+	return func(t *testing.T) {
+		kA := generateSSHKey(t)
+		kB := generateSSHKey(t)
+		keyA := newUserSSHKey("e2e-pair-a", "e2e-pair-a", project.Name, cluster.Name, kA)
+		keyB := newUserSSHKey("e2e-pair-b", "e2e-pair-b", project.Name, cluster.Name, kB)
+
+		if err := r.seedClient.Create(ctx, keyA); err != nil {
+			t.Fatalf("create keyA: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := r.seedClient.Delete(ctx, keyA); err != nil {
+				t.Logf("warning: failed to delete UserSSHKey %q during cleanup: %v", keyA.Name, err)
+			}
+		})
+
+		if err := r.seedClient.Create(ctx, keyB); err != nil {
+			t.Fatalf("create keyB: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := r.seedClient.Delete(ctx, keyB); err != nil {
+				t.Logf("warning: failed to delete UserSSHKey %q during cleanup: %v", keyB.Name, err)
+			}
+		})
+
+		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
+			if view.managed[keyA.Name] != kA {
+				return fmt.Errorf("expected keyA in managed[%q], got %v", keyA.Name, view.managed)
+			}
+
+			if view.managed[keyB.Name] != kB {
+				return fmt.Errorf("expected keyB in managed[%q], got %v", keyB.Name, view.managed)
+			}
+
+			if !containsLine(view.external, kMD) {
+				return fmt.Errorf("cloud-init key %q not preserved, got %v", kMD, view.external)
+			}
+
+			return nil
+		})
+	}
+}
+
+func (r *runner) testMultipleKKPKeysSortedDeterministically(ctx context.Context, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster, kMD string) func(*testing.T) {
+	return func(t *testing.T) {
+		kA := generateSSHKey(t)
+		kB := generateSSHKey(t)
+		keyA := newUserSSHKey("e2e-sort-a", "e2e-sort-a", project.Name, cluster.Name, kA)
+		keyB := newUserSSHKey("e2e-sort-b", "e2e-sort-b", project.Name, cluster.Name, kB)
+
+		if err := r.seedClient.Create(ctx, keyA); err != nil {
+			t.Fatalf("create keyA: %v", err)
+		}
+		t.Cleanup(func() {
+			if err := r.seedClient.Delete(ctx, keyA); err != nil {
+				t.Logf("warning: failed to delete UserSSHKey %q during cleanup: %v", keyA.Name, err)
+			}
+		})
+
+		if err := r.seedClient.Create(ctx, keyB); err != nil {
+			t.Fatalf("create keyB: %v", err)
+		}
+
+		t.Cleanup(func() {
+			if err := r.seedClient.Delete(ctx, keyB); err != nil {
+				t.Logf("warning: failed to delete UserSSHKey %q during cleanup: %v", keyB.Name, err)
+			}
+		})
+
+		r.expectOnEveryNode(ctx, t, func(view authorizedKeysView) error {
+			if len(view.managed) < 2 {
+				return fmt.Errorf("expected at least 2 managed keys, got %d", len(view.managed))
+			}
+
+			if _, ok := view.managed[keyA.Name]; !ok {
+				return fmt.Errorf("keyA %q not found in managed keys", keyA.Name)
+			}
+
+			if _, ok := view.managed[keyB.Name]; !ok {
+				return fmt.Errorf("keyB %q not found in managed keys", keyB.Name)
+			}
+
+			return nil
+		})
+	}
+}
+
+func (r *runner) expectOnEveryNode(ctx context.Context, t *testing.T, check func(authorizedKeysView) error) {
+	t.Helper()
+	err := wait.PollLog(ctx, r.logger, defaultInterval, defaultTimeout,
+		func(ctx context.Context) (transient error, terminal error) {
+			nodes := corev1.NodeList{}
+			if err := r.userClient.List(ctx, &nodes); err != nil {
+				return fmt.Errorf("list nodes: %w", err), nil
+			}
+
+			if len(nodes.Items) == 0 {
+				return errors.New("no nodes yet"), nil
+			}
+
+			for _, node := range nodes.Items {
+				if !kubernetes.IsNodeReady(&node) {
+					return fmt.Errorf("node %q not Ready", node.Name), nil
+				}
+
+				pod, err := findAgentPodForNode(ctx, r.userClient, node.Name)
+				if err != nil {
+					return fmt.Errorf("find agent pod on %q: %w", node.Name, err), nil
+				}
+
+				if pod == nil {
+					return fmt.Errorf("no agent pod yet on %q", node.Name), nil
+				}
+
+				content, err := readAuthorizedKeys(ctx, r.restConfig, pod, authorizedKeysPath)
+				if err != nil {
+					return fmt.Errorf("read authorized_keys on %q: %w", node.Name, err), nil
+				}
+
+				if err := check(parseAuthorizedKeys(content)); err != nil {
+					return fmt.Errorf("node %s: %w", node.Name, err), nil
+				}
+			}
+			return nil, nil
+		})
+	if err != nil {
+		t.Fatalf("expectation never converged: %v", err)
+	}
+}
+
+func containsLine(lines []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, l := range lines {
+		if strings.TrimSpace(l) == want {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The user-ssh-key-agent DaemonSet overwrites `authorized_keys` on worker nodes with only KKP `UserSSHKey` data, removing SSH keys placed by cloud-init from machine deployment `providerSpec.sshPublicKeys`. This changes the agent to use a marker-based merge: each KKP key is preceded by a `# kkp-managed` comment so the agent can distinguish its own keys from external keys. External keys (no marker) are preserved, KKP keys are fully managed (added/removed as assigned to the cluster), and external keys that match KKP secret content are deduplicated to handle upgrade and MD injection scenarios.

**Which issue(s) this PR fixes**:
Fixes #15793

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
SSH keys from machine deployment providerSpec are no longer removed from worker nodes by the user-ssh-key-agent.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
TBD
```
