### PR TITLE
[release/v2.30] Update default Cilium version to 1.18.10

### DIFF
--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -142,7 +142,7 @@ fi
 # cluster, which will force KKP to pull the correct image.
 docker exec "$KIND_CLUSTER_NAME-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi registry.k8s.io/kube-controller-manager:{}" || true
 
-CILIUM_VERSION="1.18.2"
+CILIUM_VERSION="1.18.10"
 
 helm repo add cilium https://helm.cilium.io/
 helm install cilium cilium/cilium \

--- a/pkg/applicationdefinitions/system-applications/cilium.yaml
+++ b/pkg/applicationdefinitions/system-applications/cilium.yaml
@@ -174,6 +174,13 @@ spec:
         source:
           helm:
             chartName: cilium
+            chartVersion: 1.17.16
+            url: oci://quay.io/kubermatic-mirror/helm-charts
+      version: 1.17.16
+    - template:
+        source:
+          helm:
+            chartName: cilium
             chartVersion: 1.18.2
             url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.18.2
@@ -184,6 +191,13 @@ spec:
             chartVersion: 1.18.6
             url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.18.6
+    - template:
+        source:
+          helm:
+            chartName: cilium
+            chartVersion: 1.18.10
+            url: oci://quay.io/kubermatic-mirror/helm-charts
+      version: 1.18.10
   documentationURL: https://docs.cilium.io/en/stable/
   sourceURL: https://github.com/cilium/cilium
   logo: |+

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -29,7 +29,7 @@ import (
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.31",
-		kubermaticv1.CNIPluginTypeCilium: "1.18.6",
+		kubermaticv1.CNIPluginTypeCilium: "1.18.10",
 	}
 )
 
@@ -51,8 +51,10 @@ var (
 			"1.16.9",
 			"1.17.7",
 			"1.17.12",
+			"1.17.16",
 			"1.18.2",
 			"1.18.6",
+			"1.18.10",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
 	}


### PR DESCRIPTION
This is a manual backport of #15961.

/assign adoi

Updated the default Cilium CNI version to `1.18.10` and added Cilium `1.17.16` and `1.18.10` as supported CNI versions for KKP 2.30.

Existing supported Cilium versions are intentionally kept selectable for this stable release branch.

```release-note
Updated the default Cilium CNI version to 1.18.10 and added Cilium 1.17.16 and 1.18.10 as supported CNI versions.
```
