### PR TITLE
fix KubeVirt ee resource quota validation for user-deployed namespaced instancetypes

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -35,7 +35,7 @@ const (
 	kubevirtVCPUs                   = 2
 	kubevirtMemory                  = "4Gi"
 	kubevirtDiskSize                = "25Gi"
-	kubevirtStorageClassName        = "local-path"
+	kubevirtStorageClassName        = "longhorn"
 	kubevirtVolumeSnapshotClassName = "longhorn-snapshot"
 )
 

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	kubevirtStorageClassName = "kubevirt-local-path"
+	kubevirtStorageClassName = "kubevirt-longhorn"
 )
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -434,7 +434,14 @@ func main() {
 	}
 	log.Info("Registered Application Installation controller")
 
-	if err := setupControllers(log, seedMgr, mgr, runOp.clusterName, versions, runOp.overwriteRegistry, caBundle, isPausedChecker, runOp.namespace, runOp.kyvernoEnabled); err != nil {
+	// Resolve the KubeVirt infra namespace: the cluster's dedicated namespace by default, or the
+	// datacenter's single-namespace ("namespaced mode") namespace when the kv-infra-namespace flag is set.
+	kvInfraNamespace := runOp.namespace
+	if runOp.kubeVirtInfraNamespace != "" {
+		kvInfraNamespace = runOp.kubeVirtInfraNamespace
+	}
+
+	if err := setupControllers(log, seedMgr, mgr, runOp.clusterName, versions, runOp.overwriteRegistry, caBundle, isPausedChecker, runOp.namespace, kvInfraNamespace, runOp.kyvernoEnabled); err != nil {
 		log.Fatalw("Failed to add controllers to mgr", zap.Error(err))
 	}
 

--- a/cmd/user-cluster-controller-manager/wrappers_ce.go
+++ b/cmd/user-cluster-controller-manager/wrappers_ce.go
@@ -59,6 +59,7 @@ func setupControllers(
 	caBundle *certificates.CABundle,
 	clusterIsPaused userclustercontrollermanager.IsPausedChecker,
 	namespace string,
+	kubeVirtInfraNamespace string,
 	kyvernoEnabled bool,
 ) error {
 	return nil

--- a/cmd/user-cluster-controller-manager/wrappers_ee.go
+++ b/cmd/user-cluster-controller-manager/wrappers_ee.go
@@ -99,9 +99,10 @@ func setupControllers(
 	caBundle *certificates.CABundle,
 	clusterIsPaused userclustercontrollermanager.IsPausedChecker,
 	namespace string,
+	kubeVirtInfraNamespace string,
 	kyvernoEnabled bool,
 ) error {
-	if err := resourceusagecontroller.Add(log, seedMgr, userMgr, clusterName, caBundle, clusterIsPaused); err != nil {
+	if err := resourceusagecontroller.Add(log, seedMgr, userMgr, clusterName, kubeVirtInfraNamespace, caBundle, clusterIsPaused); err != nil {
 		return fmt.Errorf("failed to create cluster-backup controller: %w", err)
 	}
 

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -130,7 +130,7 @@ func main() {
 	applicationinstallationvalidation.NewAdmissionHandler(log, seedMgr.GetScheme(), seedMgr.GetClient(), options.clusterName).SetupWebhookWithManager(seedMgr)
 
 	// Setup Machine Webhook in user manager.
-	machineValidator, err := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle, options.projectID)
+	machineValidator, err := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle, options.projectID, options.kubeVirtInfraNamespace)
 	if err != nil {
 		log.Fatalw("Failed to setup Machine validator", zap.Error(err))
 	}

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -29,10 +29,10 @@ import (
 )
 
 type appOptions struct {
-	seedWebhook webhook.Options
-	userWebhook webhook.Options
-	pprof       flagopts.PProf
-	log         kubermaticlog.Options
+	seedWebhook            webhook.Options
+	userWebhook            webhook.Options
+	pprof                  flagopts.PProf
+	log                    kubermaticlog.Options
 	caBundle               *certificates.CABundle
 	projectID              string
 	clusterName            string

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -33,9 +33,10 @@ type appOptions struct {
 	userWebhook webhook.Options
 	pprof       flagopts.PProf
 	log         kubermaticlog.Options
-	caBundle    *certificates.CABundle
-	projectID   string
-	clusterName string
+	caBundle               *certificates.CABundle
+	projectID              string
+	clusterName            string
+	kubeVirtInfraNamespace string
 }
 
 func initApplicationOptions() (appOptions, error) {
@@ -54,9 +55,11 @@ func initApplicationOptions() (appOptions, error) {
 	var caBundleFile string
 	var projectID string
 	var clusterName string
+	var kubeVirtInfraNamespace string
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all userclusters")
 	flag.StringVar(&projectID, "project-id", "", "Project ID in which cluster the webhook is running in")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster name in which the webhook is running in")
+	flag.StringVar(&kubeVirtInfraNamespace, "kubevirt-infra-namespace", "", "KubeVirt infra-cluster namespace that holds the cluster's namespaced VirtualMachineInstancetypes; empty falls back to an unscoped lookup")
 	flag.Parse()
 
 	caBundle, err := certificates.NewCABundleFromFile(caBundleFile)
@@ -65,6 +68,8 @@ func initApplicationOptions() (appOptions, error) {
 	}
 	c.caBundle = caBundle
 	c.projectID = projectID
+	c.clusterName = clusterName
+	c.kubeVirtInfraNamespace = kubeVirtInfraNamespace
 
 	if err := c.userWebhook.Validate(); err != nil {
 		return c, fmt.Errorf("invalid user cluster webhook configuration: %w", err)

--- a/hack/reconciling.yaml
+++ b/hack/reconciling.yaml
@@ -61,9 +61,9 @@ resourceTypes:
   - { package: k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1, resourceName: OperatingSystemProfile }
   - { package: k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1, resourceName: OperatingSystemConfig }
 
-  # instancetype/v1alpha1
-  - { package: kubevirt.io/api/instancetype/v1alpha1, resourceName: VirtualMachineInstancetype }
-  - { package: kubevirt.io/api/instancetype/v1alpha1, resourceName: VirtualMachinePreference }
+  # instancetype/v1beta1
+  - { package: kubevirt.io/api/instancetype/v1beta1, resourceName: VirtualMachineInstancetype }
+  - { package: kubevirt.io/api/instancetype/v1beta1, resourceName: VirtualMachinePreference }
 
   # cdi/v1beta1
   - { package: kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1, resourceName: DataVolume, importAlias: cdiv1beta1 }

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -52,27 +52,29 @@ import (
 const controllerName = "resource_usage_controller"
 
 type reconciler struct {
-	log             *zap.SugaredLogger
-	seedClient      ctrlruntimeclient.Client
-	userClient      ctrlruntimeclient.Client
-	clusterName     string
-	caBundle        *certificates.CABundle
-	recorder        events.EventRecorder
-	clusterIsPaused userclustercontrollermanager.IsPausedChecker
+	log                    *zap.SugaredLogger
+	seedClient             ctrlruntimeclient.Client
+	userClient             ctrlruntimeclient.Client
+	clusterName            string
+	kubeVirtInfraNamespace string
+	caBundle               *certificates.CABundle
+	recorder               events.EventRecorder
+	clusterIsPaused        userclustercontrollermanager.IsPausedChecker
 }
 
-func Add(log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterName string, caBundle *certificates.CABundle,
+func Add(log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterName, kubeVirtInfraNamespace string, caBundle *certificates.CABundle,
 	clusterIsPaused userclustercontrollermanager.IsPausedChecker) error {
 	log = log.Named(controllerName)
 
 	r := &reconciler{
-		log:             log,
-		seedClient:      seedMgr.GetClient(),
-		userClient:      userMgr.GetClient(),
-		clusterName:     clusterName,
-		caBundle:        caBundle,
-		recorder:        userMgr.GetEventRecorder(controllerName),
-		clusterIsPaused: clusterIsPaused,
+		log:                    log,
+		seedClient:             seedMgr.GetClient(),
+		userClient:             userMgr.GetClient(),
+		clusterName:            clusterName,
+		kubeVirtInfraNamespace: kubeVirtInfraNamespace,
+		caBundle:               caBundle,
+		recorder:               userMgr.GetEventRecorder(controllerName),
+		clusterIsPaused:        clusterIsPaused,
 	}
 
 	_, err := builder.ControllerManagedBy(userMgr).
@@ -118,7 +120,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, machines *clusterv1alpha1.MachineList) error {
 	resourceUsage := kubermaticv1.NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
 	for _, machine := range machines.Items {
-		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, &machine, r.caBundle)
+		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, r.kubeVirtInfraNamespace, &machine, r.caBundle)
 		if err != nil {
 			return fmt.Errorf("error getting machine resource usage for machine %q: %w", machine.Name, err)
 		}

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -273,6 +273,9 @@ func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclie
 		if err != nil {
 			return nil, fmt.Errorf("failed to get KubeVirt VMI instancetype: %w", err)
 		}
+		if capacity.CPUCores == nil || capacity.Memory == nil {
+			return nil, fmt.Errorf("KubeVirt instancetype %q has zero CPU or memory", rawConfig.VirtualMachine.Instancetype.Name)
+		}
 		cpuReq = *capacity.CPUCores
 		memReq = *capacity.Memory
 	} else {

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -88,7 +88,7 @@ const (
 	envKubeVirtKubeconfig = "KUBEVIRT_KUBECONFIG"
 )
 
-func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.Client, machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle) (*ResourceDetails, error) {
+func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.Client, kubeVirtInfraNamespace string, machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle) (*ResourceDetails, error) {
 	config, err := providerconfig.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)
@@ -105,7 +105,7 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 	case providerconfig.CloudProviderAzure:
 		quotaUsage, err = getAzureResourceRequirements(ctx, userClient, config)
 	case providerconfig.CloudProviderKubeVirt:
-		quotaUsage, err = getKubeVirtResourceRequirements(ctx, userClient, config)
+		quotaUsage, err = getKubeVirtResourceRequirements(ctx, userClient, kubeVirtInfraNamespace, config)
 	case providerconfig.CloudProviderVsphere:
 		quotaUsage, err = getVsphereResourceRequirements(config)
 	case providerconfig.CloudProviderOpenstack:
@@ -254,7 +254,13 @@ func getAzureResourceRequirements(ctx context.Context, userClient ctrlruntimecli
 	return NewResourceDetailsFromCapacity(vmSize)
 }
 
-func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, config *providerconfig.Config) (*ResourceDetails, error) {
+// getKubeVirtResourceRequirements computes the CPU/memory request of a KubeVirt machine.
+//
+// kubeVirtInfraNamespace is the KubeVirt infra-cluster namespace that holds the cluster's
+// namespaced VirtualMachineInstancetypes. It is resolved by the caller (from the cluster's
+// dedicated namespace, or the datacenter's NamespacedMode namespace when single-namespace mode
+// is enabled) and passed in here. Resolving a custom namespaced instancetype without it fails.
+func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclient.Client, kubeVirtInfraNamespace string, config *providerconfig.Config) (*ResourceDetails, error) {
 	configVarResolver := configvar.NewResolver(ctx, client)
 	rawConfig, err := kubevirttypes.GetConfig(*config)
 	if err != nil {
@@ -269,7 +275,8 @@ func getKubeVirtResourceRequirements(ctx context.Context, client ctrlruntimeclie
 		if err != nil {
 			return nil, fmt.Errorf("failed to get KubeVirt kubeconfig from machine config, error: %w", err)
 		}
-		capacity, err := kubevirt.DescribeInstanceType(ctx, kubeconfig, rawConfig.VirtualMachine.Instancetype)
+		// Scope the instancetype lookup to the cluster's KubeVirt infra namespace.
+		capacity, err := kubevirt.DescribeInstanceType(ctx, kubeconfig, kubeVirtInfraNamespace, rawConfig.VirtualMachine.Instancetype)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get KubeVirt VMI instancetype: %w", err)
 		}

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -101,7 +101,7 @@ func TestGetKubevirtResourceRequirements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &MockCtrlRuntimeClient{}
-			_, err := getKubeVirtResourceRequirements(context.Background(), mockClient, tc.config)
+			_, err := getKubeVirtResourceRequirements(context.Background(), mockClient, "", tc.config)
 			if err != nil {
 				if !tc.expectedErr {
 					t.Fatalf("unexpected error: %v", err)

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -44,11 +44,12 @@ import (
 func ValidateQuota(ctx context.Context,
 	log *zap.SugaredLogger,
 	userClient ctrlruntimeclient.Client,
+	kubeVirtInfraNamespace string,
 	machine *clusterv1alpha1.Machine,
 	caBundle *certificates.CABundle,
 	resourceQuota *kubermaticv1.ResourceQuota,
 ) error {
-	machineResourceUsage, err := GetMachineResourceUsage(ctx, userClient, machine, caBundle)
+	machineResourceUsage, err := GetMachineResourceUsage(ctx, userClient, kubeVirtInfraNamespace, machine, caBundle)
 	if err != nil {
 		return fmt.Errorf("error getting machine resource request: %w", err)
 	}

--- a/pkg/ee/validation/machine/resourcequota_test.go
+++ b/pkg/ee/validation/machine/resourcequota_test.go
@@ -70,7 +70,7 @@ func TestResourceQuotaValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := machine.ValidateQuota(context.Background(), l, nil, tc.machine, nil, genResourceQuota())
+			err := machine.ValidateQuota(context.Background(), l, nil, "", tc.machine, nil, genResourceQuota())
 			if err != nil {
 				if !tc.expectedErr {
 					t.Fatalf("unexpected error: %v", err)

--- a/pkg/provider/cloud/kubevirt/client.go
+++ b/pkg/provider/cloud/kubevirt/client.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"k8c.io/kubermatic/v2/pkg/test/fake"
@@ -38,7 +38,7 @@ var scheme = runtime.NewScheme()
 func init() {
 	utilruntime.Must(nativescheme.AddToScheme(scheme))
 	utilruntime.Must(kubevirtv1.AddToScheme(scheme))
-	utilruntime.Must(kvinstancetypev1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kvinstancetypev1beta1.AddToScheme(scheme))
 	utilruntime.Must(cdiv1beta1.AddToScheme(scheme))
 }
 

--- a/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-2.yaml
+++ b/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-2.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-2

--- a/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-4.yaml
+++ b/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-4.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-4

--- a/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-8.yaml
+++ b/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-8.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-8

--- a/pkg/provider/cloud/kubevirt/manifests/manifests_test.go
+++ b/pkg/provider/cloud/kubevirt/manifests/manifests_test.go
@@ -23,13 +23,14 @@ import (
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -48,7 +49,7 @@ var (
 
 func init() {
 	utilruntime.Must(kubevirtv1.AddToScheme(scheme.Scheme))
-	utilruntime.Must(kvinstancetypev1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(kvinstancetypev1beta1.AddToScheme(scheme.Scheme))
 	fakeclient = ctrlruntimefakeclient.
 		NewClientBuilder().
 		WithScheme(scheme.Scheme).
@@ -116,19 +117,19 @@ func getInstancetype(cpu uint32, memory, name string) []runtime.Object {
 	if err != nil {
 		return nil
 	}
-	instancetype := &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+	instancetype := &kvinstancetypev1beta1.VirtualMachineInstancetype{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: kvinstancetypev1alpha1.SchemeGroupVersion.String(),
+			APIVersion: kvinstancetypev1beta1.SchemeGroupVersion.String(),
 			Kind:       "VirtualMachineInstancetype",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-			CPU: kvinstancetypev1alpha1.CPUInstancetype{
+		Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+			CPU: kvinstancetypev1beta1.CPUInstancetype{
 				Guest: cpu,
 			},
-			Memory: kvinstancetypev1alpha1.MemoryInstancetype{
+			Memory: kvinstancetypev1beta1.MemoryInstancetype{
 				Guest: memoryQuantity,
 			},
 		},
@@ -137,17 +138,17 @@ func getInstancetype(cpu uint32, memory, name string) []runtime.Object {
 }
 
 func getPreference(name string) []runtime.Object {
-	preference := &kvinstancetypev1alpha1.VirtualMachinePreference{
+	preference := &kvinstancetypev1beta1.VirtualMachinePreference{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: kvinstancetypev1alpha1.SchemeGroupVersion.String(),
+			APIVersion: kvinstancetypev1beta1.SchemeGroupVersion.String(),
 			Kind:       "VirtualMachinePreference",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: kvinstancetypev1alpha1.VirtualMachinePreferenceSpec{
-			CPU: &kvinstancetypev1alpha1.CPUPreferences{
-				PreferredCPUTopology: kvinstancetypev1alpha1.PreferThreads,
+		Spec: kvinstancetypev1beta1.VirtualMachinePreferenceSpec{
+			CPU: &kvinstancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: ptr.To(kvinstancetypev1beta1.PreferThreads),
 			},
 		},
 	}

--- a/pkg/provider/cloud/kubevirt/manifests/preferences/sockets-advantage.yaml
+++ b/pkg/provider/cloud/kubevirt/manifests/preferences/sockets-advantage.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
 metadata:
   name: sockets-advantage

--- a/pkg/provider/cloud/kubevirt/manifests/test/instancetypes/standard-1.yaml
+++ b/pkg/provider/cloud/kubevirt/manifests/test/instancetypes/standard-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-1

--- a/pkg/provider/cloud/kubevirt/manifests/test/preferences/standard-1.yaml
+++ b/pkg/provider/cloud/kubevirt/manifests/test/preferences/standard-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
 metadata:
   name: standard-1

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kvmanifests "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt/manifests"
@@ -33,9 +33,9 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func instancetypeReconciler(instancetype *kvinstancetypev1alpha1.VirtualMachineInstancetype) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {
+func instancetypeReconciler(instancetype *kvinstancetypev1beta1.VirtualMachineInstancetype) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {
 	return func() (string, reconciling.VirtualMachineInstancetypeReconciler) {
-		return instancetype.Name, func(it *kvinstancetypev1alpha1.VirtualMachineInstancetype) (*kvinstancetypev1alpha1.VirtualMachineInstancetype, error) {
+		return instancetype.Name, func(it *kvinstancetypev1beta1.VirtualMachineInstancetype) (*kvinstancetypev1beta1.VirtualMachineInstancetype, error) {
 			it.Labels = instancetype.Labels
 			it.Spec = instancetype.Spec
 			return it, nil
@@ -45,7 +45,7 @@ func instancetypeReconciler(instancetype *kvinstancetypev1alpha1.VirtualMachineI
 
 // reconcileInstancetypes reconciles the Kubermatic standard VirtualMachineInstancetype into the dedicated namespace.
 func reconcileInstancetypes(ctx context.Context, namespace string, client ctrlruntimeclient.Client) error {
-	instancetypes := &kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
+	instancetypes := &kvinstancetypev1beta1.VirtualMachineInstancetypeList{}
 
 	// add Kubermatic standards
 	instancetypes.Items = append(instancetypes.Items, GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})...)
@@ -63,11 +63,11 @@ func reconcileInstancetypes(ctx context.Context, namespace string, client ctrlru
 }
 
 // GetKubermaticStandardInstancetypes returns the Kubermatic standard VirtualMachineInstancetypes.
-func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1alpha1.VirtualMachineInstancetype {
+func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1beta1.VirtualMachineInstancetype {
 	objs := kvmanifests.RuntimeFromYaml(client, getter)
-	instancetypes := make([]kvinstancetypev1alpha1.VirtualMachineInstancetype, 0, len(objs))
+	instancetypes := make([]kvinstancetypev1beta1.VirtualMachineInstancetype, 0, len(objs))
 	for _, obj := range objs {
-		instancetypes = append(instancetypes, *obj.(*kvinstancetypev1alpha1.VirtualMachineInstancetype))
+		instancetypes = append(instancetypes, *obj.(*kvinstancetypev1beta1.VirtualMachineInstancetype))
 	}
 	return instancetypes
 }
@@ -109,7 +109,7 @@ func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, 
 }
 
 func describeClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*provider.NodeCapacity, error) {
-	clusterInstancetypes := kvinstancetypev1alpha1.VirtualMachineClusterInstancetypeList{}
+	clusterInstancetypes := kvinstancetypev1beta1.VirtualMachineClusterInstancetypeList{}
 	if err := client.List(ctx, &clusterInstancetypes); err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclien
 	if namespace == "" {
 		return nil, fmt.Errorf("cannot resolve namespaced instancetype %q: no KubeVirt infra namespace configured", name)
 	}
-	namespacedInstancetypes := kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
+	namespacedInstancetypes := kvinstancetypev1beta1.VirtualMachineInstancetypeList{}
 	if err := client.List(ctx, &namespacedInstancetypes, ctrlruntimeclient.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclien
 }
 
 // instanceTypeToNodeCapacity extracts cpu, mem and gpu resource requests from the kubevirt instancetype.
-func instanceTypeToNodeCapacity(it kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec) (*provider.NodeCapacity, error) {
+func instanceTypeToNodeCapacity(it kvinstancetypev1beta1.VirtualMachineInstancetypeSpec) (*provider.NodeCapacity, error) {
 	capacity := provider.NewNodeCapacity()
 
 	// CPU and Memory are mandatory fields in instancetype

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -84,21 +84,21 @@ func DescribeInstanceType(ctx context.Context, kubeconfig string, it *kubevirtv1
 func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
 	switch it.Kind {
 	case "VirtualMachineInstancetype": // namespaced: kubermatic standard or user-deployed custom
-		if cap, err := describeNamespacedInstanceType(ctx, client, it.Name); cap != nil || err != nil {
-			return cap, err
+		if nodeCap, err := describeNamespacedInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
+			return nodeCap, err
 		}
 
 	case "VirtualMachineClusterInstancetype": // cluster-wide
-		if cap, err := describeClusterInstanceType(ctx, client, it.Name); cap != nil || err != nil {
-			return cap, err
+		if nodeCap, err := describeClusterInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
+			return nodeCap, err
 		}
 
 	case "": // kind absent — saved before kind was added to the API; search both types
-		if cap, err := describeClusterInstanceType(ctx, client, it.Name); cap != nil || err != nil {
-			return cap, err
+		if nodeCap, err := describeClusterInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
+			return nodeCap, err
 		}
-		if cap, err := describeNamespacedInstanceType(ctx, client, it.Name); cap != nil || err != nil {
-			return cap, err
+		if nodeCap, err := describeNamespacedInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
+			return nodeCap, err
 		}
 	}
 	return nil, fmt.Errorf("VMI instancetype %s of Kind %s not found", it.Name, it.Kind)

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -167,8 +167,5 @@ func instanceTypeToNodeCapacity(it kvinstancetypev1alpha1.VirtualMachineInstance
 	if !cpu.IsZero() {
 		capacity.WithCPUCount(int(cpu.Value()))
 	}
-	if len(it.GPUs) > 0 {
-		capacity.WithGPUCount(len(it.GPUs))
-	}
 	return capacity, nil
 }

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -73,18 +73,22 @@ func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter 
 }
 
 // DescribeInstanceType returns the NodeCapacity from the VirtualMachine instancetype.
-func DescribeInstanceType(ctx context.Context, kubeconfig string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+// namespace is the KubeVirt infra-cluster namespace that holds the cluster's namespaced
+// instancetypes. Resolving a custom (non-standard) namespaced instancetype without it fails,
+// to avoid an unscoped cross-tenant lookup. The embedded Kubermatic standard instancetypes are
+// namespace-independent and still resolve when it is empty.
+func DescribeInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
 	client, err := NewClient(kubeconfig, ClientOptions{})
 	if err != nil {
 		return nil, err
 	}
-	return describeInstanceType(ctx, client, it)
+	return describeInstanceType(ctx, client, namespace, it)
 }
 
-func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
 	switch it.Kind {
 	case "VirtualMachineInstancetype": // namespaced: kubermatic standard or user-deployed custom
-		if nodeCap, err := describeNamespacedInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
+		if nodeCap, err := describeNamespacedInstanceType(ctx, client, namespace, it.Name); nodeCap != nil || err != nil {
 			return nodeCap, err
 		}
 
@@ -97,7 +101,7 @@ func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, 
 		if nodeCap, err := describeClusterInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
 			return nodeCap, err
 		}
-		if nodeCap, err := describeNamespacedInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
+		if nodeCap, err := describeNamespacedInstanceType(ctx, client, namespace, it.Name); nodeCap != nil || err != nil {
 			return nodeCap, err
 		}
 	}
@@ -117,7 +121,7 @@ func describeClusterInstanceType(ctx context.Context, client ctrlruntimeclient.C
 	return nil, nil
 }
 
-func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*provider.NodeCapacity, error) {
+func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*provider.NodeCapacity, error) {
 	standardInstancetypes := GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
 	for _, instancetype := range standardInstancetypes {
 		if strings.EqualFold(instancetype.Name, name) {
@@ -127,15 +131,21 @@ func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclien
 	// Fall back to listing user-deployed namespaced VirtualMachineInstancetype objects
 	// from the infra cluster — these are custom instancetypes (e.g. GPU variants)
 	// that aren't part of the embedded Kubermatic standards.
-	// Note: this list is not namespace-scoped. Cross-tenant exposure is prevented at the
-	// dashboard/API layer, which restricts which instancetypes a user can reference.
+	//
+	// This requires the cluster's infra namespace: a custom instancetype must be resolved
+	// against the tenant that owns it, because two tenants may define instancetypes with the
+	// same name but different specs. Without a namespace we cannot do that safely, so we fail
+	// rather than risk feeding another tenant's spec into resource-quota validation.
+	if namespace == "" {
+		return nil, fmt.Errorf("cannot resolve namespaced instancetype %q: no KubeVirt infra namespace configured", name)
+	}
 	namespacedInstancetypes := kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
-	if err := client.List(ctx, &namespacedInstancetypes); err != nil {
+	if err := client.List(ctx, &namespacedInstancetypes, ctrlruntimeclient.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
-	for _, instancetype := range namespacedInstancetypes.Items {
-		if strings.EqualFold(instancetype.Name, name) {
-			return instanceTypeToNodeCapacity(instancetype.Spec)
+	for i := range namespacedInstancetypes.Items {
+		if strings.EqualFold(namespacedInstancetypes.Items[i].Name, name) {
+			return instanceTypeToNodeCapacity(namespacedInstancetypes.Items[i].Spec)
 		}
 	}
 	return nil, nil

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -127,6 +127,8 @@ func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclien
 	// Fall back to listing user-deployed namespaced VirtualMachineInstancetype objects
 	// from the infra cluster — these are custom instancetypes (e.g. GPU variants)
 	// that aren't part of the embedded Kubermatic standards.
+	// Note: this list is not namespace-scoped. Cross-tenant exposure is prevented at the
+	// dashboard/API layer, which restricts which instancetypes a user can reference.
 	namespacedInstancetypes := kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
 	if err := client.List(ctx, &namespacedInstancetypes); err != nil {
 		return nil, err

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -78,32 +78,68 @@ func DescribeInstanceType(ctx context.Context, kubeconfig string, it *kubevirtv1
 	if err != nil {
 		return nil, err
 	}
+	return describeInstanceType(ctx, client, it)
+}
 
+func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
 	switch it.Kind {
-	case "VirtualMachineInstancetype": // "standard" instancetype
-		standardInstancetypes := GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
-		for _, instancetype := range standardInstancetypes {
-			if strings.EqualFold(instancetype.Name, it.Name) {
-				return instanceTypeToNodeCapacity(instancetype.Spec)
-			}
+	case "VirtualMachineInstancetype": // namespaced: kubermatic standard or user-deployed custom
+		if cap, err := describeNamespacedInstanceType(ctx, client, it.Name); cap != nil || err != nil {
+			return cap, err
 		}
 
-	case "VirtualMachineClusterInstancetype": // "custom" instancetype (cluster-wide).
-		customInstancetypes := kvinstancetypev1alpha1.VirtualMachineClusterInstancetypeList{}
-		err := client.List(ctx, &customInstancetypes)
-		if err != nil {
-			return nil, err
+	case "VirtualMachineClusterInstancetype": // cluster-wide
+		if cap, err := describeClusterInstanceType(ctx, client, it.Name); cap != nil || err != nil {
+			return cap, err
 		}
-		for _, instancetype := range customInstancetypes.Items {
-			if strings.EqualFold(instancetype.Name, it.Name) {
-				return instanceTypeToNodeCapacity(instancetype.Spec)
-			}
+
+	case "": // kind absent — saved before kind was added to the API; search both types
+		if cap, err := describeClusterInstanceType(ctx, client, it.Name); cap != nil || err != nil {
+			return cap, err
+		}
+		if cap, err := describeNamespacedInstanceType(ctx, client, it.Name); cap != nil || err != nil {
+			return cap, err
 		}
 	}
 	return nil, fmt.Errorf("VMI instancetype %s of Kind %s not found", it.Name, it.Kind)
 }
 
-// instanceTypeToNodeCapacity extracts cpu and mem resource requests from the kubevirt instancetype.
+func describeClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*provider.NodeCapacity, error) {
+	clusterInstancetypes := kvinstancetypev1alpha1.VirtualMachineClusterInstancetypeList{}
+	if err := client.List(ctx, &clusterInstancetypes); err != nil {
+		return nil, err
+	}
+	for _, instancetype := range clusterInstancetypes.Items {
+		if strings.EqualFold(instancetype.Name, name) {
+			return instanceTypeToNodeCapacity(instancetype.Spec)
+		}
+	}
+	return nil, nil
+}
+
+func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*provider.NodeCapacity, error) {
+	standardInstancetypes := GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
+	for _, instancetype := range standardInstancetypes {
+		if strings.EqualFold(instancetype.Name, name) {
+			return instanceTypeToNodeCapacity(instancetype.Spec)
+		}
+	}
+	// Fall back to listing user-deployed namespaced VirtualMachineInstancetype objects
+	// from the infra cluster — these are custom instancetypes (e.g. GPU variants)
+	// that aren't part of the embedded Kubermatic standards.
+	namespacedInstancetypes := kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
+	if err := client.List(ctx, &namespacedInstancetypes); err != nil {
+		return nil, err
+	}
+	for _, instancetype := range namespacedInstancetypes.Items {
+		if strings.EqualFold(instancetype.Name, name) {
+			return instanceTypeToNodeCapacity(instancetype.Spec)
+		}
+	}
+	return nil, nil
+}
+
+// instanceTypeToNodeCapacity extracts cpu, mem and gpu resource requests from the kubevirt instancetype.
 func instanceTypeToNodeCapacity(it kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec) (*provider.NodeCapacity, error) {
 	capacity := provider.NewNodeCapacity()
 
@@ -118,6 +154,9 @@ func instanceTypeToNodeCapacity(it kvinstancetypev1alpha1.VirtualMachineInstance
 	}
 	if !cpu.IsZero() {
 		capacity.WithCPUCount(int(cpu.Value()))
+	}
+	if len(it.GPUs) > 0 {
+		capacity.WithGPUCount(len(it.GPUs))
 	}
 	return capacity, nil
 }

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -26,12 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func newTestClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
 	t.Helper()
-	return fakeclient.NewClientBuilder().
+	return ctrlruntimefakeclient.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
 		Build()

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,11 +50,11 @@ func TestDescribeInstanceType(t *testing.T) {
 			name:      "namespaced user-deployed instancetype with GPU is found (GPUs not counted in capacity)",
 			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu-2", Namespace: "kkp-dev"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
 						GPUs:   []kubevirtv1.GPU{{Name: "A100", DeviceName: "nv-a100-standard"}},
 					},
 				},
@@ -66,11 +66,11 @@ func TestDescribeInstanceType(t *testing.T) {
 			name:      "non-namespaced mode resolves instancetype in the cluster's dedicated namespace",
 			namespace: "cluster-apqx2l7v72",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom-cpu-2", Namespace: "cluster-apqx2l7v72"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
 					},
 				},
 			},
@@ -81,18 +81,18 @@ func TestDescribeInstanceType(t *testing.T) {
 			name:      "namespaced lookup ignores a same-named instancetype in another tenant namespace",
 			namespace: "tenant-a",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu", Namespace: "tenant-a"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
 					},
 				},
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu", Namespace: "tenant-b"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 8},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("32Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 8},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("32Gi")},
 					},
 				},
 			},
@@ -103,11 +103,11 @@ func TestDescribeInstanceType(t *testing.T) {
 			name:      "custom namespaced lookup fails when no infra namespace is configured",
 			namespace: "",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu", Namespace: "tenant-a"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
 					},
 				},
 			},
@@ -117,11 +117,11 @@ func TestDescribeInstanceType(t *testing.T) {
 		{
 			name: "cluster-scoped instancetype is found",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "standard-4"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 4},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
 					},
 				},
 			},
@@ -131,11 +131,11 @@ func TestDescribeInstanceType(t *testing.T) {
 		{
 			name: "empty kind resolves cluster-scoped instancetype",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "legacy-cluster"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
 					},
 				},
 			},
@@ -146,11 +146,11 @@ func TestDescribeInstanceType(t *testing.T) {
 			name:      "empty kind falls back to namespaced when no cluster-scoped match",
 			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "legacy-namespaced", Namespace: "kkp-dev"},
-					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 3},
-						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("12Gi")},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 3},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("12Gi")},
 					},
 				},
 			},

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -44,11 +44,10 @@ func TestDescribeInstanceType(t *testing.T) {
 		objects   []ctrlruntimeclient.Object
 		matcher   *kubevirtv1.InstancetypeMatcher
 		wantCPU   int64
-		wantGPUs  int64
 		wantErr   bool
 	}{
 		{
-			name:      "namespaced user-deployed instancetype with GPU is found",
+			name:      "namespaced user-deployed instancetype with GPU is found (GPUs not counted in capacity)",
 			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
@@ -60,9 +59,8 @@ func TestDescribeInstanceType(t *testing.T) {
 					},
 				},
 			},
-			matcher:  &kubevirtv1.InstancetypeMatcher{Name: "custom-gpu-2", Kind: "VirtualMachineInstancetype"},
-			wantCPU:  2,
-			wantGPUs: 1,
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "custom-gpu-2", Kind: "VirtualMachineInstancetype"},
+			wantCPU: 2,
 		},
 		{
 			name:      "non-namespaced mode resolves instancetype in the cluster's dedicated namespace",
@@ -185,9 +183,10 @@ func TestDescribeInstanceType(t *testing.T) {
 				t.Errorf("CPU: got %v, want %d", got.CPUCores, tc.wantCPU)
 			}
 
-			if got.GPUs != nil && got.GPUs.Value() != tc.wantGPUs ||
-				got.GPUs == nil && tc.wantGPUs != 0 {
-				t.Errorf("GPUs: got %v, want %d", got.GPUs, tc.wantGPUs)
+			// GPUs are intentionally not counted into node capacity for the
+			// KubeVirt provider, so they must never be set.
+			if got.GPUs != nil {
+				t.Errorf("GPUs: got %v, want nil (GPUs are not counted in capacity)", got.GPUs)
 			}
 		})
 	}

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -39,15 +39,17 @@ func newTestClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimecl
 
 func TestDescribeInstanceType(t *testing.T) {
 	testCases := []struct {
-		name     string
-		objects  []ctrlruntimeclient.Object
-		matcher  *kubevirtv1.InstancetypeMatcher
-		wantCPU  int64
-		wantGPUs int64
-		wantErr  bool
+		name      string
+		namespace string
+		objects   []ctrlruntimeclient.Object
+		matcher   *kubevirtv1.InstancetypeMatcher
+		wantCPU   int64
+		wantGPUs  int64
+		wantErr   bool
 	}{
 		{
-			name: "namespaced user-deployed instancetype with GPU is found",
+			name:      "namespaced user-deployed instancetype with GPU is found",
+			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu-2", Namespace: "kkp-dev"},
@@ -61,6 +63,58 @@ func TestDescribeInstanceType(t *testing.T) {
 			matcher:  &kubevirtv1.InstancetypeMatcher{Name: "custom-gpu-2", Kind: "VirtualMachineInstancetype"},
 			wantCPU:  2,
 			wantGPUs: 1,
+		},
+		{
+			name:      "non-namespaced mode resolves instancetype in the cluster's dedicated namespace",
+			namespace: "cluster-apqx2l7v72",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-cpu-2", Namespace: "cluster-apqx2l7v72"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "custom-cpu-2", Kind: "VirtualMachineInstancetype"},
+			wantCPU: 2,
+		},
+		{
+			name:      "namespaced lookup ignores a same-named instancetype in another tenant namespace",
+			namespace: "tenant-a",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu", Namespace: "tenant-a"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+					},
+				},
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu", Namespace: "tenant-b"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 8},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("32Gi")},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "custom-gpu", Kind: "VirtualMachineInstancetype"},
+			wantCPU: 2,
+		},
+		{
+			name:      "custom namespaced lookup fails when no infra namespace is configured",
+			namespace: "",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu", Namespace: "tenant-a"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "custom-gpu", Kind: "VirtualMachineInstancetype"},
+			wantErr: true,
 		},
 		{
 			name: "cluster-scoped instancetype is found",
@@ -91,7 +145,8 @@ func TestDescribeInstanceType(t *testing.T) {
 			wantCPU: 2,
 		},
 		{
-			name: "empty kind falls back to namespaced when no cluster-scoped match",
+			name:      "empty kind falls back to namespaced when no cluster-scoped match",
+			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "legacy-namespaced", Namespace: "kkp-dev"},
@@ -115,7 +170,7 @@ func TestDescribeInstanceType(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := newTestClient(t, tc.objects...)
-			got, err := describeInstanceType(context.Background(), client, tc.matcher)
+			got, err := describeInstanceType(context.Background(), client, tc.namespace, tc.matcher)
 
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("describeInstanceType() error = %v, wantErr = %v", err, tc.wantErr)

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirt
+
+import (
+	"context"
+	"testing"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newTestClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
+	t.Helper()
+	return fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+}
+
+func TestInstanceTypeToNodeCapacity_GPUCount(t *testing.T) {
+	spec := kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+		CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+		Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+		GPUs: []kubevirtv1.GPU{
+			{Name: "A100", DeviceName: "nv-a100-standard"},
+		},
+	}
+
+	got, err := instanceTypeToNodeCapacity(spec)
+	if err != nil {
+		t.Fatalf("instanceTypeToNodeCapacity returned error: %v", err)
+	}
+
+	if got.GPUs == nil {
+		t.Fatalf("expected GPUs to be set, got nil")
+	}
+	if got.GPUs.Value() != 1 {
+		t.Errorf("expected 1 GPU, got %d", got.GPUs.Value())
+	}
+}
+
+func TestDescribeInstanceType_NamespacedCustomFound(t *testing.T) {
+	// A user-deployed namespaced VirtualMachineInstancetype that is NOT one of the
+	// embedded Kubermatic standards — describeInstanceType must find it via the cluster.
+	custom := &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+		ObjectMeta: metav1.ObjectMeta{Name: "standard-gpu-2", Namespace: "kkp-dev"},
+		Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+			CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+			Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+			GPUs: []kubevirtv1.GPU{
+				{Name: "A100", DeviceName: "nv-a100-standard"},
+			},
+		},
+	}
+
+	client := newTestClient(t, custom)
+	matcher := &kubevirtv1.InstancetypeMatcher{Name: "standard-gpu-2", Kind: "VirtualMachineInstancetype"}
+
+	got, err := describeInstanceType(context.Background(), client, matcher)
+	if err != nil {
+		t.Fatalf("describeInstanceType returned error for custom namespaced instancetype: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil NodeCapacity for found instancetype")
+	}
+	if got.CPUCores == nil || got.CPUCores.Value() != 2 {
+		t.Errorf("expected 2 CPU cores, got %v", got.CPUCores)
+	}
+	if got.GPUs == nil || got.GPUs.Value() != 1 {
+		t.Errorf("expected 1 GPU, got %v", got.GPUs)
+	}
+}

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -37,56 +37,103 @@ func newTestClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimecl
 		Build()
 }
 
-func TestInstanceTypeToNodeCapacity_GPUCount(t *testing.T) {
-	spec := kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-		CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-		Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
-		GPUs: []kubevirtv1.GPU{
-			{Name: "A100", DeviceName: "nv-a100-standard"},
-		},
-	}
-
-	got, err := instanceTypeToNodeCapacity(spec)
-	if err != nil {
-		t.Fatalf("instanceTypeToNodeCapacity returned error: %v", err)
-	}
-
-	if got.GPUs == nil {
-		t.Fatalf("expected GPUs to be set, got nil")
-	}
-	if got.GPUs.Value() != 1 {
-		t.Errorf("expected 1 GPU, got %d", got.GPUs.Value())
-	}
-}
-
-func TestDescribeInstanceType_NamespacedCustomFound(t *testing.T) {
-	// A user-deployed namespaced VirtualMachineInstancetype that is NOT one of the
-	// embedded Kubermatic standards — describeInstanceType must find it via the cluster.
-	custom := &kvinstancetypev1alpha1.VirtualMachineInstancetype{
-		ObjectMeta: metav1.ObjectMeta{Name: "standard-gpu-2", Namespace: "kkp-dev"},
-		Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-			CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
-			Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
-			GPUs: []kubevirtv1.GPU{
-				{Name: "A100", DeviceName: "nv-a100-standard"},
+func TestDescribeInstanceType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		objects  []ctrlruntimeclient.Object
+		matcher  *kubevirtv1.InstancetypeMatcher
+		wantCPU  int64
+		wantGPUs int64
+		wantErr  bool
+	}{
+		{
+			name: "namespaced user-deployed instancetype with GPU is found",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "custom-gpu-2", Namespace: "kkp-dev"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+						GPUs:   []kubevirtv1.GPU{{Name: "A100", DeviceName: "nv-a100-standard"}},
+					},
+				},
 			},
+			matcher:  &kubevirtv1.InstancetypeMatcher{Name: "custom-gpu-2", Kind: "VirtualMachineInstancetype"},
+			wantCPU:  2,
+			wantGPUs: 1,
+		},
+		{
+			name: "cluster-scoped instancetype is found",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-4"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 4},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "standard-4", Kind: "VirtualMachineClusterInstancetype"},
+			wantCPU: 4,
+		},
+		{
+			name: "empty kind resolves cluster-scoped instancetype",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "legacy-cluster"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "legacy-cluster", Kind: ""},
+			wantCPU: 2,
+		},
+		{
+			name: "empty kind falls back to namespaced when no cluster-scoped match",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "legacy-namespaced", Namespace: "kkp-dev"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 3},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("12Gi")},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "legacy-namespaced", Kind: ""},
+			wantCPU: 3,
+		},
+		{
+			name:    "instancetype not found returns error",
+			objects: nil,
+			matcher: &kubevirtv1.InstancetypeMatcher{Name: "nonexistent", Kind: "VirtualMachineInstancetype"},
+			wantErr: true,
 		},
 	}
 
-	client := newTestClient(t, custom)
-	matcher := &kubevirtv1.InstancetypeMatcher{Name: "standard-gpu-2", Kind: "VirtualMachineInstancetype"}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, tc.objects...)
+			got, err := describeInstanceType(context.Background(), client, tc.matcher)
 
-	got, err := describeInstanceType(context.Background(), client, matcher)
-	if err != nil {
-		t.Fatalf("describeInstanceType returned error for custom namespaced instancetype: %v", err)
-	}
-	if got == nil {
-		t.Fatal("expected non-nil NodeCapacity for found instancetype")
-	}
-	if got.CPUCores == nil || got.CPUCores.Value() != 2 {
-		t.Errorf("expected 2 CPU cores, got %v", got.CPUCores)
-	}
-	if got.GPUs == nil || got.GPUs.Value() != 1 {
-		t.Errorf("expected 1 GPU, got %v", got.GPUs)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("describeInstanceType() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil NodeCapacity, got nil")
+			}
+			if got.CPUCores == nil || got.CPUCores.Value() != tc.wantCPU {
+				t.Errorf("CPU: got %v, want %d", got.CPUCores, tc.wantCPU)
+			}
+
+			if got.GPUs != nil && got.GPUs.Value() != tc.wantGPUs ||
+				got.GPUs == nil && tc.wantGPUs != 0 {
+				t.Errorf("GPUs: got %v, want %d", got.GPUs, tc.wantGPUs)
+			}
+		})
 	}
 }

--- a/pkg/provider/cloud/kubevirt/vm_preference.go
+++ b/pkg/provider/cloud/kubevirt/vm_preference.go
@@ -19,7 +19,7 @@ package kubevirt
 import (
 	"context"
 
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	kvmanifests "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt/manifests"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
@@ -27,9 +27,9 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func preferenceReconciler(preference *kvinstancetypev1alpha1.VirtualMachinePreference) reconciling.NamedVirtualMachinePreferenceReconcilerFactory {
+func preferenceReconciler(preference *kvinstancetypev1beta1.VirtualMachinePreference) reconciling.NamedVirtualMachinePreferenceReconcilerFactory {
 	return func() (string, reconciling.VirtualMachinePreferenceReconciler) {
-		return preference.Name, func(p *kvinstancetypev1alpha1.VirtualMachinePreference) (*kvinstancetypev1alpha1.VirtualMachinePreference, error) {
+		return preference.Name, func(p *kvinstancetypev1beta1.VirtualMachinePreference) (*kvinstancetypev1beta1.VirtualMachinePreference, error) {
 			p.Labels = preference.Labels
 			p.Spec = preference.Spec
 			return p, nil
@@ -39,7 +39,7 @@ func preferenceReconciler(preference *kvinstancetypev1alpha1.VirtualMachinePrefe
 
 // reconcilePreferences reconciles the Kubermatic standard VirtualMachinePreference into the dedicated namespace.
 func reconcilePreferences(ctx context.Context, namespace string, client ctrlruntimeclient.Client) error {
-	prefs := &kvinstancetypev1alpha1.VirtualMachinePreferenceList{}
+	prefs := &kvinstancetypev1beta1.VirtualMachinePreferenceList{}
 
 	// add Kubermatic standards
 	prefs.Items = append(prefs.Items, GetKubermaticStandardPreferences(client, &kvmanifests.StandardPreferenceGetter{})...)
@@ -57,11 +57,11 @@ func reconcilePreferences(ctx context.Context, namespace string, client ctrlrunt
 }
 
 // GetKubermaticStandardPreferences returns the Kubermatic standard VirtualMachinePreferences.
-func GetKubermaticStandardPreferences(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1alpha1.VirtualMachinePreference {
+func GetKubermaticStandardPreferences(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1beta1.VirtualMachinePreference {
 	objs := kvmanifests.RuntimeFromYaml(client, getter)
-	preferences := make([]kvinstancetypev1alpha1.VirtualMachinePreference, 0, len(objs))
+	preferences := make([]kvinstancetypev1beta1.VirtualMachinePreference, 0, len(objs))
 	for _, obj := range objs {
-		preferences = append(preferences, *obj.(*kvinstancetypev1alpha1.VirtualMachinePreference))
+		preferences = append(preferences, *obj.(*kvinstancetypev1beta1.VirtualMachinePreference))
 	}
 	return preferences
 }

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -33,7 +33,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	autoscalingk8siov1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -1112,7 +1112,7 @@ func ReconcileOperatingSystemConfigs(ctx context.Context, namedFactories []Named
 }
 
 // VirtualMachineInstancetypeReconciler defines an interface to create/update VirtualMachineInstancetypes.
-type VirtualMachineInstancetypeReconciler = func(existing *instancetypev1alpha1.VirtualMachineInstancetype) (*instancetypev1alpha1.VirtualMachineInstancetype, error)
+type VirtualMachineInstancetypeReconciler = func(existing *instancetypev1beta1.VirtualMachineInstancetype) (*instancetypev1beta1.VirtualMachineInstancetype, error)
 
 // NamedVirtualMachineInstancetypeReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
 type NamedVirtualMachineInstancetypeReconcilerFactory = func() (name string, reconciler VirtualMachineInstancetypeReconciler)
@@ -1122,9 +1122,9 @@ type NamedVirtualMachineInstancetypeReconcilerFactory = func() (name string, rec
 func VirtualMachineInstancetypeObjectWrapper(reconciler VirtualMachineInstancetypeReconciler) reconciling.ObjectReconciler {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return reconciler(existing.(*instancetypev1alpha1.VirtualMachineInstancetype))
+			return reconciler(existing.(*instancetypev1beta1.VirtualMachineInstancetype))
 		}
-		return reconciler(&instancetypev1alpha1.VirtualMachineInstancetype{})
+		return reconciler(&instancetypev1beta1.VirtualMachineInstancetype{})
 	}
 }
 
@@ -1140,7 +1140,7 @@ func ReconcileVirtualMachineInstancetypes(ctx context.Context, namedFactories []
 			reconcileObject = objectModifier(reconcileObject)
 		}
 
-		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1alpha1.VirtualMachineInstancetype{}, false); err != nil {
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1beta1.VirtualMachineInstancetype{}, false); err != nil {
 			return fmt.Errorf("failed to ensure VirtualMachineInstancetype %s/%s: %w", namespace, name, err)
 		}
 	}
@@ -1149,7 +1149,7 @@ func ReconcileVirtualMachineInstancetypes(ctx context.Context, namedFactories []
 }
 
 // VirtualMachinePreferenceReconciler defines an interface to create/update VirtualMachinePreferences.
-type VirtualMachinePreferenceReconciler = func(existing *instancetypev1alpha1.VirtualMachinePreference) (*instancetypev1alpha1.VirtualMachinePreference, error)
+type VirtualMachinePreferenceReconciler = func(existing *instancetypev1beta1.VirtualMachinePreference) (*instancetypev1beta1.VirtualMachinePreference, error)
 
 // NamedVirtualMachinePreferenceReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
 type NamedVirtualMachinePreferenceReconcilerFactory = func() (name string, reconciler VirtualMachinePreferenceReconciler)
@@ -1159,9 +1159,9 @@ type NamedVirtualMachinePreferenceReconcilerFactory = func() (name string, recon
 func VirtualMachinePreferenceObjectWrapper(reconciler VirtualMachinePreferenceReconciler) reconciling.ObjectReconciler {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return reconciler(existing.(*instancetypev1alpha1.VirtualMachinePreference))
+			return reconciler(existing.(*instancetypev1beta1.VirtualMachinePreference))
 		}
-		return reconciler(&instancetypev1alpha1.VirtualMachinePreference{})
+		return reconciler(&instancetypev1beta1.VirtualMachinePreference{})
 	}
 }
 
@@ -1177,7 +1177,7 @@ func ReconcileVirtualMachinePreferences(ctx context.Context, namedFactories []Na
 			reconcileObject = objectModifier(reconcileObject)
 		}
 
-		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1alpha1.VirtualMachinePreference{}, false); err != nil {
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1beta1.VirtualMachinePreference{}, false); err != nil {
 			return fmt.Errorf("failed to ensure VirtualMachinePreference %s/%s: %w", namespace, name, err)
 		}
 	}

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -105,6 +105,18 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 				fmt.Sprintf("-cluster-name=%s", data.Cluster().Name),
 			}
 
+			// For KubeVirt clusters, tell the webhook which infra-cluster namespace holds the
+			// cluster's namespaced VirtualMachineInstancetypes so the resource-quota validation
+			// resolves them in the right namespace. Defaults to the cluster's dedicated namespace,
+			// or the datacenter's single-namespace ("namespaced mode") namespace when enabled.
+			if data.Cluster().Spec.Cloud.Kubevirt != nil {
+				kubeVirtInfraNamespace := data.Cluster().Status.NamespaceName
+				if data.DC().Spec.Kubevirt != nil && data.DC().Spec.Kubevirt.NamespacedMode != nil && data.DC().Spec.Kubevirt.NamespacedMode.Enabled {
+					kubeVirtInfraNamespace = data.DC().Spec.Kubevirt.NamespacedMode.Namespace
+				}
+				args = append(args, fmt.Sprintf("-kubevirt-infra-namespace=%s", kubeVirtInfraNamespace))
+			}
+
 			if data.Cluster().Spec.DebugLog {
 				args = append(args, "-v=4", "-log-debug=true")
 			} else {

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -34,16 +34,17 @@ import (
 
 // validator for validating Kubermatic Machine CRD.
 type validator struct {
-	log             *zap.SugaredLogger
-	seedClient      ctrlruntimeclient.Client
-	userClient      ctrlruntimeclient.Client
-	caBundle        *certificates.CABundle
-	subjectSelector labels.Selector
+	log                    *zap.SugaredLogger
+	seedClient             ctrlruntimeclient.Client
+	userClient             ctrlruntimeclient.Client
+	caBundle               *certificates.CABundle
+	subjectSelector        labels.Selector
+	kubeVirtInfraNamespace string
 }
 
 // NewValidator returns a new Machine validator.
 func NewValidator(seedClient, userClient ctrlruntimeclient.Client, log *zap.SugaredLogger, caBundle *certificates.CABundle,
-	projectID string) (*validator, error) {
+	projectID, kubeVirtInfraNamespace string) (*validator, error) {
 	subjectNameReq, err := labels.NewRequirement(kubermaticv1.ResourceQuotaSubjectNameLabelKey, selection.Equals, []string{projectID})
 	if err != nil {
 		return nil, fmt.Errorf("error creating resource quota subject name requirement: %w", err)
@@ -55,11 +56,12 @@ func NewValidator(seedClient, userClient ctrlruntimeclient.Client, log *zap.Suga
 	subjectSelector := labels.NewSelector().Add(*subjectNameReq, *subjectKindReq)
 
 	return &validator{
-		log:             log,
-		seedClient:      seedClient,
-		userClient:      userClient,
-		caBundle:        caBundle,
-		subjectSelector: subjectSelector,
+		log:                    log,
+		seedClient:             seedClient,
+		userClient:             userClient,
+		caBundle:               caBundle,
+		subjectSelector:        subjectSelector,
+		kubeVirtInfraNamespace: kubeVirtInfraNamespace,
 	}, nil
 }
 
@@ -74,7 +76,7 @@ func (v *validator) ValidateCreate(ctx context.Context, machine *clusterv1alpha1
 		return nil, err
 	}
 	if quota != nil {
-		return nil, validateQuota(ctx, log, v.userClient, machine, v.caBundle, quota)
+		return nil, validateQuota(ctx, log, v.userClient, v.kubeVirtInfraNamespace, machine, v.caBundle, quota)
 	}
 	return nil, nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -31,7 +31,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine,
+func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ string, _ *clusterv1alpha1.Machine,
 	_ *certificates.CABundle, _ *kubermaticv1.ResourceQuota) error {
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -33,9 +33,9 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateQuota(ctx context.Context, log *zap.SugaredLogger, userClient ctrlruntimeclient.Client,
+func validateQuota(ctx context.Context, log *zap.SugaredLogger, userClient ctrlruntimeclient.Client, kubeVirtInfraNamespace string,
 	machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle, resourceQuota *kubermaticv1.ResourceQuota) error {
-	return eemachinevalidation.ValidateQuota(ctx, log, userClient, machine, caBundle, resourceQuota)
+	return eemachinevalidation.ValidateQuota(ctx, log, userClient, kubeVirtInfraNamespace, machine, caBundle, resourceQuota)
 }
 
 func getResourceQuota(ctx context.Context, seedClient ctrlruntimeclient.Client, subjectSelector labels.Selector) (*kubermaticv1.ResourceQuota, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When ee resource quota validation is enabled, creating a KubeVirt MachineDeployment with a user-deployed namespaced VirtualMachineInstancetype (e.g. a custom GPU variant) failed with VMI instancetype <name> of Kind VirtualMachineInstancetype not found. The ee admission webhook calls DescribeInstanceType() to resolve CPU/memory for quota accounting, but only checked Kubermatic's own embedded standard instancetypes for the namespaced case — user-deployed ones were never found.

Additionally, machine specs saved before the kind field was added to the API response had an empty kind, which hit an unhandled case and always failed.

This PR fixes both by refactoring DescribeInstanceType into testable helpers:
- Namespaced lookup now falls back to listing all user-deployed VirtualMachineInstancetype objects from the infra cluster
- An empty kind searches cluster-scoped first, then namespaced (backward compat)
- GPU count is now included in the capacity returned to quota accounting

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind regression

**Special notes for your reviewer**:

Depends on the [companion dashboard pr](https://github.com/kubermatic/dashboard/pull/8108) which makes the api return the correct kind per instancetype — required so the webhook hits the right switch case.

The empty-kind fallback in this PR handles existing MachineDeployment specs that were saved before the dashboard fix is deployed.

The machine controller already has fixes (https://github.com/kubermatic/machine-controller/pull/2031, https://github.com/kubermatic/machine-controller/pull/2038) that resolve the kind correctly when creating VMs, but those changes don't update the Machine providerSpec, so the KKP webhook still saw the wrong kind without this fix.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fixed ee resource quota validation for KubeVirt MachineDeployments using user-deployed namespaced VirtualMachineInstancetype resources (e.g. custom GPU instancetypes). Previously, machine creation was incorrectly rejected with "instancetype not found" when resource quotas were configured.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
tbd
```
