### PR TITLE
Add support for k8s patch releases v1.35.6/v1.34.9/v1.33.13

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -718,7 +718,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.34.8
+    default: v1.34.9
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -793,6 +793,7 @@ spec:
       - v1.33.10
       - v1.33.11
       - v1.33.12
+      - v1.33.13
       - v1.34.1
       - v1.34.2
       - v1.34.3
@@ -801,12 +802,14 @@ spec:
       - v1.34.6
       - v1.34.7
       - v1.34.8
+      - v1.34.9
       - v1.35.0
       - v1.35.1
       - v1.35.2
       - v1.35.3
       - v1.35.4
       - v1.35.5
+      - v1.35.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -718,7 +718,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.34.8
+    default: v1.34.9
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -793,6 +793,7 @@ spec:
       - v1.33.10
       - v1.33.11
       - v1.33.12
+      - v1.33.13
       - v1.34.1
       - v1.34.2
       - v1.34.3
@@ -801,12 +802,14 @@ spec:
       - v1.34.6
       - v1.34.7
       - v1.34.8
+      - v1.34.9
       - v1.35.0
       - v1.35.1
       - v1.35.2
       - v1.35.3
       - v1.35.4
       - v1.35.5
+      - v1.35.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -223,7 +223,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.34.8"),
+		Default: semver.NewSemverOrDie("v1.34.9"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -244,6 +244,7 @@ var (
 			newSemver("v1.33.10"),
 			newSemver("v1.33.11"),
 			newSemver("v1.33.12"),
+			newSemver("v1.33.13"),
 			// Kubernetes 1.34
 			newSemver("v1.34.1"),
 			newSemver("v1.34.2"),
@@ -253,6 +254,7 @@ var (
 			newSemver("v1.34.6"),
 			newSemver("v1.34.7"),
 			newSemver("v1.34.8"),
+			newSemver("v1.34.9"),
 			// Kubernetes 1.35
 			newSemver("v1.35.0"),
 			newSemver("v1.35.1"),
@@ -260,6 +262,7 @@ var (
 			newSemver("v1.35.3"),
 			newSemver("v1.35.4"),
 			newSemver("v1.35.5"),
+			newSemver("v1.35.6"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.32 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the latest Kubernetes patch releases v1.33.13, v1.34.9, and v1.35.6 to the supported versions and bumps the default version to v1.34.9.

**Which issue(s) this PR fixes**:
Fixes #15991

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for k8s patch releases 1.35.6/1.34.9/1.33.13
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
