### PR TITLE
Fail installer on inconsistent gateway api config

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -39,6 +39,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/flagopts"
+	"k8c.io/kubermatic/v2/pkg/util/yamled"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -206,6 +207,10 @@ func DeployFunc(logger *logrus.Logger, versions kubermatic.Versions, opt *Deploy
 			return fmt.Errorf("failed to load Helm values: %w", err)
 		}
 
+		if err := validateGatewayAPIMigrationFlags(opt, helmValues); err != nil {
+			return err
+		}
+
 		deployOptions := stack.DeployOptions{
 			HelmClient:                         helmClient,
 			HelmValues:                         helmValues,
@@ -363,6 +368,19 @@ func setupHelmClient(logger *logrus.Logger, opt *DeployOptions) (helm.Client, er
 	}
 
 	return helmClient, nil
+}
+
+func validateGatewayAPIMigrationFlags(opt *DeployOptions, helmValues *yamled.Document) error {
+	if !opt.MigrateGatewayAPI {
+		return nil
+	}
+
+	migrateGatewayAPIInValues, _ := helmValues.GetBool(yamled.Path{"migrateGatewayAPI"})
+	if migrateGatewayAPIInValues {
+		return nil
+	}
+
+	return errors.New("--migrate-gateway-api requires the migrateGatewayAPI Helm value to be set to true")
 }
 
 func setupKubermaticStack(logger *logrus.Logger, args []string, opt *DeployOptions) (stack.Stack, error) {

--- a/cmd/kubermatic-installer/cmd_deploy_test.go
+++ b/cmd/kubermatic-installer/cmd_deploy_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8c.io/kubermatic/v2/pkg/util/yamled"
+)
+
+func TestValidateGatewayAPIMigrationFlags(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		cliFlag   bool
+		helmYAML  string
+		wantError bool
+	}{
+		{
+			name:      "flag disabled and value missing",
+			cliFlag:   false,
+			helmYAML:  "---\n",
+			wantError: false,
+		},
+		{
+			name:      "flag enabled and value set to true",
+			cliFlag:   true,
+			helmYAML:  "migrateGatewayAPI: true\n",
+			wantError: false,
+		},
+		{
+			name:      "flag enabled and value missing",
+			cliFlag:   true,
+			helmYAML:  "---\n",
+			wantError: true,
+		},
+		{
+			name:      "flag enabled and value false",
+			cliFlag:   true,
+			helmYAML:  "migrateGatewayAPI: false\n",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			helmValues, err := yamled.Load(bytes.NewReader([]byte(tc.helmYAML)))
+			require.NoError(t, err)
+
+			err = validateGatewayAPIMigrationFlags(&DeployOptions{MigrateGatewayAPI: tc.cliFlag}, helmValues)
+
+			if tc.wantError {
+				require.ErrorContains(t, err, "--migrate-gateway-api requires the migrateGatewayAPI Helm value to be set to true")
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fail the kubermatic-installer when the `--migrate-gateway-api` flag is enabled without the `migrateGatewayAPI` option also being enabled within the Helm values file.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15670

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
