### PR TITLE
Validate Kubernetes version before downloading test binaries

### DIFF
--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -27,7 +27,19 @@ download_kube_test() {
 
   echodate "Kubernetes release: $RELEASES_TO_TEST"
 
-  KUBE_VERSION="$(download_archive https://dl.k8s.io/release/stable-$RELEASES_TO_TEST.txt -Ls)"
+  local KUBE_VERSION
+  local kubeVersionURL="https://dl.k8s.io/release/stable-$RELEASES_TO_TEST.txt"
+  if ! KUBE_VERSION="$(download_archive "$kubeVersionURL" --fail --show-error --silent --location)"; then
+    echodate "Failed to determine Kubernetes version for release $RELEASES_TO_TEST from $kubeVersionURL."
+    return 1
+  fi
+
+  KUBE_VERSION="$(echo "$KUBE_VERSION" | tr -d '[:space:]')"
+  if [[ ! "$KUBE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+    echodate "Invalid Kubernetes version returned for release $RELEASES_TO_TEST from $kubeVersionURL: ${KUBE_VERSION:0:120}"
+    return 1
+  fi
+
   echodate "Kubernetes version: $KUBE_VERSION"
 
   TMP_DIR="/tmp/k8s"
@@ -40,14 +52,14 @@ download_kube_test() {
 
   TEST_BINARIES=kubernetes-test-$(go env GOOS)-$(go env GOARCH).tar.gz
   mkdir -p "$TMP_DIR"
-  download_archive "https://dl.k8s.io/$KUBE_VERSION/$TEST_BINARIES" -Lo "$TMP_DIR/$TEST_BINARIES"
+  download_archive "https://dl.k8s.io/$KUBE_VERSION/$TEST_BINARIES" --fail --show-error --location --output "$TMP_DIR/$TEST_BINARIES"
   tar -zxf "$TMP_DIR/$TEST_BINARIES" -C "$TMP_DIR"
   mv $TMP_DIR/kubernetes/test/bin/* "$directory/"
   rm -rf -- "$TMP_DIR"
 
   CLIENT_BINARIES=kubernetes-client-$(go env GOOS)-$(go env GOARCH).tar.gz
   mkdir -p "$TMP_DIR"
-  download_archive "https://dl.k8s.io/$KUBE_VERSION/$CLIENT_BINARIES" -Lo "$TMP_DIR/$CLIENT_BINARIES"
+  download_archive "https://dl.k8s.io/$KUBE_VERSION/$CLIENT_BINARIES" --fail --show-error --location --output "$TMP_DIR/$CLIENT_BINARIES"
   tar -zxf "$TMP_DIR/$CLIENT_BINARIES" -C "$TMP_DIR"
   mv $TMP_DIR/kubernetes/client/bin/* "$directory/"
   rm -rf -- "$TMP_DIR"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the conformance tester script fail fast on HTTP errors and validates that the Kubernetes version has the expected format. The conformance setup was downloading from `dl.k8s.io` and using the response as the Kubernetes version for downloading client binaries. This causes confusion during investigation of issues. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind flake

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
