### PR TITLE
Reduce operator cache sync duration by ignoring creation events for secondary watches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	kubevirt.io/api v1.3.1
 	kubevirt.io/containerized-data-importer-api v1.60.3
-	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/yaml v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1757,8 +1757,8 @@ oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 h1:qPrZsv1cwQiFeieFlRqT627fVZ+tyfou/+S5S0H5ua0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.23.1 h1:TjJSM80Nf43Mg21+RCy3J70aj/W6KyvDtOlpKf+PupE=
-sigs.k8s.io/controller-runtime v0.23.1/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
+sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
+sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/controller-tools v0.20.1 h1:gkfMt9YodI0K85oT8rVi80NTXO/kDmabKR5Ajn5GYxs=
 sigs.k8s.io/controller-tools v0.20.1/go.mod h1:b4qPmjGU3iZwqn34alUU5tILhNa9+VXK+J3QV0fT/uU=
 sigs.k8s.io/gateway-api v1.4.1 h1:NPxFutNkKNa8UfLd2CMlEuhIPMQgDQ6DXNKG9sHbJU8=

--- a/pkg/controller/operator/master/controller.go
+++ b/pkg/controller/operator/master/controller.go
@@ -161,14 +161,14 @@ func Add(
 	}
 
 	for _, t := range namespacedResources {
-		bldr.Watches(t, childEventHandler, builder.WithPredicates(namespacePredicate, common.ManagedByOperatorPredicate))
+		bldr.Watches(t, childEventHandler, builder.WithPredicates(namespacePredicate, common.ManagedByOperatorPredicate, predicateutil.SkipCreateEvents()))
 	}
 
 	for _, t := range []ctrlruntimeclient.Object{
 		&admissionregistrationv1.ValidatingWebhookConfiguration{},
 		&rbacv1.ClusterRoleBinding{},
 	} {
-		bldr.Watches(t, childEventHandler, builder.WithPredicates(common.ManagedByOperatorPredicate))
+		bldr.Watches(t, childEventHandler, builder.WithPredicates(common.ManagedByOperatorPredicate, predicateutil.SkipCreateEvents()))
 	}
 
 	for _, t := range []ctrlruntimeclient.Object{

--- a/pkg/controller/operator/seed/controller.go
+++ b/pkg/controller/operator/seed/controller.go
@@ -210,7 +210,7 @@ func createSeedWatches(bldr *builder.Builder, seedName string, seedManager manag
 	}
 
 	for _, t := range namespacedTypesToWatch {
-		watch(t, predicateutil.ByNamespace(namespace), common.ManagedByOperatorPredicate)
+		watch(t, predicateutil.ByNamespace(namespace), common.ManagedByOperatorPredicate, predicateutil.SkipCreateEvents())
 	}
 
 	globalTypesToWatch := []ctrlruntimeclient.Object{
@@ -219,7 +219,7 @@ func createSeedWatches(bldr *builder.Builder, seedName string, seedManager manag
 	}
 
 	for _, t := range globalTypesToWatch {
-		watch(t, common.ManagedByOperatorPredicate)
+		watch(t, common.ManagedByOperatorPredicate, predicateutil.SkipCreateEvents())
 	}
 
 	// Seeds are not managed by the operator, but we still need to be notified when
@@ -242,7 +242,7 @@ func createSeedWatches(bldr *builder.Builder, seedName string, seedManager manag
 	}
 
 	for _, t := range namespacedVPATypes {
-		watch(t, predicateutil.ByNamespace(metav1.NamespaceSystem), common.ManagedByOperatorPredicate)
+		watch(t, predicateutil.ByNamespace(metav1.NamespaceSystem), common.ManagedByOperatorPredicate, predicateutil.SkipCreateEvents())
 	}
 
 	globalVPATypes := []ctrlruntimeclient.Object{


### PR DESCRIPTION
**What this PR does / why we need it**:
Workaround the cache sync timeout error by letting the kubermatic-operator ignore resource creation events for secondary watches (e.g. for Secrets and ClusterRoleBindings) in order to reduce the controller-runtime client cache sync duration during startup (where lots of resources are loaded at once and a synthetic creation event is emitted for each).

Hypothesis: The cache sync may take such a long time (>10 seconds) particularly due to the accumulated high amount of Helm chart release Secrets in old environments that have been upgraded many times and due to a high amount of ClusterRoleBindings and ClusterRoles.

Relates to #15722

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15843

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
