### PR TITLE
wait for Gatekeeper health before asserting OPA enforcement

### DIFF
--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -385,6 +385,45 @@ func (j *ClusterJig) WaitForHealthyControlPlane(ctx context.Context, timeout tim
 	})
 }
 
+// WaitForGatekeeperHealthy waits until the Gatekeeper controller and audit deployments
+// in the user cluster are reported as healthy. These statuses are excluded from
+// ExtendedClusterHealth.AllHealthy() because OPA integration is optional, so
+// WaitForHealthyControlPlane does not cover them.
+func (j *ClusterJig) WaitForGatekeeperHealthy(ctx context.Context, timeout time.Duration) error {
+	if j.clusterName == "" {
+		return errors.New("cluster jig has not created a cluster yet")
+	}
+
+	return wait.PollLog(ctx, j.log, 5*time.Second, timeout, func(ctx context.Context) (transient error, terminal error) {
+		curCluster := kubermaticv1.Cluster{}
+		if err := j.client.Get(ctx, types.NamespacedName{Name: j.clusterName}, &curCluster); err != nil {
+			return fmt.Errorf("failed to retrieve cluster: %w", err), nil
+		}
+
+		health := curCluster.Status.ExtendedHealth
+
+		// the statuses are nil until the usercluster-controller-manager has picked up
+		// the enabled OPA integration and reconciled the Gatekeeper deployments
+		if health.GatekeeperController == nil || *health.GatekeeperController != kubermaticv1.HealthStatusUp {
+			return fmt.Errorf("gatekeeperController is %v", formatOptionalHealth(health.GatekeeperController)), nil
+		}
+
+		if health.GatekeeperAudit == nil || *health.GatekeeperAudit != kubermaticv1.HealthStatusUp {
+			return fmt.Errorf("gatekeeperAudit is %v", formatOptionalHealth(health.GatekeeperAudit)), nil
+		}
+
+		return nil, nil
+	})
+}
+
+func formatOptionalHealth(s *kubermaticv1.HealthStatus) string {
+	if s == nil {
+		return "not reported yet"
+	}
+
+	return string(*s)
+}
+
 func getUnhealthyComponents(health kubermaticv1.ExtendedClusterHealth) []string {
 	unhealthy := sets.New[string]()
 	handle := func(key string, s kubermaticv1.HealthStatus) {

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -101,6 +101,14 @@ func (j *TestJig) WaitForHealthyControlPlane(ctx context.Context, timeout time.D
 	return errors.New("no cluster created yet")
 }
 
+func (j *TestJig) WaitForGatekeeperHealthy(ctx context.Context, timeout time.Duration) error {
+	if j.ClusterJig != nil {
+		return j.ClusterJig.WaitForGatekeeperHealthy(ctx, timeout)
+	}
+
+	return errors.New("no cluster created yet")
+}
+
 func NewAlibabaCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, credentials AlibabaCredentials, replicas int) *TestJig {
 	projectJig := NewProjectJig(client, log)
 

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -107,6 +107,14 @@ func TestOPAIntegration(t *testing.T) {
 		t.Fatalf("Cluster did not get healthy: %v", err)
 	}
 
+	// AllHealthy() does not include Gatekeeper, but its webhook uses failurePolicy=Ignore,
+	// so requests pass silently until the Gatekeeper pods are running; pulling the images
+	// on the fresh worker node alone can take more than a minute
+	logger.Info("Waiting for Gatekeeper to get healthy...")
+	if err := testJig.WaitForGatekeeperHealthy(ctx, 5*time.Minute); err != nil {
+		t.Fatalf("Gatekeeper did not get healthy: %v", err)
+	}
+
 	// Create CT
 	logger.Info("Creating Constraint Template (CT)...")
 	ct, err := createTestConstraintTemplate(ctx, seedClient)
@@ -227,7 +235,9 @@ func genTestConfigMap() *corev1.ConfigMap {
 }
 
 func testConstraintForConfigMap(ctx context.Context, userClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
-	return wait.PollLog(ctx, log, 3*time.Second, 2*time.Minute, func(ctx context.Context) (error, error) {
+	// even with Gatekeeper healthy, registering the webhook and ingesting the
+	// constraint into OPA takes a moment, so keep a generous polling budget
+	return wait.PollLog(ctx, log, 3*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
 		cm := genTestConfigMap()
 		err := userClient.Create(ctx, cm)
 		if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The OPA e2e test enabled OPA and then immediately checked that the Gatekeeper webhook blocks a policy-breaking ConfigMap. Because "AllHealthy" excludes the optional Gatekeeper components and the webhook uses a failurePolicy of "Ignore", requests passed silently while the Gatekeeper pods were still pulling images on the fresh worker node, making the test flaky.

The test now waits for the Gatekeeper controller and audit deployments to report healthy before creating constraints, and the enforcement poll window grows from two to five minutes to absorb the remaining webhook registration delay.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
