### PR TITLE
Make the installer's deploy command support Helm 4

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"time"
 
-	semverlib "github.com/Masterminds/semver/v3"
 	"github.com/go-logr/zapr"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,7 +49,6 @@ import (
 )
 
 var (
-	MinHelmVersion            = semverlib.MustParse("v3.0.0")
 	UserClusterMinHelmTimeout = 15 * time.Minute
 )
 
@@ -359,24 +357,9 @@ func greeting() string {
 }
 
 func setupHelmClient(logger *logrus.Logger, opt *DeployOptions) (*helm.Client, error) {
-	// error out early if there is no useful Helm binary
 	helmClient, err := helm.NewCLI(opt.HelmBinary, opt.Kubeconfig, opt.KubeContext, opt.HelmTimeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Helm client: %w", err)
-	}
-
-	helmVersion, err := helmClient.Version()
-	if err != nil {
-		return nil, fmt.Errorf("failed to check Helm version: %w", err)
-	}
-
-	if helmVersion.LessThan(MinHelmVersion) {
-		return nil, fmt.Errorf(
-			"the installer requires Helm >= %s, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
-			MinHelmVersion,
-			opt.HelmBinary,
-			helmVersion,
-		)
 	}
 
 	return &helmClient, nil

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -207,7 +207,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 		}
 
 		deployOptions := stack.DeployOptions{
-			HelmClient:                         *helmClient,
+			HelmClient:                         helmClient,
 			HelmValues:                         helmValues,
 			KubermaticConfiguration:            kubermaticConfig,
 			RawKubermaticConfiguration:         rawKubermaticConfig,
@@ -356,13 +356,13 @@ func greeting() string {
 	return greetings[rand.Intn(len(greetings))]
 }
 
-func setupHelmClient(logger *logrus.Logger, opt *DeployOptions) (*helm.Client, error) {
+func setupHelmClient(logger *logrus.Logger, opt *DeployOptions) (helm.Client, error) {
 	helmClient, err := helm.NewCLI(opt.HelmBinary, opt.Kubeconfig, opt.KubeContext, opt.HelmTimeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Helm client: %w", err)
 	}
 
-	return &helmClient, nil
+	return helmClient, nil
 }
 
 func setupKubermaticStack(logger *logrus.Logger, args []string, opt *DeployOptions) (stack.Stack, error) {

--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -482,18 +482,6 @@ func localKindFunc(logger *logrus.Logger, opt LocalOptions) cobraFuncE {
 		if err != nil {
 			logger.Fatalf("Failed to create helm client: %v", err)
 		}
-		helmVersion, err := helmClient.Version()
-		if err != nil {
-			logger.Fatalf("Failed to check Helm version: %v", err)
-		}
-		if helmVersion.LessThan(MinHelmVersion) {
-			logger.Fatalf(
-				"the installer requires Helm >= %s, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
-				MinHelmVersion,
-				opt.HelmBinary,
-				helmVersion,
-			)
-		}
 		installKubevirt(logger, helmClient, opt)
 		endpoint := installKubermatic(logger, exampleDir, kubeClient, helmClient, opt)
 		logger.Infoln()

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -400,24 +400,9 @@ func collectHelmChartImages(ctx context.Context, logger *logrus.Logger, kubermat
 		return imageSet, nil
 	}
 
-	// error out early if there is no useful Helm binary
 	helmClient, err := helm.NewCLI(options.HelmBinary, "", "", options.HelmTimeout, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Helm client: %w", err)
-	}
-
-	helmVersion, err := helmClient.Version()
-	if err != nil {
-		return nil, fmt.Errorf("failed to check Helm version: %w", err)
-	}
-
-	if helmVersion.LessThan(MinHelmVersion) {
-		return nil, fmt.Errorf(
-			"the installer requires Helm >= %s, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
-			MinHelmVersion,
-			options.HelmBinary,
-			helmVersion,
-		)
 	}
 
 	chartsLogger := logger.WithField("charts-directory", options.ChartsDirectory)

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -79,8 +79,8 @@ func NewCLI(binary string, kubeconfig string, kubeContext string, timeout time.D
 }
 
 func (c *cli) detectHelmVersion() (*semverlib.Version, error) {
-	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
-	// Helm-2-style templating string "{{ .Client.SemVer }}"
+	// Helm 2 will output "<no value>" for this template, whereas Helm 3 returns
+	// the version string via "{{ .Version }}".
 	output, err := c.run("", "version", "--template", "{{ .Version }}")
 	if err != nil {
 		return nil, err

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -36,6 +36,10 @@ import (
 var (
 	minHelmVersionMajor uint64 = 3
 	maxHelmVersionMajor uint64 = 4
+
+	// runCmd is the internal method used to execute Helm commands.
+	// It is overwritten by the unit test.
+	runCmd = runCmdImplementation
 )
 
 type cli struct {
@@ -99,7 +103,6 @@ func (c *cli) detectHelmVersion() (*semverlib.Version, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	out := strings.TrimSpace(string(output))
 	if out == "<no value>" {
 		out = "v2.99.99"
@@ -314,6 +317,10 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 
 	c.logger.Debugf("$ KUBECONFIG=%s %s", c.kubeconfig, strings.Join(cmd.Args, " "))
 
+	return runCmd(cmd)
+}
+
+func runCmdImplementation(cmd *exec.Cmd) ([]byte, error) {
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
@@ -322,10 +329,10 @@ func (c *cli) run(namespace string, args ...string) ([]byte, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		err = errors.New(strings.TrimSpace(stderr.String()))
+		return nil, errors.New(strings.TrimSpace(stderr.String()))
 	}
 
-	return stdout.Bytes(), err
+	return stdout.Bytes(), nil
 }
 
 func valuesToFlags(values map[string]string) []string {

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -33,7 +33,10 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
-var minHelmVersion = semverlib.MustParse("v3.0.0")
+var (
+	minHelmVersionMajor uint64 = 3
+	maxHelmVersionMajor uint64 = 4
+)
 
 type cli struct {
 	binary      string
@@ -64,10 +67,21 @@ func NewCLI(binary string, kubeconfig string, kubeContext string, timeout time.D
 		return nil, fmt.Errorf("failed to get Helm version: %w", err)
 	}
 
-	if helmVersion.LessThan(minHelmVersion) {
+	if helmVersion.Major() < minHelmVersionMajor {
 		return nil, fmt.Errorf(
-			"the installer requires Helm >= %s, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
-			minHelmVersion,
+			"the installer requires Helm >= %d and <= %d, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
+			minHelmVersionMajor,
+			maxHelmVersionMajor,
+			binary,
+			helmVersion,
+		)
+	}
+
+	if helmVersion.Major() > maxHelmVersionMajor {
+		return nil, fmt.Errorf(
+			"the installer requires Helm >= %d and <= %d, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
+			minHelmVersionMajor,
+			maxHelmVersionMajor,
 			binary,
 			helmVersion,
 		)

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -192,7 +192,7 @@ func (c *cli) GetRelease(namespace string, name string) (*Release, error) {
 
 func (c *cli) ListReleases(namespace string) ([]Release, error) {
 	args := []string{"list", "-o", "json"}
-	if c.version.Major() < 4 {
+	if c.version.Major() == 3 {
 		// Helm 3 requires the --all flag in order to also return releases that are not deployed successfully.
 		// Helm 4 returns all releases by default, and the --all flag is not supported anymore.
 		args = append(args, "--all")

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -33,11 +33,14 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
+var minHelmVersion = semverlib.MustParse("v3.0.0")
+
 type cli struct {
 	binary      string
 	kubeconfig  string
 	kubeContext string
 	timeout     time.Duration
+	version     semverlib.Version
 	logger      logrus.FieldLogger
 }
 
@@ -48,13 +51,52 @@ func NewCLI(binary string, kubeconfig string, kubeContext string, timeout time.D
 		return nil, errors.New("timeout must be >= 10 seconds")
 	}
 
-	return &cli{
+	c := &cli{
 		binary:      binary,
 		kubeconfig:  kubeconfig,
 		kubeContext: kubeContext,
 		timeout:     timeout,
 		logger:      logger,
-	}, nil
+	}
+
+	helmVersion, err := c.detectHelmVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Helm version: %w", err)
+	}
+
+	if helmVersion.LessThan(minHelmVersion) {
+		return nil, fmt.Errorf(
+			"the installer requires Helm >= %s, but detected %q as %s (use --helm-binary or $HELM_BINARY to override)",
+			minHelmVersion,
+			binary,
+			helmVersion,
+		)
+	}
+
+	c.version = *helmVersion
+
+	return c, nil
+}
+
+func (c *cli) detectHelmVersion() (*semverlib.Version, error) {
+	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
+	// Helm-2-style templating string "{{ .Client.SemVer }}"
+	output, err := c.run("", "version", "--template", "{{ .Version }}")
+	if err != nil {
+		return nil, err
+	}
+
+	out := strings.TrimSpace(string(output))
+	if out == "<no value>" {
+		out = "v2.99.99"
+	}
+
+	version, err := semverlib.NewVersion(out)
+	if err != nil {
+		return nil, err
+	}
+
+	return version, nil
 }
 
 func (c *cli) BuildChartDependencies(chartDirectory string, flags []string) (err error) {
@@ -149,7 +191,12 @@ func (c *cli) GetRelease(namespace string, name string) (*Release, error) {
 }
 
 func (c *cli) ListReleases(namespace string) ([]Release, error) {
-	args := []string{"list", "--all", "-o", "json"}
+	args := []string{"list", "-o", "json"}
+	if c.version.Major() < 4 {
+		// Helm 3 requires the --all flag in order to also return releases that are not deployed successfully.
+		// Helm 4 returns all releases by default, and the --all flag is not supported anymore.
+		args = append(args, "--all")
+	}
 	if namespace == "" {
 		args = append(args, "--all-namespaces")
 	}
@@ -232,22 +279,6 @@ func (c *cli) GetValues(namespace string, releaseName string) (*yamled.Document,
 	}
 
 	return yamled.Load(bytes.NewReader(output))
-}
-
-func (c *cli) Version() (*semverlib.Version, error) {
-	// Helm 2 will output "<no value>", whereas Helm 3 would outright reject the
-	// Helm-2-style templating string "{{ .Client.SemVer }}"
-	output, err := c.run("", "version", "--template", "{{ .Version }}")
-	if err != nil {
-		return nil, err
-	}
-
-	out := strings.TrimSpace(string(output))
-	if out == "<no value>" {
-		out = "v2.99.99"
-	}
-
-	return semverlib.NewVersion(out)
 }
 
 func (c *cli) run(namespace string, args ...string) ([]byte, error) {

--- a/pkg/install/helm/cli_test.go
+++ b/pkg/install/helm/cli_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package helm
 
 import (
+	"os/exec"
 	"testing"
+	"time"
 
 	semverlib "github.com/Masterminds/semver/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGuessReleaseVersion(t *testing.T) {
@@ -80,6 +84,63 @@ func TestGuessReleaseVersion(t *testing.T) {
 					t.Fatalf("Expected chart %q, but got chart %q.", testcase.expectedChart, chart)
 				}
 			}
+		})
+	}
+}
+
+func TestListReleasesUsesCorrectFlagsForHelmVersion(t *testing.T) {
+	testcases := []struct {
+		name         string
+		helmVersion  string
+		expectedArgs []string
+	}{
+		{
+			name:        "helm v3 adds --all",
+			helmVersion: "3.19.0",
+			expectedArgs: []string{
+				"helm",
+				"--namespace", "test-namespace",
+				"list", "-o", "json", "--all",
+			},
+		},
+		{
+			name:        "helm v4 does not add --all",
+			helmVersion: "4.0.0",
+			expectedArgs: []string{
+				"helm",
+				"--namespace", "test-namespace",
+				"list", "-o", "json",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalRunCmd := runCmd
+			t.Cleanup(func() {
+				runCmd = originalRunCmd
+			})
+
+			capturedArgs := []string{}
+			runCmd = func(cmd *exec.Cmd) ([]byte, error) {
+				capturedArgs = append([]string{}, cmd.Args...)
+				return []byte(`[{"name":"release","namespace":"test-namespace","chart":"test-chart-1.2.3"}]`), nil
+			}
+
+			c := &cli{
+				binary:     "helm",
+				kubeconfig: "test-kubeconfig",
+				timeout:    30 * time.Second,
+				version:    *semverlib.MustParse(tc.helmVersion),
+				logger:     logrus.New(),
+			}
+
+			releases, err := c.ListReleases("test-namespace")
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedArgs, capturedArgs)
+			require.Len(t, releases, 1)
+			require.Equal(t, "test-chart", releases[0].Chart)
+			require.Equal(t, "1.2.3", releases[0].Version.String())
 		})
 	}
 }

--- a/pkg/install/helm/interface.go
+++ b/pkg/install/helm/interface.go
@@ -17,8 +17,6 @@ limitations under the License.
 package helm
 
 import (
-	semverlib "github.com/Masterminds/semver/v3"
-
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
@@ -26,7 +24,6 @@ import (
 // the installer. This is the minimum set of operations required to
 // perform a Kubermatic installation.
 type Client interface {
-	Version() (*semverlib.Version, error)
 	BuildChartDependencies(chartDirectory string, flags []string) error
 	InstallChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) error
 	GetRelease(namespace string, name string) (*Release, error)


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the `kubermatic-installer deploy` command support Helm 4 by adding the `--all` option to the `helm ls` command only in case Helm 3 is used. This is because Helm 4 doesn't support the option anymore but makes it the default behaviour (instead it provides additional options to filter out certain releases now).

Also, the Helm version check is moved from the CLI commands into the Helm CLI client constructor. This is done to get rid of the code duplication and to maintain the Helm CLI compatibility concern in a central place along with the rest of the Helm CLI-specific logic.

Relates to #15573 and #15897

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15898

**What type of PR is this?**
/kind feature
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The kubermatic-installer supports Helm 4 now in addition to Helm 3.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
