### PR TITLE
Fix KubeLB enabled/enforced settings being omitted when set to false

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -248,7 +248,8 @@ func createBaseExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kuberm
 							Templates: imageList,
 						},
 						KubeLB: &kubermaticv1.KubeLBDatacenterSettings{
-							Enabled:                  true,
+							Enabled:                  ptr.To(true),
+							Enforced:                 ptr.To(false),
 							NodeAddressType:          "ExternalIP",
 							UseLoadBalancerClass:     true,
 							EnableGatewayAPI:         false,

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -145,7 +145,7 @@ func DefaultClusterSpec(
 	}
 
 	// Enable KubeLB if it is enforced by the datacenter.
-	if datacenter.Spec.KubeLB != nil && datacenter.Spec.KubeLB.Enforced {
+	if datacenter.Spec.KubeLB != nil && datacenter.Spec.KubeLB.Enforced != nil && *datacenter.Spec.KubeLB.Enforced {
 		if spec.KubeLB == nil {
 			spec.KubeLB = &kubermaticv1.KubeLB{
 				Enabled:              true,

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -213,7 +213,9 @@ func ValidateNewClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec,
 	// a) It's either enforced or enabled at the datacenter level.
 	// b) It's enabled for all datacenters at the seed level.
 	if spec.IsKubeLBEnabled() {
-		if (seed.Spec.KubeLB == nil || !seed.Spec.KubeLB.EnableForAllDatacenters) && (dc.Spec.KubeLB == nil || (!dc.Spec.KubeLB.Enabled && !dc.Spec.KubeLB.Enforced)) {
+		dcKubeLBEnabled := dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Enabled != nil && *dc.Spec.KubeLB.Enabled
+		dcKubeLBEnforced := dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Enforced != nil && *dc.Spec.KubeLB.Enforced
+		if (seed.Spec.KubeLB == nil || !seed.Spec.KubeLB.EnableForAllDatacenters) && (dc.Spec.KubeLB == nil || (!dcKubeLBEnabled && !dcKubeLBEnforced)) {
 			allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("kubeLB"), "KubeLB is not enabled for this seed/datacenter"))
 		}
 	}
@@ -242,14 +244,16 @@ func validateKubeLBUpdate(oldCluster, newCluster *kubermaticv1.Cluster, dc *kube
 		// KubeLB can only be enabled on the cluster when
 		// a) It's either enforced or enabled at the datacenter level.
 		// b) It's enabled for all datacenters at the seed level.
-		if (seed.Spec.KubeLB == nil || !seed.Spec.KubeLB.EnableForAllDatacenters) && (dc.Spec.KubeLB == nil || (!dc.Spec.KubeLB.Enabled && !dc.Spec.KubeLB.Enforced)) {
+		dcKubeLBEnabled := dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Enabled != nil && *dc.Spec.KubeLB.Enabled
+		dcKubeLBEnforced := dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Enforced != nil && *dc.Spec.KubeLB.Enforced
+		if (seed.Spec.KubeLB == nil || !seed.Spec.KubeLB.EnableForAllDatacenters) && (dc.Spec.KubeLB == nil || (!dcKubeLBEnabled && !dcKubeLBEnforced)) {
 			allErrs = append(allErrs, field.Forbidden(specPath.Child("kubeLB"), "KubeLB is not enabled for this seed/datacenter"))
 		}
 	}
 
 	if oldCluster.Spec.IsKubeLBEnabled() && !newCluster.Spec.IsKubeLBEnabled() {
 		// KubeLB can not be disabled if it's enforced on the datacenter.
-		if dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Enforced {
+		if dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Enforced != nil && *dc.Spec.KubeLB.Enforced {
 			allErrs = append(allErrs, field.Forbidden(specPath.Child("kubeLB"), "KubeLB can not be disabled if it's enforced on the datacenter"))
 		}
 	}

--- a/sdk/apis/kubermatic/v1/datacenter.go
+++ b/sdk/apis/kubermatic/v1/datacenter.go
@@ -1363,9 +1363,9 @@ type KubeLBDatacenterSettings struct {
 	// Used to configure and override the default kubeLB settings.
 	KubeLBSettings `json:",inline"`
 	// Enabled is used to enable/disable kubeLB for the datacenter. This is used to control whether installing kubeLB is allowed or not for the datacenter.
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled *bool `json:"enabled,omitempty"`
 	// Enforced is used to enforce kubeLB installation for all the user clusters belonging to this datacenter. Setting enforced to false will not uninstall kubeLB from the user clusters and it needs to be disabled manually.
-	Enforced bool `json:"enforced,omitempty"`
+	Enforced *bool `json:"enforced,omitempty"`
 	// NodeAddressType is used to configure the address type from node, used for load balancing.
 	// Optional: Defaults to ExternalIP.
 	// +kubebuilder:validation:Enum=InternalIP;ExternalIP

--- a/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/sdk/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -4687,6 +4687,16 @@ func (in *KubeLBConfiguration) DeepCopy() *KubeLBConfiguration {
 func (in *KubeLBDatacenterSettings) DeepCopyInto(out *KubeLBDatacenterSettings) {
 	*out = *in
 	out.KubeLBSettings = in.KubeLBSettings
+	if in.Enabled != nil {
+		in, out := &in.Enabled, &out.Enabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.Enforced != nil {
+		in, out := &in.Enforced, &out.Enforced
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ExtraArgs != nil {
 		in, out := &in.ExtraArgs, &out.ExtraArgs
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where disabled KubeLB datacenter settings were not correctly reflected in API responses.

Previously, the enabled and enforced fields in `KubeLBDatacenterSettings` were defined as non-pointer booleans with omitempty. As a result, when either field was explicitly set to false, it was omitted from the serialized API response. Downstream consumers, including the KKP Dashboard, could not distinguish between an explicitly configured false value and an unset field.

This caused KubeLB to remain available in the Dashboard for datacenters where it had been explicitly disabled in the Seed configuration.

This PR changes the enabled and enforced fields to pointer booleans so that explicit false values are preserved during serialization. The related defaulting, validation, deepcopy generation, and example configuration have been updated accordingly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15713 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
