### PR TITLE
[release/v2.29] Fix Helm release recovery for stuck ApplicationInstallations

### DIFF
--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -64,6 +64,11 @@ func (a *ApplicationInstallerRecorder) IsStuck(ctx context.Context, log *zap.Sug
 	return false, nil
 }
 
+func (a *ApplicationInstallerRecorder) IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	// NOOP
+	return false, nil
+}
+
 func (a *ApplicationInstallerRecorder) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	return nil
 }
@@ -95,6 +100,11 @@ func (a ApplicationInstallerLogger) IsStuck(ctx context.Context, log *zap.Sugare
 	return false, nil
 }
 
+func (a ApplicationInstallerLogger) IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	// NOOP
+	return false, nil
+}
+
 func (a ApplicationInstallerLogger) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	// NOOP
 	return nil
@@ -107,6 +117,9 @@ type CustomApplicationInstaller struct {
 	DownloadSourceFunc func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation, downloadDest string) (string, error)
 	ApplyFunc          func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error)
 	DeleteFunc         func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error)
+	IsStuckFunc        func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+	IsDeployedFunc     func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+	RollbackFunc       func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 
 func (c CustomApplicationInstaller) GetAppCache() string {
@@ -138,11 +151,22 @@ func (c CustomApplicationInstaller) Delete(ctx context.Context, log *zap.Sugared
 }
 
 func (c CustomApplicationInstaller) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
-	// NOOP
+	if c.IsStuckFunc != nil {
+		return c.IsStuckFunc(ctx, log, seedClient, userClient, applicationInstallation)
+	}
+	return false, nil
+}
+
+func (c CustomApplicationInstaller) IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	if c.IsDeployedFunc != nil {
+		return c.IsDeployedFunc(ctx, log, seedClient, userClient, applicationInstallation)
+	}
 	return false, nil
 }
 
 func (c CustomApplicationInstaller) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
-	// NOOP
+	if c.RollbackFunc != nil {
+		return c.RollbackFunc(ctx, log, seedClient, userClient, applicationInstallation)
+	}
 	return nil
 }

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -546,10 +546,11 @@ func (h HelmClient) releaseHistorySummary(releaseName string) (string, int, int)
 			continue
 		}
 		latestRevision = rel.Version
-		latestStatus = "unknown"
-		if rel.Info != nil {
-			latestStatus = string(rel.Info.Status)
+		if rel.Info == nil {
+			latestStatus = "unknown"
+			continue
 		}
+		latestStatus = string(rel.Info.Status)
 	}
 
 	return latestStatus, revisionCount, latestRevision

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -483,7 +483,8 @@ func (h HelmClient) IsPending(releaseName string) (bool, error) {
 	return release.Status(metadata.Status).IsPending(), nil
 }
 
-// IsDeployed returns true when the latest release revision is deployed.
+// IsDeployed returns true when the latest release revision is deployed. Superseded revisions
+// are considered successful rollback targets, but they do not mean the current release is deployed.
 func (h HelmClient) IsDeployed(releaseName string) (bool, error) {
 	metadata, err := h.GetMetadata(releaseName)
 	if err != nil {
@@ -497,6 +498,7 @@ func (h HelmClient) IsDeployed(releaseName string) (bool, error) {
 }
 
 // Rollback wraps helms Rollback command to be used with our ActionConfig.
+// It rolls back to the latest successful revision, or uninstalls the release if no successful revision exists.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
 	// Set the last successful revision explicitly because otherwise Helm uses the current revision minus 1,
@@ -504,7 +506,7 @@ func (h HelmClient) Rollback(releaseName string) error {
 	lastSuccessfulRelease, err := h.lastSuccessfulRelease(releaseName)
 	if err != nil {
 		if errors.Is(err, driver.ErrNoDeployedReleases) {
-			h.logger.Infow("No successful release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName)
+			h.logger.Warnw("No successful release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName, "status", h.latestReleaseStatus(releaseName))
 			if _, uninstallErr := h.Uninstall(releaseName); uninstallErr != nil {
 				return fmt.Errorf("could not uninstall release %q after failing to fetch last successful release: %w", releaseName, uninstallErr)
 			}
@@ -518,6 +520,22 @@ func (h HelmClient) Rollback(releaseName string) error {
 		return fmt.Errorf("could not rollback release %q: %w", releaseName, err)
 	}
 	return nil
+}
+
+func (h HelmClient) latestReleaseStatus(releaseName string) string {
+	latestRelease, err := h.actionConfig.Releases.Last(releaseName)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return "not-found"
+		}
+		h.logger.Debugw("Failed to retrieve Helm release status", "release", releaseName, "error", err)
+		return "unknown"
+	}
+	if latestRelease == nil || latestRelease.Info == nil {
+		return "unknown"
+	}
+
+	return string(latestRelease.Info.Status)
 }
 
 func (h HelmClient) lastSuccessfulRelease(releaseName string) (*release.Release, error) {

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -470,22 +470,83 @@ func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
 	return res, nil
 }
 
+// IsPending returns true when the latest release revision is in any Helm pending state.
+func (h HelmClient) IsPending(releaseName string) (bool, error) {
+	metadata, err := h.GetMetadata(releaseName)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return release.Status(metadata.Status).IsPending(), nil
+}
+
+// IsDeployed returns true when the latest release revision is deployed.
+func (h HelmClient) IsDeployed(releaseName string) (bool, error) {
+	metadata, err := h.GetMetadata(releaseName)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return release.Status(metadata.Status) == release.StatusDeployed, nil
+}
+
 // Rollback wraps helms Rollback command to be used with our ActionConfig.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
-	// we need to set the last successful deployed revision explicit because otherwise it would be the current revision minus 1
-	// which could lead to errors due to missing revisions when the latest ones failed because we configure history limits
-	// on upgrade actions
-	latestDeployedRelease, err := h.actionConfig.Releases.Deployed(releaseName)
+	// Set the last successful revision explicitly because otherwise Helm uses the current revision minus 1,
+	// which can point at a failed/pending release when history is incomplete or was pruned.
+	lastSuccessfulRelease, err := h.lastSuccessfulRelease(releaseName)
 	if err != nil {
+		if errors.Is(err, driver.ErrNoDeployedReleases) {
+			h.logger.Infow("No deployed release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName)
+			if _, uninstallErr := h.Uninstall(releaseName); uninstallErr != nil {
+				return fmt.Errorf("could not uninstall release %q after failing to fetch last successful release: %w", releaseName, uninstallErr)
+			}
+			return nil
+		}
 		return fmt.Errorf("could not fetch last successful release %q: %w", releaseName, err)
 	}
-	client.Version = latestDeployedRelease.Version
+	client.Version = lastSuccessfulRelease.Version
 	err = client.Run(releaseName)
 	if err != nil {
 		return fmt.Errorf("could not rollback release %q: %w", releaseName, err)
 	}
 	return nil
+}
+
+func (h HelmClient) lastSuccessfulRelease(releaseName string) (*release.Release, error) {
+	history, err := h.actionConfig.Releases.History(releaseName)
+	if err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			return nil, driver.NewErrNoDeployedReleases(releaseName)
+		}
+		return nil, err
+	}
+
+	var latestSuccessfulRelease *release.Release
+	for _, rel := range history {
+		if rel == nil || rel.Info == nil {
+			continue
+		}
+		if rel.Info.Status != release.StatusDeployed && rel.Info.Status != release.StatusSuperseded {
+			continue
+		}
+		if latestSuccessfulRelease == nil || rel.Version > latestSuccessfulRelease.Version {
+			latestSuccessfulRelease = rel
+		}
+	}
+
+	if latestSuccessfulRelease == nil {
+		return nil, driver.NewErrNoDeployedReleases(releaseName)
+	}
+
+	return latestSuccessfulRelease, nil
 }
 
 // buildDependencies adds missing repositories and then does a Helm dependency build (i.e. download the chart dependencies

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -565,12 +565,17 @@ func (h HelmClient) lastSuccessfulRelease(releaseName string) (*release.Release,
 		return nil, err
 	}
 
+	revisionsSupersededByFailedRollback := revisionsSupersededByFailedRollback(releaseName, history)
 	var latestSuccessfulRelease *release.Release
 	for _, rel := range history {
 		if rel == nil || rel.Info == nil {
 			continue
 		}
-		if rel.Info.Status != release.StatusDeployed && rel.Info.Status != release.StatusSuperseded {
+		if rel.Info.Status == release.StatusSuperseded {
+			if _, ok := revisionsSupersededByFailedRollback[rel.Version]; ok {
+				continue
+			}
+		} else if rel.Info.Status != release.StatusDeployed {
 			continue
 		}
 		if latestSuccessfulRelease == nil || rel.Version > latestSuccessfulRelease.Version {
@@ -583,6 +588,46 @@ func (h HelmClient) lastSuccessfulRelease(releaseName string) (*release.Release,
 	}
 
 	return latestSuccessfulRelease, nil
+}
+
+func revisionsSupersededByFailedRollback(releaseName string, history []*release.Release) map[int]struct{} {
+	revisions := map[int]struct{}{}
+	releasesByRevision := map[int]*release.Release{}
+	for _, rel := range history {
+		if rel != nil {
+			releasesByRevision[rel.Version] = rel
+		}
+	}
+
+	failedRollbackDescriptionPrefix := fmt.Sprintf("Rollback %q failed:", releaseName)
+	for _, rel := range history {
+		if rel == nil || rel.Info == nil || rel.Info.Status != release.StatusFailed {
+			continue
+		}
+		if !strings.HasPrefix(rel.Info.Description, failedRollbackDescriptionPrefix) {
+			continue
+		}
+		if rel.Version <= 1 {
+			continue
+		}
+		previousRevision := releasesByRevision[rel.Version-1]
+		if !wasUnsuccessfulSupersededByFailedRollback(releaseName, previousRevision) {
+			continue
+		}
+		// Helm marks the previous current revision as superseded when rollback execution fails. If
+		// that current revision was pending or failed, the superseded status does not mean it succeeded.
+		revisions[previousRevision.Version] = struct{}{}
+	}
+	return revisions
+}
+
+func wasUnsuccessfulSupersededByFailedRollback(releaseName string, rel *release.Release) bool {
+	if rel == nil || rel.Info == nil {
+		return false
+	}
+	return rel.Info.Description == "Initial install underway" ||
+		rel.Info.Description == "Preparing upgrade" ||
+		strings.HasPrefix(rel.Info.Description, fmt.Sprintf("Upgrade %q failed:", releaseName))
 }
 
 // buildDependencies adds missing repositories and then does a Helm dependency build (i.e. download the chart dependencies

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -56,6 +56,11 @@ import (
 // More information at https://helm.sh/docs/topics/advanced/#storage-backends
 const secretStorageDriver = "secret"
 
+const (
+	helmInitialInstallDescription   = "Initial install underway"
+	helmPreparingUpgradeDescription = "Preparing upgrade"
+)
+
 // HelmSettings holds the Helm configuration for caching repositories.
 type HelmSettings struct {
 	// RepositoryConfig is the path to the repositories file.
@@ -497,8 +502,9 @@ func (h HelmClient) IsDeployed(releaseName string) (bool, error) {
 	return release.Status(metadata.Status) == release.StatusDeployed, nil
 }
 
-// Rollback wraps helms Rollback command to be used with our ActionConfig.
-// It rolls back to the latest successful revision, or uninstalls the release if no successful revision exists.
+// Rollback wraps helms Rollback command to be used with our ActionConfig. It rolls back to the
+// latest successful revision, or uninstalls the release if no successful revision exists. A successful
+// uninstall fallback means callers can proceed with a fresh install of the desired release.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
 	// Set the last successful revision explicitly because otherwise Helm uses the current revision minus 1,
@@ -592,6 +598,8 @@ func (h HelmClient) lastSuccessfulRelease(releaseName string) (*release.Release,
 
 func revisionsSupersededByFailedRollback(releaseName string, history []*release.Release) map[int]struct{} {
 	revisions := map[int]struct{}{}
+	// Helm storage history is not treated as ordered here; use a revision map so failed rollback
+	// records can be matched to their previous current revision regardless of slice order.
 	releasesByRevision := map[int]*release.Release{}
 	for _, rel := range history {
 		if rel != nil {
@@ -625,9 +633,15 @@ func wasUnsuccessfulSupersededByFailedRollback(releaseName string, rel *release.
 	if rel == nil || rel.Info == nil {
 		return false
 	}
-	return rel.Info.Description == "Initial install underway" ||
-		rel.Info.Description == "Preparing upgrade" ||
-		strings.HasPrefix(rel.Info.Description, fmt.Sprintf("Upgrade %q failed:", releaseName))
+	// These descriptions come from Helm's action package. If Helm changes them, the rollback
+	// history tests should be updated with the new emitted descriptions.
+	return rel.Info.Description == helmInitialInstallDescription ||
+		rel.Info.Description == helmPreparingUpgradeDescription ||
+		strings.HasPrefix(rel.Info.Description, helmFailedUpgradeDescriptionPrefix(releaseName))
+}
+
+func helmFailedUpgradeDescriptionPrefix(releaseName string) string {
+	return fmt.Sprintf("Upgrade %q failed:", releaseName)
 }
 
 // buildDependencies adds missing repositories and then does a Helm dependency build (i.e. download the chart dependencies

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -504,7 +504,7 @@ func (h HelmClient) Rollback(releaseName string) error {
 	lastSuccessfulRelease, err := h.lastSuccessfulRelease(releaseName)
 	if err != nil {
 		if errors.Is(err, driver.ErrNoDeployedReleases) {
-			h.logger.Infow("No deployed release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName)
+			h.logger.Infow("No successful release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName)
 			if _, uninstallErr := h.Uninstall(releaseName); uninstallErr != nil {
 				return fmt.Errorf("could not uninstall release %q after failing to fetch last successful release: %w", releaseName, uninstallErr)
 			}

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -506,7 +506,8 @@ func (h HelmClient) Rollback(releaseName string) error {
 	lastSuccessfulRelease, err := h.lastSuccessfulRelease(releaseName)
 	if err != nil {
 		if errors.Is(err, driver.ErrNoDeployedReleases) {
-			h.logger.Warnw("No successful release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName, "status", h.latestReleaseStatus(releaseName))
+			status, revisionCount, latestRevision := h.releaseHistorySummary(releaseName)
+			h.logger.Warnw("No successful release found while recovering stuck Helm release, uninstalling release before reinstall", "release", releaseName, "latestStatus", status, "historyRevisions", revisionCount, "latestRevision", latestRevision)
 			if _, uninstallErr := h.Uninstall(releaseName); uninstallErr != nil {
 				return fmt.Errorf("could not uninstall release %q after failing to fetch last successful release: %w", releaseName, uninstallErr)
 			}
@@ -515,6 +516,7 @@ func (h HelmClient) Rollback(releaseName string) error {
 		return fmt.Errorf("could not fetch last successful release %q: %w", releaseName, err)
 	}
 	client.Version = lastSuccessfulRelease.Version
+	h.logger.Infow("Rolling back stuck Helm release to latest successful revision", "release", releaseName, "revision", lastSuccessfulRelease.Version, "status", lastSuccessfulRelease.Info.Status)
 	err = client.Run(releaseName)
 	if err != nil {
 		return fmt.Errorf("could not rollback release %q: %w", releaseName, err)
@@ -522,20 +524,35 @@ func (h HelmClient) Rollback(releaseName string) error {
 	return nil
 }
 
-func (h HelmClient) latestReleaseStatus(releaseName string) string {
-	latestRelease, err := h.actionConfig.Releases.Last(releaseName)
+func (h HelmClient) releaseHistorySummary(releaseName string) (string, int, int) {
+	history, err := h.actionConfig.Releases.History(releaseName)
 	if err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
-			return "not-found"
+			return "not-found", 0, 0
 		}
-		h.logger.Debugw("Failed to retrieve Helm release status", "release", releaseName, "error", err)
-		return "unknown"
-	}
-	if latestRelease == nil || latestRelease.Info == nil {
-		return "unknown"
+		h.logger.Debugw("Failed to retrieve Helm release history", "release", releaseName, "error", err)
+		return "unknown", 0, 0
 	}
 
-	return string(latestRelease.Info.Status)
+	latestStatus := "unknown"
+	latestRevision := 0
+	revisionCount := 0
+	for _, rel := range history {
+		if rel == nil {
+			continue
+		}
+		revisionCount++
+		if rel.Version <= latestRevision {
+			continue
+		}
+		latestRevision = rel.Version
+		latestStatus = "unknown"
+		if rel.Info != nil {
+			latestStatus = string(rel.Info.Status)
+		}
+	}
+
+	return latestStatus, revisionCount, latestRevision
 }
 
 func (h HelmClient) lastSuccessfulRelease(releaseName string) (*release.Release, error) {

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -119,6 +119,74 @@ func TestRollbackUsesLatestSuccessfulRevision(t *testing.T) {
 	}
 }
 
+func TestRollbackIgnoresRevisionSupersededByFailedRollback(t *testing.T) {
+	tests := []struct {
+		name               string
+		supersededRevision string
+	}{
+		{
+			name:               "pending upgrade superseded by failed rollback",
+			supersededRevision: "Preparing upgrade",
+		},
+		{
+			name:               "failed upgrade superseded by failed rollback",
+			supersededRevision: `Upgrade "test-release" failed: update failed`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helmClient := newTestHelmClient(t, []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusSuperseded),
+				testReleaseWithDescription("test-release", "default", 2, release.StatusSuperseded, tt.supersededRevision),
+				testReleaseWithDescription("test-release", "default", 3, release.StatusFailed, `Rollback "test-release" failed: update failed`),
+				testRelease("test-release", "default", 4, release.StatusPendingUpgrade),
+			}, &kubefake.PrintingKubeClient{Out: io.Discard})
+
+			if err := helmClient.Rollback("test-release"); err != nil {
+				t.Fatalf("expected rollback to succeed, got %v", err)
+			}
+
+			latestRelease, err := helmClient.actionConfig.Releases.Last("test-release")
+			if err != nil {
+				t.Fatalf("failed to get latest release: %v", err)
+			}
+			if latestRelease.Info.Status != release.StatusDeployed {
+				t.Fatalf("expected rollback release to be deployed, got %s", latestRelease.Info.Status)
+			}
+			expectedDescription := "Rollback to 1"
+			if latestRelease.Info.Description != expectedDescription {
+				t.Fatalf("expected rollback description %q, got %q", expectedDescription, latestRelease.Info.Description)
+			}
+		})
+	}
+}
+
+func TestRollbackKeepsDeployedRevisionSupersededByFailedRollback(t *testing.T) {
+	helmClient := newTestHelmClient(t, []*release.Release{
+		testRelease("test-release", "default", 1, release.StatusSuperseded),
+		testReleaseWithDescription("test-release", "default", 2, release.StatusSuperseded, "Upgrade complete"),
+		testReleaseWithDescription("test-release", "default", 3, release.StatusFailed, `Rollback "test-release" failed: update failed`),
+		testRelease("test-release", "default", 4, release.StatusPendingUpgrade),
+	}, &kubefake.PrintingKubeClient{Out: io.Discard})
+
+	if err := helmClient.Rollback("test-release"); err != nil {
+		t.Fatalf("expected rollback to succeed, got %v", err)
+	}
+
+	latestRelease, err := helmClient.actionConfig.Releases.Last("test-release")
+	if err != nil {
+		t.Fatalf("failed to get latest release: %v", err)
+	}
+	if latestRelease.Info.Status != release.StatusDeployed {
+		t.Fatalf("expected rollback release to be deployed, got %s", latestRelease.Info.Status)
+	}
+	expectedDescription := "Rollback to 2"
+	if latestRelease.Info.Description != expectedDescription {
+		t.Fatalf("expected rollback description %q, got %q", expectedDescription, latestRelease.Info.Description)
+	}
+}
+
 func TestRollbackUninstallsOnlyWhenNoSuccessfulRevisionExists(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -275,6 +343,12 @@ func testRelease(name, namespace string, version int, status release.Status) *re
 			LastDeployed: helmtime.Now(),
 		},
 	}
+}
+
+func testReleaseWithDescription(name, namespace string, version int, status release.Status, description string) *release.Release {
+	rel := testRelease(name, namespace, version, status)
+	rel.Info.Description = description
+	return rel
 }
 
 func TestNewDeploySettings(t *testing.T) {

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -36,6 +36,7 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	helmtime "helm.sh/helm/v3/pkg/time"
 
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
@@ -175,6 +176,69 @@ func TestRollbackDoesNotUninstallWhenRollbackExecutionFails(t *testing.T) {
 	}
 }
 
+func TestIsPending(t *testing.T) {
+	tests := []struct {
+		name        string
+		releases    []*release.Release
+		releaseName string
+		wantPending bool
+	}{
+		{
+			name:        "release does not exist",
+			releaseName: "missing-release",
+			wantPending: false,
+		},
+		{
+			name: "deployed release is not pending",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusDeployed),
+			},
+			releaseName: "test-release",
+			wantPending: false,
+		},
+		{
+			name: "pending install is pending",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusPendingInstall),
+			},
+			releaseName: "test-release",
+			wantPending: true,
+		},
+		{
+			name: "pending upgrade is pending",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusDeployed),
+				testRelease("test-release", "default", 2, release.StatusPendingUpgrade),
+			},
+			releaseName: "test-release",
+			wantPending: true,
+		},
+		{
+			name: "pending rollback is pending",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusDeployed),
+				testRelease("test-release", "default", 2, release.StatusPendingRollback),
+			},
+			releaseName: "test-release",
+			wantPending: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helmClient := newTestHelmClient(t, tt.releases, &kubefake.PrintingKubeClient{Out: io.Discard})
+
+			got, err := helmClient.IsPending(tt.releaseName)
+			if err != nil {
+				t.Fatalf("expected IsPending to succeed, got %v", err)
+			}
+			if got != tt.wantPending {
+				t.Fatalf("IsPending() = %v, want %v", got, tt.wantPending)
+			}
+		})
+	}
+}
+
 func newTestHelmClient(t *testing.T, releases []*release.Release, kubeClient kube.Interface) HelmClient {
 	t.Helper()
 
@@ -200,9 +264,15 @@ func testRelease(name, namespace string, version int, status release.Status) *re
 		Name:      name,
 		Namespace: namespace,
 		Version:   version,
-		Chart:     &chart.Chart{},
+		Chart: &chart.Chart{
+			Metadata: &chart.Metadata{
+				Name:    "test-chart",
+				Version: "0.1.0",
+			},
+		},
 		Info: &release.Info{
-			Status: status,
+			Status:       status,
+			LastDeployed: helmtime.Now(),
 		},
 	}
 }

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -20,13 +20,22 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/kube"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/provenance"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
 
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 
@@ -50,6 +59,131 @@ func TestNewShouldFailWhenRESTClientGetterNamespaceIsDifferentThanTargetNamespac
 	expectedErrMsg := "namespace set in RESTClientGetter should be the same as targetNamespace"
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Fatalf("helmclient.NewClient() fails for the wrong reason. expected error message: '%s' to contain: '%s'", err, expectedErrMsg)
+	}
+}
+
+func TestRollbackUsesLatestSuccessfulRevision(t *testing.T) {
+	tests := []struct {
+		name             string
+		releases         []*release.Release
+		expectedRollback int
+	}{
+		{
+			name: "pending upgrade with superseded revision and no deployed revision",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusSuperseded),
+				testRelease("test-release", "default", 2, release.StatusPendingUpgrade),
+			},
+			expectedRollback: 1,
+		},
+		{
+			name: "pending rollback with deployed revision",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusDeployed),
+				testRelease("test-release", "default", 2, release.StatusPendingRollback),
+			},
+			expectedRollback: 1,
+		},
+		{
+			name: "latest successful revision is selected",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusDeployed),
+				testRelease("test-release", "default", 2, release.StatusSuperseded),
+				testRelease("test-release", "default", 3, release.StatusPendingUpgrade),
+			},
+			expectedRollback: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helmClient := newTestHelmClient(t, tt.releases, &kubefake.PrintingKubeClient{Out: io.Discard})
+
+			if err := helmClient.Rollback("test-release"); err != nil {
+				t.Fatalf("expected rollback to succeed, got %v", err)
+			}
+
+			latestRelease, err := helmClient.actionConfig.Releases.Last("test-release")
+			if err != nil {
+				t.Fatalf("failed to get latest release: %v", err)
+			}
+			if latestRelease.Info.Status != release.StatusDeployed {
+				t.Fatalf("expected rollback release to be deployed, got %s", latestRelease.Info.Status)
+			}
+			expectedDescription := "Rollback to " + strconv.Itoa(tt.expectedRollback)
+			if latestRelease.Info.Description != expectedDescription {
+				t.Fatalf("expected rollback description %q, got %q", expectedDescription, latestRelease.Info.Description)
+			}
+		})
+	}
+}
+
+func TestRollbackUninstallsOnlyWhenNoSuccessfulRevisionExists(t *testing.T) {
+	helmClient := newTestHelmClient(t, []*release.Release{
+		testRelease("test-release", "default", 1, release.StatusFailed),
+		testRelease("test-release", "default", 2, release.StatusPendingUpgrade),
+	}, &kubefake.PrintingKubeClient{Out: io.Discard})
+
+	if err := helmClient.Rollback("test-release"); err != nil {
+		t.Fatalf("expected uninstall fallback to succeed, got %v", err)
+	}
+
+	if _, err := helmClient.actionConfig.Releases.History("test-release"); !errors.Is(err, driver.ErrReleaseNotFound) {
+		t.Fatalf("expected uninstall fallback to purge release history, got %v", err)
+	}
+}
+
+func TestRollbackDoesNotUninstallWhenRollbackExecutionFails(t *testing.T) {
+	helmClient := newTestHelmClient(t, []*release.Release{
+		testRelease("test-release", "default", 1, release.StatusSuperseded),
+		testRelease("test-release", "default", 2, release.StatusPendingUpgrade),
+	}, &kubefake.FailingKubeClient{
+		PrintingKubeClient: kubefake.PrintingKubeClient{Out: io.Discard},
+		UpdateError:        errors.New("update failed"),
+	})
+
+	if err := helmClient.Rollback("test-release"); err == nil {
+		t.Fatal("expected rollback error")
+	}
+
+	history, err := helmClient.actionConfig.Releases.History("test-release")
+	if err != nil {
+		t.Fatalf("expected release history to remain after rollback failure, got %v", err)
+	}
+	if len(history) == 0 {
+		t.Fatal("expected release history to remain after rollback failure")
+	}
+}
+
+func newTestHelmClient(t *testing.T, releases []*release.Release, kubeClient kube.Interface) HelmClient {
+	t.Helper()
+
+	actionConfig := &action.Configuration{
+		Releases:   storage.Init(driver.NewMemory()),
+		KubeClient: kubeClient,
+		Log:        func(string, ...interface{}) {},
+	}
+	for _, rel := range releases {
+		if err := actionConfig.Releases.Create(rel); err != nil {
+			t.Fatalf("failed to create test release: %v", err)
+		}
+	}
+
+	return HelmClient{
+		actionConfig: actionConfig,
+		logger:       kubermaticlog.Logger,
+	}
+}
+
+func testRelease(name, namespace string, version int, status release.Status) *release.Release {
+	return &release.Release{
+		Name:      name,
+		Namespace: namespace,
+		Version:   version,
+		Chart:     &chart.Chart{},
+		Info: &release.Info{
+			Status: status,
+		},
 	}
 }
 

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -119,17 +119,37 @@ func TestRollbackUsesLatestSuccessfulRevision(t *testing.T) {
 }
 
 func TestRollbackUninstallsOnlyWhenNoSuccessfulRevisionExists(t *testing.T) {
-	helmClient := newTestHelmClient(t, []*release.Release{
-		testRelease("test-release", "default", 1, release.StatusFailed),
-		testRelease("test-release", "default", 2, release.StatusPendingUpgrade),
-	}, &kubefake.PrintingKubeClient{Out: io.Discard})
-
-	if err := helmClient.Rollback("test-release"); err != nil {
-		t.Fatalf("expected uninstall fallback to succeed, got %v", err)
+	tests := []struct {
+		name     string
+		releases []*release.Release
+	}{
+		{
+			name: "pending upgrade after failed revision",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusFailed),
+				testRelease("test-release", "default", 2, release.StatusPendingUpgrade),
+			},
+		},
+		{
+			name: "pending install without any successful revision",
+			releases: []*release.Release{
+				testRelease("test-release", "default", 1, release.StatusPendingInstall),
+			},
+		},
 	}
 
-	if _, err := helmClient.actionConfig.Releases.History("test-release"); !errors.Is(err, driver.ErrReleaseNotFound) {
-		t.Fatalf("expected uninstall fallback to purge release history, got %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helmClient := newTestHelmClient(t, tt.releases, &kubefake.PrintingKubeClient{Out: io.Discard})
+
+			if err := helmClient.Rollback("test-release"); err != nil {
+				t.Fatalf("expected uninstall fallback to succeed, got %v", err)
+			}
+
+			if _, err := helmClient.actionConfig.Releases.History("test-release"); !errors.Is(err, driver.ErrReleaseNotFound) {
+				t.Fatalf("expected uninstall fallback to purge release history, got %v", err)
+			}
+		})
 	}
 }
 

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -54,6 +54,7 @@ type ApplicationInstaller interface {
 	IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
 	// Rollback rolls an Application back to the latest successful release, or uninstalls it when no successful release exists.
+	// A successful uninstall fallback allows the next reconcile to install the desired release cleanly.
 	Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 
@@ -203,6 +204,7 @@ func namespaceExists(ctx context.Context, userClient ctrlruntimeclient.Client, n
 }
 
 // Rollback rolls an Application back to the latest successful release, or uninstalls it when no successful release exists.
+// A successful uninstall fallback allows the next reconcile to install the desired release cleanly.
 func (a *ApplicationManager) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -53,7 +53,7 @@ type ApplicationInstaller interface {
 	// IsDeployed determines if the release is currently deployed.
 	IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
-	// Rollback rolls an Application back to the previous release
+	// Rollback rolls an Application back to the latest successful release, or uninstalls it when no successful release exists.
 	Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 
@@ -202,7 +202,7 @@ func namespaceExists(ctx context.Context, userClient ctrlruntimeclient.Client, n
 	return true, nil
 }
 
-// Rollback rolls an Application back to the previous release.
+// Rollback rolls an Application back to the latest successful release, or uninstalls it when no successful release exists.
 func (a *ApplicationManager) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -28,6 +28,8 @@ import (
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,6 +49,9 @@ type ApplicationInstaller interface {
 
 	// IsStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries
 	IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+
+	// IsDeployed determines if the release is currently deployed.
+	IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
 	// Rollback rolls an Application back to the previous release
 	Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
@@ -150,12 +155,51 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 
 // IsStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries.
 func (a *ApplicationManager) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	targetNamespaceExists, err := namespaceExists(ctx, userClient, applicationInstallation.Spec.Namespace.Name)
+	if err != nil {
+		return false, err
+	}
+	if !targetNamespaceExists {
+		log.Debugw("skipping stuck release check because target namespace does not exist", "namespace", applicationInstallation.Spec.Namespace.Name)
+		return false, nil
+	}
+
 	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return false, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
 
 	return templateProvider.IsStuck(applicationInstallation)
+}
+
+// IsDeployed determines if the release is currently deployed.
+func (a *ApplicationManager) IsDeployed(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	targetNamespaceExists, err := namespaceExists(ctx, userClient, applicationInstallation.Spec.Namespace.Name)
+	if err != nil {
+		return false, err
+	}
+	if !targetNamespaceExists {
+		return false, nil
+	}
+
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.ClusterName, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	if err != nil {
+		return false, fmt.Errorf("failed to initialize template provider: %w", err)
+	}
+
+	return templateProvider.IsDeployed(applicationInstallation)
+}
+
+func namespaceExists(ctx context.Context, userClient ctrlruntimeclient.Client, namespace string) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get namespace %q: %w", namespace, err)
+	}
+
+	return true, nil
 }
 
 // Rollback rolls an Application back to the previous release.

--- a/pkg/applications/installer_test.go
+++ b/pkg/applications/installer_test.go
@@ -179,6 +179,32 @@ func TestApplicationManager_applyNamespaceDoNotSetLabelsAndAnnotationWhenCreateN
 	}
 }
 
+func TestApplicationManager_IsStuckSkipsHelmLookupWhenTargetNamespaceDoesNotExist(t *testing.T) {
+	ctx := context.Background()
+	userClient := fake.NewClientBuilder().Build()
+
+	app := genApplicationInstallation(appskubermaticv1.AppNamespaceSpec{
+		Name:   "new-namespace",
+		Create: true,
+	})
+	app.Status.Method = appskubermaticv1.HelmTemplateMethod
+
+	appManager := &ApplicationManager{}
+	stuck, err := appManager.IsStuck(ctx, kubermaticlog.Logger, userClient, userClient, app)
+	if err != nil {
+		t.Fatalf("expected missing target namespace to skip the stuck check, got error: %v", err)
+	}
+	if stuck {
+		t.Fatal("expected missing target namespace to be treated as not stuck")
+	}
+
+	ns := &corev1.Namespace{}
+	err = userClient.Get(ctx, types.NamespacedName{Name: "new-namespace"}, ns)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected stuck check to leave target namespace absent, got error: %v", err)
+	}
+}
+
 // contains returns an error if actual does not contain expected. If actual and expected are nil, no error is returned.
 func contains(actual map[string]string, expected map[string]string) error {
 	if expected == nil && actual != nil {

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -223,15 +223,6 @@ func getDeployOpts(appDefinition *appskubermaticv1.ApplicationDefinition, appIns
 // - https://github.com/helm/helm/issues/7476
 // - https://github.com/helm/helm/issues/4558
 func (h HelmTemplate) IsStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
-	// if the release was successful, exit early
-	if applicationInstallation.Status.Conditions[appskubermaticv1.Ready].Status == "True" {
-		return false, nil
-	}
-	// currently we observe the stuck error exclusively with this message. If it does not exist, exit early
-	if applicationInstallation.Status.Conditions[appskubermaticv1.Ready].Message != "another operation (install/upgrade/rollback) is in progress" {
-		return false, nil
-	}
-
 	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
 	if err != nil {
 		return false, fmt.Errorf("failed to create helmCacheDir: %w", err)
@@ -252,19 +243,46 @@ func (h HelmTemplate) IsStuck(applicationInstallation *appskubermaticv1.Applicat
 		return false, fmt.Errorf("failed to create helmClient: %w", err)
 	}
 
-	// retrieve metadata of the latest release
+	// Helm pending states block subsequent install/upgrade/rollback operations. Detect them from Helm
+	// release metadata directly instead of relying on a previous controller status message.
 	releaseName := getReleaseName(applicationInstallation)
-	metadata, err := helmClient.GetMetadata(releaseName)
+	pending, err := helmClient.IsPending(releaseName)
 	if err != nil {
-		return false, fmt.Errorf("failed to retrieve metadata for checking if release %q is stuck: %w", releaseName, err)
+		return false, fmt.Errorf("failed to check if release %q is pending: %w", releaseName, err)
 	}
 
-	// if the status of the release is not still pending, exit early
-	if metadata.Status != "pending-upgrade" {
-		return false, nil
+	return pending, nil
+}
+
+// IsDeployed returns true if the latest Helm release revision is deployed.
+func (h HelmTemplate) IsDeployed(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to create helmCacheDir: %w", err)
 	}
 
-	return true, nil
+	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
+	restClientGetter := &genericclioptions.ConfigFlags{
+		KubeConfig: &h.Kubeconfig,
+		Namespace:  &applicationInstallation.Spec.Namespace.Name,
+	}
+	helmClient, err := helmclient.NewClient(
+		h.Ctx,
+		restClientGetter,
+		helmclient.NewSettings(helmCacheDir),
+		applicationInstallation.Spec.Namespace.Name,
+		h.Log)
+	if err != nil {
+		return false, fmt.Errorf("failed to create helmClient: %w", err)
+	}
+
+	releaseName := getReleaseName(applicationInstallation)
+	deployed, err := helmClient.IsDeployed(releaseName)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if release %q is deployed: %w", releaseName, err)
+	}
+
+	return deployed, nil
 }
 
 // Rollback rolls an Application back to the previous release.

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -253,7 +253,9 @@ func isCurrentAndReady(applicationInstallation *appskubermaticv1.ApplicationInst
 		applicationInstallation.Status.Failures == 0
 }
 
-// IsDeployed returns true if the latest Helm release revision is deployed.
+// IsDeployed returns true if the latest Helm release revision is deployed. Unlike IsStuck, this
+// intentionally does not skip Helm lookup when the local Ready condition is current and true: callers
+// use it to verify Helm state while recovering stale failure counters.
 func (h HelmTemplate) IsDeployed(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	helmClient, cleanup, err := h.newHelmClient(applicationInstallation.Spec.Namespace.Name)
 	if err != nil {

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/applications/helmclient"
 	"k8c.io/kubermatic/v2/pkg/applications/providers/util"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -223,25 +224,15 @@ func getDeployOpts(appDefinition *appskubermaticv1.ApplicationDefinition, appIns
 // - https://github.com/helm/helm/issues/7476
 // - https://github.com/helm/helm/issues/4558
 func (h HelmTemplate) IsStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
-	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
-	if err != nil {
-		return false, fmt.Errorf("failed to create helmCacheDir: %w", err)
+	if isCurrentAndReady(applicationInstallation) {
+		return false, nil
 	}
 
-	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
-	restClientGetter := &genericclioptions.ConfigFlags{
-		KubeConfig: &h.Kubeconfig,
-		Namespace:  &applicationInstallation.Spec.Namespace.Name,
-	}
-	helmClient, err := helmclient.NewClient(
-		h.Ctx,
-		restClientGetter,
-		helmclient.NewSettings(helmCacheDir),
-		applicationInstallation.Spec.Namespace.Name,
-		h.Log)
+	helmClient, cleanup, err := h.newHelmClient(applicationInstallation.Spec.Namespace.Name)
 	if err != nil {
-		return false, fmt.Errorf("failed to create helmClient: %w", err)
+		return false, err
 	}
+	defer cleanup()
 
 	// Helm pending states block subsequent install/upgrade/rollback operations. Detect them from Helm
 	// release metadata directly instead of relying on a previous controller status message.
@@ -254,27 +245,21 @@ func (h HelmTemplate) IsStuck(applicationInstallation *appskubermaticv1.Applicat
 	return pending, nil
 }
 
+func isCurrentAndReady(applicationInstallation *appskubermaticv1.ApplicationInstallation) bool {
+	readyCondition, exists := applicationInstallation.Status.Conditions[appskubermaticv1.Ready]
+	return exists &&
+		readyCondition.Status == corev1.ConditionTrue &&
+		readyCondition.ObservedGeneration == applicationInstallation.Generation &&
+		applicationInstallation.Status.Failures == 0
+}
+
 // IsDeployed returns true if the latest Helm release revision is deployed.
 func (h HelmTemplate) IsDeployed(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
-	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
+	helmClient, cleanup, err := h.newHelmClient(applicationInstallation.Spec.Namespace.Name)
 	if err != nil {
-		return false, fmt.Errorf("failed to create helmCacheDir: %w", err)
+		return false, err
 	}
-
-	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
-	restClientGetter := &genericclioptions.ConfigFlags{
-		KubeConfig: &h.Kubeconfig,
-		Namespace:  &applicationInstallation.Spec.Namespace.Name,
-	}
-	helmClient, err := helmclient.NewClient(
-		h.Ctx,
-		restClientGetter,
-		helmclient.NewSettings(helmCacheDir),
-		applicationInstallation.Spec.Namespace.Name,
-		h.Log)
-	if err != nil {
-		return false, fmt.Errorf("failed to create helmClient: %w", err)
-	}
+	defer cleanup()
 
 	releaseName := getReleaseName(applicationInstallation)
 	deployed, err := helmClient.IsDeployed(releaseName)
@@ -285,29 +270,42 @@ func (h HelmTemplate) IsDeployed(applicationInstallation *appskubermaticv1.Appli
 	return deployed, nil
 }
 
-// Rollback rolls an Application back to the previous release.
+// Rollback rolls an Application back to the latest successful release, or uninstalls it when no successful release exists.
 func (h HelmTemplate) Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+	helmClient, cleanup, err := h.newHelmClient(applicationInstallation.Spec.Namespace.Name)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return helmClient.Rollback(getReleaseName(applicationInstallation))
+}
+
+func (h HelmTemplate) newHelmClient(namespace string) (*helmclient.HelmClient, func(), error) {
 	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
 	if err != nil {
-		return fmt.Errorf("failed to create helmCacheDir: %w", err)
+		return nil, nil, fmt.Errorf("failed to create helmCacheDir: %w", err)
 	}
 
-	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
+	cleanup := func() {
+		util.CleanUpHelmTempDir(helmCacheDir, h.Log)
+	}
 	restClientGetter := &genericclioptions.ConfigFlags{
 		KubeConfig: &h.Kubeconfig,
-		Namespace:  &applicationInstallation.Spec.Namespace.Name,
+		Namespace:  &namespace,
 	}
 	helmClient, err := helmclient.NewClient(
 		h.Ctx,
 		restClientGetter,
 		helmclient.NewSettings(helmCacheDir),
-		applicationInstallation.Spec.Namespace.Name,
+		namespace,
 		h.Log)
 	if err != nil {
-		return fmt.Errorf("failed to create helmClient: %w", err)
+		cleanup()
+		return nil, nil, fmt.Errorf("failed to create helmClient: %w", err)
 	}
 
-	return helmClient.Rollback(getReleaseName(applicationInstallation))
+	return helmClient, cleanup, nil
 }
 
 func (h *HelmTemplate) templatePreDefinedValues(applicationValues map[string]any) (map[string]any, error) {

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -273,6 +273,7 @@ func (h HelmTemplate) IsDeployed(applicationInstallation *appskubermaticv1.Appli
 }
 
 // Rollback rolls an Application back to the latest successful release, or uninstalls it when no successful release exists.
+// A successful uninstall fallback allows the next reconcile to install the desired release cleanly.
 func (h HelmTemplate) Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	helmClient, cleanup, err := h.newHelmClient(applicationInstallation.Spec.Namespace.Name)
 	if err != nil {

--- a/pkg/applications/providers/template/helm_test.go
+++ b/pkg/applications/providers/template/helm_test.go
@@ -24,6 +24,7 @@ import (
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/applications/helmclient"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -229,4 +230,116 @@ func newDeployOpts(t *testing.T, wait bool, timeout time.Duration, atomic bool, 
 		t.Fatalf("failed to build deployOpts: %s", err)
 	}
 	return deployOps
+}
+
+func TestIsStuckSkipsHelmLookupWhenApplicationInstallationIsCurrentAndReady(t *testing.T) {
+	appInstallation := &appskubermaticv1.ApplicationInstallation{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 7,
+		},
+		Status: appskubermaticv1.ApplicationInstallationStatus{
+			Conditions: map[appskubermaticv1.ApplicationInstallationConditionType]appskubermaticv1.ApplicationInstallationCondition{
+				appskubermaticv1.Ready: {
+					Status:             corev1.ConditionTrue,
+					ObservedGeneration: 7,
+				},
+			},
+		},
+	}
+
+	stuck, err := (HelmTemplate{
+		CacheDir:   "/does/not/exist",
+		Kubeconfig: "invalid-kubeconfig",
+	}).IsStuck(appInstallation)
+	if err != nil {
+		t.Fatalf("expected current ready ApplicationInstallation to skip Helm lookup, got error: %v", err)
+	}
+	if stuck {
+		t.Fatal("expected current ready ApplicationInstallation not to be stuck")
+	}
+}
+
+func TestIsCurrentAndReady(t *testing.T) {
+	tests := []struct {
+		name             string
+		generation       int64
+		readyCondition   *appskubermaticv1.ApplicationInstallationCondition
+		failures         int
+		wantCurrentReady bool
+	}{
+		{
+			name:       "current ready with no failures",
+			generation: 7,
+			readyCondition: &appskubermaticv1.ApplicationInstallationCondition{
+				Status:             corev1.ConditionTrue,
+				ObservedGeneration: 7,
+			},
+			wantCurrentReady: true,
+		},
+		{
+			name:             "missing ready condition",
+			generation:       7,
+			wantCurrentReady: false,
+		},
+		{
+			name:       "ready condition is false",
+			generation: 7,
+			readyCondition: &appskubermaticv1.ApplicationInstallationCondition{
+				Status:             corev1.ConditionFalse,
+				ObservedGeneration: 7,
+			},
+			wantCurrentReady: false,
+		},
+		{
+			name:       "ready condition is unknown",
+			generation: 7,
+			readyCondition: &appskubermaticv1.ApplicationInstallationCondition{
+				Status:             corev1.ConditionUnknown,
+				ObservedGeneration: 7,
+			},
+			wantCurrentReady: false,
+		},
+		{
+			name:       "observed generation is stale",
+			generation: 7,
+			readyCondition: &appskubermaticv1.ApplicationInstallationCondition{
+				Status:             corev1.ConditionTrue,
+				ObservedGeneration: 6,
+			},
+			wantCurrentReady: false,
+		},
+		{
+			name:       "failures are present",
+			generation: 7,
+			readyCondition: &appskubermaticv1.ApplicationInstallationCondition{
+				Status:             corev1.ConditionTrue,
+				ObservedGeneration: 7,
+			},
+			failures:         1,
+			wantCurrentReady: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conditions := map[appskubermaticv1.ApplicationInstallationConditionType]appskubermaticv1.ApplicationInstallationCondition{}
+			if tt.readyCondition != nil {
+				conditions[appskubermaticv1.Ready] = *tt.readyCondition
+			}
+
+			appInstallation := &appskubermaticv1.ApplicationInstallation{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: tt.generation,
+				},
+				Status: appskubermaticv1.ApplicationInstallationStatus{
+					Conditions: conditions,
+					Failures:   tt.failures,
+				},
+			}
+
+			if got := isCurrentAndReady(appInstallation); got != tt.wantCurrentReady {
+				t.Fatalf("isCurrentAndReady() = %v, want %v", got, tt.wantCurrentReady)
+			}
+		})
+	}
 }

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -66,7 +66,8 @@ type TemplateProvider interface {
 	// IsDeployed checks if a release is deployed
 	IsDeployed(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
-	// Rollback the Application to the previous release
+	// Rollback rolls the Application back to the latest successful release, or uninstalls it so
+	// the next reconcile can install the desired release when no successful release exists.
 	Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -63,6 +63,9 @@ type TemplateProvider interface {
 	// IsStuck checks if a release is stuck
 	IsStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
+	// IsDeployed checks if a release is deployed
+	IsDeployed(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+
 	// Rollback the Application to the previous release
 	Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -287,7 +287,7 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		}
 		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
 			if restoreErr := r.setFailures(ctx, appInstallation, previousFailures); restoreErr != nil {
-				return fmt.Errorf("failed to recover release: %w; additionally failed to restore failure count: %v", err, restoreErr)
+				return fmt.Errorf("failed to recover release: %w; additionally failed to restore failure count: %w", err, restoreErr)
 			}
 			return fmt.Errorf("failed to recover release: %w", err)
 		}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -70,6 +70,9 @@ const (
 
 	// initialRequeueDuration is the time interval which is used until a node object to schedule workloads is registered in the cluster.
 	initialRequeueDuration = 10 * time.Second
+
+	installationFailedRetriesExceededReason        = "InstallationFailedRetriesExceeded"
+	installationFailedRetriesExceededMessagePrefix = "Max number of retries was exceeded. Last error: "
 )
 
 type reconciler struct {
@@ -268,30 +271,39 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return err
 	}
 
-	// Install or upgrade application only if max number of retries is not exceeded.
-	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
-		oldAppInstallation := appInstallation.DeepCopy()
-		appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, "InstallationFailedRetriesExceeded", "Max number of retries was exceeded. Last error: "+oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message)
-
-		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
-			return fmt.Errorf("failed to update status: %w", err)
-		}
-		log.Infow("Max number of retries was exceeded. Do not reconcile application", "failures", appInstallation.Status.Failures, "maxRetries", maxRetries)
-		return nil
-	}
-
 	// Because some upstream tools are not completely idempotent, we need a check to make sure a release is not stuck.
-	// This should be run before we make any changes to the status field, so we can use it in our analysis
+	// This must run before the retry limit is enforced so pending Helm releases can still be recovered.
 	stuck, err := r.appInstaller.IsStuck(ctx, log, r.seedClient, r.userClient, appInstallation)
 	if err != nil {
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
 	}
 	if stuck {
-		log.Infof("Release for ApplicationInstallation seems to be stuck, attempting rollback now")
+		log.Infof("Release for ApplicationInstallation seems to be stuck, attempting recovery now")
 		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
-			return fmt.Errorf("failed to rollback release: %w", err)
+			return fmt.Errorf("failed to recover release: %w", err)
 		}
-		log.Infof("Release for ApplicationInstallation has been rolled back successfully")
+		if err := r.resetFailures(ctx, appInstallation); err != nil {
+			return err
+		}
+		log.Infof("Release for ApplicationInstallation has been recovered successfully")
+	}
+
+	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
+		deployed, err := r.appInstaller.IsDeployed(ctx, log, r.seedClient, r.userClient, appInstallation)
+		if err != nil {
+			return fmt.Errorf("failed to check if the previous release is deployed: %w", err)
+		}
+		if deployed {
+			log.Infow("ApplicationInstallation exceeded max retries but Helm release is deployed; resetting failures and reconciling", "failures", appInstallation.Status.Failures, "maxRetries", maxRetries)
+			if err := r.resetFailures(ctx, appInstallation); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Install or upgrade application only if max number of retries is not exceeded.
+	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
+		return r.stopAfterMaxRetries(ctx, log, appInstallation)
 	}
 
 	downloadDest, err := os.MkdirTemp(r.appInstaller.GetAppCache(), appInstallation.Namespace+"-"+appInstallation.Name)
@@ -349,14 +361,49 @@ func hasLimitedRetries(appDefinition *appskubermaticv1.ApplicationDefinition, ap
 	return false
 }
 
-// resetFailuresIfSpecHasChanged set Status.Failures to 0 if the spec has changed. Returns an error if status can not be updated.
-func (r reconciler) resetFailuresIfSpecHasChanged(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+func (r *reconciler) stopAfterMaxRetries(ctx context.Context, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation) error {
 	oldAppInstallation := appInstallation.DeepCopy()
-	if appInstallation.Status.Conditions[appskubermaticv1.Ready].ObservedGeneration != appInstallation.Generation {
-		appInstallation.Status.Failures = 0
+	message := maxRetriesExceededMessage(oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message)
+	if oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Reason != installationFailedRetriesExceededReason ||
+		oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message != message {
+		appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, installationFailedRetriesExceededReason, message)
+
 		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
 			return fmt.Errorf("failed to update status: %w", err)
 		}
+	}
+	log.Infow("Max number of retries was exceeded. Do not reconcile application", "failures", appInstallation.Status.Failures, "maxRetries", maxRetries)
+	return nil
+}
+
+func maxRetriesExceededMessage(previousMessage string) string {
+	return installationFailedRetriesExceededMessagePrefix + unwrapMaxRetriesExceededMessage(previousMessage)
+}
+
+func unwrapMaxRetriesExceededMessage(message string) string {
+	for strings.HasPrefix(message, installationFailedRetriesExceededMessagePrefix) {
+		message = strings.TrimPrefix(message, installationFailedRetriesExceededMessagePrefix)
+	}
+	return message
+}
+
+// resetFailuresIfSpecHasChanged set Status.Failures to 0 if the spec has changed. Returns an error if status can not be updated.
+func (r reconciler) resetFailuresIfSpecHasChanged(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+	if appInstallation.Status.Conditions[appskubermaticv1.Ready].ObservedGeneration != appInstallation.Generation {
+		return r.resetFailures(ctx, appInstallation)
+	}
+	return nil
+}
+
+func (r reconciler) resetFailures(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+	if appInstallation.Status.Failures == 0 {
+		return nil
+	}
+
+	oldAppInstallation := appInstallation.DeepCopy()
+	appInstallation.Status.Failures = 0
+	if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+		return fmt.Errorf("failed to update status: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -420,6 +420,7 @@ func (r *reconciler) setFailures(ctx context.Context, appInstallation *appskuber
 	oldAppInstallation := appInstallation.DeepCopy()
 	appInstallation.Status.Failures = failures
 	if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+		appInstallation.Status.Failures = oldAppInstallation.Status.Failures
 		return fmt.Errorf("failed to update status: %w", err)
 	}
 	return nil

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -279,12 +279,16 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 	}
 	if stuck {
 		log.Infof("Release for ApplicationInstallation seems to be stuck, attempting recovery now")
+		previousFailures := appInstallation.Status.Failures
 		// Persist the retry reset before changing Helm state so a crash after recovery cannot
 		// leave the release repaired while the ApplicationInstallation remains retry-blocked.
 		if err := r.resetFailures(ctx, appInstallation); err != nil {
 			return err
 		}
 		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
+			if restoreErr := r.setFailures(ctx, appInstallation, previousFailures); restoreErr != nil {
+				return fmt.Errorf("failed to recover release: %w; additionally failed to restore failure count: %v", err, restoreErr)
+			}
 			return fmt.Errorf("failed to recover release: %w", err)
 		}
 		log.Infof("Release for ApplicationInstallation has been recovered successfully")
@@ -405,12 +409,16 @@ func (r *reconciler) resetFailuresIfSpecHasChanged(ctx context.Context, appInsta
 }
 
 func (r *reconciler) resetFailures(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
-	if appInstallation.Status.Failures == 0 {
+	return r.setFailures(ctx, appInstallation, 0)
+}
+
+func (r *reconciler) setFailures(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation, failures int) error {
+	if appInstallation.Status.Failures == failures {
 		return nil
 	}
 
 	oldAppInstallation := appInstallation.DeepCopy()
-	appInstallation.Status.Failures = 0
+	appInstallation.Status.Failures = failures
 	if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
 		return fmt.Errorf("failed to update status: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -290,7 +290,7 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		log.Infof("Release for ApplicationInstallation has been recovered successfully")
 	}
 
-	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) && hasCurrentReadyCondition(appInstallation) {
+	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) && readyConditionMatchesCurrentSpec(appInstallation) {
 		deployed, err := r.appInstaller.IsDeployed(ctx, log, r.seedClient, r.userClient, appInstallation)
 		if err != nil {
 			return fmt.Errorf("failed to check if the previous release is deployed: %w", err)
@@ -377,8 +377,9 @@ func (r *reconciler) stopAfterMaxRetries(ctx context.Context, log *zap.SugaredLo
 	return nil
 }
 
-func hasCurrentReadyCondition(appInstallation *appskubermaticv1.ApplicationInstallation) bool {
+func readyConditionMatchesCurrentSpec(appInstallation *appskubermaticv1.ApplicationInstallation) bool {
 	readyCondition, exists := appInstallation.Status.Conditions[appskubermaticv1.Ready]
+	// Failures is intentionally ignored: this gates recovery for stale counters that already exceed maxRetries.
 	return exists &&
 		readyCondition.Status == corev1.ConditionTrue &&
 		readyCondition.ObservedGeneration == appInstallation.Generation

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -279,16 +279,18 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 	}
 	if stuck {
 		log.Infof("Release for ApplicationInstallation seems to be stuck, attempting recovery now")
-		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
-			return fmt.Errorf("failed to recover release: %w", err)
-		}
+		// Persist the retry reset before changing Helm state so a crash after recovery cannot
+		// leave the release repaired while the ApplicationInstallation remains retry-blocked.
 		if err := r.resetFailures(ctx, appInstallation); err != nil {
 			return err
+		}
+		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
+			return fmt.Errorf("failed to recover release: %w", err)
 		}
 		log.Infof("Release for ApplicationInstallation has been recovered successfully")
 	}
 
-	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
+	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) && hasCurrentReadyCondition(appInstallation) {
 		deployed, err := r.appInstaller.IsDeployed(ctx, log, r.seedClient, r.userClient, appInstallation)
 		if err != nil {
 			return fmt.Errorf("failed to check if the previous release is deployed: %w", err)
@@ -364,16 +366,22 @@ func hasLimitedRetries(appDefinition *appskubermaticv1.ApplicationDefinition, ap
 func (r *reconciler) stopAfterMaxRetries(ctx context.Context, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation) error {
 	oldAppInstallation := appInstallation.DeepCopy()
 	message := maxRetriesExceededMessage(oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message)
-	if oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Reason != installationFailedRetriesExceededReason ||
-		oldAppInstallation.Status.Conditions[appskubermaticv1.Ready].Message != message {
-		appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, installationFailedRetriesExceededReason, message)
+	// Always refresh the condition to keep LastHeartbeatTime useful while the retry gate blocks reconciliation.
+	appInstallation.SetCondition(appskubermaticv1.Ready, corev1.ConditionFalse, installationFailedRetriesExceededReason, message)
 
-		if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
-			return fmt.Errorf("failed to update status: %w", err)
-		}
+	if err := r.userClient.Status().Patch(ctx, appInstallation, ctrlruntimeclient.MergeFrom(oldAppInstallation)); err != nil {
+		return fmt.Errorf("failed to update status: %w", err)
 	}
+
 	log.Infow("Max number of retries was exceeded. Do not reconcile application", "failures", appInstallation.Status.Failures, "maxRetries", maxRetries)
 	return nil
+}
+
+func hasCurrentReadyCondition(appInstallation *appskubermaticv1.ApplicationInstallation) bool {
+	readyCondition, exists := appInstallation.Status.Conditions[appskubermaticv1.Ready]
+	return exists &&
+		readyCondition.Status == corev1.ConditionTrue &&
+		readyCondition.ObservedGeneration == appInstallation.Generation
 }
 
 func maxRetriesExceededMessage(previousMessage string) string {
@@ -388,14 +396,14 @@ func unwrapMaxRetriesExceededMessage(message string) string {
 }
 
 // resetFailuresIfSpecHasChanged set Status.Failures to 0 if the spec has changed. Returns an error if status can not be updated.
-func (r reconciler) resetFailuresIfSpecHasChanged(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+func (r *reconciler) resetFailuresIfSpecHasChanged(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
 	if appInstallation.Status.Conditions[appskubermaticv1.Ready].ObservedGeneration != appInstallation.Generation {
 		return r.resetFailures(ctx, appInstallation)
 	}
 	return nil
 }
 
-func (r reconciler) resetFailures(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
+func (r *reconciler) resetFailures(ctx context.Context, appInstallation *appskubermaticv1.ApplicationInstallation) error {
 	if appInstallation.Status.Failures == 0 {
 		return nil
 	}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -318,6 +318,123 @@ func TestMaxRetriesOnInstallation(t *testing.T) {
 	}
 }
 
+func TestStuckReleaseRecoveryRunsBeforeMaxRetries(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 1, 1)
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	rollbackCalled := false
+	applyCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsStuckFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			return true, nil
+		},
+		RollbackFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+			rollbackCalled = true
+			return nil
+		},
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	if err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall); err != nil {
+		t.Fatalf("expected stuck release recovery to succeed, got %v", err)
+	}
+	if !rollbackCalled {
+		t.Fatal("expected rollback/recovery to be called before enforcing max retries")
+	}
+	if !applyCalled {
+		t.Fatal("expected apply to run after stuck release recovery reset failures")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	if updatedAppInstall.Status.Failures != 0 {
+		t.Fatalf("expected failures to be reset after recovery, got %d", updatedAppInstall.Status.Failures)
+	}
+}
+
+func TestDeployedReleaseClearsStaleMaxRetries(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 1, 1)
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	applyCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsDeployedFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			return true, nil
+		},
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	if err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall); err != nil {
+		t.Fatalf("expected stale max retries on deployed release to recover, got %v", err)
+	}
+	if !applyCalled {
+		t.Fatal("expected apply to run after clearing stale max retries")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	if updatedAppInstall.Status.Failures != 0 {
+		t.Fatalf("expected failures to be reset after successful apply, got %d", updatedAppInstall.Status.Failures)
+	}
+}
+
+func TestMaxRetriesMessageDoesNotGrow(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 1, 1)
+	appInstall.Status.Conditions[appskubermaticv1.Ready] = appskubermaticv1.ApplicationInstallationCondition{
+		Status:             corev1.ConditionFalse,
+		Reason:             installationFailedRetriesExceededReason,
+		Message:            installationFailedRetriesExceededMessagePrefix + installationFailedRetriesExceededMessagePrefix + "previous error",
+		ObservedGeneration: appInstall.Generation,
+	}
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	applyCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	if err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall); err != nil {
+		t.Fatalf("expected max retries handling to succeed, got %v", err)
+	}
+	if applyCalled {
+		t.Fatal("expected apply to remain blocked while max retries are exceeded and release is not deployed")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	expectedMessage := installationFailedRetriesExceededMessagePrefix + "previous error"
+	if updatedAppInstall.Status.Conditions[appskubermaticv1.Ready].Message != expectedMessage {
+		t.Fatalf("expected max retries message %q, got %q", expectedMessage, updatedAppInstall.Status.Conditions[appskubermaticv1.Ready].Message)
+	}
+}
+
 func genApplicationDefinition(name string, defaultAppNamespace *appskubermaticv1.AppNamespaceSpec) *appskubermaticv1.ApplicationDefinition {
 	return &appskubermaticv1.ApplicationDefinition{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -454,6 +454,9 @@ func TestStuckReleaseRecoveryDoesNotRollbackWhenFailureResetCannotBePersisted(t 
 	if rollbackCalled {
 		t.Fatal("expected rollback not to run when failure reset cannot be persisted")
 	}
+	if appInstall.Status.Failures != maxRetries+1 {
+		t.Fatalf("expected in-memory failures to remain unchanged after failed reset, got %d", appInstall.Status.Failures)
+	}
 }
 
 func TestStuckReleaseCheckErrorStopsReconcile(t *testing.T) {

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -373,6 +373,50 @@ func TestStuckReleaseRecoveryRunsBeforeMaxRetries(t *testing.T) {
 	}
 }
 
+func TestStuckReleaseRecoveryRestoresFailuresWhenRollbackFails(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	previousFailures := maxRetries + 1
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", previousFailures, 1, 1)
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	rollbackErr := errors.New("rollback failed")
+	applyCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsStuckFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			return true, nil
+		},
+		RollbackFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+			if applicationInstallation.Status.Failures != 0 {
+				t.Fatalf("expected failures to be reset before rollback, got %d", applicationInstallation.Status.Failures)
+			}
+			return rollbackErr
+		},
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall)
+	if !errors.Is(err, rollbackErr) {
+		t.Fatalf("expected rollback error, got %v", err)
+	}
+	if applyCalled {
+		t.Fatal("expected apply not to run after rollback recovery fails")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	if updatedAppInstall.Status.Failures != previousFailures {
+		t.Fatalf("expected failures to be restored after failed recovery, got %d", updatedAppInstall.Status.Failures)
+	}
+}
+
 func TestStuckReleaseRecoveryDoesNotRollbackWhenFailureResetCannotBePersisted(t *testing.T) {
 	ctx := context.Background()
 	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -38,6 +38,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -327,17 +328,25 @@ func TestStuckReleaseRecoveryRunsBeforeMaxRetries(t *testing.T) {
 
 	rollbackCalled := false
 	applyCalled := false
+	isDeployedCalled := false
 	appInstaller := fake.CustomApplicationInstaller{
 		IsStuckFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 			return true, nil
 		},
 		RollbackFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 			rollbackCalled = true
+			if applicationInstallation.Status.Failures != 0 {
+				t.Fatalf("expected failures to be reset before rollback, got %d", applicationInstallation.Status.Failures)
+			}
 			return nil
 		},
 		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
 			applyCalled = true
 			return util.NoStatusUpdate, nil
+		},
+		IsDeployedFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			isDeployedCalled = true
+			return false, nil
 		},
 	}
 
@@ -351,6 +360,9 @@ func TestStuckReleaseRecoveryRunsBeforeMaxRetries(t *testing.T) {
 	if !applyCalled {
 		t.Fatal("expected apply to run after stuck release recovery reset failures")
 	}
+	if isDeployedCalled {
+		t.Fatal("expected deployed check not to run after stuck release recovery reset failures")
+	}
 
 	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
 	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
@@ -361,16 +373,105 @@ func TestStuckReleaseRecoveryRunsBeforeMaxRetries(t *testing.T) {
 	}
 }
 
+func TestStuckReleaseRecoveryDoesNotRollbackWhenFailureResetCannotBePersisted(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 1, 1)
+	statusPatchErr := errors.New("status patch failed")
+	userClient := kubermaticfake.NewClientBuilder().
+		WithObjects(appInstall).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c ctrlruntimeclient.Client, subResourceName string, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.SubResourcePatchOption) error {
+				if subResourceName == "status" {
+					return statusPatchErr
+				}
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	rollbackCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsStuckFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			return true, nil
+		},
+		RollbackFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+			rollbackCalled = true
+			return nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall)
+	if !errors.Is(err, statusPatchErr) {
+		t.Fatalf("expected failure reset error, got %v", err)
+	}
+	if rollbackCalled {
+		t.Fatal("expected rollback not to run when failure reset cannot be persisted")
+	}
+}
+
+func TestStuckReleaseCheckErrorStopsReconcile(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", 0, 1, 1)
+	expectedReadyCondition := appInstall.Status.Conditions[appskubermaticv1.Ready]
+	expectedFailures := appInstall.Status.Failures
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	stuckCheckErr := errors.New("helm metadata lookup failed")
+	applyCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsStuckFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			return false, stuckCheckErr
+		},
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall)
+	if !errors.Is(err, stuckCheckErr) {
+		t.Fatalf("expected stuck release check error to be returned, got %v", err)
+	}
+	if applyCalled {
+		t.Fatal("expected apply not to run when stuck release check fails")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	if updatedAppInstall.Status.Conditions[appskubermaticv1.Ready] != expectedReadyCondition {
+		t.Fatalf("expected ready condition not to change on stuck release check error, got %+v", updatedAppInstall.Status.Conditions[appskubermaticv1.Ready])
+	}
+	if updatedAppInstall.Status.Failures != expectedFailures {
+		t.Fatalf("expected failures not to change on stuck release check error, got %d", updatedAppInstall.Status.Failures)
+	}
+}
+
 func TestDeployedReleaseClearsStaleMaxRetries(t *testing.T) {
 	ctx := context.Background()
 	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
 
 	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 1, 1)
+	appInstall.Status.Conditions[appskubermaticv1.Ready] = appskubermaticv1.ApplicationInstallationCondition{
+		Status:             corev1.ConditionTrue,
+		Reason:             "InstallationSuccessful",
+		Message:            "application successfully installed or upgraded",
+		ObservedGeneration: appInstall.Generation,
+	}
 	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
 
 	applyCalled := false
+	isDeployedCalled := false
 	appInstaller := fake.CustomApplicationInstaller{
 		IsDeployedFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			isDeployedCalled = true
 			return true, nil
 		},
 		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
@@ -386,6 +487,9 @@ func TestDeployedReleaseClearsStaleMaxRetries(t *testing.T) {
 	if !applyCalled {
 		t.Fatal("expected apply to run after clearing stale max retries")
 	}
+	if !isDeployedCalled {
+		t.Fatal("expected deployed release check to run before enforcing max retries")
+	}
 
 	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
 	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
@@ -394,6 +498,163 @@ func TestDeployedReleaseClearsStaleMaxRetries(t *testing.T) {
 	if updatedAppInstall.Status.Failures != 0 {
 		t.Fatalf("expected failures to be reset after successful apply, got %d", updatedAppInstall.Status.Failures)
 	}
+
+	readyCondition := updatedAppInstall.Status.Conditions[appskubermaticv1.Ready]
+	if readyCondition.Reason != "InstallationSuccessful" {
+		t.Fatalf("expected ready condition reason InstallationSuccessful, got %q", readyCondition.Reason)
+	}
+}
+
+func TestDeployedRollbackAfterFailedAtomicUpgradePreservesMaxRetries(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 2, 2)
+	appInstall.Status.Conditions[appskubermaticv1.Ready] = appskubermaticv1.ApplicationInstallationCondition{
+		Status:             corev1.ConditionFalse,
+		Reason:             "InstallationFailed",
+		Message:            "upgrade failed",
+		ObservedGeneration: appInstall.Generation,
+	}
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	applyCalled := false
+	isDeployedCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsDeployedFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			isDeployedCalled = true
+			return true, nil
+		},
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	if err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall); err != nil {
+		t.Fatalf("expected failed atomic upgrade to remain blocked by max retries, got %v", err)
+	}
+	if applyCalled {
+		t.Fatal("expected apply to remain blocked after max retries when only the rolled-back Helm release is deployed")
+	}
+	if isDeployedCalled {
+		t.Fatal("expected deployed release check not to run when Ready condition is not current and true")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	if updatedAppInstall.Status.Failures != maxRetries+1 {
+		t.Fatalf("expected failures to remain above max retries, got %d", updatedAppInstall.Status.Failures)
+	}
+
+	readyCondition := updatedAppInstall.Status.Conditions[appskubermaticv1.Ready]
+	if readyCondition.Reason != installationFailedRetriesExceededReason {
+		t.Fatalf("expected ready condition reason %q, got %q", installationFailedRetriesExceededReason, readyCondition.Reason)
+	}
+	expectedMessage := installationFailedRetriesExceededMessagePrefix + "upgrade failed"
+	if readyCondition.Message != expectedMessage {
+		t.Fatalf("expected ready condition message %q, got %q", expectedMessage, readyCondition.Message)
+	}
+}
+
+func TestSpecChangeResetsFailuresBeforeDeployedReleaseCheck(t *testing.T) {
+	ctx := context.Background()
+	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
+
+	const (
+		generation         int64 = 2
+		observedGeneration int64 = 1
+	)
+	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, generation, observedGeneration)
+	userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+	applyCalled := false
+	isDeployedCalled := false
+	appInstaller := fake.CustomApplicationInstaller{
+		IsDeployedFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+			isDeployedCalled = true
+			return true, nil
+		},
+		ApplyFunc: func(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
+			applyCalled = true
+			return util.NoStatusUpdate, nil
+		},
+	}
+
+	r := reconciler{log: kubermaticlog.Logger, seedClient: userClient, userClient: userClient, appInstaller: appInstaller}
+	if err := r.handleInstallation(ctx, kubermaticlog.Logger, genApplicationDefinition("app-def-1", nil), appInstall); err != nil {
+		t.Fatalf("expected spec change to clear stale failures and reconcile, got %v", err)
+	}
+	if !applyCalled {
+		t.Fatal("expected apply to run after spec change reset failures")
+	}
+	if isDeployedCalled {
+		t.Fatal("expected deployed release check not to run after spec change reset failures")
+	}
+
+	updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+	if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+		t.Fatalf("failed to get application installation: %v", err)
+	}
+	if updatedAppInstall.Status.Failures != 0 {
+		t.Fatalf("expected failures to be reset after spec change reconciliation, got %d", updatedAppInstall.Status.Failures)
+	}
+}
+
+func TestResetFailuresIfSpecHasChanged(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name               string
+		failures           int
+		generation         int64
+		observedGeneration int64
+		wantFailures       int
+	}{
+		{
+			name:               "spec generation changed",
+			failures:           maxRetries + 1,
+			generation:         2,
+			observedGeneration: 1,
+			wantFailures:       0,
+		},
+		{
+			name:               "spec generation unchanged",
+			failures:           maxRetries + 1,
+			generation:         2,
+			observedGeneration: 2,
+			wantFailures:       maxRetries + 1,
+		},
+		{
+			name:               "spec generation changed with no failures",
+			generation:         2,
+			observedGeneration: 1,
+			wantFailures:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", tt.failures, tt.generation, tt.observedGeneration)
+			userClient := kubermaticfake.NewClientBuilder().WithObjects(appInstall).Build()
+
+			r := reconciler{userClient: userClient}
+			if err := r.resetFailuresIfSpecHasChanged(ctx, appInstall); err != nil {
+				t.Fatalf("expected resetFailuresIfSpecHasChanged to succeed, got %v", err)
+			}
+
+			updatedAppInstall := &appskubermaticv1.ApplicationInstallation{}
+			if err := userClient.Get(ctx, types.NamespacedName{Name: "appInstallation-1", Namespace: applicationNamespaceName}, updatedAppInstall); err != nil {
+				t.Fatalf("failed to get application installation: %v", err)
+			}
+			if updatedAppInstall.Status.Failures != tt.wantFailures {
+				t.Fatalf("expected failures %d, got %d", tt.wantFailures, updatedAppInstall.Status.Failures)
+			}
+		})
+	}
 }
 
 func TestMaxRetriesMessageDoesNotGrow(t *testing.T) {
@@ -401,8 +662,10 @@ func TestMaxRetriesMessageDoesNotGrow(t *testing.T) {
 	kubermaticlog.Logger = kubermaticlog.New(true, kubermaticlog.FormatJSON).Sugar()
 
 	appInstall := genApplicationInstallation("appInstallation-1", &defaultApplicationNamespace, "app-def-1", "1.0.0", maxRetries+1, 1, 1)
+	previousHeartbeat := metav1.NewTime(time.Now().Add(-time.Hour))
 	appInstall.Status.Conditions[appskubermaticv1.Ready] = appskubermaticv1.ApplicationInstallationCondition{
 		Status:             corev1.ConditionFalse,
+		LastHeartbeatTime:  previousHeartbeat,
 		Reason:             installationFailedRetriesExceededReason,
 		Message:            installationFailedRetriesExceededMessagePrefix + installationFailedRetriesExceededMessagePrefix + "previous error",
 		ObservedGeneration: appInstall.Generation,
@@ -430,8 +693,12 @@ func TestMaxRetriesMessageDoesNotGrow(t *testing.T) {
 		t.Fatalf("failed to get application installation: %v", err)
 	}
 	expectedMessage := installationFailedRetriesExceededMessagePrefix + "previous error"
-	if updatedAppInstall.Status.Conditions[appskubermaticv1.Ready].Message != expectedMessage {
-		t.Fatalf("expected max retries message %q, got %q", expectedMessage, updatedAppInstall.Status.Conditions[appskubermaticv1.Ready].Message)
+	readyCondition := updatedAppInstall.Status.Conditions[appskubermaticv1.Ready]
+	if readyCondition.Message != expectedMessage {
+		t.Fatalf("expected max retries message %q, got %q", expectedMessage, readyCondition.Message)
+	}
+	if !readyCondition.LastHeartbeatTime.After(previousHeartbeat.Time) {
+		t.Fatalf("expected max retries handling to update ready condition heartbeat, got %v", readyCondition.LastHeartbeatTime)
 	}
 }
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 	"go.uber.org/zap"


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/15892

/assign adoi

```release-note
Fixed recovery for Helm-based ApplicationInstallations whose Helm release is stuck in a pending state or whose retry state no longer matches the deployed Helm release.
```