### PR TITLE
fix(rbac): honor projectResource.namespace when building watches

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_resource_controller.go
@@ -30,8 +30,23 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// resourcePredicates returns the predicates the rbac controllers should apply
+// for a given projectResource. The resource's user-supplied predicate is always
+// included; when the resource specifies a namespace, an additional predicate
+// scopes the controller to objects in that namespace so cluster-wide watches
+// don't reconcile unrelated resources (e.g. Secrets matching the
+// `credential` name prefix in third-party namespaces, kubermatic/kubermatic#11292).
+func resourcePredicates(resource projectResource) []predicate.Predicate {
+	preds := []predicate.Predicate{predicateutil.Factory(resource.predicate)}
+	if resource.namespace != "" {
+		preds = append(preds, predicateutil.ByNamespace(resource.namespace))
+	}
+	return preds
+}
 
 type resourcesController struct {
 	log              *zap.SugaredLogger
@@ -69,7 +84,7 @@ func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.
 		// Create a new controller
 		_, err := builder.ControllerManagedBy(mgr).
 			Named("rbac_generator_resources").
-			For(clonedObject, builder.WithPredicates(predicateutil.Factory(resource.predicate))).
+			For(clonedObject, builder.WithPredicates(resourcePredicates(resource)...)).
 			Build(mc)
 		if err != nil {
 			return nil, err
@@ -103,7 +118,7 @@ func newResourcesControllers(ctx context.Context, metrics *Metrics, mgr manager.
 			// Create a new controller
 			_, err := builder.ControllerManagedBy(seedManager).
 				Named(fmt.Sprintf("rbac_generator_resources_%s", seedName)).
-				For(clonedObject, builder.WithPredicates(predicateutil.Factory(resource.predicate))).
+				For(clonedObject, builder.WithPredicates(resourcePredicates(resource)...)).
 				Build(c)
 			if err != nil {
 				return nil, err

--- a/pkg/controller/master-controller-manager/rbac/rbac_resource_controller_test.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_resource_controller_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// TestResourcePredicates locks in the kubermatic/kubermatic#11292 regression: a
+// projectResource that sets a non-empty namespace must not reconcile events for
+// objects in other namespaces, even when its predicate matches.
+func TestResourcePredicates(t *testing.T) {
+	supportedPredicate := func(o ctrlruntimeclient.Object) bool {
+		return shouldEnqueueSecret(o.GetName())
+	}
+
+	tests := []struct {
+		name          string
+		resource      projectResource
+		objectName    string
+		objectNS      string
+		expectMatches bool
+	}{
+		{
+			name: "scoped namespace blocks Secret in third-party namespace",
+			resource: projectResource{
+				object:    &corev1.Secret{},
+				namespace: "kubermatic",
+				predicate: supportedPredicate,
+			},
+			objectName:    "credentials-test",
+			objectNS:      "test",
+			expectMatches: false,
+		},
+		{
+			name: "scoped namespace allows Secret in kubermatic namespace",
+			resource: projectResource{
+				object:    &corev1.Secret{},
+				namespace: "kubermatic",
+				predicate: supportedPredicate,
+			},
+			objectName:    "credentials-test",
+			objectNS:      "kubermatic",
+			expectMatches: true,
+		},
+		{
+			name: "empty resource.namespace is cluster-scoped",
+			resource: projectResource{
+				object:    &corev1.Secret{},
+				namespace: "",
+				predicate: supportedPredicate,
+			},
+			objectName:    "credentials-test",
+			objectNS:      "test",
+			expectMatches: true,
+		},
+		{
+			name: "predicate still excludes unsupported name prefixes in scoped namespace",
+			resource: projectResource{
+				object:    &corev1.Secret{},
+				namespace: "kubermatic",
+				predicate: supportedPredicate,
+			},
+			objectName:    "unrelated-secret",
+			objectNS:      "kubermatic",
+			expectMatches: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.objectName, Namespace: tc.objectNS},
+			}
+			preds := resourcePredicates(tc.resource)
+			matches := true
+			for _, p := range preds {
+				if !p.Create(event.CreateEvent{Object: obj}) {
+					matches = false
+					break
+				}
+			}
+			if matches != tc.expectMatches {
+				t.Errorf("predicate chain matches=%v, want %v", matches, tc.expectMatches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `rbac_controller_aggregator` declares a `namespace: "kubermatic"` field on the `projectResource` entries for `Secret` and `ClusterBackupStorageLocation`, but `newResourcesControllers` never consumed that field: it only passed `resource.predicate` into `builder.WithPredicates`. As a result the rbac-controller's watch was cluster-scoped, and any Secret whose name matched the supported-prefix predicate (`sa-token`, `credential`, `kubeconfig-external-cluster`, `manifest-kubeone`, `ssh-kubeone`) in any namespace was sent through `Reconcile`. For Secrets that live outside the kubermatic namespace this fails with the error reported in #11292:

    failed to reconcile Secret <ns>/<name> in master cluster:
    failed to reconcile namespaced resources:
    unable to find owning project for Secret <name>

This PR introduces a small helper, `resourcePredicates(resource projectResource)`, that always includes the user-supplied predicate and additionally appends `predicateutil.ByNamespace(resource.namespace)` whenever `resource.namespace` is non-empty. Both the master and per-seed controller construction call sites now go through the helper, so the field finally has the effect its name suggests. Resources that leave `namespace` empty (the cluster-scoped ones - `Cluster`, `UserSSHKey`, `UserProjectBinding`, etc.) are unaffected.

A new unit test, `TestResourcePredicates`, locks the behavior in for the four relevant cases:

- `kubermatic` namespace + `credentials-*` Secret -> reconcile,
- third-party namespace + `credentials-*` Secret -> filtered out (the regression),
- empty `resource.namespace` -> still cluster-scoped (no change),
- `kubermatic` namespace + non-matching name -> still filtered by the existing predicate.

**Which issue(s) this PR fixes**:
Fixes #11292

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

I reproduced the original error path from #11292 by reading the predicate chain at `rbac_resource_controller.go:72,106`: the existing code only feeds `predicateutil.Factory(resource.predicate)` into `builder.WithPredicates`, so a `corev1.Secret` named `credentials-test` in namespace `test` passes the predicate (`shouldEnqueueSecret("credentials-test") == true`) and reaches `Reconcile`, where the project lookup fails. The new namespace predicate short-circuits that path before the work-queue enqueue happens. I considered changing the existing `predicateutil.Factory` call to inline the namespace check, but a small helper keeps the call sites readable and makes the new test target one stable surface rather than mocking the controller builder.

Apart from the unit test, I did not exercise this end-to-end against a live KKP cluster (no master/seed available in my environment). The change is a pure predicate-chain extension and the existing rbac suite still passes (`go test ./pkg/controller/master-controller-manager/rbac/...`).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed an rbac-controller error loop in which a Secret created in a non-`kubermatic` namespace, with a name matching one of the supported prefixes (`sa-token`, `credential`, `kubeconfig-external-cluster`, `manifest-kubeone`, `ssh-kubeone`), repeatedly failed reconciliation with "unable to find owning project for Secret ...". The watch is now scoped to the namespace declared on the corresponding `projectResource` entry.
```

**Documentation**:
```documentation
NONE (no documentation needed for this PR)
```

**Test issue**:
```test-issue
NONE
```

---

AI disclosure: fix and PR body drafted with Claude as a coding assistant; I reviewed the predicate semantics and ran the rbac unit test suite locally before pushing.
