### PR TITLE
Mirror Cilium 1.17.16 and 1.18.10 charts to Kubermatic mirror

### DIFF
--- a/hack/ci/lint-mirror-application-charts.sh
+++ b/hack/ci/lint-mirror-application-charts.sh
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 ### Lints hack/mirror-application-charts.sh by sourcing it and asserting
-### CHART_URLS and CHART_VERSIONS have identical key sets.
+### CHART_URLS and CHART_VERSIONS have identical key sets. Also verifies that
+### optional CHART_ADDITIONAL_VERSIONS entries reference known charts.
 ###
 ### Catches the most common contributor mistake: adding a chart to one
-### array but forgetting the other. Also serves as a smoke test that
-### mirror-application-charts.sh remains sourceable (which the post-submit
-### detection wrapper relies on).
+### array but forgetting the other, or adding additional versions for an unknown
+### chart. Also serves as a smoke test that mirror-application-charts.sh remains
+### sourceable (which the post-submit detection wrapper relies on).
 
 set -euo pipefail
 
@@ -35,7 +36,7 @@ trap 'rm -f "$stripped"' EXIT
 sed '/^main "\$@"$/d' "$SCRIPT" > "$stripped"
 
 # source in a subshell to keep our env clean, then print sorted key lists
-# from both arrays. awk compares the two key sets and prints mismatches.
+# from all relevant arrays. awk compares the key sets and prints mismatches.
 mismatch=$(
   (
     # shellcheck disable=SC1090
@@ -45,15 +46,22 @@ mismatch=$(
       for k in "${!CHART_URLS[@]}"; do printf '%s\n' "$k"; done | sort
       printf 'versions\n'
       for k in "${!CHART_VERSIONS[@]}"; do printf '%s\n' "$k"; done | sort
+      printf 'additional_versions\n'
+      if [[ "$(declare -p CHART_ADDITIONAL_VERSIONS 2> /dev/null)" == "declare -A"* ]]; then
+        for k in "${!CHART_ADDITIONAL_VERSIONS[@]}"; do printf '%s\n' "$k"; done | sort
+      fi
     }
   ) | awk '
-    /^urls$/     { mode="urls"; next }
-    /^versions$/ { mode="versions"; next }
-    mode=="urls"     { urls[$0]=1 }
-    mode=="versions" { versions[$0]=1 }
+    /^urls$/                { mode="urls"; next }
+    /^versions$/            { mode="versions"; next }
+    /^additional_versions$/ { mode="additional_versions"; next }
+    mode=="urls"                { urls[$0]=1 }
+    mode=="versions"            { versions[$0]=1 }
+    mode=="additional_versions" { additional_versions[$0]=1 }
     END {
       for (k in urls)     if (!(k in versions)) print "missing in CHART_VERSIONS: " k
       for (k in versions) if (!(k in urls))     print "missing in CHART_URLS: "    k
+      for (k in additional_versions) if (!(k in urls)) print "unknown chart in CHART_ADDITIONAL_VERSIONS: " k
     }
   '
 )
@@ -62,15 +70,24 @@ if [[ -n "$mismatch" ]]; then
   echo "FAIL: ${SCRIPT} has inconsistent CHART_URLS / CHART_VERSIONS keys:"
   echo "$mismatch" | sed 's/^/  /'
   echo
-  echo "Both arrays must contain the same set of chart names."
+  echo "CHART_URLS and CHART_VERSIONS must contain the same chart names; CHART_ADDITIONAL_VERSIONS may only reference those charts."
   exit 1
 fi
 
-count=$(
+read -r chart_count additional_count < <(
   (
     # shellcheck disable=SC1090
     source "$stripped" > /dev/null 2>&1
-    echo "${#CHART_URLS[@]}"
+    additional_count=0
+    if [[ "$(declare -p CHART_ADDITIONAL_VERSIONS 2> /dev/null)" == "declare -A"* ]]; then
+      for k in "${!CHART_ADDITIONAL_VERSIONS[@]}"; do
+        for version in ${CHART_ADDITIONAL_VERSIONS[$k]}; do
+          [[ -n "$version" ]] && additional_count=$((additional_count + 1))
+        done
+      done
+    fi
+
+    echo "${#CHART_URLS[@]} ${additional_count}"
   )
 )
-echo "OK: ${SCRIPT}: ${count} charts, CHART_URLS and CHART_VERSIONS keys match."
+echo "OK: ${SCRIPT}: ${chart_count} charts, ${additional_count} additional chart version(s), chart keys are valid."

--- a/hack/ci/lint-mirror-application-charts.sh
+++ b/hack/ci/lint-mirror-application-charts.sh
@@ -81,7 +81,9 @@ read -r chart_count additional_count < <(
     additional_count=0
     if [[ "$(declare -p CHART_ADDITIONAL_VERSIONS 2> /dev/null)" == "declare -A"* ]]; then
       for k in "${!CHART_ADDITIONAL_VERSIONS[@]}"; do
-        for version in ${CHART_ADDITIONAL_VERSIONS[$k]}; do
+        IFS=',' read -r -a versions <<< "${CHART_ADDITIONAL_VERSIONS[$k]}"
+        for version in "${versions[@]}"; do
+          version="${version//[[:space:]]/}"
           [[ -n "$version" ]] && additional_count=$((additional_count + 1))
         done
       done

--- a/hack/ci/mirror-new-application-charts.sh
+++ b/hack/ci/mirror-new-application-charts.sh
@@ -20,12 +20,13 @@
 ### Runs as a Prow post-submit job when mirror-application-charts.sh changes.
 ### Detects two types of changes:
 ###   1. New chart entries added to CHART_URLS / CHART_VERSIONS
-###   2. Version bumps in CHART_VERSIONS for existing charts
-### Then calls mirror-application-charts.sh for each affected chart.
+###   2. Version bumps or additions in CHART_VERSIONS / CHART_ADDITIONAL_VERSIONS
+###      for existing charts
+### Then calls mirror-application-charts.sh for each affected chart/version pair.
 ###
 ### Detection works by sourcing the current and previous versions of
 ### mirror-application-charts.sh in a subshell. This relies only on the file
-### being valid bash with the two associative arrays - no formatting assumptions.
+### being valid bash with the expected associative arrays - no formatting assumptions.
 ###
 ### Environment variables:
 ### * `DRY_RUN=true` - skip actual mirroring, only print charts that would be mirrored
@@ -47,9 +48,11 @@ SCRIPT_PATH="hack/mirror-application-charts.sh"
 OLD_SCRIPT=$(mktemp)
 trap 'rm -f "$OLD_SCRIPT"' EXIT
 
-# sources the given script file in a subshell and prints sorted "name=version"
-# lines from its CHART_VERSIONS array. the subshell isolates the source from
-# our environment so set -u, traps, and any other side effects don't leak.
+# sources the given script file in a subshell and prints sorted
+# "source<TAB>name<TAB>version" lines from CHART_VERSIONS and optional
+# CHART_ADDITIONAL_VERSIONS. the source field lets us detect a version that
+# moved from default to supplemental, which is useful when a previous mirror
+# attempt failed and we still want to retry that version.
 # returns empty output (exit 0) if the file is missing, unreadable, or doesn't
 # define CHART_VERSIONS (e.g. truncated, totally unrelated file).
 read_chart_versions_from() {
@@ -64,9 +67,17 @@ read_chart_versions_from() {
     # and we'd silently lose pairs we should have read.
     [[ "$(declare -p CHART_VERSIONS 2> /dev/null)" == "declare -A"* ]] || exit 0
     for key in "${!CHART_VERSIONS[@]}"; do
-      printf '%s=%s\n' "$key" "${CHART_VERSIONS[$key]}"
+      printf 'default\t%s\t%s\n' "$key" "${CHART_VERSIONS[$key]}"
     done
-  ) | sort
+
+    if [[ "$(declare -p CHART_ADDITIONAL_VERSIONS 2> /dev/null)" == "declare -A"* ]]; then
+      for key in "${!CHART_ADDITIONAL_VERSIONS[@]}"; do
+        for version in ${CHART_ADDITIONAL_VERSIONS[$key]}; do
+          [[ -n "$version" ]] && printf 'additional\t%s\t%s\n' "$key" "$version"
+        done
+      done
+    fi
+  ) | sort -u
 }
 
 # --- Main ----------------------------------------------------------------------
@@ -80,39 +91,41 @@ main() {
     echo "WARNING: No previous version of ${SCRIPT_PATH} found in the last ${MAX_HISTORY} commits. Treating all charts as new." >&2
   fi
 
-  local old_pairs new_pairs
-  old_pairs=$(read_chart_versions_from "$OLD_SCRIPT")
-  new_pairs=$(read_chart_versions_from "$SCRIPT_PATH")
+  local old_entries new_entries
+  old_entries=$(read_chart_versions_from "$OLD_SCRIPT")
+  new_entries=$(read_chart_versions_from "$SCRIPT_PATH")
 
-  # any "name=version" line in new but not old is either a newly added chart
-  # OR a version bump on an existing chart. both should trigger a mirror.
-  local changed_pairs
-  changed_pairs=$(comm -13 <(echo "$old_pairs") <(echo "$new_pairs"))
+  # any source/name/version entry in new but not old is either a newly added
+  # chart, a version bump on an existing chart, or an additional version added
+  # for a chart. all cases should trigger mirroring for that exact
+  # chart/version pair.
+  local changed_entries
+  changed_entries=$(comm -13 <(echo "$old_entries") <(echo "$new_entries"))
 
-  if [[ -z "$changed_pairs" ]]; then
+  if [[ -z "$changed_entries" ]]; then
     echodate "No new charts or version changes detected."
     return 0
   fi
 
-  # extract just the chart names for the loop. the inner script reads the
-  # version from CHART_VERSIONS itself when no version arg is passed, so we
-  # don't need to forward the version explicitly.
-  local charts_to_mirror
-  charts_to_mirror=$(echo "$changed_pairs" | cut -d= -f1 | sort -u)
-
   echodate "Charts to mirror:"
-  echo "$changed_pairs" | sed 's/^/  - /'
+  echo "$changed_entries" | awk -F '\t' '{ printf "  - %s=%s", $2, $3; if ($1 == "additional") printf " (additional)"; print "" }'
 
-  local chart version
-  while IFS= read -r chart; do
-    version=$(echo "$new_pairs" | grep "^${chart}=" | cut -d= -f2)
+  local source chart version pair
+  local -A mirrored_pairs=()
+  while IFS=$'\t' read -r source chart version; do
+    pair="${chart}=${version}"
+    if [[ -n "${mirrored_pairs[$pair]:-}" ]]; then
+      continue
+    fi
+    mirrored_pairs[$pair]=1
+
     if [[ "$DRY_RUN" == "true" ]]; then
       echodate "[DRY-RUN] Would mirror: ${chart} @ ${version}"
     else
       echodate "Mirroring: ${chart} @ ${version}"
-      ./"${SCRIPT_PATH}" "${chart}"
+      ./"${SCRIPT_PATH}" "${chart}" "${version}"
     fi
-  done <<< "$charts_to_mirror"
+  done <<< "$changed_entries"
 
   echodate "Done."
 }

--- a/hack/ci/mirror-new-application-charts.sh
+++ b/hack/ci/mirror-new-application-charts.sh
@@ -72,7 +72,9 @@ read_chart_versions_from() {
 
     if [[ "$(declare -p CHART_ADDITIONAL_VERSIONS 2> /dev/null)" == "declare -A"* ]]; then
       for key in "${!CHART_ADDITIONAL_VERSIONS[@]}"; do
-        for version in ${CHART_ADDITIONAL_VERSIONS[$key]}; do
+        IFS=',' read -r -a versions <<< "${CHART_ADDITIONAL_VERSIONS[$key]}"
+        for version in "${versions[@]}"; do
+          version="${version//[[:space:]]/}"
           [[ -n "$version" ]] && printf 'additional\t%s\t%s\n' "$key" "$version"
         done
       done

--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -53,7 +53,7 @@ declare -A CHART_URLS=(
 # Default versions for each chart
 declare -A CHART_VERSIONS=(
   ["cluster-autoscaler"]="9.46.6"
-  ["cilium"]="1.17.16"
+  ["cilium"]="1.18.10"
   # Add more default versions here as needed
   ["aikit"]="0.18.0"
   ["argo-cd"]="8.0.0"
@@ -72,6 +72,13 @@ declare -A CHART_VERSIONS=(
   ["kueue"]="0.13.4"
   ["mcp-server-kubernetes"]="2.9.9"
   ["velero"]="1.17.1"
+)
+
+# Optional supplemental versions to mirror in addition to the default versions
+# above. Values are whitespace-separated version lists. This is consumed by the
+# postsubmit wrapper; direct script callers can still pass explicit versions.
+declare -A CHART_ADDITIONAL_VERSIONS=(
+  ["cilium"]="1.17.16"
 )
 
 # Re-enable unset variable checking after array declarations

--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -75,7 +75,7 @@ declare -A CHART_VERSIONS=(
 )
 
 # Optional supplemental versions to mirror in addition to the default versions
-# above. Values are whitespace-separated version lists. This is consumed by the
+# above. Values are comma-separated version lists. This is consumed by the
 # postsubmit wrapper; direct script callers can still pass explicit versions.
 declare -A CHART_ADDITIONAL_VERSIONS=(
   ["cilium"]="1.17.16"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Cilium chart mirror configuration to mirror Cilium `1.18.10` and also adds support for supplemental chart versions. The supplemental version list lets the chart mirroring postsubmit mirror additional chart versions alongside the default version without changing the existing default-version behavior.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/15943

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
