### PR TITLE
Record ApplicationInstallation Prometheus metrics

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -314,6 +314,8 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 
 	// Install or upgrade application only if max number of retries is not exceeded.
 	if appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation) {
+		r.updateApplicationMetrics(appInstallation, appDefinition)
+
 		return r.stopAfterMaxRetries(ctx, log, appInstallation)
 	}
 
@@ -355,7 +357,6 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to update status: %w", err)
 	}
 
-	// Update Prometheus metrics
 	r.updateApplicationMetrics(appInstallation, appDefinition)
 
 	return installErr

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -380,12 +380,6 @@ func (r *reconciler) updateApplicationMetrics(appInstallation *appskubermaticv1.
 	// Determine if the application is stuck (failures > maxRetries and has limited retries)
 	isStuck := appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation)
 
-	// Get last success timestamp (when Ready condition became True)
-	var lastSuccessTime float64
-	if exists && readyCondition.Status == corev1.ConditionTrue && !readyCondition.LastTransitionTime.IsZero() {
-		lastSuccessTime = float64(readyCondition.LastTransitionTime.Unix())
-	}
-
 	updateApplicationMetrics(
 		appInstallation.Namespace,
 		appInstallation.Name,
@@ -393,7 +387,6 @@ func (r *reconciler) updateApplicationMetrics(appInstallation *appskubermaticv1.
 		appInstallation.Status.Failures,
 		isStuck,
 		readyStatus,
-		lastSuccessTime,
 	)
 }
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -355,7 +355,45 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to update status: %w", err)
 	}
 
+	// Update Prometheus metrics
+	r.updateApplicationMetrics(appInstallation, appDefinition)
+
 	return installErr
+}
+
+// updateApplicationMetrics updates the Prometheus metrics for an ApplicationInstallation.
+func (r *reconciler) updateApplicationMetrics(appInstallation *appskubermaticv1.ApplicationInstallation, appDefinition *appskubermaticv1.ApplicationDefinition) {
+	readyCondition, exists := appInstallation.Status.Conditions[appskubermaticv1.Ready]
+
+	// Determine ready status: 1=ready, 0=not ready, -1=unknown
+	readyStatus := -1
+	if exists {
+		switch readyCondition.Status {
+		case corev1.ConditionTrue:
+			readyStatus = 1
+		case corev1.ConditionFalse:
+			readyStatus = 0
+		}
+	}
+
+	// Determine if the application is stuck (failures > maxRetries and has limited retries)
+	isStuck := appInstallation.Status.Failures > maxRetries && hasLimitedRetries(appDefinition, appInstallation)
+
+	// Get last success timestamp (when Ready condition became True)
+	var lastSuccessTime float64
+	if exists && readyCondition.Status == corev1.ConditionTrue && !readyCondition.LastTransitionTime.IsZero() {
+		lastSuccessTime = float64(readyCondition.LastTransitionTime.Unix())
+	}
+
+	updateApplicationMetrics(
+		appInstallation.Namespace,
+		appInstallation.Name,
+		appInstallation.Spec.ApplicationRef.Name,
+		appInstallation.Status.Failures,
+		isStuck,
+		readyStatus,
+		lastSuccessTime,
+	)
 }
 
 func hasLimitedRetries(appDefinition *appskubermaticv1.ApplicationDefinition, appInstallation *appskubermaticv1.ApplicationInstallation) bool {
@@ -451,6 +489,10 @@ func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger,
 			return fmt.Errorf("failed to remove application installation finalizer %s: %w", appInstallation.Name, err)
 		}
 	}
+
+	// Clean up Prometheus metrics when the application is uninstalled
+	deleteApplicationMetrics(appInstallation.Namespace, appInstallation.Name, appInstallation.Spec.ApplicationRef.Name)
+
 	return nil
 }
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package applicationinstallationcontroller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricsNamespace = "kkp"
+	metricsSubsystem = "application_installation"
+)
+
+var (
+	// applicationInstallationFailures tracks the number of failures for each ApplicationInstallation.
+	// This metric can be used to alert when an application is approaching or has exceeded the retry limit.
+	applicationInstallationFailures = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "failures",
+			Help:      "Number of installation/upgrade failures for an ApplicationInstallation",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+
+	// applicationInstallationStuck indicates whether an ApplicationInstallation is stuck (1) or not (0).
+	// An application is considered stuck when it has exceeded the maximum retry limit.
+	applicationInstallationStuck = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "stuck",
+			Help:      "Whether an ApplicationInstallation is stuck (1=stuck, 0=ok). An application is stuck when it has exceeded the maximum retry limit.",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+
+	// applicationInstallationReady indicates the ready status of an ApplicationInstallation.
+	// Values: 1 = ready (successfully installed), 0 = not ready (failed or in progress), -1 = unknown.
+	applicationInstallationReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "ready",
+			Help:      "Ready status of an ApplicationInstallation (1=ready, 0=not ready, -1=unknown)",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+
+	// applicationInstallationLastSuccessTimestamp records the timestamp of the last successful installation/upgrade.
+	applicationInstallationLastSuccessTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "last_success_timestamp_seconds",
+			Help:      "Unix timestamp of the last successful installation/upgrade",
+		},
+		[]string{"namespace", "name", "application"},
+	)
+)
+
+func init() {
+	// Register metrics with the controller-runtime metrics registry
+	metrics.Registry.MustRegister(
+		applicationInstallationFailures,
+		applicationInstallationStuck,
+		applicationInstallationReady,
+		applicationInstallationLastSuccessTimestamp,
+	)
+}
+
+// updateApplicationMetrics updates the Prometheus metrics for an ApplicationInstallation.
+func updateApplicationMetrics(namespace, name, application string, failures int, isStuck bool, readyStatus int, lastSuccessTime float64) {
+	applicationInstallationFailures.WithLabelValues(namespace, name, application).Set(float64(failures))
+
+	stuckValue := 0.0
+	if isStuck {
+		stuckValue = 1.0
+	}
+	applicationInstallationStuck.WithLabelValues(namespace, name, application).Set(stuckValue)
+
+	applicationInstallationReady.WithLabelValues(namespace, name, application).Set(float64(readyStatus))
+
+	if lastSuccessTime > 0 {
+		applicationInstallationLastSuccessTimestamp.WithLabelValues(namespace, name, application).Set(lastSuccessTime)
+	}
+}
+
+// deleteMetrics removes the Prometheus metrics for an ApplicationInstallation when it's deleted.
+func deleteApplicationMetrics(namespace, name, application string) {
+	applicationInstallationFailures.DeleteLabelValues(namespace, name, application)
+	applicationInstallationStuck.DeleteLabelValues(namespace, name, application)
+	applicationInstallationReady.DeleteLabelValues(namespace, name, application)
+	applicationInstallationLastSuccessTimestamp.DeleteLabelValues(namespace, name, application)
+}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
@@ -63,17 +63,6 @@ var (
 		},
 		[]string{"namespace", "name", "application"},
 	)
-
-	// applicationInstallationLastSuccessTimestamp records the timestamp of the last successful installation/upgrade.
-	applicationInstallationLastSuccessTimestamp = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
-			Name:      "last_success_timestamp_seconds",
-			Help:      "Unix timestamp of the last successful installation/upgrade",
-		},
-		[]string{"namespace", "name", "application"},
-	)
 )
 
 func init() {
@@ -82,12 +71,11 @@ func init() {
 		applicationInstallationFailures,
 		applicationInstallationStuck,
 		applicationInstallationReady,
-		applicationInstallationLastSuccessTimestamp,
 	)
 }
 
 // updateApplicationMetrics updates the Prometheus metrics for an ApplicationInstallation.
-func updateApplicationMetrics(namespace, name, application string, failures int, isStuck bool, readyStatus int, lastSuccessTime float64) {
+func updateApplicationMetrics(namespace, name, application string, failures int, isStuck bool, readyStatus int) {
 	stuckValue := 0.0
 	if isStuck {
 		stuckValue = 1.0
@@ -96,10 +84,6 @@ func updateApplicationMetrics(namespace, name, application string, failures int,
 	applicationInstallationFailures.WithLabelValues(namespace, name, application).Set(float64(failures))
 	applicationInstallationStuck.WithLabelValues(namespace, name, application).Set(stuckValue)
 	applicationInstallationReady.WithLabelValues(namespace, name, application).Set(float64(readyStatus))
-
-	if lastSuccessTime > 0 {
-		applicationInstallationLastSuccessTimestamp.WithLabelValues(namespace, name, application).Set(lastSuccessTime)
-	}
 }
 
 // deleteMetrics removes the Prometheus metrics for an ApplicationInstallation when it's deleted.
@@ -107,5 +91,4 @@ func deleteApplicationMetrics(namespace, name, application string) {
 	applicationInstallationFailures.DeleteLabelValues(namespace, name, application)
 	applicationInstallationStuck.DeleteLabelValues(namespace, name, application)
 	applicationInstallationReady.DeleteLabelValues(namespace, name, application)
-	applicationInstallationLastSuccessTimestamp.DeleteLabelValues(namespace, name, application)
 }

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/metrics.go
@@ -88,14 +88,13 @@ func init() {
 
 // updateApplicationMetrics updates the Prometheus metrics for an ApplicationInstallation.
 func updateApplicationMetrics(namespace, name, application string, failures int, isStuck bool, readyStatus int, lastSuccessTime float64) {
-	applicationInstallationFailures.WithLabelValues(namespace, name, application).Set(float64(failures))
-
 	stuckValue := 0.0
 	if isStuck {
 		stuckValue = 1.0
 	}
-	applicationInstallationStuck.WithLabelValues(namespace, name, application).Set(stuckValue)
 
+	applicationInstallationFailures.WithLabelValues(namespace, name, application).Set(float64(failures))
+	applicationInstallationStuck.WithLabelValues(namespace, name, application).Set(stuckValue)
 	applicationInstallationReady.WithLabelValues(namespace, name, application).Set(float64(readyStatus))
 
 	if lastSuccessTime > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Prometheus metrics to monitor stuck ApplicationInstallations.

Relates to #14880 and #14705.
This is a follow-up of #15892, pulling in the metrics introduced by #15841.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This PR was created based on @adoi's suggestion.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds ApplicationInstallation Prometheus metrics.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
