### PR TITLE
[release/v2.28] pin Flatcar AMI in AWS dualstack e2e tests to work around Flatcar 459…

### DIFF
--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -33,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
+	awstypes "k8c.io/machine-controller/sdk/cloudprovider/aws"
 	"k8c.io/machine-controller/sdk/net"
 	"k8c.io/machine-controller/sdk/providerconfig"
 	"k8c.io/operating-system-manager/pkg/providerconfig/flatcar"
@@ -431,6 +432,20 @@ func TestNewClusters(t *testing.T) {
 					WithNetworkConfig(&providerconfig.NetworkConfig{
 						IPFamily: net.IPFamilyIPv4IPv6,
 					})
+
+				// pin Flatcar AMI on AWS to a pre-4593.2.0 build until OSM ships a fix.
+				// Flatcar Stable 4593.2.0 made /etc/environment a symlink to read-only
+				// /usr/lib/pam/environment, which makes the OSP bootstrap's `tee -a /etc/environment`
+				// fail and bootstrap.service loop forever.
+				if test.cloudProvider == kubermaticv1.AWSCloudProvider && osName == providerconfig.OperatingSystemFlatcar {
+					osMachineJig.WithCloudProviderSpecPatch(func(spec interface{}) interface{} {
+						awsSpec := spec.(awstypes.RawConfig)
+						awsSpec.AMI = providerconfig.ConfigVarString{Value: "ami-07a16a557a7b240e3"} // Flatcar 4459.2.4, eu-west-1
+						return awsSpec
+					})
+
+					osMachineJig.WithOSSpec(flatcar.Config{DisableAutoUpdate: true})
+				}
 
 				// no need to keep track of machine cleanups, as KKP will delete all machines in the
 				// cluster when the cluster itself is being deleted


### PR DESCRIPTION
…3.2.0 regression

Flatcar Stable 4593.2.0 changed /etc/environment from a regular file to a symlink pointing to read-only /usr/lib/pam/environment. The OSP bootstrap script uses `tee -a /etc/environment`, which now fails with "Read-only file system" and causes bootstrap.service to loop forever. This prevents Flatcar nodes from joining in dualstack e2e tests on AWS.

Pin Flatcar AMI to 4459.2.4 (ami-07a16a557a7b240e3, eu-west-1) and disable Flatcar auto-updates for the AWS test cases only. Other OS providers and operating systems are unaffected.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue

```
