### PR TITLE
Remove Cilium skip for multi-protocol service conformance test

### DIFF
--- a/cmd/conformance-tester/pkg/tests/conformance.go
+++ b/cmd/conformance-tester/pkg/tests/conformance.go
@@ -226,12 +226,6 @@ func getGinkgoRuns(
 		"Services should have session affinity work for NodePort service",
 	}
 
-	// Cilium does not support Kubernetes 1.29 conformance tests yet,
-	// see https://github.com/cilium/cilium/issues/29913
-	if cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCilium {
-		ginkgoSkipParallel = append(ginkgoSkipParallel, "Services should serve endpoints on same port and different protocols")
-	}
-
 	runs := []struct {
 		name          string
 		ginkgoFocus   string


### PR DESCRIPTION
**What this PR does / why we need it**:

The conformance tester skipped the test "Services should serve endpoints on same port and different protocols" for Cilium clusters due to an upstream bug (cilium/cilium#29913). That issue has been closed and Cilium now supports this test, so the skip is no longer needed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

The upstream Cilium issue https://github.com/cilium/cilium/issues/29913 is closed. This is a straightforward removal of a stale test skip.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
