### PR TITLE
[release/v2.29] Add support of k8s patch releases v1.34.8/v1.33.12

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -583,7 +583,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.33.11
+    default: v1.33.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -676,6 +676,7 @@ spec:
       - v1.33.9
       - v1.33.10
       - v1.33.11
+      - v1.33.12
       - v1.34.1
       - v1.34.2
       - v1.34.3
@@ -683,6 +684,7 @@ spec:
       - v1.34.5
       - v1.34.6
       - v1.34.7
+      - v1.34.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -583,7 +583,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.33.11
+    default: v1.33.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -676,6 +676,7 @@ spec:
       - v1.33.9
       - v1.33.10
       - v1.33.11
+      - v1.33.12
       - v1.34.1
       - v1.34.2
       - v1.34.3
@@ -683,6 +684,7 @@ spec:
       - v1.34.5
       - v1.34.6
       - v1.34.7
+      - v1.34.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -226,7 +226,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.33.11"),
+		Default: semver.NewSemverOrDie("v1.33.12"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -265,6 +265,7 @@ var (
 			newSemver("v1.33.9"),
 			newSemver("v1.33.10"),
 			newSemver("v1.33.11"),
+			newSemver("v1.33.12"),
 			// Kubernetes 1.34
 			newSemver("v1.34.1"),
 			newSemver("v1.34.2"),
@@ -273,6 +274,7 @@ var (
 			newSemver("v1.34.5"),
 			newSemver("v1.34.6"),
 			newSemver("v1.34.7"),
+			newSemver("v1.34.8"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.31 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherrypick for https://github.com/kubermatic/kubermatic/pull/15869

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support of k8s patch releases v1.34.8/v1.33.12
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
