### PR TITLE
Use mirror Quay credentials for chart mirroring

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -288,7 +288,7 @@ postsubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-docker-mirror: "true"
-      preset-docker-push-kubermatic: "true"
+      preset-docker-push-kubermatic-mirror: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the application chart mirroring postsubmit to use the mirror-specific Quay preset. The job pushes charts to `quay.io/kubermatic-mirror/helm-charts/*`, so it needs credentials for the `kubermatic-mirror` Quay organization instead of the regular `kubermatic` organization.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/15943

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
