### PR TITLE
add traceability annotations to conformance LB test Service

### DIFF
--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -46,6 +48,73 @@ func supportsLoadBalancer(cluster *kubermaticv1.Cluster) bool {
 		cluster.Spec.Cloud.Hetzner != nil ||
 		cluster.Spec.Cloud.Kubevirt != nil ||
 		cluster.Spec.Cloud.Openstack != nil
+}
+
+const (
+	// tagPrefix namespaces the traceability annotations on the LB test Service.
+	tagPrefix = "kkp-test/"
+
+	// awsAdditionalTagsKey is honored by the AWS CCM (provider-aws) to apply the
+	// listed key=value pairs as tags on the ELB/NLB created for the Service.
+	awsAdditionalTagsKey = "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags"
+)
+
+// buildTraceabilityAnnotations returns Service annotations identifying the CI
+// run that requested this LoadBalancer. Values come from Prow-injected env
+// (JOB_NAME, BUILD_ID, PULL_NUMBER); they are empty outside Prow.
+func buildTraceabilityAnnotations(now time.Time) map[string]string {
+	ann := map[string]string{
+		tagPrefix + "triggered-at": now.UTC().Format(time.RFC3339),
+	}
+
+	if v := os.Getenv("JOB_NAME"); v != "" {
+		ann[tagPrefix+"prowjob"] = v
+	}
+	if v := os.Getenv("BUILD_ID"); v != "" {
+		ann[tagPrefix+"build-id"] = v
+	}
+	if v := os.Getenv("PULL_NUMBER"); v != "" {
+		ann[tagPrefix+"pr"] = v
+	}
+
+	return ann
+}
+
+// awsAdditionalResourceTags builds the comma-separated key=value string the AWS
+// CCM expects for the aws-load-balancer-additional-resource-tags annotation.
+// Keys are sorted so the value is deterministic.
+func awsAdditionalResourceTags(tags map[string]string) string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", k, tags[k]))
+	}
+	return strings.Join(parts, ",")
+}
+
+// mergeServiceAnnotations combines the traceability annotations with the
+// provider-specific ones the test already uses. For AWS clusters it also mirrors
+// the traceability values into the AWS additional-resource-tags annotation so
+// they become ELB tags visible in the AWS console.
+func mergeServiceAnnotations(traceability map[string]string, cluster *kubermaticv1.Cluster) map[string]string {
+	ann := map[string]string{
+		// preserved existing behavior; no-op on non-Hetzner providers
+		"load-balancer.hetzner.cloud/location": "nbg1",
+	}
+	for k, v := range traceability {
+		ann[k] = v
+	}
+
+	if cluster.Spec.Cloud.AWS != nil {
+		ann[awsAdditionalTagsKey] = awsAdditionalResourceTags(traceability)
+	}
+
+	return ann
 }
 
 func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, attempt int) error {
@@ -88,11 +157,9 @@ func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.
 	labels := map[string]string{"app": "hello"}
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: ns.Name,
-			Annotations: map[string]string{
-				"load-balancer.hetzner.cloud/location": "nbg1",
-			},
+			Name:        "test",
+			Namespace:   ns.Name,
+			Annotations: mergeServiceAnnotations(buildTraceabilityAnnotations(time.Now()), cluster),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeLoadBalancer,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `kkp-test/*` annotations to that Service from Prow env vars (`build-id`, `prowjob`, `pr`) plus a `triggered-at` timestamp. For AWS clusters it also writes those values into `aws-load-balancer-additional-resource-tags`, so they appear as tags on the ELB/NLB in the AWS console.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
