### PR TITLE
Fix app catalog e2e CRD installation to unblock CI

### DIFF
--- a/hack/ci/run-appcatalog-manager-e2e-tests.sh
+++ b/hack/ci/run-appcatalog-manager-e2e-tests.sh
@@ -51,7 +51,7 @@ source hack/ci/setup-kind-cluster.sh
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
-kubectl apply -f pkg/crd/k8c.io
+create_crds_for_fresh_cluster pkg/crd/k8c.io
 source hack/ci/setup-kubermatic-in-kind.sh
 
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"

--- a/hack/ci/run-application-definitions-e2e-test.sh
+++ b/hack/ci/run-application-definitions-e2e-test.sh
@@ -39,7 +39,7 @@ source hack/ci/setup-kind-cluster.sh
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
-kubectl apply -f pkg/crd/k8c.io
+create_crds_for_fresh_cluster pkg/crd/k8c.io
 source hack/ci/setup-kubermatic-in-kind.sh
 
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"

--- a/hack/ci/run-default-application-e2e-test.sh
+++ b/hack/ci/run-default-application-e2e-test.sh
@@ -49,7 +49,7 @@ source hack/ci/setup-kind-cluster.sh
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
-kubectl apply -f pkg/crd/k8c.io
+create_crds_for_fresh_cluster pkg/crd/k8c.io
 source hack/ci/setup-kubermatic-in-kind.sh
 
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -509,6 +509,15 @@ set_crds_version_annotation() {
   done < <(find "$directory" -name '*.yaml' -print0 | sort --zero-terminated)
 }
 
+# create_crds_for_fresh_cluster installs CRDs without client-side apply's
+# kubectl.kubernetes.io/last-applied-configuration annotation, which can exceed
+# Kubernetes' annotation size limit for large generated CRDs.
+create_crds_for_fresh_cluster() {
+  local directory="$1"
+
+  kubectl create --save-config=false --filename "$directory"
+}
+
 # go_test wraps running `go test` commands. The first argument needs to be file name
 # for a junit result file that will be generated if go-junit-report is present and
 # $ARTIFACTS is set. The remaining arguments are passed to `go test`.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes app catalog e2e CRD installation by creating CRDs without storing kubectl's client-side apply configuration annotation.

Some generated KKP CRDs are large enough that `kubectl apply` can exceed Kubernetes' annotation size limit when it writes `kubectl.kubernetes.io/last-applied- configuration`, causing the e2e setup to fail with `metadata.annotations: Too long`. Since these tests install CRDs into a fresh kind cluster, `kubectl create --save-config=false` is sufficient and avoids the oversized annotation.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
