### PR TITLE
fix: finalize EtcdBackupConfig when owning Cluster CR is already gone

### DIFF
--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -177,7 +177,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	cluster := &kubermaticv1.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Name: backupConfig.Spec.Cluster.Name}, cluster); err != nil {
-		return reconcile.Result{}, err
+		if !apierrors.IsNotFound(err) {
+			return reconcile.Result{}, err
+		}
+		// Cluster is already gone. If this backupConfig is also being deleted, clear stale
+		// backup entries and remove the finalizer so the namespace can be garbage-collected.
+		if backupConfig.DeletionTimestamp != nil {
+			return reconcile.Result{}, r.finalizeOrphanedBackupConfig(ctx, backupConfig)
+		}
+		return reconcile.Result{}, nil
 	}
 
 	if cluster.Status.NamespaceName == "" {
@@ -803,6 +811,18 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 	err := kuberneteshelper.TryRemoveFinalizer(ctx, r, backupConfig, DeleteAllBackupsFinalizer)
 
 	return nil, err
+}
+
+// finalizeOrphanedBackupConfig removes stale backup status entries and the finalizer from an
+// EtcdBackupConfig whose owning Cluster CR no longer exists. Without this, the finalizer would
+// block namespace cleanup indefinitely.
+func (r *Reconciler) finalizeOrphanedBackupConfig(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig) error {
+	old := backupConfig.DeepCopy()
+	backupConfig.Status.CurrentBackups = nil
+	if err := r.Status().Patch(ctx, backupConfig, ctrlruntimeclient.MergeFrom(old)); err != nil {
+		return fmt.Errorf("failed to clear stale backup status: %w", err)
+	}
+	return kuberneteshelper.TryRemoveFinalizer(ctx, r, backupConfig, DeleteAllBackupsFinalizer)
 }
 
 func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cluster) error {

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -30,6 +30,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/sdk/v2/semver"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
@@ -43,6 +44,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1820,4 +1822,65 @@ func isInsecureURL(u string) bool {
 	// an HTTP url
 
 	return strings.ToLower(parsed.Scheme) == "http" && parsed.Host != ""
+}
+
+// TestOrphanedBackupConfigFinalization verifies that an EtcdBackupConfig being deleted
+// whose owning Cluster CR is already gone gets its finalizer removed instead of looping
+// with a not-found error (https://github.com/kubermatic/kubermatic/issues/15876).
+func TestOrphanedBackupConfigFinalization(t *testing.T) {
+	t.Parallel()
+
+	cluster := genTestCluster()
+	backupConfig := genBackupConfig(cluster, "testbackup")
+
+	now := metav1.Now()
+	backupConfig.DeletionTimestamp = &now
+	kuberneteshelper.AddFinalizer(backupConfig, DeleteAllBackupsFinalizer)
+	backupConfig.Status.CurrentBackups = []kubermaticv1.BackupStatus{
+		{
+			BackupName:  "testbackup-stale",
+			BackupPhase: kubermaticv1.BackupStatusPhaseCompleted,
+		},
+	}
+
+	// Intentionally omit the cluster from the fake client to simulate it being already gone.
+	fc := fake.NewClientBuilder().WithObjects(backupConfig).WithStatusSubresource(backupConfig).Build()
+
+	reconciler := Reconciler{
+		log:      kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar(),
+		Client:   fc,
+		scheme:   scheme.Scheme,
+		recorder: events.NewFakeRecorder(10),
+		clock:    clocktesting.NewFakeClock(time.Unix(60, 0).UTC()),
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return generator.GenTestSeed(addSeedDestinations), nil
+		},
+		configGetter: getConfigGetter(t),
+	}
+
+	ctx := context.Background()
+	_, err := reconciler.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: backupConfig.Namespace, Name: backupConfig.Name},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	result := &kubermaticv1.EtcdBackupConfig{}
+	err = fc.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(backupConfig), result)
+	if err != nil {
+		// Object deleted entirely after finalizer removal — expected outcome.
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		t.Fatalf("failed to read back EtcdBackupConfig: %v", err)
+	}
+
+	if kuberneteshelper.HasFinalizer(result, DeleteAllBackupsFinalizer) {
+		t.Error("expected finalizer to be removed, but it is still present")
+	}
+
+	if len(result.Status.CurrentBackups) != 0 {
+		t.Errorf("expected CurrentBackups to be empty, got %d entries", len(result.Status.CurrentBackups))
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If an `EtcdBackupConfig` is being deleted and its owning `Cluster` CR is already gone, the etcd-backup controller hits a `not-found` error on every reconcile and never makes progress. The `DeleteAllBackupsFinalizer` stays on forever, blocking the namespace from being garbage collected and spamming errors in the `seed-controller-manager` logs.

The fix: when we detect the cluster is missing and the `EtcdBackupConfig` has a `DeletionTimestamp`, we clear the stale `CurrentBackups` entries (the cluster namespace is gone, so those job references are orphaned anyway) and remove the finalizer, letting namespace cleanup proceed normally.

**Which issue(s) this PR fixes**:
Fixes #15876

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix EtcdBackupConfig getting stuck on deletion when its owning Cluster CR is already gone, which blocked namespace GC and caused continuous error spam in seed-controller-manager logs.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```