### PR TITLE
Bump Go version to 1.26.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,6 @@ linters:
     - errname
     - errorlint
     - fatcontext
-    - goconst
     - gocritic
     - gocyclo
     - godot
@@ -71,8 +70,6 @@ linters:
               desc: https://go.dev/doc/go1.16#ioutil
             - pkg: github.com/ghodss/yaml
               desc: use sigs.k8s.io/yaml instead
-    goconst:
-      min-occurrences: 5
     govet:
       enable:
         - nilness # find tautologies / impossible conditions
@@ -183,9 +180,6 @@ linters:
       - linters:
           - staticcheck
         text: "SA1019: registry.GetOverwriteFunc is deprecated"
-      - linters:
-          - goconst
-        path: (.+)_test\.go
     paths:
       - zz_generated.*.go
       # This package was forked from upstream (in #9826)

--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -73,7 +73,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -120,7 +120,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -167,7 +167,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -257,7 +257,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -302,7 +302,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -347,7 +347,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -482,7 +482,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -527,7 +527,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -572,7 +572,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -617,7 +617,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -662,7 +662,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -707,7 +707,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -752,7 +752,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -797,7 +797,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-application-definitions-e2e-test.sh"
           env:
@@ -832,7 +832,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-appcatalog-manager-e2e-tests.sh"
           env:

--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -437,7 +437,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.27-6
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-canal-e2e-test.sh"
           env:
@@ -164,7 +164,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-gateway-api-e2e-tests.sh"
           env:
@@ -198,7 +198,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-gateway-api-migration-e2e.sh"
           env:
@@ -232,7 +232,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -265,7 +265,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -292,7 +292,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -325,7 +325,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -355,7 +355,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -391,7 +391,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:
@@ -422,7 +422,7 @@ presubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-argocd-e2e-tests.sh"
           env:
@@ -444,7 +444,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-encryption-at-rest-tests.sh"
           env:
@@ -480,7 +480,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-user-ssh-key-agent-e2e-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -122,7 +122,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -115,7 +115,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -117,7 +117,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -204,7 +204,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -247,7 +247,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -286,7 +286,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -122,7 +122,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -159,7 +159,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -118,7 +118,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -208,7 +208,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -256,7 +256,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
           args:
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - make
             - test-integration
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/release-utility-images.sh"
           env:
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-addons-integration-test.sh"
           resources:
@@ -269,7 +269,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/lint-mirror-application-charts.sh"
           resources:
@@ -291,7 +291,7 @@ postsubmits:
       preset-docker-push-kubermatic-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/mirror-new-application-charts.sh"
           resources:

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -186,7 +186,7 @@ func (e *Cluster) DeleteUnwantedDeadMembers(ctx context.Context, log *zap.Sugare
 		return true, nil
 	}
 
-	// to avoide race conditions, we will run only on the cluster leader
+	// to avoid race conditions, we will run only on the cluster leader
 	leader, err := e.isLeader(ctx, log)
 	if err != nil {
 		log.Warnw("failed to determine if member is cluster leader", zap.Error(err))

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.26.4 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.26.4 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.26.4 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -480,7 +480,7 @@ func validateReflect(value reflect.Value, path []string) error {
 	valueType := value.Type()
 
 	// resolve pointer types to their underlying value
-	if valueType.Kind() == reflect.Ptr {
+	if valueType.Kind() == reflect.Pointer {
 		if value.IsNil() {
 			// nil-pointers are not allowed for complex types
 			if isComplexType(valueType) {
@@ -553,7 +553,7 @@ func validateReflect(value reflect.Value, path []string) error {
 }
 
 func isComplexType(t reflect.Type) bool {
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8c.io/kubermatic/v2
 
-go 1.25.7
+go 1.26.4
 
 // follow repository deprecation
 replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -119,12 +119,12 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get",
-					request:  httptest.NewRequest(http.MethodGet, AlertmanagerConfigEndpoint, nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, AlertmanagerConfigEndpoint, nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequest(http.MethodPost,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
 						AlertmanagerConfigEndpoint,
 						bytes.NewBuffer([]byte(resources.DefaultAlertmanagerConfig))),
 					response: &http.Response{StatusCode: http.StatusCreated},
@@ -163,12 +163,12 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get",
-					request:  httptest.NewRequest(http.MethodGet, AlertmanagerConfigEndpoint, nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, AlertmanagerConfigEndpoint, nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequest(http.MethodPost,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
 						AlertmanagerConfigEndpoint,
 						bytes.NewBuffer([]byte(generateAlertmanagerConfig("test-user")))),
 					response: &http.Response{
@@ -210,7 +210,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequest(http.MethodDelete,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
 						AlertmanagerConfigEndpoint,
 						nil),
 					response: &http.Response{StatusCode: http.StatusOK},
@@ -248,7 +248,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequest(http.MethodDelete,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
 						AlertmanagerConfigEndpoint,
 						nil),
 					response: &http.Response{
@@ -270,7 +270,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequest(http.MethodDelete,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
 						AlertmanagerConfigEndpoint,
 						nil),
 					response: &http.Response{StatusCode: http.StatusOK},

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller_test.go
@@ -119,12 +119,12 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, AlertmanagerConfigEndpoint, nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, AlertmanagerConfigEndpoint, nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodPost,
 						AlertmanagerConfigEndpoint,
 						bytes.NewBuffer([]byte(resources.DefaultAlertmanagerConfig))),
 					response: &http.Response{StatusCode: http.StatusCreated},
@@ -163,12 +163,12 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, AlertmanagerConfigEndpoint, nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, AlertmanagerConfigEndpoint, nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodPost,
 						AlertmanagerConfigEndpoint,
 						bytes.NewBuffer([]byte(generateAlertmanagerConfig("test-user")))),
 					response: &http.Response{
@@ -210,7 +210,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
 						AlertmanagerConfigEndpoint,
 						nil),
 					response: &http.Response{StatusCode: http.StatusOK},
@@ -248,7 +248,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
 						AlertmanagerConfigEndpoint,
 						nil),
 					response: &http.Response{
@@ -270,7 +270,7 @@ func TestAlertmanagerReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
 						AlertmanagerConfigEndpoint,
 						nil),
 					response: &http.Response{StatusCode: http.StatusOK},

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
@@ -118,12 +118,12 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "set dashboard",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -202,12 +202,12 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete dashboard",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/dashboards/uid/"+"unique", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/dashboards/uid/"+"unique", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "Dashboard dashboard deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
@@ -118,12 +118,12 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "set dashboard",
-					request:  httptest.NewRequest(http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -202,12 +202,12 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete dashboard",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/dashboards/uid/"+"unique", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/dashboards/uid/"+"unique", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "Dashboard dashboard deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -122,7 +122,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -222,7 +222,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -293,7 +293,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -413,7 +413,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -488,7 +488,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -582,7 +582,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -122,7 +122,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -222,7 +222,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -293,7 +293,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -413,7 +413,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -488,7 +488,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
@@ -582,7 +582,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -113,7 +113,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -150,12 +150,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "set dashboard",
-					request:  httptest.NewRequest(http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -186,22 +186,22 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -221,17 +221,17 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name:     "create",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusConflict},
 				},
 				{
 					name:     "get org by name",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/name/projectName-create", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/name/projectName-create", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -252,12 +252,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/2", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/2", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"oldName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update",
-					request:  httptest.NewRequest(http.MethodPut, "/api/orgs/2", strings.NewReader(`{"id":2,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/orgs/2", strings.NewReader(`{"id":2,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -282,7 +282,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "delete org by id",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -113,7 +113,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -150,12 +150,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "set dashboard",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -186,22 +186,22 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "org created", "OrgID": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -221,17 +221,17 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name:     "create",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs", strings.NewReader(`{"id":0,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusConflict},
 				},
 				{
 					name:     "get org by name",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/name/projectName-create", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/name/projectName-create", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -252,12 +252,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/2", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/2", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"oldName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/orgs/2", strings.NewReader(`{"id":2,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/orgs/2", strings.NewReader(`{"id":2,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -282,7 +282,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "delete org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
@@ -80,14 +80,14 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "get",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodGet,
 						fmt.Sprintf("%s%s/%s", MetricsRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodPost,
 						MetricsRuleGroupConfigEndpoint+defaultNamespace,
 						bytes.NewBuffer(generator.GenerateTestRuleGroupData("test-rule"))),
 					response: &http.Response{StatusCode: http.StatusAccepted},
@@ -108,14 +108,14 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "get",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodGet,
 						fmt.Sprintf("%s%s/%s", LogRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodPost,
 						LogRuleGroupConfigEndpoint+defaultNamespace,
 						bytes.NewBuffer(generator.GenerateTestRuleGroupData("test-rule"))),
 					response: &http.Response{StatusCode: http.StatusAccepted},
@@ -148,7 +148,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
 						fmt.Sprintf("%s%s/%s", MetricsRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusAccepted},
@@ -169,7 +169,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
+					request: httptest.NewRequestWithContext(t.Context(), http.MethodDelete,
 						fmt.Sprintf("%s%s/%s", LogRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusAccepted},

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller_test.go
@@ -80,14 +80,14 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "get",
-					request: httptest.NewRequest(http.MethodGet,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 						fmt.Sprintf("%s%s/%s", MetricsRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequest(http.MethodPost,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
 						MetricsRuleGroupConfigEndpoint+defaultNamespace,
 						bytes.NewBuffer(generator.GenerateTestRuleGroupData("test-rule"))),
 					response: &http.Response{StatusCode: http.StatusAccepted},
@@ -108,14 +108,14 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "get",
-					request: httptest.NewRequest(http.MethodGet,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodGet,
 						fmt.Sprintf("%s%s/%s", LogRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusNotFound},
 				},
 				{
 					name: "post",
-					request: httptest.NewRequest(http.MethodPost,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodPost,
 						LogRuleGroupConfigEndpoint+defaultNamespace,
 						bytes.NewBuffer(generator.GenerateTestRuleGroupData("test-rule"))),
 					response: &http.Response{StatusCode: http.StatusAccepted},
@@ -148,7 +148,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequest(http.MethodDelete,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
 						fmt.Sprintf("%s%s/%s", MetricsRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusAccepted},
@@ -169,7 +169,7 @@ func TestRuleGroupReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name: "delete",
-					request: httptest.NewRequest(http.MethodDelete,
+					request: httptest.NewRequestWithContext(context.Background(), http.MethodDelete,
 						fmt.Sprintf("%s%s/%s", LogRuleGroupConfigEndpoint, defaultNamespace, "test-rule"),
 						nil),
 					response: &http.Response{StatusCode: http.StatusAccepted},

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -91,12 +91,12 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -128,34 +128,34 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -199,47 +199,47 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -292,66 +292,66 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				}, {
 					name:     "delete org user",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/2", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/2", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2-project2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/2/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/2/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org 2 by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/2", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/2", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2-project2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/2/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/2/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -376,12 +376,12 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/admin/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/admin/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -426,47 +426,47 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequest(http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequest(http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequest(http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
+					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -91,12 +91,12 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -128,34 +128,34 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": false, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Editor"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -199,47 +199,47 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -292,66 +292,66 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				}, {
 					name:     "delete org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/2", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/2", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2-project2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/2/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/2/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":true}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org 2 by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/2", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/2", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2-project2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/2/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/2/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -376,12 +376,12 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/admin/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/admin/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -426,47 +426,47 @@ func TestUserGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "create OAuth user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/user", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/user", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1, "isGrafanaAdmin": true, "email": "user@email.com", "login": "user@email.com"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete user from default org",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message":"org user deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodDelete, "/api/orgs/1/users/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/orgs/1/users/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update permissions",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/admin/users/1/permissions", io.NopCloser(strings.NewReader(`{"isGrafanaAdmin":false}`))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User permissions updated"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "lookup user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/users/lookup?loginOrEmail=user@email.com", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"email":"user@email.com","login":"admin"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/orgs/1/users", nil),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/orgs/1/users", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`[]`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "add org user",
-					request:  httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
+					request:  httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/orgs/1/users", strings.NewReader(`{"loginOrEmail":"user@email.com","role":"Viewer"}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "User added to organization"}`)), StatusCode: http.StatusOK},
 				},
 			},

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,6 +1,6 @@
 module k8c.io/kubermatic/sdk/v2
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is to bump Go image version to 1.26.4.

Removed `goconst` as part of upgrading, since it is causing unnecessary noise.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15953 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go version to 1.26.4
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
