### PR TITLE
Enforce bumping OSM and machine-controller in a single PR

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -82,6 +82,21 @@ presubmits:
             - name: KUBERMATIC_EDITION
               value: ee
 
+  - name: pre-kubermatic-verify-component-bumps
+    run_if_changed: "pkg/resources/(operatingsystemmanager|machinecontroller)/deployment.go"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    path_alias: k8c.io/kubermatic
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+          command:
+            - ./hack/ci/verify-component-bumps.sh
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 0.2
+
   - name: pre-kubermatic-lint
     run_if_changed: "^(cmd/|codegen/|hack/|pkg/|go.mod|go.sum)"
     decorate: true

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -16,6 +16,25 @@ to creating a new release. All these tests must be executed with every supported
 
 This section covers the process to create a new Kubermatic release. Reflects the procedure as of 2020-09-16.
 
+### Patch release
+
+For a patch release on an existing `release/vX.Y` branch:
+
+1. Bump the OSM and machine-controller images in a **single PR**, not two.
+    - Update both image `Tag` values: `pkg/resources/operatingsystemmanager/deployment.go`
+      and `pkg/resources/machinecontroller/deployment.go`, plus the matching `go.mod`
+      lines and the re-vendored tree.
+    - One PR runs the conformance suite once for both components. Two separate PRs run
+      it twice and, on a release branch, force a Tide base-move retest of the second PR
+      after the first merges, costing an extra full conformance run.
+    - The `pre-kubermatic-verify-component-bumps` presubmit enforces this: a PR that
+      bumps only one of the two image Tags fails the check.
+    - If you genuinely need to bump only one component (OSM and machine-controller
+      release independently), add the `release/single-component-bump` label and comment
+      `/retest` to re-run the check, which then passes.
+1. Add the changelog in a separate cheap PR (`docs/changelogs/CHANGELOG-X.Y.md`).
+1. Tag the release (dashboard first, then kubermatic) as in the tagging step below.
+
 ### Major|Minor release
 
 1. Kubernetes lifecycle

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -16,24 +16,23 @@ to creating a new release. All these tests must be executed with every supported
 
 This section covers the process to create a new Kubermatic release. Reflects the procedure as of 2020-09-16.
 
-### Patch release
+### Component image bumps
 
-For a patch release on an existing `release/vX.Y` branch:
+This applies to every release, minor and patch alike, whenever the OSM and
+machine-controller images are updated for the release.
 
 1. Bump the OSM and machine-controller images in a **single PR**, not two.
     - Update both image `Tag` values: `pkg/resources/operatingsystemmanager/deployment.go`
       and `pkg/resources/machinecontroller/deployment.go`, plus the matching `go.mod`
       lines and the re-vendored tree.
     - One PR runs the conformance suite once for both components. Two separate PRs run
-      it twice and, on a release branch, force a Tide base-move retest of the second PR
-      after the first merges, costing an extra full conformance run.
+      it twice and force a Tide base-move retest of the second PR after the first merges,
+      costing an extra full conformance run.
     - The `pre-kubermatic-verify-component-bumps` presubmit enforces this: a PR that
       bumps only one of the two image Tags fails the check.
     - If you genuinely need to bump only one component (OSM and machine-controller
       release independently), add the `release/single-component-bump` label and comment
       `/retest` to re-run the check, which then passes.
-1. Add the changelog in a separate cheap PR (`docs/changelogs/CHANGELOG-X.Y.md`).
-1. Tag the release (dashboard first, then kubermatic) as in the tagging step below.
 
 ### Major|Minor release
 

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -52,12 +52,13 @@ job to (mostly) ensure that the changes will work.
 ## lint-mirror-application-charts.sh
 
 Lints hack/mirror-application-charts.sh by sourcing it and asserting
-CHART_URLS and CHART_VERSIONS have identical key sets.
+CHART_URLS and CHART_VERSIONS have identical key sets. Also verifies that
+optional CHART_ADDITIONAL_VERSIONS entries reference known charts.
 
 Catches the most common contributor mistake: adding a chart to one
-array but forgetting the other. Also serves as a smoke test that
-mirror-application-charts.sh remains sourceable (which the post-submit
-detection wrapper relies on).
+array but forgetting the other, or adding additional versions for an unknown
+chart. Also serves as a smoke test that mirror-application-charts.sh remains
+sourceable (which the post-submit detection wrapper relies on).
 
 ## mirror-new-application-charts.sh
 
@@ -67,15 +68,17 @@ and mirrors them to the OCI registry.
 Runs as a Prow post-submit job when mirror-application-charts.sh changes.
 Detects two types of changes:
   1. New chart entries added to CHART_URLS / CHART_VERSIONS
-  2. Version bumps in CHART_VERSIONS for existing charts
-Then calls mirror-application-charts.sh for each affected chart.
+  2. Version bumps or additions in CHART_VERSIONS / CHART_ADDITIONAL_VERSIONS
+     for existing charts
+Then calls mirror-application-charts.sh for each affected chart/version pair.
 
-Detection works by sourcing the current and previous (HEAD~1) versions of
+Detection works by sourcing the current and previous versions of
 mirror-application-charts.sh in a subshell. This relies only on the file
-being valid bash with the two associative arrays - no formatting assumptions.
+being valid bash with the expected associative arrays - no formatting assumptions.
 
 Environment variables:
 * `DRY_RUN=true` - skip actual mirroring, only print charts that would be mirrored
+* `MAX_HISTORY` - how many commits back to look for a valid previous version of the script (default: 5)
 
 ## release-images.sh
 
@@ -181,6 +184,10 @@ Operator. The presubmit job for this script is currently not used.
 This script sets up a local KKP installation in kind, deploys a
 couple of test Presets and Users and then runs the OPA e2e tests.
 
+## run-user-ssh-key-agent-e2e-tests.sh
+
+TBD
+
 ## run-user-ssh-key-agent-tests.sh
 
 This script tests whether we can successfully build the multiarch
@@ -257,6 +264,18 @@ files, like CRD examples and the Prometheus runbook.
 Runs as a postsubmit and refreshes the gocache by downloading the
 previous version, compiling everything and then tar'ing up the
 Go cache again.
+
+## verify-component-bumps.sh
+
+KKP releases bump the OSM and machine-controller images together in one PR so
+the conformance suite runs once for both instead of twice (and to avoid a Tide
+base-move retest of the second PR on release branches). This check fails if a PR
+moves only one of the two image Tags, to give fast feedback before the expensive
+e2e suite finishes. It is intentional to bump a single component (the two projects
+release independently); in that case add the "release/single-component-bump" label
+and comment /retest to re-run this check, which then passes.
+
+Runs on PRs targeting main and release branches alike.
 
 ## verify-go-version.sh
 

--- a/hack/ci/README.md
+++ b/hack/ci/README.md
@@ -275,8 +275,6 @@ e2e suite finishes. It is intentional to bump a single component (the two projec
 release independently); in that case add the "release/single-component-bump" label
 and comment /retest to re-run this check, which then passes.
 
-Runs on PRs targeting main and release branches alike.
-
 ## verify-go-version.sh
 
 This that when we're in a PR targeting a release branch, the minimum

--- a/hack/ci/verify-component-bumps.sh
+++ b/hack/ci/verify-component-bumps.sh
@@ -21,31 +21,32 @@
 ### e2e suite finishes. It is intentional to bump a single component (the two projects
 ### release independently); in that case add the "release/single-component-bump" label
 ### and comment /retest to re-run this check, which then passes.
-###
-### Runs on PRs targeting main and release branches alike.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 source hack/lib.sh
 
-TARGET_BRANCH="${PULL_BASE_REF:-}"
 SKIP_LABEL="release/single-component-bump"
 
 OSM_FILE="pkg/resources/operatingsystemmanager/deployment.go"
 MC_FILE="pkg/resources/machinecontroller/deployment.go"
 
-if [ -z "$TARGET_BRANCH" ]; then
-  echo "This check can only work in CI when \$PULL_BASE_REF is set."
+# Prow checks out the PR as a detached merge and does not leave an "origin/$branch"
+# ref behind, so diffing against that name silently produces nothing. Use the base
+# SHA Prow injects instead, falling back to the merge-base of FETCH_HEAD.
+BASE_REF="${PULL_BASE_SHA:-}"
+if [ -z "$BASE_REF" ]; then
+  BASE_REF="$(git merge-base HEAD FETCH_HEAD 2> /dev/null || true)"
+fi
+if [ -z "$BASE_REF" ]; then
+  echo "Could not determine the base revision (\$PULL_BASE_SHA empty and no FETCH_HEAD)."
   exit 1
 fi
 
-if ! [[ "$TARGET_BRANCH" =~ ^(main|release/) ]]; then
-  echo "This PR targets neither main nor a release branch, skipping component-bump check."
-  exit 0
-fi
+echo "Diffing against base ${BASE_REF}"
 
-# did the Tag const change vs the base branch? compare only the "Tag =" line so an
+# did the Tag const change vs the base? compare only the "Tag =" line so an
 # unrelated edit elsewhere in the file does not count as a component bump.
 tag_line() {
   grep -nE '^[[:space:]]*Tag[[:space:]]*=' "$1" || true
@@ -53,10 +54,14 @@ tag_line() {
 
 tag_changed() {
   local file="$1"
-  # diff the file against the merge-base; grep the hunk for a changed Tag line.
-  git diff "origin/${TARGET_BRANCH}...HEAD" -- "$file" 2> /dev/null |
-    grep -E '^[+-][[:space:]]*Tag[[:space:]]*=' |
-    grep -qvE '^[+-][+-]' # drop the +++/--- file headers
+  # diff the file against the base SHA and count changed "Tag =" lines. The +++/---
+  # file headers also start with +/- so they are excluded by requiring whitespace or
+  # a tab before "Tag". A non-zero count means the Tag const moved.
+  # no 2>/dev/null here: a broken diff must fail loudly, not read as "no bump".
+  local changed
+  changed="$(git diff "${BASE_REF}" HEAD -- "$file" |
+    grep -cE '^[+-][[:space:]]+Tag[[:space:]]*=' || true)"
+  [ "$changed" -gt 0 ]
 }
 
 osm_changed=false
@@ -64,7 +69,7 @@ mc_changed=false
 tag_changed "$OSM_FILE" && osm_changed=true
 tag_changed "$MC_FILE" && mc_changed=true
 
-echo "Component image Tag changes vs ${TARGET_BRANCH}:"
+echo "Component image Tag changes vs ${BASE_REF}:"
 printf "  %-18s : %s (%s)\n" "OSM" "$osm_changed" "$(tag_line "$OSM_FILE")"
 printf "  %-18s : %s (%s)\n" "machine-controller" "$mc_changed" "$(tag_line "$MC_FILE")"
 echo

--- a/hack/ci/verify-component-bumps.sh
+++ b/hack/ci/verify-component-bumps.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### KKP releases bump the OSM and machine-controller images together in one PR so
+### the conformance suite runs once for both instead of twice (and to avoid a Tide
+### base-move retest of the second PR on release branches). This check fails if a PR
+### moves only one of the two image Tags, to give fast feedback before the expensive
+### e2e suite finishes. It is intentional to bump a single component (the two projects
+### release independently); in that case add the "release/single-component-bump" label
+### and comment /retest to re-run this check, which then passes.
+###
+### Runs on PRs targeting main and release branches alike.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
+
+TARGET_BRANCH="${PULL_BASE_REF:-}"
+SKIP_LABEL="release/single-component-bump"
+
+OSM_FILE="pkg/resources/operatingsystemmanager/deployment.go"
+MC_FILE="pkg/resources/machinecontroller/deployment.go"
+
+if [ -z "$TARGET_BRANCH" ]; then
+  echo "This check can only work in CI when \$PULL_BASE_REF is set."
+  exit 1
+fi
+
+if ! [[ "$TARGET_BRANCH" =~ ^(main|release/) ]]; then
+  echo "This PR targets neither main nor a release branch, skipping component-bump check."
+  exit 0
+fi
+
+# did the Tag const change vs the base branch? compare only the "Tag =" line so an
+# unrelated edit elsewhere in the file does not count as a component bump.
+tag_line() {
+  grep -nE '^[[:space:]]*Tag[[:space:]]*=' "$1" || true
+}
+
+tag_changed() {
+  local file="$1"
+  # diff the file against the merge-base; grep the hunk for a changed Tag line.
+  git diff "origin/${TARGET_BRANCH}...HEAD" -- "$file" 2> /dev/null |
+    grep -E '^[+-][[:space:]]*Tag[[:space:]]*=' |
+    grep -qvE '^[+-][+-]' # drop the +++/--- file headers
+}
+
+osm_changed=false
+mc_changed=false
+tag_changed "$OSM_FILE" && osm_changed=true
+tag_changed "$MC_FILE" && mc_changed=true
+
+echo "Component image Tag changes vs ${TARGET_BRANCH}:"
+printf "  %-18s : %s (%s)\n" "OSM" "$osm_changed" "$(tag_line "$OSM_FILE")"
+printf "  %-18s : %s (%s)\n" "machine-controller" "$mc_changed" "$(tag_line "$MC_FILE")"
+echo
+
+# both changed, or neither changed: nothing to enforce.
+if [ "$osm_changed" = "$mc_changed" ]; then
+  echo "OSM and machine-controller Tags are consistent (both or neither bumped)."
+  exit 0
+fi
+
+# exactly one changed. allow it only if the skip label is present.
+# pr_has_label (hack/lib.sh) queries the GitHub API for PULL_NUMBER; same idiom the
+# rest of the repo uses, so no extra gh CLI dependency in the CI image.
+if pr_has_label "$SKIP_LABEL"; then
+  echo "Only one component bumped, but the '$SKIP_LABEL' label is present. Allowing."
+  exit 0
+fi
+
+cat << EOF
+Error: this PR bumps only one of OSM / machine-controller.
+
+KKP releases usually bump both in a single PR so the conformance suite runs once
+for both instead of twice (and to avoid a Tide base-move retest of the second PR).
+
+Either:
+  - add the other component's image Tag bump to this PR, or
+  - if you intentionally need only one, add the label '$SKIP_LABEL'
+    and comment /retest to re-run this check.
+EOF
+exit 1

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -55,7 +55,7 @@ var controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
 }
 
 const (
-	Tag = "v1.10.5"
+	Tag = "v1.10.6"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -55,7 +55,7 @@ var controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
 }
 
 const (
-	Tag = "v1.10.6"
+	Tag = "v1.10.5"
 )
 
 type operatingSystemManagerData interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

KKP patch releases bump the OSM and machine-controller images in two separate PRs, so the conformance suite runs twice and, on a release branch, Tide retests the second PR after the first merges (the base moved), costing an extra full conformance run. This adds a `pre-kubermatic-verify-component-bumps` presubmit that fails when a PR moves only one of the two image `Tag` values, nudging contributors to bump both in one PR so conformance runs once.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
