### PR TITLE
chore: Grant write access to chart mirror script

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -287,7 +287,8 @@ postsubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-push-kubermatic: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8

--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -149,14 +149,17 @@ login_vault() {
 
 # ─── Authenticate to OCI registry ─────────────────────────────────────────────
 login_registry() {
-  login_vault
+  if [ -z "${QUAY_IO_USERNAME:-}" ] || [ -z "${QUAY_IO_PASSWORD:-}" ]; then
+    # Use read-only registry credentials from Vault in case the script is run locally for testing purposes.
+    # Registry write access is only granted to the prow job which gets the QUAY_IO_* env vars injected by the preset.
+    echo "WARNING: Using read-only $REGISTRY_HOST registry credentials from Vault - for local testing purposes only!"
+    login_vault
+    : "${QUAY_IO_USERNAME:=$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
+    : "${QUAY_IO_PASSWORD:=$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"
+  fi
 
   echo "🌐 Authenticating to registry..."
-
-  REGISTRY_USER="${REGISTRY_USER:-$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
-  REGISTRY_PASSWORD="${REGISTRY_PASSWORD:-$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"
-
-  echo "${REGISTRY_PASSWORD}" | helm registry login "${REGISTRY_HOST}" --username "${REGISTRY_USER}" --password-stdin
+  echo "${QUAY_IO_PASSWORD}" | helm registry login "${REGISTRY_HOST}" --username "${QUAY_IO_USERNAME}" --password-stdin
 }
 
 # ─── Logout from the OCI registry ─────────────────────────────────────────────


### PR DESCRIPTION
**What this PR does / why we need it**:

Grant registry write access to the `mirror-application-charts.sh` script.
This is because the credentials within Vault don't provide registry write access anymore but read-only access.
Instead, another prow preset is used that provides registry write access.

This is a follow-up of:
* #15839
* #15846
* #15851

Relates to https://github.com/kubermatic/machine-controller/pull/2022

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Relates to:
* #15684
* #15693

**What type of PR is this?**
/kind bug
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
