### PR TITLE
[WIP] Trigger nvidia-gpu-operator appdef validation err

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nvidia-gpu-operator-app.yaml
@@ -22,6 +22,8 @@ apiVersion: apps.kubermatic.k8c.io/v1
 kind: ApplicationDefinition
 metadata:
   name: nvidia-gpu-operator
+  annotations:
+    some.annotation: just-to-change-the-file-to-reproduce-the-problem
 spec:
   description: Nvidia GPU management for Kubernetes
   displayName: NVIDIA GPU Operator


### PR DESCRIPTION
**What this PR does / why we need it**:
Trigger nvidia-gpu-operator ApplicationDefinition validation error to verify that the Helm `timeout` must be set within the `defaultDeployOptions` since `wait` is enabled.

Relates to #15843, #15649 and #15752

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue

```
