### PR TITLE
Deprecate superseded Cilium CNI versions from supported versions

### DIFF
--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -47,15 +47,7 @@ var (
 		kubermaticv1.CNIPluginTypeCilium: sets.New(
 			// NOTE: as of 1.13.0, we moved to Application infra for Cilium CNI management and started using real semver
 			// See pkg/cni/cilium docs for details on introducing a new version.
-			"1.15.16",
-			"1.16.9",
-			"1.17.7",
-			"1.17.12",
-			"1.17.14",
 			"1.17.16",
-			"1.18.2",
-			"1.18.6",
-			"1.18.8",
 			"1.18.10",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
@@ -82,7 +74,15 @@ var (
 			"1.14.16", // CVE-2025-23028, CVE-2025-23047 (Moderate Severity)
 			"1.15.3",  // CVE-2024-47825 (Moderate Severity)
 			"1.15.10", // CVE-2025-32793 (Moderate Severity)
+			"1.15.16", // CVE-2025-64715, CVE-2026-33726, CVE-2026-41520
 			"1.16.6",  // CVE-2025-32793 (Moderate Severity)
+			"1.16.9",  // CVE-2025-64715, CVE-2026-33726, CVE-2026-41520
+			"1.17.7",  // CVE-2025-64715, CVE-2026-33726, CVE-2026-41520
+			"1.17.12", // CVE-2026-33726, CVE-2026-41520
+			"1.17.14", // CVE-2026-41520
+			"1.18.2",  // CVE-2025-64715, CVE-2026-26963, CVE-2026-33726, CVE-2026-41520
+			"1.18.6",  // CVE-2026-33726, CVE-2026-41520
+			"1.18.8",  // CVE-2026-41520
 		),
 	}
 )

--- a/pkg/cni/version_test.go
+++ b/pkg/cni/version_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cni
+
+import (
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+)
+
+func TestDeprecatedCiliumVersionsAreAllowedButNotSupported(t *testing.T) {
+	supported, err := GetSupportedCNIPluginVersions(kubermaticv1.CNIPluginTypeCilium)
+	if err != nil {
+		t.Fatalf("failed to get supported Cilium versions: %v", err)
+	}
+
+	allowed, err := GetAllowedCNIPluginVersions(kubermaticv1.CNIPluginTypeCilium)
+	if err != nil {
+		t.Fatalf("failed to get allowed Cilium versions: %v", err)
+	}
+
+	currentVersions := []string{"1.17.16", "1.18.10"}
+	for _, version := range currentVersions {
+		if !supported.Has(version) {
+			t.Errorf("expected Cilium %s to be supported", version)
+		}
+		if !allowed.Has(version) {
+			t.Errorf("expected Cilium %s to be allowed", version)
+		}
+	}
+
+	deprecatedVersions := []string{
+		"1.15.16",
+		"1.16.9",
+		"1.17.7",
+		"1.17.12",
+		"1.17.14",
+		"1.18.2",
+		"1.18.6",
+		"1.18.8",
+	}
+	for _, version := range deprecatedVersions {
+		if supported.Has(version) {
+			t.Errorf("expected Cilium %s to be deprecated, not supported", version)
+		}
+		if !allowed.Has(version) {
+			t.Errorf("expected deprecated Cilium %s to remain allowed", version)
+		}
+	}
+
+	defaultVersion := GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCilium)
+	if !supported.Has(defaultVersion) {
+		t.Errorf("expected default Cilium version %s to be supported", defaultVersion)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deprecates older Cilium CNI versions by moving them from the supported CNI version list to the deprecated list. This will be part of KKP 2.31. Deprecated CNI versions are no longer exposed as supported versions, but they are still accepted by validation for backwards compatibility. This means existing clusters that use these versions continue to reconcile after upgrading KKP.

Please keep in mind that KKP enforces CNI version upgrades one minor version at a time, unless the `unsafe-cni-upgrade` label is set. Users who still run Cilium `1.15.x` on KKP 2.30 should upgrade Cilium before upgrading to KKP 2.31, at least to Cilium `1.16.x` and ideally to `1.17.16`, so they can continue using the standard CNI upgrade path after the KKP upgrade (this is stated explicitly in the release notes also, as a required action).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15943

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup
/kind deprecation


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Action required: Deprecated Cilium versions are no longer offered as supported CNI versions. Existing clusters continue to work, but users should upgrade to Cilium 1.17.16 or 1.18.10. Very important: Clusters on Cilium 1.15.x must upgrade one minor at a time, for example 1.15.16 -> 1.16.9 -> 1.17.16.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/kubermatic/issues/15975
```
