### PR TITLE
Add `existingSecret` support across KKP-authored Helm charts

### DIFF
--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -70,7 +70,7 @@ spec:
         {{- end }}
         envFrom:
         - secretRef:
-            name: iap-{{ .name }}-secret
+            name: {{ .existingSecret | default (printf "iap-%s-secret" .name) }}
         ports:
         - name: http
           containerPort: {{ $.Values.iap.port }}

--- a/charts/iap/templates/secrets.yaml
+++ b/charts/iap/templates/secrets.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{ range .Values.iap.deployments }}
+{{- if not .existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -23,4 +24,5 @@ data:
   OAUTH2_PROXY_CLIENT_ID: {{ .client_id | b64enc }}
   OAUTH2_PROXY_CLIENT_SECRET: {{ .client_secret | b64enc }}
   OAUTH2_PROXY_COOKIE_SECRET: {{ .encryption_key | b64enc }}
+{{- end }}
 {{ end }}

--- a/charts/iap/test/values.existing-secret.yaml
+++ b/charts/iap/test/values.existing-secret.yaml
@@ -1,0 +1,60 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iap:
+  deployments:
+    # alertmanager references a pre-created secret; the chart must skip generating
+    # iap-alertmanager-secret and point envFrom at the supplied name.
+    alertmanager:
+      name: alertmanager
+      existingSecret: my-alertmanager-oauth
+      config:
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+      upstream_service: alertmanager.monitoring.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        host: "alertmanager.kubermatic.tld"
+        annotations: {}
+        class: "nginx"
+    # grafana uses the chart-generated secret (existingSecret unset) to prove
+    # per-deployment isolation.
+    grafana:
+      name: grafana
+      client_id: grafana
+      client_secret: xxx
+      encryption_key: xxx
+      config:
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+      upstream_service: grafana.monitoring.svc.cluster.local
+      upstream_port: 3000
+      ingress:
+        host: "grafana.kubermatic.tld"
+        annotations: {}
+        class: "nginx"
+
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 25Mi
+    limits:
+      cpu: 100m
+      memory: 50Mi

--- a/charts/iap/test/values.existing-secret.yaml.out
+++ b/charts/iap/test/values.existing-secret.yaml.out
@@ -1,0 +1,462 @@
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-alertmanager
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-grafana-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: Z3JhZmFuYQ==
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-alertmanager-configmap
+data:
+  config.toml: |
+    approval_prompt = "none"
+    email_domains = ["*"]
+    scope = "groups openid email"
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-grafana-configmap
+data:
+  config.toml: |
+    approval_prompt = "none"
+    email_domains = ["*"]
+    scope = "groups openid email"
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: alertmanager
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: grafana
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-alertmanager
+  labels:
+    app: iap
+    target: alertmanager
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: alertmanager
+      annotations:
+        checksum/config: 86c9e60873ee8dcaaf64db1319b738ba1a630c75ad17abfecabb07774342184e
+        checksum/secrets: 68778a50e424df0e5dd14087364c0a1fd8782077e8d2b23e43e474a22ba88035
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://alertmanager.monitoring.svc.cluster.local:9093
+        - --cookie-name=alertmanager_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.toml
+        envFrom:
+        - secretRef:
+            name: my-alertmanager-oauth
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: iap-alertmanager-configmap
+          items:
+          - key: config.toml
+            path: config.toml
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: alertmanager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-grafana
+  labels:
+    app: iap
+    target: grafana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: grafana
+      annotations:
+        checksum/config: 86c9e60873ee8dcaaf64db1319b738ba1a630c75ad17abfecabb07774342184e
+        checksum/secrets: 68778a50e424df0e5dd14087364c0a1fd8782077e8d2b23e43e474a22ba88035
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://grafana.monitoring.svc.cluster.local:3000
+        - --cookie-name=grafana_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.toml
+        envFrom:
+        - secretRef:
+            name: iap-grafana-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: iap-grafana-configmap
+          items:
+          - key: config.toml
+            path: config.toml
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: grafana
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - secretName: alertmanager-tls
+    hosts:
+    - alertmanager.kubermatic.tld
+  rules:
+  - host: alertmanager.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: alertmanager-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - secretName: grafana-tls
+    hosts:
+    - grafana.kubermatic.tld
+  rules:
+  - host: grafana.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/configmaps.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/deployments.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/httproutes.yaml
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/ingresses.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/pdbs.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/secrets.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/services.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -68,6 +68,12 @@ iap:
     #   client_id: alertmanager
     #   client_secret: xxx
     #   encryption_key: xxx
+    #   ## (optional) existingSecret references a pre-created Secret instead of generating
+    #   ## iap-<name>-secret from client_id/client_secret/encryption_key above. When set,
+    #   ## the chart skips creating the Secret for this deployment; the referenced Secret
+    #   ## must contain the keys OAUTH2_PROXY_CLIENT_ID, OAUTH2_PROXY_CLIENT_SECRET and
+    #   ## OAUTH2_PROXY_COOKIE_SECRET.
+    #   existingSecret: ""
     #   config: ## see https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview
     #     scope: "groups openid email"
     #     email_domains:

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             name: ca-bundle
       serviceAccountName: kubermatic-operator
       imagePullSecrets:
-      - name: dockercfg
+      - name: {{ .Values.kubermaticOperator.imagePullSecretExistingSecret | default "dockercfg" }}
       containers:
       - name: operator
         image: '{{ .Values.kubermaticOperator.image.repository }}:{{ .Values.kubermaticOperator.image.tag | default .Chart.AppVersion }}'

--- a/charts/kubermatic-operator/templates/dockercfg.yaml
+++ b/charts/kubermatic-operator/templates/dockercfg.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.kubermaticOperator.imagePullSecret }}
+{{- if and .Values.kubermaticOperator.imagePullSecret (not .Values.kubermaticOperator.imagePullSecretExistingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/kubermatic-operator/values.yaml
+++ b/charts/kubermatic-operator/values.yaml
@@ -36,6 +36,13 @@ kubermaticOperator:
       "quay.io": {}
     }
 
+  # imagePullSecretExistingSecret optionally points the operator at a pre-created image
+  # pull Secret instead of generating the "dockercfg" Secret from imagePullSecret above.
+  # When set, the chart skips creating that Secret; the referenced Secret must live in
+  # the operator's namespace, be of type kubernetes.io/dockerconfigjson, and contain the
+  # key ".dockerconfigjson".
+  imagePullSecretExistingSecret: ""
+
   debug: false
   leaderElection: true
   resources:

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if not .Values.grafana.existingSecret }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: grafana-config
-data:
-  grafana.ini: {{ tpl (.Files.Get "config/grafana.ini") . | b64enc }}
-{{- end }}
+
+{{/*
+returns the Secret name holding the minio root credentials: the existing one
+when minio.credentials.existingSecret is set, otherwise the chart-managed "minio".
+*/}}
+{{- define "minio.credentialsSecretName" -}}
+{{- .Values.minio.credentials.existingSecret | default "minio" -}}
+{{- end -}}

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -62,12 +62,12 @@ spec:
         - name: MINIO_ROOT_USER
           valueFrom:
             secretKeyRef:
-              name: minio
+              name: {{ include "minio.credentialsSecretName" . }}
               key: accessKey
         - name: MINIO_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: minio
+              name: {{ include "minio.credentialsSecretName" . }}
               key: secretKey
         # disable authentication for /metrics endpoints
         - name: MINIO_PROMETHEUS_AUTH_TYPE
@@ -99,12 +99,12 @@ spec:
         - name: MINIO_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: minio
+              name: {{ include "minio.credentialsSecretName" . }}
               key: accessKey
         - name: MINIO_SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: minio
+              name: {{ include "minio.credentialsSecretName" . }}
               key: secretKey
         volumeMounts:
         - mountPath: /backup

--- a/charts/minio/templates/secret-external.yaml
+++ b/charts/minio/templates/secret-external.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 {{ with .Values.minio.credentials.secret }}
+{{- if not .existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,4 +23,5 @@ type: Opaque
 data:
   ACCESS_KEY_ID: {{ $.Values.minio.credentials.accessKey | b64enc | quote }}
   SECRET_ACCESS_KEY: {{ $.Values.minio.credentials.secretKey | b64enc | quote }}
+{{- end }}
 {{ end }}

--- a/charts/minio/templates/secret.yaml
+++ b/charts/minio/templates/secret.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{ if not .Values.minio.credentials.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,3 +20,4 @@ type: Opaque
 data:
   accessKey: "{{ .Values.minio.credentials.accessKey | b64enc }}"
   secretKey: "{{ .Values.minio.credentials.secretKey | b64enc }}"
+{{- end }}

--- a/charts/minio/test/existing-secret.yaml
+++ b/charts/minio/test/existing-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if not .Values.grafana.existingSecret }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: grafana-config
-data:
-  grafana.ini: {{ tpl (.Files.Get "config/grafana.ini") . | b64enc }}
-{{- end }}
+
+minio:
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+  credentials:
+    # both secrets point at pre-created Secrets; the chart must create neither the
+    # in-namespace "minio" Secret nor the kube-system "kubermatic-s3-credentials" one.
+    existingSecret: my-minio-creds
+    secret:
+      name: kubermatic-s3-credentials
+      namespace: kube-system
+      existingSecret: my-s3-creds

--- a/charts/minio/test/existing-secret.yaml.out
+++ b/charts/minio/test/existing-secret.yaml.out
@@ -1,0 +1,224 @@
+---
+# Source: minio/templates/pvc.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  labels:
+    app: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: minio/templates/service.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  type: ClusterIP
+  ports:
+    - name: server
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+    - name: console
+      port: 80
+      targetPort: 80
+      protocol: TCP
+  selector:
+    app: minio
+---
+# Source: minio/templates/deployment.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9000"
+        prometheus.io/metrics_path: /minio/prometheus/metrics
+        kubermatic.io/chart: minio
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: minio-backup
+        backup.velero.io/backup-volumes: minio-backup
+        pre.hook.backup.velero.io/container: backup
+        pre.hook.backup.velero.io/timeout: 60m
+        pre.hook.backup.velero.io/command: '["mc", "mirror", "--remove", "--quiet", "src", "/backup"]'
+    spec:
+      containers:
+      - name: minio
+        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
+        args:
+        - server
+        - /storage
+        - --console-address
+        - :80
+        env:
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              name: my-minio-creds
+              key: accessKey
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: my-minio-creds
+              key: secretKey
+        # disable authentication for /metrics endpoints
+        - name: MINIO_PROMETHEUS_AUTH_TYPE
+          value: public
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+        resources:
+          limits:
+            cpu: 1
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 32Mi
+      - name: backup
+        image: 'quay.io/kubermatic/util:2.7.0'
+        args:
+        - /bin/sh
+        - -c
+        - mc alias set src http://127.0.0.1:9000 "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY" && while true; do sleep 1h; done
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: my-minio-creds
+              key: accessKey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: my-minio-creds
+              key: secretKey
+        volumeMounts:
+        - mountPath: /backup
+          name: minio-backup
+          readOnly: false
+        securityContext:
+          runAsNonRoot: false
+          runAsUser: 0
+        resources:
+          limits:
+            cpu: 1
+            memory: 1500Mi
+          requests:
+            cpu: 50m
+            memory: 32Mi
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: minio-data
+      - name: minio-backup
+        emptyDir: {}
+      nodeSelector:
+        {}
+      affinity:
+        {}
+      tolerations:
+        []
+---
+# Source: minio/templates/ingress.yaml
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: minio/templates/secret-external.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: minio/templates/secret.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -40,6 +40,12 @@ minio:
     accessKey: "" # 32 byte long
     secretKey: "" # 64 byte long
 
+    # existingSecret optionally points the MinIO deployment at a pre-created Secret
+    # instead of generating one from accessKey/secretKey above. When set, the chart
+    # skips creating the "minio" Secret. The referenced Secret must live in the
+    # release namespace and contain the keys "accessKey" and "secretKey".
+    existingSecret: ""
+
     # When set to true, a Secret will be created in the given namespace.
     # Kubermatic requires an "kubermatic-s3-credentials" Secret in the kube-system
     # namespace to perform usercluster etcd snapshots, _if_ the default
@@ -49,6 +55,11 @@ minio:
     secret:
       name: kubermatic-s3-credentials
       namespace: kube-system
+      # existingSecret optionally points the etcd-backup integration at a pre-created
+      # Secret instead of generating the kube-system one above. When set, the chart
+      # skips creating the kube-system Secret; the operator must manage a Secret named
+      # `name` in `namespace` containing the keys "ACCESS_KEY_ID" and "SECRET_ACCESS_KEY".
+      existingSecret: ""
 
   flags:
     # Set to true to enable Minio's strict S3 compatibility mode.

--- a/charts/monitoring/grafana/templates/deployment.yaml
+++ b/charts/monitoring/grafana/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
         name: grafana-datasources
       - name: grafana-config
         secret:
-          secretName: grafana-config
+          secretName: {{ .Values.grafana.existingSecret | default "grafana-config" }}
       - name: grafana-default-datasources
         configMap:
           name: grafana-datasources

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 grafana:
+  # existingSecret optionally points the Grafana config volume at a pre-created Secret
+  # instead of generating the "grafana-config" Secret from config/grafana.ini. When set,
+  # the chart skips creating that Secret; the referenced Secret must live in the release
+  # namespace and contain the key "grafana.ini" with the full Grafana configuration.
+  existingSecret: ""
+
   # Admin login credentials, only relevant if the `disable_login_form` option
   # further down is set to false. Using an identity aware proxy like
   # Keycloak-Gatekeeper (see iap chart) is strongly recommended though.

--- a/charts/telemetry/templates/cronjob.yaml
+++ b/charts/telemetry/templates/cronjob.yaml
@@ -74,7 +74,7 @@ spec:
                 - name: CLIENT_UUID
                   valueFrom:
                     secretKeyRef:
-                      name: {{ .Release.Name }}-client-uuid
+                      name: {{ .Values.telemetry.existingSecret | default (printf "%s-client-uuid" .Release.Name) }}
                       key: uuid
               volumeMounts:
                 - mountPath: "/records"

--- a/charts/telemetry/templates/secret.yaml
+++ b/charts/telemetry/templates/secret.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+{{ if not .Values.telemetry.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -29,3 +29,4 @@ data:
   {{- else }}
   uuid: {{ uuidv4 | b64enc }}
   {{- end }}
+{{- end }}

--- a/charts/telemetry/test/existing-secret.yaml
+++ b/charts/telemetry/test/existing-secret.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if not .Values.grafana.existingSecret }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: grafana-config
-data:
-  grafana.ini: {{ tpl (.Files.Get "config/grafana.ini") . | b64enc }}
-{{- end }}
+
+# existingSecret points the agent at a pre-created Secret; the chart must skip
+# generating the "<release>-client-uuid" Secret and the cronjob must reference the
+# supplied name.
+telemetry:
+  existingSecret: my-telemetry-uuid

--- a/charts/telemetry/test/existing-secret.yaml.out
+++ b/charts/telemetry/test/existing-secret.yaml.out
@@ -1,0 +1,266 @@
+---
+# Source: telemetry/templates/serviceaccount.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-agent-sa
+  namespace:  default
+---
+# Source: telemetry/templates/kubermatic-role.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-kubermatic-agent-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - kubermatic.k8c.io
+  resources:
+  - clusters
+  - kubermaticconfigurations
+  - projects
+  - seeds
+  - users
+  - usersshkeys
+  verbs:
+  - list
+---
+# Source: telemetry/templates/kubernetes-role.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-kubernetes-agent-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: telemetry/templates/kubermatic-rolebinding.yml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-kubermatic-agent-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-kubermatic-agent-role
+subjects:
+  - kind: ServiceAccount
+    name: release-name-agent-sa
+    namespace: default
+---
+# Source: telemetry/templates/kubernetes-rolebinding.yml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-kubernetes-agent-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-kubernetes-agent-role
+subjects:
+  - kind: ServiceAccount
+    name: release-name-agent-sa
+    namespace: default
+---
+# Source: telemetry/templates/cronjob.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: release-name-job
+  namespace: default
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            control-plane: release-name
+        spec:
+          serviceAccountName: release-name-agent-sa
+          initContainers:
+            - name: kubernetes-agent
+              image: "quay.io/kubermatic/telemetry-agent:v0.5.2"
+              imagePullPolicy: IfNotPresent
+              command:
+                - kubernetes-agent
+              args:
+                - "--record-dir=$(RECORD_DIR)"
+              env:
+                - name: RECORD_DIR
+                  value: "/records"
+              volumeMounts:
+                - name: records
+                  mountPath: "/records"
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 100Mi
+                requests:
+                  cpu: "0.5"
+                  memory: 100Mi
+            - name: kubermatic-agent
+              image: "quay.io/kubermatic/telemetry-agent:v0.5.2"
+              imagePullPolicy: IfNotPresent
+              command:
+                - kubermatic-agent
+              args:
+                - "--record-dir=$(RECORD_DIR)"
+              env:
+                - name: RECORD_DIR
+                  value: "/records"
+              volumeMounts:
+                - name: records
+                  mountPath: "/records"
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 100Mi
+                requests:
+                  cpu: "0.5"
+                  memory: 100Mi
+          containers:
+            - name: reporter
+              image: "quay.io/kubermatic/telemetry-agent:v0.5.2"
+              imagePullPolicy: IfNotPresent
+              command:
+                - reporter
+              args:
+                - http
+                - --client-uuid=$(CLIENT_UUID)
+                - --url=$(URL)
+                - --record-dir=$(RECORD_DIR)
+              env:
+                - name: RECORD_DIR
+                  value: "/records"
+                - name: URL
+                  value: "https://telemetry.k8c.io/api/v1"
+                - name: CLIENT_UUID
+                  valueFrom:
+                    secretKeyRef:
+                      name: my-telemetry-uuid
+                      key: uuid
+              volumeMounts:
+                - mountPath: "/records"
+                  name: records
+              resources:
+                limits:
+                  cpu: "1"
+                  memory: 100Mi
+                requests:
+                  cpu: "0.5"
+                  memory: 100Mi
+          volumes:
+            - name: records
+              emptyDir: {}
+          restartPolicy: OnFailure
+---
+# Source: telemetry/templates/secret.yaml
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -20,6 +20,12 @@ telemetry:
   # This field is optional.
   uuid: ""
 
+  # existingSecret optionally points the agent at a pre-created Secret instead of
+  # generating the "<release>-client-uuid" Secret. When set, the chart skips creating
+  # that Secret; the referenced Secret must live in the release namespace and contain
+  # the key "uuid".
+  existingSecret: ""
+
   kubermaticAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent


### PR DESCRIPTION
**What this PR does / why we need it**:

Several KKP charts keep credentials inline in `values.yaml`, so operators running GitOps (Argo CD, ESO, Vault) end up committing secrets to Git. This PR adds an `existingSecret` parameter to the `iap`, `minio`, `monitoring/grafana`, `telemetry`, and `kubermatic-operator` charts so they can point at a pre-created Kubernetes Secret instead. It defaults to `""`, and when empty the charts render the same as they do today.

**Which issue(s) this PR fixes**:
Fixes #15278

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

When `existingSecret` is set, the chart skips its Secret template and points the consumer at the supplied name. When it is unset, the render is unchanged, which the unchanged golden-master `.out` fixtures confirm.

The `minio` chart needs the most attention. It emits two unrelated Secrets: the in-namespace `minio` Secret that the deployment reads, and the `kube-system` `kubermatic-s3-credentials` Secret that the user-cluster etcd backup subsystem reads. They get separate toggles (`minio.credentials.existingSecret` and `minio.credentials.secret.existingSecret`), so turning one on leaves the other alone. The etcd backup path looks the credentials Secret up by name and namespace (`pkg/resources/resources.go`, `BackupDestination.Credentials`) rather than by chart ownership, so as long as the pre-created Secret keeps the same name and namespace, backups keep working. The minio credentials name was repeated in four places, so it now lives in a `minio.credentialsSecretName` helper.

No `lookup`-based existence probing on the new path. The MLA charts and `dex` are out of scope since they already support bring-your-own secret upstream.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The iap, minio, monitoring/grafana, telemetry, and kubermatic-operator Helm charts now support an `existingSecret` parameter to reference a pre-created Kubernetes Secret instead of generating one from values, enabling GitOps secret management without storing credentials in values.yaml.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
TBD
```
