### PR TITLE
Support `ReclaimPolicy` and `AllowVolumeExpansion` for the KubeVirt CSI Driver

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -1393,7 +1393,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: {{ Image "quay.io/kubermatic/kubevirt-csi-driver-operator:v0.5.0" }}
+          image: {{ Image "quay.io/kubermatic/kubevirt-csi-driver-operator:v0.5.1" }}
           imagePullPolicy: Always
           command:
             - /manager
@@ -1439,6 +1439,12 @@ spec:
      isDefaultClass: {{ .IsDefaultClass }}
 {{- if .VolumeBindingMode  }}
      volumeBindingMode: {{ .VolumeBindingMode }}
+{{- end }}
+{{- if .AllowVolumeExpansion  }}
+     allowVolumeExpansion: {{ default false .AllowVolumeExpansion }}
+{{- end }}
+{{- if .ReclaimPolicy  }}
+     reclaimPolicy: {{ .ReclaimPolicy }}
 {{- end }}
      bus: scsi
 {{- if .Regions }}

--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -871,8 +871,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: tenants.csiprovisioner.kubevirt.io
 spec:
   group: csiprovisioner.kubevirt.io
@@ -889,14 +888,19 @@ spec:
           description: Tenant is the Schema for the tenants API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -916,6 +920,10 @@ spec:
                     description: StorageClass represents a storage class that should
                       reference a KubeVirt storage class on infra cluster.
                     properties:
+                      allowVolumeExpansion:
+                        description: AllowVolumeExpansion shows whether the storage
+                          class allow volume expand.
+                        type: boolean
                       bus:
                         description: The VM bus type, defaults to scsi.
                         type: string
@@ -924,35 +932,41 @@ spec:
                           cluster.
                         type: string
                       isDefaultClass:
-                        description: 'Optional: IsDefaultClass if true, the created
-                        StorageClass will be annotated with: storageclass.kubernetes.io/is-default-class
-                        : true If missing or false, annotation will be: storageclass.kubernetes.io/is-default-class
-                        : false'
+                        description: |-
+                          Optional: IsDefaultClass if true, the created StorageClass will be annotated with:
+                          storageclass.kubernetes.io/is-default-class : true
+                          If missing or false, annotation will be:
+                          storageclass.kubernetes.io/is-default-class : false
                         type: boolean
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels is a map of string keys and values that
-                          can be used to organize and categorize (scope and select)
-                          objects. May match selectors of replication controllers and
-                          services.
+                        description: |-
+                          Labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
                         type: object
+                      reclaimPolicy:
+                        description: |-
+                          ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+                          Defaults to Delete.
+                        type: string
                       regions:
-                        description: Regions represents a larger domain, made up of
-                          one or more zones. It is uncommon for Kubernetes clusters
+                        description: |-
+                          Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
                           to span multiple regions
                         items:
                           type: string
                         type: array
                       volumeBindingMode:
-                        description: VolumeBindingMode indicates how PersistentVolumeClaims
-                          should be provisioned and bound. When unset, VolumeBindingImmediate
-                          is used.
+                        description: |-
+                          VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound. When unset,
+                          VolumeBindingImmediate is used.
                         type: string
                       zones:
-                        description: Zones represent a logical failure domain. It is
-                          common for Kubernetes clusters to span multiple zones for
-                          increased availability
+                        description: |-
+                          Zones represent a logical failure domain. It is common for Kubernetes clusters to span multiple zones
+                          for increased availability
                         items:
                           type: string
                         type: array
@@ -964,9 +978,9 @@ spec:
                   description: VolumeSnapshotClasses represents volume snapshot classes
                     that the tenant operator should create.
                   items:
-                    description: VolumeSnapshotClass contains a list of KubeVirt infra
-                      cluster VolumeSnapshotClasses names used to initialise VolumeSnapshotClasses
-                      in the tenant cluster.
+                    description: |-
+                      VolumeSnapshotClass contains a list of KubeVirt infra cluster VolumeSnapshotClasses names used
+                      to initialise VolumeSnapshotClasses in the tenant cluster.
                     properties:
                       deletionPolicy:
                         description: 'Optional: DeletionPolicy defines how the VolumeSnapshotClass
@@ -977,11 +991,11 @@ spec:
                           class to use on the infrastructure cluster.
                         type: string
                       isDefaultClass:
-                        description: 'Optional: IsDefaultClass. If true, the created
-                        VolumeSnapshotClass in the tenant cluster will be annotated
-                        with: snapshot.storage.kubernetes.io/is-default-class: true
-                        If missing or false, annotation will be: snapshot.storage.kubernetes.io/is-default-class:
-                        false'
+                        description: |-
+                          Optional: IsDefaultClass. If true, the created VolumeSnapshotClass in the tenant cluster will be annotated with:
+                          snapshot.storage.kubernetes.io/is-default-class: true
+                          If missing or false, annotation will be:
+                          snapshot.storage.kubernetes.io/is-default-class: false
                         type: boolean
                     required:
                       - infraVolumeSnapshotClass
@@ -1393,7 +1407,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: manager
-          image: {{ Image "quay.io/kubermatic/kubevirt-csi-driver-operator:v0.5.1" }}
+          image: {{ Image "quay.io/kubermatic/kubevirt-csi-driver-operator:v0.5.2" }}
           imagePullPolicy: Always
           command:
             - /manager
@@ -1441,7 +1455,7 @@ spec:
      volumeBindingMode: {{ .VolumeBindingMode }}
 {{- end }}
 {{- if .AllowVolumeExpansion  }}
-     allowVolumeExpansion: {{ default false .AllowVolumeExpansion }}
+     allowVolumeExpansion: {{ .AllowVolumeExpansion }}
 {{- end }}
 {{- if .ReclaimPolicy  }}
      reclaimPolicy: {{ .ReclaimPolicy }}

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -223,7 +223,9 @@ spec:
           # In the tenant cluster, the created StorageClass name will have as name:
           # kubevirt-<infra-storageClass-name>
           infraStorageClasses:
-            - # Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
+            - # AllowVolumeExpansion shows whether the storage class allow volume expand.
+              allowVolumeExpansion: false
+              # Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
               # storageclass.kubernetes.io/is-default-class : true
               # If missing or false, annotation will be:
               # storageclass.kubernetes.io/is-default-class : false
@@ -233,6 +235,9 @@ spec:
               # and services.
               labels: null
               name: rook-ceph-block
+              # ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+              # Defaults to Delete.
+              reclaimPolicy: ""
               # Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
               # to span multiple regions
               regions: null

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -271,7 +271,9 @@ spec:
           # In the tenant cluster, the created StorageClass name will have as name:
           # kubevirt-<infra-storageClass-name>
           infraStorageClasses:
-            - # Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
+            - # AllowVolumeExpansion shows whether the storage class allow volume expand.
+              allowVolumeExpansion: false
+              # Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
               # storageclass.kubernetes.io/is-default-class : true
               # If missing or false, annotation will be:
               # storageclass.kubernetes.io/is-default-class : false
@@ -281,6 +283,9 @@ spec:
               # and services.
               labels: null
               name: rook-ceph-block
+              # ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+              # Defaults to Delete.
+              reclaimPolicy: ""
               # Regions represents a larger domain, made up of one or more zones. It is uncommon for Kubernetes clusters
               # to span multiple regions
               regions: null

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1189,6 +1189,9 @@ spec:
                             It contains also some flag specifying which one is the default one.
                           items:
                             properties:
+                              allowVolumeExpansion:
+                                description: AllowVolumeExpansion shows whether the storage class allow volume expand.
+                                type: boolean
                               isDefaultClass:
                                 description: |-
                                   Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
@@ -1205,6 +1208,11 @@ spec:
                                   and services.
                                 type: object
                               name:
+                                type: string
+                              reclaimPolicy:
+                                description: |-
+                                  ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+                                  Defaults to Delete.
                                 type: string
                               regions:
                                 description: |-

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1183,6 +1183,9 @@ spec:
                             It contains also some flag specifying which one is the default one.
                           items:
                             properties:
+                              allowVolumeExpansion:
+                                description: AllowVolumeExpansion shows whether the storage class allow volume expand.
+                                type: boolean
                               isDefaultClass:
                                 description: |-
                                   Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
@@ -1199,6 +1202,11 @@ spec:
                                   and services.
                                 type: object
                               name:
+                                type: string
+                              reclaimPolicy:
+                                description: |-
+                                  ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+                                  Defaults to Delete.
                                 type: string
                               regions:
                                 description: |-

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1285,6 +1285,9 @@ spec:
                                   kubevirt-<infra-storageClass-name>
                                 items:
                                   properties:
+                                    allowVolumeExpansion:
+                                      description: AllowVolumeExpansion shows whether the storage class allow volume expand.
+                                      type: boolean
                                     isDefaultClass:
                                       description: |-
                                         Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:
@@ -1301,6 +1304,11 @@ spec:
                                         and services.
                                       type: object
                                     name:
+                                      type: string
+                                    reclaimPolicy:
+                                      description: |-
+                                        ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+                                        Defaults to Delete.
                                       type: string
                                     regions:
                                       description: |-

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -1061,6 +1061,11 @@ type KubeVirtInfraStorageClass struct {
 	// cluster. However, if the value is set to `kubevirt-csi-driver`, the storage class cannot be used by CDI for VM disk
 	// image creation.
 	VolumeProvisioner KubeVirtVolumeProvisioner `json:"volumeProvisioner,omitempty"`
+	// ReclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class.
+	// Defaults to Delete.
+	ReclaimPolicy string `json:"reclaimPolicy,omitempty"`
+	// AllowVolumeExpansion shows whether the storage class allow volume expand.
+	AllowVolumeExpansion bool `json:"allowVolumeExpansion,omitempty"`
 }
 
 type KubeVirtInfraVolumeSnapshotClass struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request introduces support for configuring `allowVolumeExpansion` and `reclaimPolicy` for KubeVirt infra storage classes. These options can now be set in the CRDs, Helm charts, and documentation, allowing users to control whether storage volumes can be expanded and to specify the reclaim policy for dynamically provisioned PersistentVolumes.

**KubeVirt Storage Class Configuration Enhancements:**

* Added `allowVolumeExpansion` and `reclaimPolicy` fields to the `KubeVirtInfraStorageClass` struct in the API, enabling explicit configuration of volume expansion and reclaim policy.
* Updated CRDs (`kubermatic.k8c.io_clusters.yaml`, `kubermatic.k8c.io_clustertemplates.yaml`, `kubermatic.k8c.io_seeds.yaml`) to include schema and descriptions for the new fields. [[1]](diffhunk://#diff-7b07e20158ce231fa6c00919655962f45584bf4963805c33d15f94b18371d822R1192-R1194) [[2]](diffhunk://#diff-7b07e20158ce231fa6c00919655962f45584bf4963805c33d15f94b18371d822R1212-R1216) [[3]](diffhunk://#diff-e242254aaabca3826d448771b85d473c1209a5f1ac499083da77ab6e047550d5R1186-R1188) [[4]](diffhunk://#diff-e242254aaabca3826d448771b85d473c1209a5f1ac499083da77ab6e047550d5R1206-R1210) [[5]](diffhunk://#diff-9f3acd1f9a0bbcd71f14aa63f5027324e61fa784e50e37894d852f7f70efa9eaR1288-R1290) [[6]](diffhunk://#diff-9f3acd1f9a0bbcd71f14aa63f5027324e61fa784e50e37894d852f7f70efa9eaR1308-R1312)
* Extended Helm chart templates (`csi-driver-operator.yaml`) to render `allowVolumeExpansion` and `reclaimPolicy` if set.
* Updated documentation and example configurations to demonstrate usage of the new fields. [[1]](diffhunk://#diff-0d725f69366dd9d01318e723ec7e50ee75ab2999269ead6fc742f845e9251d72L226-R228) [[2]](diffhunk://#diff-0d725f69366dd9d01318e723ec7e50ee75ab2999269ead6fc742f845e9251d72R238-R240) [[3]](diffhunk://#diff-f9c5413fc42d8ee03933e9856a7b468ba11f3dd1988892f4605e0d7bb0e7d632L274-R276) [[4]](diffhunk://#diff-f9c5413fc42d8ee03933e9856a7b468ba11f3dd1988892f4605e0d7bb0e7d632R286-R288)

**Other Updates:**

* Bumped the `kubevirt-csi-driver-operator` image version from `v0.5.0` to `v0.5.1` in the Helm chart.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added allowVolumeExpansion and reclaimPolicy fields to the KubeVirtInfraStorageClass struct in the API, enabling explicit configuration of volume expansion and reclaim policy.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
