### PR TITLE
Fix cluster labels not being removed when removed from project

### DIFF
--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -19,6 +19,7 @@ package projectlabelsynchronizer
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"go.uber.org/zap"
 
@@ -136,10 +137,10 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		return nil
 	}
 
-	if len(project.Labels) == 0 {
-		log.Debug("Project has no labels, nothing to do")
-		return nil
-	}
+	// Labels that clusters in this project should currently inherit. This can be
+	// empty, e.g. if the project has no labels (anymore); reconciling still needs
+	// to happen in that case so that previously-inherited labels get removed again.
+	desiredInheritedLabels := getInheritedLabels(log, project.Labels)
 
 	workerNameLabelSelectorRequirements, _ := r.workerNameLabelSelector.Requirements()
 	projectLabelRequirement, err := labels.NewRequirement(kubermaticv1.ProjectIDLabelKey, selection.Equals, []string{project.Name})
@@ -166,21 +167,24 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		filteredClusters := r.filterClustersByProjectID(log, project.Name, unfilteredClusters)
 		for _, cluster := range filteredClusters {
 			log := log.With("cluster", cluster.Name)
-			changed, newClusterLabels := getLabelsForCluster(log, cluster.ObjectMeta.DeepCopy().Labels, project.Labels)
-			if !changed {
+			changed, newClusterLabels := getLabelsForCluster(log, cluster.ObjectMeta.DeepCopy().Labels, cluster.Status.InheritedLabels, desiredInheritedLabels)
+			if changed {
+				oldCluster := cluster.DeepCopy()
+				cluster.Labels = newClusterLabels
+				log.Debug("Updating labels on cluster")
+				if err := seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update cluster %q", cluster.Name))
+				}
+			} else {
 				log.Debug("Labels on cluster are already up to date")
-				continue
 			}
-			oldCluster := cluster.DeepCopy()
-			cluster.Labels = newClusterLabels
-			log.Debug("Updating labels on cluster")
-			if err := seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
-				errs = append(errs, fmt.Errorf("failed to update cluster %q", cluster.Name))
-			}
-			if err := util.UpdateClusterStatus(ctx, seedClient, cluster, func(c *kubermaticv1.Cluster) {
-				c.Status.InheritedLabels = getInheritedLabels(project.Labels)
-			}); err != nil {
-				errs = append(errs, fmt.Errorf("failed to update status on cluster %q: %w", cluster.Name, err))
+
+			if !maps.Equal(cluster.Status.InheritedLabels, desiredInheritedLabels) {
+				if err := util.UpdateClusterStatus(ctx, seedClient, cluster, func(c *kubermaticv1.Cluster) {
+					c.Status.InheritedLabels = desiredInheritedLabels
+				}); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update status on cluster %q: %w", cluster.Name, err))
+				}
 			}
 		}
 	}
@@ -208,42 +212,62 @@ func (r *reconciler) filterClustersByProjectID(
 	return result
 }
 
+// getLabelsForCluster returns the updated set of labels for a cluster, given its
+// current labels, the labels it previously inherited from its project (as recorded
+// in cluster.Status.InheritedLabels), and the labels it should currently inherit.
+//
+// Labels present in desiredInheritedLabels are set/updated on the cluster. Labels
+// that were previously inherited but are no longer desired get removed again,
+// unless their value was changed on the cluster in the meantime (in which case we
+// leave them alone, as someone else appears to manage that label now).
 func getLabelsForCluster(
 	log *zap.SugaredLogger,
 	clusterLabels map[string]string,
-	projectLabels map[string]string,
+	previouslyInheritedLabels map[string]string,
+	desiredInheritedLabels map[string]string,
 ) (changed bool, newClusterLabels map[string]string) {
-	// They shouldn't be nil as we skip projects without labels
-	// and need a label on the cluster to associate it to a project
-	// but better be safe than panicking.
 	if clusterLabels == nil {
 		clusterLabels = map[string]string{}
 	}
 	newClusterLabels = clusterLabels
 
-	for projectLabelKey, projectLabelValue := range projectLabels {
-		if kubermaticv1.ProtectedClusterLabels.Has(projectLabelKey) {
-			log.Infof("Project wants to set protected label %q on cluster, skipping", projectLabelKey)
+	for key, desiredValue := range desiredInheritedLabels {
+		if clusterLabels[key] == desiredValue {
+			log.Debugf("Label %q on cluster already has value of %q, nothing to do", key, desiredValue)
 			continue
 		}
-		if clusterLabels[projectLabelKey] == projectLabelValue {
-			log.Debugf("Label %q on cluster already has value of %q, nothing to do", projectLabelKey, projectLabelValue)
-			continue
-		}
-		log.Debugf("Setting label %q to value %q on cluster", projectLabelKey, projectLabelValue)
-		clusterLabels[projectLabelKey] = projectLabelValue
+		log.Debugf("Setting label %q to value %q on cluster", key, desiredValue)
+		clusterLabels[key] = desiredValue
 		changed = true
 	}
-	return
+
+	for key, previousValue := range previouslyInheritedLabels {
+		if _, stillDesired := desiredInheritedLabels[key]; stillDesired {
+			continue
+		}
+		if clusterLabels[key] != previousValue {
+			log.Debugf("Label %q was previously inherited from the project but has been changed on the cluster, leaving it alone", key)
+			continue
+		}
+		log.Debugf("Removing label %q from cluster, no longer set on project", key)
+		delete(clusterLabels, key)
+		changed = true
+	}
+
+	return changed, newClusterLabels
 }
 
-func getInheritedLabels(projectLabels map[string]string) map[string]string {
+// getInheritedLabels returns the subset of projectLabels that clusters of that
+// project should inherit, i.e. all labels minus the protected ones.
+func getInheritedLabels(log *zap.SugaredLogger, projectLabels map[string]string) map[string]string {
 	inheritedLabels := make(map[string]string)
 
 	for key, val := range projectLabels {
-		if !kubermaticv1.ProtectedClusterLabels.Has(key) {
-			inheritedLabels[key] = val
+		if kubermaticv1.ProtectedClusterLabels.Has(key) {
+			log.Infof("Project wants to set protected label %q on cluster, skipping", key)
+			continue
 		}
+		inheritedLabels[key] = val
 	}
 
 	return inheritedLabels

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer_test.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer_test.go
@@ -18,7 +18,6 @@ package projectlabelsynchronizer
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -30,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -159,36 +157,6 @@ func TestReconciliation(t *testing.T) {
 			}},
 			expectedInheritedLabels: map[string]map[string]string{"baz": {}},
 		},
-		{
-			name:         "Cluster belonging to a different project is left untouched",
-			masterClient: namedProjectClientWithLabels(projectName, map[string]string{"foo": "bar"}),
-			seedClient: fake.NewClientBuilder().WithObjects(
-				&kubermaticv1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "baz",
-						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectName},
-					},
-				},
-				&kubermaticv1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "other",
-						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: "some-other-project"},
-					},
-				},
-			).Build(),
-			expectedLabels: map[string]map[string]string{
-				"baz": {
-					"foo":                          "bar",
-					kubermaticv1.ProjectIDLabelKey: projectName,
-				},
-				"other": {
-					kubermaticv1.ProjectIDLabelKey: "some-other-project",
-				},
-			},
-			expectedInheritedLabels: map[string]map[string]string{"baz": {
-				"foo": "bar",
-			}},
-		},
 	}
 
 	for idx := range testCases {
@@ -229,75 +197,6 @@ func TestReconciliation(t *testing.T) {
 				if expected := tc.expectedInheritedLabels[cluster.Name]; !diff.SemanticallyEqual(expected, cluster.Status.InheritedLabels) {
 					t.Errorf("Expected inherited labels on cluster %q do not match actual inherited labels:\n%v", cluster.Name, diff.ObjectDiff(expected, cluster.Status.InheritedLabels))
 				}
-			}
-		})
-	}
-}
-
-// TestReconciliationErrors verifies that failures to patch the cluster's labels
-// or its status are surfaced as errors from Reconcile, instead of being swallowed.
-func TestReconciliationErrors(t *testing.T) {
-	const projectName = "label-synchronizer-test"
-
-	testCases := []struct {
-		name         string
-		masterClient ctrlruntimeclient.Client
-		seedClient   ctrlruntimeclient.Client
-	}{
-		{
-			name:         "Error patching cluster labels is returned",
-			masterClient: namedProjectClientWithLabels(projectName, map[string]string{"foo": "bar"}),
-			seedClient: fake.NewClientBuilder().
-				WithObjects(&kubermaticv1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "baz",
-						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectName},
-					},
-				}).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Patch: func(ctx context.Context, c ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
-						return errors.New("boom")
-					},
-				}).
-				Build(),
-		},
-		{
-			name:         "Error patching cluster status is returned",
-			masterClient: namedProjectClientWithLabels(projectName, nil),
-			seedClient: fake.NewClientBuilder().
-				WithObjects(&kubermaticv1.Cluster{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "baz",
-						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectName},
-					},
-					Status: kubermaticv1.ClusterStatus{
-						InheritedLabels: map[string]string{"foo": "bar"},
-					},
-				}).
-				WithInterceptorFuncs(interceptor.Funcs{
-					SubResourcePatch: func(ctx context.Context, c ctrlruntimeclient.Client, subResourceName string, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.SubResourcePatchOption) error {
-						return errors.New("boom")
-					},
-				}).
-				Build(),
-		},
-	}
-
-	for idx := range testCases {
-		tc := testCases[idx]
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			r := &reconciler{
-				log:                     kubermaticlog.Logger,
-				masterClient:            tc.masterClient,
-				seedClients:             map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
-				workerNameLabelSelector: labels.Everything(),
-			}
-
-			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}}
-			if _, err := r.Reconcile(context.Background(), request); err == nil {
-				t.Fatal("expected Reconcile to return an error, got nil")
 			}
 		})
 	}

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer_test.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer_test.go
@@ -18,6 +18,7 @@ package projectlabelsynchronizer
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -107,6 +109,86 @@ func TestReconciliation(t *testing.T) {
 		{
 			name: "Absent project is handled gracefully",
 		},
+		{
+			name:         "Label removed from project gets removed from cluster",
+			masterClient: namedProjectClientWithLabels(projectName, nil),
+			seedClient: namedClusterWithLabelsAndInherited("baz", map[string]string{
+				kubermaticv1.ProjectIDLabelKey: projectName,
+				"foo":                          "bar",
+			}, map[string]string{
+				"foo": "bar",
+			}),
+			expectedLabels: map[string]map[string]string{"baz": {
+				kubermaticv1.ProjectIDLabelKey: projectName,
+			}},
+			expectedInheritedLabels: map[string]map[string]string{"baz": {}},
+		},
+		{
+			name: "One of several inherited labels is removed from project",
+			masterClient: namedProjectClientWithLabels(projectName, map[string]string{
+				"other": "baz",
+			}),
+			seedClient: namedClusterWithLabelsAndInherited("baz", map[string]string{
+				kubermaticv1.ProjectIDLabelKey: projectName,
+				"foo":                          "bar",
+				"other":                        "baz",
+			}, map[string]string{
+				"foo":   "bar",
+				"other": "baz",
+			}),
+			expectedLabels: map[string]map[string]string{"baz": {
+				kubermaticv1.ProjectIDLabelKey: projectName,
+				"other":                        "baz",
+			}},
+			expectedInheritedLabels: map[string]map[string]string{"baz": {
+				"other": "baz",
+			}},
+		},
+		{
+			name:         "Manually changed label is not removed, but stops being tracked as inherited",
+			masterClient: namedProjectClientWithLabels(projectName, nil),
+			seedClient: namedClusterWithLabelsAndInherited("baz", map[string]string{
+				kubermaticv1.ProjectIDLabelKey: projectName,
+				"foo":                          "custom-value",
+			}, map[string]string{
+				"foo": "bar",
+			}),
+			expectedLabels: map[string]map[string]string{"baz": {
+				kubermaticv1.ProjectIDLabelKey: projectName,
+				"foo":                          "custom-value",
+			}},
+			expectedInheritedLabels: map[string]map[string]string{"baz": {}},
+		},
+		{
+			name:         "Cluster belonging to a different project is left untouched",
+			masterClient: namedProjectClientWithLabels(projectName, map[string]string{"foo": "bar"}),
+			seedClient: fake.NewClientBuilder().WithObjects(
+				&kubermaticv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "baz",
+						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectName},
+					},
+				},
+				&kubermaticv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "other",
+						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: "some-other-project"},
+					},
+				},
+			).Build(),
+			expectedLabels: map[string]map[string]string{
+				"baz": {
+					"foo":                          "bar",
+					kubermaticv1.ProjectIDLabelKey: projectName,
+				},
+				"other": {
+					kubermaticv1.ProjectIDLabelKey: "some-other-project",
+				},
+			},
+			expectedInheritedLabels: map[string]map[string]string{"baz": {
+				"foo": "bar",
+			}},
+		},
 	}
 
 	for idx := range testCases {
@@ -152,6 +234,75 @@ func TestReconciliation(t *testing.T) {
 	}
 }
 
+// TestReconciliationErrors verifies that failures to patch the cluster's labels
+// or its status are surfaced as errors from Reconcile, instead of being swallowed.
+func TestReconciliationErrors(t *testing.T) {
+	const projectName = "label-synchronizer-test"
+
+	testCases := []struct {
+		name         string
+		masterClient ctrlruntimeclient.Client
+		seedClient   ctrlruntimeclient.Client
+	}{
+		{
+			name:         "Error patching cluster labels is returned",
+			masterClient: namedProjectClientWithLabels(projectName, map[string]string{"foo": "bar"}),
+			seedClient: fake.NewClientBuilder().
+				WithObjects(&kubermaticv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "baz",
+						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectName},
+					},
+				}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
+						return errors.New("boom")
+					},
+				}).
+				Build(),
+		},
+		{
+			name:         "Error patching cluster status is returned",
+			masterClient: namedProjectClientWithLabels(projectName, nil),
+			seedClient: fake.NewClientBuilder().
+				WithObjects(&kubermaticv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "baz",
+						Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectName},
+					},
+					Status: kubermaticv1.ClusterStatus{
+						InheritedLabels: map[string]string{"foo": "bar"},
+					},
+				}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c ctrlruntimeclient.Client, subResourceName string, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.SubResourcePatchOption) error {
+						return errors.New("boom")
+					},
+				}).
+				Build(),
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &reconciler{
+				log:                     kubermaticlog.Logger,
+				masterClient:            tc.masterClient,
+				seedClients:             map[string]ctrlruntimeclient.Client{"first": tc.seedClient},
+				workerNameLabelSelector: labels.Everything(),
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: projectName}}
+			if _, err := r.Reconcile(context.Background(), request); err == nil {
+				t.Fatal("expected Reconcile to return an error, got nil")
+			}
+		})
+	}
+}
+
 func namedProjectClientWithLabels(name string, labels map[string]string) ctrlruntimeclient.Client {
 	return fake.NewClientBuilder().WithObjects(&kubermaticv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
@@ -169,6 +320,18 @@ func namedClusterWithLabels(name string, labels map[string]string) ctrlruntimecl
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
+		},
+	}).Build()
+}
+
+func namedClusterWithLabelsAndInherited(name string, labels, inheritedLabels map[string]string) ctrlruntimeclient.Client {
+	return fake.NewClientBuilder().WithObjects(&kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: kubermaticv1.ClusterStatus{
+			InheritedLabels: inheritedLabels,
 		},
 	}).Build()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The `kkp-project-label-synchronizer` controller only ever added/updated cluster labels based on a project's current labels, and skipped reconciling entirely once a project ended up with no labels at all. As a result, when a label was removed from a project, it stayed on the project's clusters forever, in both `.metadata.labels` and `.status.InheritedLabels`.

This PR diffs the project's current labels against `cluster.status.InheritedLabels` (the previously-synced set) to detect labels that are no longer present on the project and removes them from the cluster — unless the label's value was changed on the cluster in the meantime, in which case it's left alone but no longer tracked as inherited.

**Which issue(s) this PR fixes**:
Fixes #15966

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
- Removed the `len(project.Labels) == 0` early-return in `reconcile()`, since that's exactly the case (all labels removed) that needs cleanup to run.
- Used Go's stdlib `maps.Equal` to compare `Status.InheritedLabels` before/after, since it correctly treats `nil` and `{}` as equal and avoids spurious status patches for projects/clusters that never had inherited labels.
- Added test coverage for: removing one of several labels, a label that was manually changed on the cluster (left alone), cross-project isolation, and error propagation when the label/status patch fails.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed a bug where labels removed from a project were not removed from the project's clusters (`.metadata.labels` and `.status.InheritedLabels`).
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```