### PR TITLE
Upgrade Seed MLA Loki chart to v7.0.0

### DIFF
--- a/charts/logging/loki/Chart.lock
+++ b/charts/logging/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana.github.io/helm-charts
-  version: 5.47.2
-digest: sha256:b5165be4ab93df82c4021130025fb5af051e29d842197c4ec0b978905fd63909
-generated: "2024-04-11T13:46:42.576949182+02:00"
+  version: 7.0.0
+digest: sha256:b76cef90516b99c644317dd1e16dcd7f93713c662774ebb6048e05b56c1ff6a6
+generated: "2026-05-08T18:12:18.429490346+02:00"

--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: loki
 version: 9.9.9-dev
-appVersion: v2.9.6
+appVersion: v3.6.7
 description: "Loki: like Prometheus, but for logs."
 keywords:
   - kubermatic
@@ -32,4 +32,4 @@ maintainers:
 dependencies:
   - name: loki
     repository: https://grafana.github.io/helm-charts
-    version: 5.47.2
+    version: 7.0.0

--- a/charts/logging/loki/test/default.yaml.out
+++ b/charts/logging/loki/test/default.yaml.out
@@ -6,11 +6,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 automountServiceAccountToken: true
 ---
 # Source: loki/charts/loki/templates/config.yaml
@@ -20,40 +19,48 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 data:
   config.yaml: |
     
     auth_enabled: false
+    bloom_build:
+      builder:
+        planner_address: ""
+      enabled: false
+    bloom_gateway:
+      client:
+        addresses: ""
+      enabled: false
     common:
-      compactor_address: 'http://loki:3100'
+      compactor_grpc_address: 'loki.default.svc.cluster.local:9095'
       path_prefix: /var/loki
       replication_factor: 3
       storage:
-        s3:
-          bucketnames: chunks
-          insecure: false
-          s3forcepathstyle: false
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
     compactor:
       compaction_interval: 10m
+      delete_request_store: filesystem
       max_compaction_parallelism: 10
       retention_delete_delay: 10m
       retention_delete_worker_count: 150
       retention_enabled: true
-      shared_store: filesystem
-      working_directory: /var/loki/boltdb-shipper-compactor
+      working_directory: /var/loki/tsdb-shipper-compactor
     frontend:
       scheduler_address: ""
+      tail_proxy_url: ""
     frontend_worker:
       scheduler_address: ""
     index_gateway:
-      mode: ring
+      mode: simple
     ingester:
       chunk_block_size: 262144
+      chunk_encoding: snappy
       chunk_idle_period: 3m
       chunk_retain_period: 1m
       lifecycler:
@@ -62,42 +69,30 @@ data:
             store: inmemory
           replication_factor: 1
     limits_config:
-      enforce_metric_name: false
       max_cache_freshness_per_query: 10m
+      query_timeout: 300s
       reject_old_samples: true
       reject_old_samples_max_age: 144h
       retention_period: 720h
       split_queries_by_interval: 15m
+      volume_enabled: true
     memberlist:
-      join_members:
-      - loki-memberlist
+      join_members: []
+    pattern_ingester:
+      enabled: false
+    querier:
+      max_concurrent: 2
     query_range:
       align_queries_with_step: true
     ruler:
       storage:
-        s3:
-          bucketnames: ruler
-          insecure: false
-          s3forcepathstyle: false
-        type: s3
+        type: local
+      wal:
+        dir: /var/loki/ruler-wal
     runtime_config:
       file: /etc/loki/runtime-config/runtime-config.yaml
     schema_config:
       configs:
-      - from: "2018-04-15"
-        index:
-          period: 144h
-          prefix: index_
-        object_store: filesystem
-        schema: v9
-        store: boltdb
-      - from: "2021-07-01"
-        index:
-          period: 24h
-          prefix: index_
-        object_store: filesystem
-        schema: v11
-        store: boltdb-shipper
       - from: "2022-01-11"
         index:
           period: 24h
@@ -105,23 +100,42 @@ data:
         object_store: filesystem
         schema: v12
         store: boltdb-shipper
+      - from: "2026-05-13"
+        index:
+          period: 24h
+          prefix: index_
+        object_store: filesystem
+        schema: v13
+        store: tsdb
     server:
       grpc_listen_port: 9095
       http_listen_port: 3100
+      http_server_read_timeout: 600s
+      http_server_write_timeout: 600s
     storage_config:
+      bloom_shipper:
+        working_directory: /var/loki/data/bloomshipper
       boltdb:
         directory: /var/loki/index
       boltdb_shipper:
         active_index_directory: /var/loki/boltdb-shipper-active
         cache_location: /var/loki/boltdb-shipper-cache
         cache_ttl: 24h
-        shared_store: filesystem
+        index_gateway_client:
+          server_address: ""
       filesystem:
         directory: /var/loki/chunks
       hedging:
         at: 250ms
         max_per_second: 20
         up_to: 3
+      tsdb_shipper:
+        active_index_directory: /var/loki/tsdb-shipper/active
+        cache_location: /var/loki/tsdb-shipper/cache
+        cache_ttl: 24h
+        index_gateway_client:
+          server_address: ""
+      use_thanos_objstore: false
     table_manager:
       retention_deletes_enabled: true
       retention_period: 720h
@@ -135,11 +149,10 @@ metadata:
   name: loki-runtime
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 data:
   runtime-config.yaml: |
     {}
@@ -149,11 +162,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
   name: loki-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -166,11 +178,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: loki-clusterrolebinding
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 subjects:
   - kind: ServiceAccount
     name: loki
@@ -187,11 +198,11 @@ metadata:
   name: loki-memberlist
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
+  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -212,11 +223,10 @@ metadata:
   name: loki-headless
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
     variant: headless
     prometheus.io/service-monitor: "false"
   annotations:
@@ -238,11 +248,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
   annotations:
 spec:
   type: ClusterIP
@@ -267,11 +276,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
     app.kubernetes.io/component: single-binary
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -290,10 +298,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cda108a31c2d09ccf82f099f4373cb12635a2c04f8bfd335390ecaa7241df48
+        checksum/config: 08d83b7a1a77344ca3f9936c23216052e4cdd092d3773af1613559948e1d2db8
+        storage/size: "15Gi"
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
+        kubectl.kubernetes.io/default-container: "loki"
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: release-name
@@ -306,13 +316,14 @@ spec:
       
       securityContext:
         fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
       terminationGracePeriodSeconds: 30
       containers:
         - name: loki
-          image: docker.io/grafana/loki:2.9.6
+          image: docker.io/grafana/loki:3.6.7
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -327,6 +338,9 @@ spec:
             - name: http-memberlist
               containerPort: 7946
               protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 750MiB
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -334,10 +348,13 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /ready
               port: http-metrics
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
             timeoutSeconds: 1
           volumeMounts:
             - name: tmp
@@ -348,6 +365,8 @@ spec:
               mountPath: /etc/loki/runtime-config
             - name: storage
               mountPath: /var/loki
+            - name: sc-rules-volume
+              mountPath: "/rules"
           resources:
             limits:
               cpu: "1"
@@ -355,16 +374,44 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+        - name: loki-sc-rules
+          image: docker.io/kiwigrid/k8s-sidecar:2.5.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: "loki_rule"
+            - name: FOLDER
+              value: "/rules"
+            - name: RESOURCE
+              value: "both"
+            - name: WATCH_SERVER_TIMEOUT
+              value: "60"
+            - name: WATCH_CLIENT_TIMEOUT
+              value: "60"
+            - name: LOG_LEVEL
+              value: "INFO"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: sc-rules-volume
+              mountPath: "/rules"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: loki
-                  app.kubernetes.io/instance: release-name
-                  app.kubernetes.io/component: single-binary
-              topologyKey: kubernetes.io/hostname
-        
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: single-binary
+                app.kubernetes.io/instance: 'release-name'
+                app.kubernetes.io/name: 'loki'
+            topologyKey: kubernetes.io/hostname
       volumes:
         - name: tmp
           emptyDir: {}
@@ -377,6 +424,8 @@ spec:
         - name: runtime-config
           configMap:
             name: loki-runtime
+        - name: sc-rules-volume
+          emptyDir: {}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/charts/logging/loki/test/values.example.ce.yaml.out
+++ b/charts/logging/loki/test/values.example.ce.yaml.out
@@ -6,11 +6,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 automountServiceAccountToken: true
 ---
 # Source: loki/charts/loki/templates/config.yaml
@@ -20,40 +19,48 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 data:
   config.yaml: |
     
     auth_enabled: false
+    bloom_build:
+      builder:
+        planner_address: ""
+      enabled: false
+    bloom_gateway:
+      client:
+        addresses: ""
+      enabled: false
     common:
-      compactor_address: 'http://loki:3100'
+      compactor_grpc_address: 'loki.default.svc.cluster.local:9095'
       path_prefix: /var/loki
       replication_factor: 3
       storage:
-        s3:
-          bucketnames: chunks
-          insecure: false
-          s3forcepathstyle: false
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
     compactor:
       compaction_interval: 10m
+      delete_request_store: filesystem
       max_compaction_parallelism: 10
       retention_delete_delay: 10m
       retention_delete_worker_count: 150
       retention_enabled: true
-      shared_store: filesystem
-      working_directory: /var/loki/boltdb-shipper-compactor
+      working_directory: /var/loki/tsdb-shipper-compactor
     frontend:
       scheduler_address: ""
+      tail_proxy_url: ""
     frontend_worker:
       scheduler_address: ""
     index_gateway:
-      mode: ring
+      mode: simple
     ingester:
       chunk_block_size: 262144
+      chunk_encoding: snappy
       chunk_idle_period: 3m
       chunk_retain_period: 1m
       lifecycler:
@@ -62,42 +69,30 @@ data:
             store: inmemory
           replication_factor: 1
     limits_config:
-      enforce_metric_name: false
       max_cache_freshness_per_query: 10m
+      query_timeout: 300s
       reject_old_samples: true
       reject_old_samples_max_age: 144h
       retention_period: 720h
       split_queries_by_interval: 15m
+      volume_enabled: true
     memberlist:
-      join_members:
-      - loki-memberlist
+      join_members: []
+    pattern_ingester:
+      enabled: false
+    querier:
+      max_concurrent: 2
     query_range:
       align_queries_with_step: true
     ruler:
       storage:
-        s3:
-          bucketnames: ruler
-          insecure: false
-          s3forcepathstyle: false
-        type: s3
+        type: local
+      wal:
+        dir: /var/loki/ruler-wal
     runtime_config:
       file: /etc/loki/runtime-config/runtime-config.yaml
     schema_config:
       configs:
-      - from: "2018-04-15"
-        index:
-          period: 144h
-          prefix: index_
-        object_store: filesystem
-        schema: v9
-        store: boltdb
-      - from: "2021-07-01"
-        index:
-          period: 24h
-          prefix: index_
-        object_store: filesystem
-        schema: v11
-        store: boltdb-shipper
       - from: "2022-01-11"
         index:
           period: 24h
@@ -105,23 +100,42 @@ data:
         object_store: filesystem
         schema: v12
         store: boltdb-shipper
+      - from: "2026-05-13"
+        index:
+          period: 24h
+          prefix: index_
+        object_store: filesystem
+        schema: v13
+        store: tsdb
     server:
       grpc_listen_port: 9095
       http_listen_port: 3100
+      http_server_read_timeout: 600s
+      http_server_write_timeout: 600s
     storage_config:
+      bloom_shipper:
+        working_directory: /var/loki/data/bloomshipper
       boltdb:
         directory: /var/loki/index
       boltdb_shipper:
         active_index_directory: /var/loki/boltdb-shipper-active
         cache_location: /var/loki/boltdb-shipper-cache
         cache_ttl: 24h
-        shared_store: filesystem
+        index_gateway_client:
+          server_address: ""
       filesystem:
         directory: /var/loki/chunks
       hedging:
         at: 250ms
         max_per_second: 20
         up_to: 3
+      tsdb_shipper:
+        active_index_directory: /var/loki/tsdb-shipper/active
+        cache_location: /var/loki/tsdb-shipper/cache
+        cache_ttl: 24h
+        index_gateway_client:
+          server_address: ""
+      use_thanos_objstore: false
     table_manager:
       retention_deletes_enabled: true
       retention_period: 720h
@@ -135,11 +149,10 @@ metadata:
   name: loki-runtime
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 data:
   runtime-config.yaml: |
     {}
@@ -149,11 +162,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
   name: loki-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -166,11 +178,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: loki-clusterrolebinding
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 subjects:
   - kind: ServiceAccount
     name: loki
@@ -187,11 +198,11 @@ metadata:
   name: loki-memberlist
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
+  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -212,11 +223,10 @@ metadata:
   name: loki-headless
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
     variant: headless
     prometheus.io/service-monitor: "false"
   annotations:
@@ -238,11 +248,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
   annotations:
 spec:
   type: ClusterIP
@@ -267,11 +276,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
     app.kubernetes.io/component: single-binary
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -290,10 +298,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cda108a31c2d09ccf82f099f4373cb12635a2c04f8bfd335390ecaa7241df48
+        checksum/config: 08d83b7a1a77344ca3f9936c23216052e4cdd092d3773af1613559948e1d2db8
+        storage/size: "15Gi"
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
+        kubectl.kubernetes.io/default-container: "loki"
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: release-name
@@ -306,13 +316,14 @@ spec:
       
       securityContext:
         fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
       terminationGracePeriodSeconds: 30
       containers:
         - name: loki
-          image: docker.io/grafana/loki:2.9.6
+          image: docker.io/grafana/loki:3.6.7
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -327,6 +338,9 @@ spec:
             - name: http-memberlist
               containerPort: 7946
               protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 750MiB
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -334,10 +348,13 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /ready
               port: http-metrics
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
             timeoutSeconds: 1
           volumeMounts:
             - name: tmp
@@ -348,6 +365,8 @@ spec:
               mountPath: /etc/loki/runtime-config
             - name: storage
               mountPath: /var/loki
+            - name: sc-rules-volume
+              mountPath: "/rules"
           resources:
             limits:
               cpu: "1"
@@ -355,16 +374,44 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+        - name: loki-sc-rules
+          image: docker.io/kiwigrid/k8s-sidecar:2.5.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: "loki_rule"
+            - name: FOLDER
+              value: "/rules"
+            - name: RESOURCE
+              value: "both"
+            - name: WATCH_SERVER_TIMEOUT
+              value: "60"
+            - name: WATCH_CLIENT_TIMEOUT
+              value: "60"
+            - name: LOG_LEVEL
+              value: "INFO"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: sc-rules-volume
+              mountPath: "/rules"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: loki
-                  app.kubernetes.io/instance: release-name
-                  app.kubernetes.io/component: single-binary
-              topologyKey: kubernetes.io/hostname
-        
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: single-binary
+                app.kubernetes.io/instance: 'release-name'
+                app.kubernetes.io/name: 'loki'
+            topologyKey: kubernetes.io/hostname
       volumes:
         - name: tmp
           emptyDir: {}
@@ -377,6 +424,8 @@ spec:
         - name: runtime-config
           configMap:
             name: loki-runtime
+        - name: sc-rules-volume
+          emptyDir: {}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/charts/logging/loki/test/values.example.ee.yaml.out
+++ b/charts/logging/loki/test/values.example.ee.yaml.out
@@ -6,11 +6,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 automountServiceAccountToken: true
 ---
 # Source: loki/charts/loki/templates/config.yaml
@@ -20,40 +19,48 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 data:
   config.yaml: |
     
     auth_enabled: false
+    bloom_build:
+      builder:
+        planner_address: ""
+      enabled: false
+    bloom_gateway:
+      client:
+        addresses: ""
+      enabled: false
     common:
-      compactor_address: 'http://loki:3100'
+      compactor_grpc_address: 'loki.default.svc.cluster.local:9095'
       path_prefix: /var/loki
       replication_factor: 3
       storage:
-        s3:
-          bucketnames: chunks
-          insecure: false
-          s3forcepathstyle: false
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
     compactor:
       compaction_interval: 10m
+      delete_request_store: filesystem
       max_compaction_parallelism: 10
       retention_delete_delay: 10m
       retention_delete_worker_count: 150
       retention_enabled: true
-      shared_store: filesystem
-      working_directory: /var/loki/boltdb-shipper-compactor
+      working_directory: /var/loki/tsdb-shipper-compactor
     frontend:
       scheduler_address: ""
+      tail_proxy_url: ""
     frontend_worker:
       scheduler_address: ""
     index_gateway:
-      mode: ring
+      mode: simple
     ingester:
       chunk_block_size: 262144
+      chunk_encoding: snappy
       chunk_idle_period: 3m
       chunk_retain_period: 1m
       lifecycler:
@@ -62,42 +69,30 @@ data:
             store: inmemory
           replication_factor: 1
     limits_config:
-      enforce_metric_name: false
       max_cache_freshness_per_query: 10m
+      query_timeout: 300s
       reject_old_samples: true
       reject_old_samples_max_age: 144h
       retention_period: 720h
       split_queries_by_interval: 15m
+      volume_enabled: true
     memberlist:
-      join_members:
-      - loki-memberlist
+      join_members: []
+    pattern_ingester:
+      enabled: false
+    querier:
+      max_concurrent: 2
     query_range:
       align_queries_with_step: true
     ruler:
       storage:
-        s3:
-          bucketnames: ruler
-          insecure: false
-          s3forcepathstyle: false
-        type: s3
+        type: local
+      wal:
+        dir: /var/loki/ruler-wal
     runtime_config:
       file: /etc/loki/runtime-config/runtime-config.yaml
     schema_config:
       configs:
-      - from: "2018-04-15"
-        index:
-          period: 144h
-          prefix: index_
-        object_store: filesystem
-        schema: v9
-        store: boltdb
-      - from: "2021-07-01"
-        index:
-          period: 24h
-          prefix: index_
-        object_store: filesystem
-        schema: v11
-        store: boltdb-shipper
       - from: "2022-01-11"
         index:
           period: 24h
@@ -105,23 +100,42 @@ data:
         object_store: filesystem
         schema: v12
         store: boltdb-shipper
+      - from: "2026-05-13"
+        index:
+          period: 24h
+          prefix: index_
+        object_store: filesystem
+        schema: v13
+        store: tsdb
     server:
       grpc_listen_port: 9095
       http_listen_port: 3100
+      http_server_read_timeout: 600s
+      http_server_write_timeout: 600s
     storage_config:
+      bloom_shipper:
+        working_directory: /var/loki/data/bloomshipper
       boltdb:
         directory: /var/loki/index
       boltdb_shipper:
         active_index_directory: /var/loki/boltdb-shipper-active
         cache_location: /var/loki/boltdb-shipper-cache
         cache_ttl: 24h
-        shared_store: filesystem
+        index_gateway_client:
+          server_address: ""
       filesystem:
         directory: /var/loki/chunks
       hedging:
         at: 250ms
         max_per_second: 20
         up_to: 3
+      tsdb_shipper:
+        active_index_directory: /var/loki/tsdb-shipper/active
+        cache_location: /var/loki/tsdb-shipper/cache
+        cache_ttl: 24h
+        index_gateway_client:
+          server_address: ""
+      use_thanos_objstore: false
     table_manager:
       retention_deletes_enabled: true
       retention_period: 720h
@@ -135,11 +149,10 @@ metadata:
   name: loki-runtime
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 data:
   runtime-config.yaml: |
     {}
@@ -149,11 +162,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
   name: loki-clusterrole
 rules:
 - apiGroups: [""] # "" indicates the core API group
@@ -166,11 +178,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: loki-clusterrolebinding
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
 subjects:
   - kind: ServiceAccount
     name: loki
@@ -187,11 +198,11 @@ metadata:
   name: loki-memberlist
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
+  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -212,11 +223,10 @@ metadata:
   name: loki-headless
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
     variant: headless
     prometheus.io/service-monitor: "false"
   annotations:
@@ -238,11 +248,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
   annotations:
 spec:
   type: ClusterIP
@@ -267,11 +276,10 @@ metadata:
   name: loki
   namespace: default
   labels:
-    helm.sh/chart: loki-5.47.2
+    helm.sh/chart: loki-7.0.0
     app.kubernetes.io/name: loki
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "2.9.6"
-    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "3.6.7"
     app.kubernetes.io/component: single-binary
     app.kubernetes.io/part-of: memberlist
 spec:
@@ -290,10 +298,12 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5cda108a31c2d09ccf82f099f4373cb12635a2c04f8bfd335390ecaa7241df48
+        checksum/config: 08d83b7a1a77344ca3f9936c23216052e4cdd092d3773af1613559948e1d2db8
+        storage/size: "15Gi"
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
+        kubectl.kubernetes.io/default-container: "loki"
       labels:
         app.kubernetes.io/name: loki
         app.kubernetes.io/instance: release-name
@@ -306,13 +316,14 @@ spec:
       
       securityContext:
         fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
         runAsGroup: 10001
         runAsNonRoot: true
         runAsUser: 10001
       terminationGracePeriodSeconds: 30
       containers:
         - name: loki
-          image: docker.io/grafana/loki:2.9.6
+          image: docker.io/grafana/loki:3.6.7
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -327,6 +338,9 @@ spec:
             - name: http-memberlist
               containerPort: 7946
               protocol: TCP
+          env:
+            - name: GOMEMLIMIT
+              value: 750MiB
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -334,10 +348,13 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           readinessProbe:
+            failureThreshold: 3
             httpGet:
               path: /ready
               port: http-metrics
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
             timeoutSeconds: 1
           volumeMounts:
             - name: tmp
@@ -348,6 +365,8 @@ spec:
               mountPath: /etc/loki/runtime-config
             - name: storage
               mountPath: /var/loki
+            - name: sc-rules-volume
+              mountPath: "/rules"
           resources:
             limits:
               cpu: "1"
@@ -355,16 +374,44 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+        - name: loki-sc-rules
+          image: docker.io/kiwigrid/k8s-sidecar:2.5.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METHOD
+              value: WATCH
+            - name: LABEL
+              value: "loki_rule"
+            - name: FOLDER
+              value: "/rules"
+            - name: RESOURCE
+              value: "both"
+            - name: WATCH_SERVER_TIMEOUT
+              value: "60"
+            - name: WATCH_CLIENT_TIMEOUT
+              value: "60"
+            - name: LOG_LEVEL
+              value: "INFO"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: sc-rules-volume
+              mountPath: "/rules"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: loki
-                  app.kubernetes.io/instance: release-name
-                  app.kubernetes.io/component: single-binary
-              topologyKey: kubernetes.io/hostname
-        
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: single-binary
+                app.kubernetes.io/instance: 'release-name'
+                app.kubernetes.io/name: 'loki'
+            topologyKey: kubernetes.io/hostname
       volumes:
         - name: tmp
           emptyDir: {}
@@ -377,6 +424,8 @@ spec:
         - name: runtime-config
           configMap:
             name: loki-runtime
+        - name: sc-rules-volume
+          emptyDir: {}
   volumeClaimTemplates:
     - apiVersion: v1
       kind: PersistentVolumeClaim

--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -15,13 +15,13 @@
 loki:
   fullnameOverride: loki
 
-  # enable tracing for debug, need install jaeger and specify right jaeger_agent_host
   tracing:
-    jaegerAgentHost:
+    enabled: false
 
   loki:
     auth_enabled: false
     ingester:
+      chunk_encoding: snappy
       chunk_idle_period: 3m
       chunk_block_size: 262144
       chunk_retain_period: 1m
@@ -30,27 +30,20 @@ loki:
           kvstore:
             store: inmemory
           replication_factor: 1
+    querier:
+      # Default is 4, if you have enough memory and CPU you can increase, reduce if OOMing
+      max_concurrent: 2
+    memberlistConfig:
+      # Force empty memberlist since we're running in single binary mode with 1 replica.
+      # This is instead of the single member loki-memberlist.logging.svc.cluster.local.
+      # Otherwise Loki logs an error at startup: "failed to fast-join the memberlist".
+      join_members: []
     limits_config:
-      enforce_metric_name: false
       reject_old_samples: true
       reject_old_samples_max_age: 144h
       retention_period: 720h
     schemaConfig:
       configs:
-      - from: 2018-04-15
-        store: boltdb
-        object_store: filesystem
-        schema: v9
-        index:
-          prefix: index_
-          period: 144h
-      - from: 2021-07-01
-        store: boltdb-shipper
-        object_store: filesystem
-        schema: v11
-        index:
-          prefix: index_
-          period: 24h
       - from: 2022-01-11
         store: boltdb-shipper
         object_store: filesystem
@@ -58,6 +51,18 @@ loki:
         index:
           prefix: loki_index_
           period: 24h
+      - from: 2026-05-13
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: index_
+          period: 24h
+    storage:
+      type: filesystem
+      filesystem:
+        chunks_directory: /var/loki/chunks
+        rules_directory: /var/loki/rules
     storage_config:
       boltdb:
         directory: /var/loki/index
@@ -67,12 +72,15 @@ loki:
         active_index_directory: /var/loki/boltdb-shipper-active
         cache_location: /var/loki/boltdb-shipper-cache
         cache_ttl: 24h
-        shared_store: filesystem
+      tsdb_shipper:
+        active_index_directory: /var/loki/tsdb-shipper/active
+        cache_location: /var/loki/tsdb-shipper/cache
+        cache_ttl: 24h
     chunk_store_config:
       max_look_back_period: 720h
     compactor:
-      working_directory: /var/loki/boltdb-shipper-compactor
-      shared_store: filesystem
+      working_directory: /var/loki/tsdb-shipper-compactor
+      delete_request_store: filesystem
       compaction_interval: 10m
       retention_enabled: true
       retention_delete_delay: 10m
@@ -83,6 +91,7 @@ loki:
     retention_deletes_enabled: true
     retention_period: 720h
 
+  deploymentMode: SingleBinary
   singleBinary:
     replicas: 1
 
@@ -100,6 +109,10 @@ loki:
       requests:
         cpu: 300m
         memory: 256Mi
+    extraEnv:
+      # Keep a little bit lower than memory limits
+      - name: GOMEMLIMIT
+        value: 750MiB
 
     podLabels: {}
     podAnnotations:
@@ -107,18 +120,26 @@ loki:
       prometheus.io/port: "3100"
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
 
+  chunksCache:
+    # if enabled, the chunks cache is served via a memcached StatefulSet
+    enabled: false
+
+  resultsCache:
+    # if enabled, the results cache is served via a memcached StatefulSet
+    enabled: false
+
+  backend:
+    replicas: 0
+  read:
+    replicas: 0
+  write:
+    replicas: 0
+
   gateway:
     enabled: false
 
   test:
     enabled: false
 
-  monitoring:
-    dashboards:
-      enabled: false
-    selfMonitoring:
-      enabled: false
-      grafanaAgent:
-        installOperator: false
-    lokiCanary:
-      enabled: false
+  lokiCanary:
+    enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade the loki chart of the seed MLA stack from version 5.47.2 (Loki 2.9.6) to 7.0.0 (Loki 3.6.7).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15200
Relates to #15516

**What type of PR is this?**
/kind feature
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

This is how I migrated to the new version:
1. Using the same chart version migrate from using BoltDB to using TSDB by adding an entry to `schemaConfig` and configuring `storageConfig.tsdb_shipper` as well as `compactor`. See [Loki chart TSDB migration docs](https://grafana.com/docs/loki/latest/setup/migrate/migrate-to-tsdb/). (I double-checked that the new `schemaConfig` entry can be applied along with the chart upgrade at the same time without problems as opposed to what the documentation indicates.)
2. Upgrade Loki chart to version 7 which uses Loki 3.6.7. See [Loki chart upgrade to v6 docs](https://grafana.com/docs/loki/latest/setup/upgrade/upgrade-to-6x/) as well as the [single-binary chart values example](https://github.com/grafana/loki/blob/dc21099f771746314c9810829fc9673b284c9ad2/production/helm/loki/single-binary-values.yaml).
3. Iterated on installing the new chart version until the Pod became available successfully (after all unsupported config fields had been removed and the new configuration was corrected) as well as to reduce the amount of error logs as much as possible (there are fewer than before the upgrade now). Remaining known transient error logs: 
  * `error getting ingester clients` is logged once when the Pod starts due to the empty client list which is expected for the single-binary deployment mode and therefore has no impact on the functionality.
  * `msg="skipping compaction since we can't find schema for table" table=loki_index_20588` is logged by the compactor every 10 minutes, referring to the old `schemaConfig` entry which I left for now for historic clarity but which can be removed in the future. The log line has no impact on the functionality.
4. I successfully tested running the previous Loki chart version v5 for a while to gather logs before upgrading the Helm release to the newer version chart version with the new values and ensuring that the Loki Pod becomes available after the upgrade and that old logs (from before the upgrade) can still be found via Grafana/Loki. As test environment I used the KKP example setup that I enhanced correspondingly [here](https://github.com/kubermatic/community-components/pull/158):
4.1. To spin up the environment, I followed the updated instructions within the README.md of that example until the `make kkp-apply` command.
4.2. To install the Seed MLA stack with the old Loki version, I called `make kkp-apply-seed-mla`.
4.3. I've let Loki gather some Pod logs and wait for it to do the compaction (every 10 minutes).
4.4. I've replaced the downloaded logging/loki chart within the `20-kkp/release/kubermatic-ce-v2.30.3-linux-amd64/charts/logging/loki` directory with the updated version from this PR (`rm -rf 20-kkp/release/kubermatic-ce-v2.30.3-linux-amd64/charts/logging/loki && cp -r ../../../kubermatic/charts/logging/loki 20-kkp/release/kubermatic-ce-v2.30.3-linux-amd64/charts/logging/loki`).
4.5. I called  `make kkp-apply-seed-mla` again, to upgrade the Loki installation to the new chart version (during subsequent iterations I had to bump the version within the Loki Chart.yaml to make the Kubermatic installer really reinstall the Loki chart instead of skipping the reinstallation since the chart version didn't change).

I did not upgrade the Loki installation to use the new Loki community chart (v13) yet, see [community chart migration docs](https://grafana.com/docs/loki/latest/setup/upgrade/upgrade-to-community/). That would have to happen for a subsequent KKP release since the Loki v7 is the last official chart version that was just deprecated in favour of the community chart.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Seed MLA Loki chart has been upgraded to version v7.0.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/kubermatic/issues/15889
```
