### PR TITLE
fix mirror-images ignoring dockerTagSuffix on --ignore-repository-overrides

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -123,7 +123,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
 	cmd.PersistentFlags().BoolVar(&opt.Insecure, "insecure", false, "Insecure option to bypass HTTPS/TLS certificate verification")
 
-	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
+	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides and tag suffixes in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that the development-only dockerTag override is still observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
 
 	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
 	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
@@ -162,21 +162,10 @@ func getKubermaticConfiguration(options *MirrorImagesOptions) (*kubermaticv1.Kub
 	}
 
 	// if we pass the option to ignore repository overrides in the KubermaticConfiguration,
-	// we make sure we omit any repository configured in the loaded config so they get
-	// properly defaulted.
+	// we make sure we omit any repository and tag suffix configured in the loaded config
+	// so they get properly defaulted.
 	if options.IgnoreRepositoryOverrides {
-		config.Spec.API.DockerRepository = ""
-		config.Spec.UI.DockerRepository = ""
-		config.Spec.MasterController.DockerRepository = ""
-		config.Spec.SeedController.DockerRepository = ""
-		config.Spec.Webhook.DockerRepository = ""
-		config.Spec.UserCluster.KubermaticDockerRepository = ""
-		config.Spec.UserCluster.DNATControllerDockerRepository = ""
-		config.Spec.UserCluster.EtcdLauncherDockerRepository = ""
-		config.Spec.UserCluster.Addons.DockerRepository = ""
-		config.Spec.VerticalPodAutoscaler.Recommender.DockerRepository = ""
-		config.Spec.VerticalPodAutoscaler.Updater.DockerRepository = ""
-		config.Spec.VerticalPodAutoscaler.AdmissionController.DockerRepository = ""
+		clearRepositoryOverrides(config)
 	}
 
 	kubermaticConfig, err := defaulting.DefaultConfiguration(config, zap.NewNop().Sugar())
@@ -185,6 +174,32 @@ func getKubermaticConfiguration(options *MirrorImagesOptions) (*kubermaticv1.Kub
 	}
 
 	return kubermaticConfig, nil
+}
+
+// clearRepositoryOverrides blanks all image repository overrides and tag suffixes in
+// the KubermaticConfiguration so DefaultConfiguration re-fills them with upstream
+// defaults. A DockerTagSuffix names a customer-built artifact that only exists in a
+// custom repository, so it must be cleared alongside the repositories; otherwise the
+// upstream repository is paired with a tag that upstream never published. The
+// development-only DockerTag override is intentionally left untouched.
+func clearRepositoryOverrides(config *kubermaticv1.KubermaticConfiguration) {
+	config.Spec.API.DockerRepository = ""
+	config.Spec.UI.DockerRepository = ""
+	config.Spec.MasterController.DockerRepository = ""
+	config.Spec.SeedController.DockerRepository = ""
+	config.Spec.Webhook.DockerRepository = ""
+	config.Spec.UserCluster.KubermaticDockerRepository = ""
+	config.Spec.UserCluster.DNATControllerDockerRepository = ""
+	config.Spec.UserCluster.EtcdLauncherDockerRepository = ""
+	config.Spec.UserCluster.Addons.DockerRepository = ""
+	config.Spec.VerticalPodAutoscaler.Recommender.DockerRepository = ""
+	config.Spec.VerticalPodAutoscaler.Updater.DockerRepository = ""
+	config.Spec.VerticalPodAutoscaler.AdmissionController.DockerRepository = ""
+
+	// tag suffixes are tied to a custom repository and must be cleared too
+	config.Spec.API.DockerTagSuffix = ""
+	config.Spec.UI.DockerTagSuffix = ""
+	config.Spec.UserCluster.Addons.DockerTagSuffix = ""
 }
 
 func getAddonsPath(ctx context.Context, logger *logrus.Logger, options *MirrorImagesOptions, kubermaticConfig *kubermaticv1.KubermaticConfiguration) (string, error) {

--- a/cmd/kubermatic-installer/cmd_mirror_images_test.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images_test.go
@@ -19,6 +19,10 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -115,6 +119,146 @@ func TestParseProviderFilter(t *testing.T) {
 				if result.Len() != tc.expectedCount {
 					t.Errorf("expected %d providers, got %d: %v", tc.expectedCount, result.Len(), sets.List(result))
 				}
+			}
+		})
+	}
+}
+
+// TestClearRepositoryOverrides covers the helper behind mirror-images
+// --ignore-repository-overrides. Every DockerRepository override and the three
+// DockerTagSuffix fields (API, UI, Addons) must be blanked so DefaultConfiguration
+// re-fills them with upstream defaults; the development-only DockerTag override must
+// survive. Leaving the addons suffix in place was the cause of issue #15868, where the
+// upstream addons repository was paired with a customer-only tag (e.g. v2.30.0-17) and
+// failed with MANIFEST_UNKNOWN.
+func TestClearRepositoryOverrides(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config *kubermaticv1.KubermaticConfiguration
+		// assertCleared lists fields that must be empty after the call.
+		assertCleared func(t *testing.T, c *kubermaticv1.KubermaticConfiguration)
+		// assertPreserved checks fields that must keep their value after the call.
+		assertPreserved func(t *testing.T, c *kubermaticv1.KubermaticConfiguration)
+	}{
+		{
+			name: "every repository override and every tag suffix is cleared",
+			config: &kubermaticv1.KubermaticConfiguration{
+				Spec: kubermaticv1.KubermaticConfigurationSpec{
+					API: kubermaticv1.KubermaticAPIConfiguration{
+						DockerRepository: "myreg.io/kubermatic",
+						DockerTagSuffix:  "17",
+					},
+					UI: kubermaticv1.KubermaticUIConfiguration{
+						DockerRepository: "myreg.io/dashboard",
+						DockerTagSuffix:  "17",
+					},
+					MasterController: kubermaticv1.KubermaticMasterControllerConfiguration{
+						DockerRepository: "myreg.io/master-controller",
+					},
+					SeedController: kubermaticv1.KubermaticSeedControllerConfiguration{
+						DockerRepository: "myreg.io/seed-controller",
+					},
+					Webhook: kubermaticv1.KubermaticWebhookConfiguration{
+						DockerRepository: "myreg.io/webhook",
+					},
+					UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
+						KubermaticDockerRepository:     "myreg.io/ucc",
+						DNATControllerDockerRepository: "myreg.io/dnat",
+						EtcdLauncherDockerRepository:   "myreg.io/etcd-launcher",
+						Addons: kubermaticv1.KubermaticAddonsConfiguration{
+							DockerRepository: "myreg.io/addons",
+							DockerTagSuffix:  "17",
+						},
+					},
+					VerticalPodAutoscaler: kubermaticv1.KubermaticVPAConfiguration{
+						Recommender:         kubermaticv1.KubermaticVPAComponent{DockerRepository: "myreg.io/vpa-recommender"},
+						Updater:             kubermaticv1.KubermaticVPAComponent{DockerRepository: "myreg.io/vpa-updater"},
+						AdmissionController: kubermaticv1.KubermaticVPAComponent{DockerRepository: "myreg.io/vpa-admission"},
+					},
+				},
+			},
+			assertCleared: func(t *testing.T, c *kubermaticv1.KubermaticConfiguration) {
+				assert.Empty(t, c.Spec.API.DockerRepository)
+				assert.Empty(t, c.Spec.UI.DockerRepository)
+				assert.Empty(t, c.Spec.MasterController.DockerRepository)
+				assert.Empty(t, c.Spec.SeedController.DockerRepository)
+				assert.Empty(t, c.Spec.Webhook.DockerRepository)
+				assert.Empty(t, c.Spec.UserCluster.KubermaticDockerRepository)
+				assert.Empty(t, c.Spec.UserCluster.DNATControllerDockerRepository)
+				assert.Empty(t, c.Spec.UserCluster.EtcdLauncherDockerRepository)
+				assert.Empty(t, c.Spec.UserCluster.Addons.DockerRepository)
+				assert.Empty(t, c.Spec.VerticalPodAutoscaler.Recommender.DockerRepository)
+				assert.Empty(t, c.Spec.VerticalPodAutoscaler.Updater.DockerRepository)
+				assert.Empty(t, c.Spec.VerticalPodAutoscaler.AdmissionController.DockerRepository)
+
+				assert.Empty(t, c.Spec.API.DockerTagSuffix)
+				assert.Empty(t, c.Spec.UI.DockerTagSuffix)
+				assert.Empty(t, c.Spec.UserCluster.Addons.DockerTagSuffix)
+			},
+		},
+		{
+			// the exact #15868 scenario: only the addons suffix is set on top of a
+			// repository override; both must be cleared so the upstream addons image
+			// resolves with its plain version tag instead of v<version>-17.
+			name: "issue 15868: addons repository and tag suffix are cleared together",
+			config: &kubermaticv1.KubermaticConfiguration{
+				Spec: kubermaticv1.KubermaticConfigurationSpec{
+					UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
+						Addons: kubermaticv1.KubermaticAddonsConfiguration{
+							DockerRepository: "myreg.io/addons",
+							DockerTagSuffix:  "17",
+						},
+					},
+				},
+			},
+			assertCleared: func(t *testing.T, c *kubermaticv1.KubermaticConfiguration) {
+				assert.Empty(t, c.Spec.UserCluster.Addons.DockerRepository)
+				assert.Empty(t, c.Spec.UserCluster.Addons.DockerTagSuffix)
+			},
+		},
+		{
+			// DockerTag is a development-only full-tag override and is outside the
+			// repository-override contract, so it must survive on both API and UI.
+			name: "development-only DockerTag is preserved on API and UI",
+			config: &kubermaticv1.KubermaticConfiguration{
+				Spec: kubermaticv1.KubermaticConfigurationSpec{
+					API: kubermaticv1.KubermaticAPIConfiguration{
+						DockerRepository: "myreg.io/kubermatic",
+						DockerTag:        "dev-api",
+					},
+					UI: kubermaticv1.KubermaticUIConfiguration{
+						DockerRepository: "myreg.io/dashboard",
+						DockerTag:        "dev-ui",
+					},
+				},
+			},
+			assertCleared: func(t *testing.T, c *kubermaticv1.KubermaticConfiguration) {
+				assert.Empty(t, c.Spec.API.DockerRepository)
+				assert.Empty(t, c.Spec.UI.DockerRepository)
+			},
+			assertPreserved: func(t *testing.T, c *kubermaticv1.KubermaticConfiguration) {
+				assert.Equal(t, "dev-api", c.Spec.API.DockerTag)
+				assert.Equal(t, "dev-ui", c.Spec.UI.DockerTag)
+			},
+		},
+		{
+			name:   "empty config stays empty",
+			config: &kubermaticv1.KubermaticConfiguration{},
+			assertCleared: func(t *testing.T, c *kubermaticv1.KubermaticConfiguration) {
+				assert.Equal(t, &kubermaticv1.KubermaticConfiguration{}, c)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearRepositoryOverrides(tc.config)
+
+			if tc.assertCleared != nil {
+				tc.assertCleared(t, tc.config)
+			}
+			if tc.assertPreserved != nil {
+				tc.assertPreserved(t, tc.config)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubermatic-installer mirror-images --ignore-repository-overrides` cleared every `DockerRepository` override in the `KubermaticConfiguration` but left the `DockerTagSuffix` fields in place, so the upstream repository was paired with a customer-only tag (e.g. `quay.io/kubermatic/addons:v2.30.0-17`) and failed with `MANIFEST_UNKNOWN`. This PR extracts the clearing logic into `clearRepositoryOverrides` and also blanks the three suffixes (`API`, `UI`, `UserCluster.Addons`) so mirroring resolves the upstream images with their original version tags. The development-only `DockerTag` override is left untouched.

**Which issue(s) this PR fixes**:
Fixes #15868

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

A `DockerTagSuffix` names a customer-built artifact that only exists in a custom repository, so it has to be cleared alongside the repository override; `DockerTag` is dev-only and outside the override contract, so it stays. All three suffixes reach mirror-images output: addons via `getAddonsPath`, API/UI via the operator deployment reconcilers in `getImagesFromReconcilers`.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
mirror-images now ignores configured dockerTagSuffix values together with repository overrides when --ignore-repository-overrides is set, so reused offline configurations resolve upstream images instead of failing with MANIFEST_UNKNOWN.
```

**Documentation**:
```documentation
TBD
```

**Test issue**:
```test-issue
TBD
```
