### PR TITLE
fix Cilium NodeLocalDNS access with network policies

### DIFF
--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -63,9 +63,11 @@ const (
 
 // Cilium specific constants.
 const (
-	ciliumHelmChartName                = "cilium"
-	ciliumImageRegistry                = "quay.io/cilium/"
-	ciliumExcludeLocalAddressConfigKey = "exclude-local-address"
+	ciliumHelmChartName = "cilium"
+	ciliumImageRegistry = "quay.io/cilium/"
+
+	// ciliumExtraConfigExcludeLocalAddressKey configures Cilium to not treat matching local addresses as host addresses.
+	ciliumExtraConfigExcludeLocalAddressKey = "exclude-local-address"
 )
 
 // UserClusterClientProvider provides functionality to get a user cluster client.
@@ -464,8 +466,11 @@ func getAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 	}
 
 	if cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled == nil || *cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled {
+		// Exclude KKP's NodeLocalDNS address from Cilium's local address detection.
+		// Otherwise Cilium can classify 169.254.20.10 as host identity, so Kubernetes NetworkPolicies
+		// that allow egress to CIDRs like 0.0.0.0/0 do not allow DNS traffic to NodeLocalDNS.
 		values["extraConfig"] = map[string]any{
-			ciliumExcludeLocalAddressConfigKey: fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress),
+			ciliumExtraConfigExcludeLocalAddressKey: fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress),
 		}
 	}
 

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -63,8 +63,9 @@ const (
 
 // Cilium specific constants.
 const (
-	ciliumHelmChartName = "cilium"
-	ciliumImageRegistry = "quay.io/cilium/"
+	ciliumHelmChartName                = "cilium"
+	ciliumImageRegistry                = "quay.io/cilium/"
+	ciliumExcludeLocalAddressConfigKey = "exclude-local-address"
 )
 
 // UserClusterClientProvider provides functionality to get a user cluster client.
@@ -459,6 +460,12 @@ func getAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 		ipamOperator["clusterPoolIPv6PodCIDRList"] = cluster.Spec.ClusterNetwork.Pods.GetIPv6CIDRs()
 		if cluster.Spec.ClusterNetwork.NodeCIDRMaskSizeIPv6 != nil {
 			ipamOperator["clusterPoolIPv6MaskSize"] = *cluster.Spec.ClusterNetwork.NodeCIDRMaskSizeIPv6
+		}
+	}
+
+	if cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled == nil || *cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled {
+		values["extraConfig"] = map[string]any{
+			ciliumExcludeLocalAddressConfigKey: fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress),
 		}
 	}
 

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -368,6 +369,7 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 			if err := mergo.Merge(&values, overrideValues, mergo.WithOverride); err != nil {
 				return app, fmt.Errorf("failed to merge CNI values: %w", err)
 			}
+			ensureCiliumNodeLocalDNSExcludeLocalAddress(cluster, values)
 
 			// Set new values
 			rawValues, err := yaml.Marshal(values)
@@ -465,15 +467,6 @@ func getAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 		}
 	}
 
-	if cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled == nil || *cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled {
-		// Exclude KKP's NodeLocalDNS address from Cilium's local address detection.
-		// Otherwise Cilium can classify 169.254.20.10 as host identity, so Kubernetes NetworkPolicies
-		// that allow egress to CIDRs like 0.0.0.0/0 do not allow DNS traffic to NodeLocalDNS.
-		values["extraConfig"] = map[string]any{
-			ciliumExtraConfigExcludeLocalAddressKey: fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress),
-		}
-	}
-
 	values["ipam"] = map[string]any{"operator": ipamOperator}
 
 	// Override images if registry override is configured
@@ -525,4 +518,33 @@ func getAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 	}
 
 	return values
+}
+
+func ensureCiliumNodeLocalDNSExcludeLocalAddress(cluster *kubermaticv1.Cluster, values map[string]any) {
+	if cluster.Spec.CNIPlugin.Type != kubermaticv1.CNIPluginTypeCilium {
+		return
+	}
+	if cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled != nil && !*cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled {
+		return
+	}
+
+	extraConfig, ok := values["extraConfig"].(map[string]any)
+	if !ok {
+		extraConfig = map[string]any{}
+		values["extraConfig"] = extraConfig
+	}
+
+	// Exclude KKP's NodeLocalDNS address from Cilium's local address detection.
+	// Otherwise Cilium can classify 169.254.20.10 as host identity, so Kubernetes NetworkPolicies
+	// that allow egress to CIDRs like 0.0.0.0/0 do not allow DNS traffic to NodeLocalDNS.
+	excludedCIDRs := []string{}
+	if existingValue, ok := extraConfig[ciliumExtraConfigExcludeLocalAddressKey].(string); ok {
+		excludedCIDRs = strings.Fields(strings.ReplaceAll(existingValue, ",", " "))
+	}
+
+	nodeLocalDNSCIDR := fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress)
+	if !slices.Contains(excludedCIDRs, nodeLocalDNSCIDR) {
+		excludedCIDRs = append(excludedCIDRs, nodeLocalDNSCIDR)
+	}
+	extraConfig[ciliumExtraConfigExcludeLocalAddressKey] = strings.Join(excludedCIDRs, " ")
 }

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
@@ -254,8 +254,8 @@ func TestReconcile(t *testing.T) {
 				if !ok {
 					return fmt.Errorf("CNI value extraConfig is not present")
 				}
-				if extraConfig[ciliumExcludeLocalAddressConfigKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
-					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExcludeLocalAddressConfigKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExcludeLocalAddressConfigKey])
+				if extraConfig[ciliumExtraConfigExcludeLocalAddressKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
+					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExtraConfigExcludeLocalAddressKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExtraConfigExcludeLocalAddressKey])
 				}
 				return nil
 			},
@@ -266,8 +266,8 @@ func TestReconcile(t *testing.T) {
 			appDefinitionDefaultValues: nil,
 			existingAppInstallationValues: map[string]any{
 				"extraConfig": map[string]any{
-					"custom-key":                       "custom-value",
-					ciliumExcludeLocalAddressConfigKey: "192.0.2.1/32",
+					"custom-key":                            "custom-value",
+					ciliumExtraConfigExcludeLocalAddressKey: "192.0.2.1/32",
 				},
 			},
 			validate: func(cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, reconcileErr error) error {
@@ -285,8 +285,8 @@ func TestReconcile(t *testing.T) {
 				if extraConfig["custom-key"] != "custom-value" {
 					return fmt.Errorf("CNI value extraConfig.custom-key should be preserved, got %q", extraConfig["custom-key"])
 				}
-				if extraConfig[ciliumExcludeLocalAddressConfigKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
-					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExcludeLocalAddressConfigKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExcludeLocalAddressConfigKey])
+				if extraConfig[ciliumExtraConfigExcludeLocalAddressKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
+					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExtraConfigExcludeLocalAddressKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExtraConfigExcludeLocalAddressKey])
 				}
 				return nil
 			},
@@ -309,8 +309,8 @@ func TestReconcile(t *testing.T) {
 					return err
 				}
 				if extraConfig, ok := values["extraConfig"].(map[string]any); ok {
-					if _, ok := extraConfig[ciliumExcludeLocalAddressConfigKey]; ok {
-						return fmt.Errorf("CNI value extraConfig.%s should not be present when NodeLocalDNS is disabled", ciliumExcludeLocalAddressConfigKey)
+					if _, ok := extraConfig[ciliumExtraConfigExcludeLocalAddressKey]; ok {
+						return fmt.Errorf("CNI value extraConfig.%s should not be present when NodeLocalDNS is disabled", ciliumExtraConfigExcludeLocalAddressKey)
 					}
 				}
 				return nil

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
@@ -238,6 +238,85 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:                          "NodeLocalDNS enabled by default sets Cilium exclude-local-address",
+			cluster:                       genCluster(""),
+			appDefinitionDefaultValues:    nil,
+			existingAppInstallationValues: nil,
+			validate: func(cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, reconcileErr error) error {
+				if reconcileErr != nil {
+					return fmt.Errorf("reconciling should not have produced an error, but returned: %w", reconcileErr)
+				}
+				values, err := getApplicationInstallationValues(userClusterClient)
+				if err != nil {
+					return err
+				}
+				extraConfig, ok := values["extraConfig"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("CNI value extraConfig is not present")
+				}
+				if extraConfig[ciliumExcludeLocalAddressConfigKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
+					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExcludeLocalAddressConfigKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExcludeLocalAddressConfigKey])
+				}
+				return nil
+			},
+		},
+		{
+			name:                       "existing Cilium extraConfig values are preserved while enforcing exclude-local-address",
+			cluster:                    genCluster(""),
+			appDefinitionDefaultValues: nil,
+			existingAppInstallationValues: map[string]any{
+				"extraConfig": map[string]any{
+					"custom-key":                       "custom-value",
+					ciliumExcludeLocalAddressConfigKey: "192.0.2.1/32",
+				},
+			},
+			validate: func(cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, reconcileErr error) error {
+				if reconcileErr != nil {
+					return fmt.Errorf("reconciling should not have produced an error, but returned: %w", reconcileErr)
+				}
+				values, err := getApplicationInstallationValues(userClusterClient)
+				if err != nil {
+					return err
+				}
+				extraConfig, ok := values["extraConfig"].(map[string]any)
+				if !ok {
+					return fmt.Errorf("CNI value extraConfig is not present")
+				}
+				if extraConfig["custom-key"] != "custom-value" {
+					return fmt.Errorf("CNI value extraConfig.custom-key should be preserved, got %q", extraConfig["custom-key"])
+				}
+				if extraConfig[ciliumExcludeLocalAddressConfigKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
+					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExcludeLocalAddressConfigKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExcludeLocalAddressConfigKey])
+				}
+				return nil
+			},
+		},
+		{
+			name: "NodeLocalDNS disabled does not set Cilium exclude-local-address",
+			cluster: func() *kubermaticv1.Cluster {
+				cluster := genCluster("")
+				cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled = ptr.To(false)
+				return cluster
+			}(),
+			appDefinitionDefaultValues:    nil,
+			existingAppInstallationValues: nil,
+			validate: func(cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, reconcileErr error) error {
+				if reconcileErr != nil {
+					return fmt.Errorf("reconciling should not have produced an error, but returned: %w", reconcileErr)
+				}
+				values, err := getApplicationInstallationValues(userClusterClient)
+				if err != nil {
+					return err
+				}
+				if extraConfig, ok := values["extraConfig"].(map[string]any); ok {
+					if _, ok := extraConfig[ciliumExcludeLocalAddressConfigKey]; ok {
+						return fmt.Errorf("CNI value extraConfig.%s should not be present when NodeLocalDNS is disabled", ciliumExcludeLocalAddressConfigKey)
+					}
+				}
+				return nil
+			},
+		},
+		{
 			name:                          "invalid annotation",
 			cluster:                       genCluster("INVALID"),
 			appDefinitionDefaultValues:    map[string]any{appDefDefaultCNIValue: "true"},

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
@@ -267,7 +267,7 @@ func TestReconcile(t *testing.T) {
 			existingAppInstallationValues: map[string]any{
 				"extraConfig": map[string]any{
 					"custom-key":                            "custom-value",
-					ciliumExtraConfigExcludeLocalAddressKey: "192.0.2.1/32",
+					ciliumExtraConfigExcludeLocalAddressKey: "192.0.2.1/32 198.51.100.0/24",
 				},
 			},
 			validate: func(cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, reconcileErr error) error {
@@ -285,8 +285,9 @@ func TestReconcile(t *testing.T) {
 				if extraConfig["custom-key"] != "custom-value" {
 					return fmt.Errorf("CNI value extraConfig.custom-key should be preserved, got %q", extraConfig["custom-key"])
 				}
-				if extraConfig[ciliumExtraConfigExcludeLocalAddressKey] != fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress) {
-					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExtraConfigExcludeLocalAddressKey, fmt.Sprintf("%s/32", resources.NodeLocalDNSCacheAddress), extraConfig[ciliumExtraConfigExcludeLocalAddressKey])
+				expectedExcludeLocalAddress := fmt.Sprintf("192.0.2.1/32 198.51.100.0/24 %s/32", resources.NodeLocalDNSCacheAddress)
+				if extraConfig[ciliumExtraConfigExcludeLocalAddressKey] != expectedExcludeLocalAddress {
+					return fmt.Errorf("CNI value extraConfig.%s should be %q, got %q", ciliumExtraConfigExcludeLocalAddressKey, expectedExcludeLocalAddress, extraConfig[ciliumExtraConfigExcludeLocalAddressKey])
 				}
 				return nil
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR configures Cilium to exclude our reserved NodeLocalDNS address (`169.254.20.10/32`) from Cilium's local address detection when NodeLocalDNS is enabled. With our current setup Cilium adds the NodeLocalDNS address as host identity. NetworkPolicies that allow egress to CIDRs like `0.0.0.0/0` do not allow DNS traffic to NodeLocalDNS and this breaks Web Terminal DNS when internet access is disabled in KKP. 

In this PR I intentionally didn't add any option to restart the cilium agents, we had an option to do this when the configmap changes (with `rollOutCiliumPods` this could have been possible for us), but this changes the general rollout behavior for all configmap changes. That could cause unexpected agent restarts. Another option for existing clusters is also to add a pod annotation to perform the restart one time, but that is also not preferred, in the case when disabling web terminal internet access for existing clusters, the user would need to restart the agent (this is specified in the release notes too).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15236

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KKP now configures Cilium to exclude the reserved (KKP) NodeLocalDNS address from local address detection when NodeLocalDNS is enabled. This fixes DNS access to NodeLocalDNS for Cilium clusters with restrictive egress NetworkPolicies, for example Web Terminal sessions with internet access disabled. Existing clusters require a restart of the Cilium DaemonSet for the new startup configuration to take effect if needed. Admins can either restart it manually or set Cilium's `rollOutCiliumPods=true` Helm value, this will roll the agents automatically on configmap changes.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
