### PR TITLE
[release/v2.29] Add support for k8s patch releases v1.34.9/v1.33.13

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -583,7 +583,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.33.12
+    default: v1.33.13
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -677,6 +677,7 @@ spec:
       - v1.33.10
       - v1.33.11
       - v1.33.12
+      - v1.33.13
       - v1.34.1
       - v1.34.2
       - v1.34.3
@@ -685,6 +686,7 @@ spec:
       - v1.34.6
       - v1.34.7
       - v1.34.8
+      - v1.34.9
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -583,7 +583,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.33.12
+    default: v1.33.13
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -677,6 +677,7 @@ spec:
       - v1.33.10
       - v1.33.11
       - v1.33.12
+      - v1.33.13
       - v1.34.1
       - v1.34.2
       - v1.34.3
@@ -685,6 +686,7 @@ spec:
       - v1.34.6
       - v1.34.7
       - v1.34.8
+      - v1.34.9
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -226,7 +226,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.33.12"),
+		Default: semver.NewSemverOrDie("v1.33.13"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -266,6 +266,7 @@ var (
 			newSemver("v1.33.10"),
 			newSemver("v1.33.11"),
 			newSemver("v1.33.12"),
+			newSemver("v1.33.13"),
 			// Kubernetes 1.34
 			newSemver("v1.34.1"),
 			newSemver("v1.34.2"),
@@ -275,6 +276,7 @@ var (
 			newSemver("v1.34.6"),
 			newSemver("v1.34.7"),
 			newSemver("v1.34.8"),
+			newSemver("v1.34.9"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.31 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the latest Kubernetes patch releases v1.33.13 and v1.34.9 to the supported versions and bumps the default version to v1.33.13 on the v2.29 release branch.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for k8s patch releases 1.34.9/1.33.13
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
