### PR TITLE
Clean up LB conformance test namespace to avoid exhausting LB quota

### DIFF
--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -33,7 +33,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -73,32 +72,15 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 
 	// clean up the namespace on every exit (pass or fail) so a failed attempt does not
 	// leave an orphaned Service of type LoadBalancer behind, which keeps a cloud LB alive
-	// against the provider's per-region quota.
+	// against the provider's per-region quota. use a detached context so deletion still
+	// runs if ctx was cancelled by the failing test.
 	defer func() {
-		to := 10 * time.Minute
-
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), to)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 
 		err := userClusterClient.Delete(cleanupCtx, ns)
 		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
 			log.Warnf("Failed to delete LoadBalancer test namespace %q: %v", ns.Name, err)
-			return
-		}
-
-		err = wait.Poll(cleanupCtx, 3*time.Second, to, func(ctx context.Context) (transient error, terminal error) {
-			if err := userClusterClient.Get(ctx, types.NamespacedName{Name: ns.Name}, &corev1.Namespace{}); err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil, nil
-				}
-
-				return fmt.Errorf("failed to get namespace: %w", err), nil
-			}
-
-			return errors.New("namespace is still terminating"), nil
-		})
-		if err != nil {
-			log.Warnf("Failed to wait for LoadBalancer test namespace %q to be deleted: %v", ns.Name, err)
 		}
 	}()
 

--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -33,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -69,6 +70,37 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 	if err := userClusterClient.Create(ctx, ns); err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
+
+	// clean up the namespace on every exit (pass or fail) so a failed attempt does not
+	// leave an orphaned Service of type LoadBalancer behind, which keeps a cloud LB alive
+	// against the provider's per-region quota.
+	defer func() {
+		to := 10 * time.Minute
+
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), to)
+		defer cancel()
+
+		err := userClusterClient.Delete(cleanupCtx, ns)
+		if ctrlruntimeclient.IgnoreNotFound(err) != nil {
+			log.Warnf("Failed to delete LoadBalancer test namespace %q: %v", ns.Name, err)
+			return
+		}
+
+		err = wait.Poll(cleanupCtx, 3*time.Second, to, func(ctx context.Context) (transient error, terminal error) {
+			if err := userClusterClient.Get(ctx, types.NamespacedName{Name: ns.Name}, &corev1.Namespace{}); err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil, nil
+				}
+
+				return fmt.Errorf("failed to get namespace: %w", err), nil
+			}
+
+			return errors.New("namespace is still terminating"), nil
+		})
+		if err != nil {
+			log.Warnf("Failed to wait for LoadBalancer test namespace %q to be deleted: %v", ns.Name, err)
+		}
+	}()
 
 	log.Info("Creating a Service of type LoadBalancer...")
 	labels := map[string]string{"app": "hello"}


### PR DESCRIPTION
**What this PR does / why we need it**:
The LoadBalancer conformance test never cleaned up its namespace. A failed attempt left a Service of type LoadBalancer behind, keeping a cloud LB alive against the provider's per-region quota. This PR adds a deferred cleanup that deletes the namespace and waits for it to be fully gone before returning, so the cloud LB is released before the next retry.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
