### PR TITLE
Update control-plane version skew logic to allow 3-version difference

### DIFF
--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -282,7 +282,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 	// update rules configured in the KubermaticConfiguration make a distinction between control-plane upgrades
 	// and node upgrades). However we must still ensure that this controller doesn't advance the control-plane
 	// to a point where it is not compatible with the nodes anymore.
-	// Kubelets can be 2 versions behind the control-plane.
+	// Kubelets can be 2 versions behind the control-plane (or 3 versions starting from Kubernetes 1.28).
 	if cpStatus.nodes != nil {
 		a := int(cpStatus.nodes.Semver().Minor())
 		b := int(cluster.Status.Versions.ControlPlane.Semver().Minor())
@@ -292,12 +292,16 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 			distance = -distance
 		}
 
-		if distance >= 2 {
+		maxSkew := 2
+		if b >= 27 { // Updating starting from 1.27 to 1.28 will require a skew size of 3 to be allowed
+			maxSkew = 3
+		}
+		if distance > maxSkew {
 			log.Debugw("Cluster control plane is healthy but cluster still has old nodes.", "controlPlane", cluster.Status.Versions.ControlPlane, "oldestNode", cpStatus.nodes)
 			return r.setClusterCondition(ctx, cluster, ClusterConditionOldNodes, fmt.Sprintf("Update in progress, control plane (v%s) is healthy but cluster still has old nodes (v%s).", cluster.Status.Versions.ControlPlane.String(), cpStatus.nodes.String()))
 		}
 
-		// Distance is at most 1 release, so the control plane is free to be updated at any time.
+		// Distance is within allowed release skew, so the control plane is free to be updated at any time.
 	}
 
 	// At this point we know that the entire control plane is healthy, that scheduler/ctrlmgr versions


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the control-plane/node version skew validation logic to support the Kubernetes version skew policy introduced in Kubernetes 1.28.

Previously, the controller blocked control-plane upgrades when worker nodes were 2 minor versions behind. Starting from Kubernetes 1.28, kubelets are allowed to be up to 3 minor versions behind the kube-apiserver. This change adjusts the reconciliation logic accordingly by dynamically allowing a skew of 3 for Kubernetes 1.28+ upgrades while preserving the previous behavior for older versions.


**What type of PR is this?**
```text
/kind bug
````

**Special notes for your reviewer**:

The skew calculation logic now dynamically determines the allowed maximum skew based on the target control-plane version:

* Kubernetes < 1.28 → max skew = 2
* Kubernetes >= 1.28 → max skew = 3

This aligns the controller behavior with the upstream Kubernetes version skew policy.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Updated the seed update controller to allow Kubernetes control-plane upgrades with up to 3 minor version skew between kubelets and the control plane starting from Kubernetes 1.28, matching upstream Kubernetes compatibility policy.
```

**Documentation**:

```documentation
NONE
```

**Test issue**:

```test-issue
NONE
```
