### PR TITLE
Update Alloy with appversion v1.17.0

### DIFF
--- a/charts/logging/alloy/Chart.lock
+++ b/charts/logging/alloy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: alloy
   repository: https://grafana.github.io/helm-charts
-  version: 1.1.2
-digest: sha256:66403884b7f293e86e2a61d0d822fd0878a6b4a64e5e88f181b93022bc4f9bcd
-generated: "2025-07-01T07:40:35.471977301+02:00"
+  version: 1.10.0
+digest: sha256:951f3db18b62c35188f28738ddcedd0f1e5f54ab896873fa9567ee9f71f2d96c
+generated: "2026-06-24T03:00:31.528091374+05:30"

--- a/charts/logging/alloy/Chart.yaml
+++ b/charts/logging/alloy/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: grafana-alloy
 version: 9.9.9-dev
-appVersion: v1.9.2
+appVersion: v1.17.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:
   - kubermatic
@@ -31,5 +31,5 @@ maintainers:
     email: support@kubermatic.com
 dependencies:
   - name: alloy
-    version: "1.1.2"
+    version: "1.10.0"
     repository: "https://grafana.github.io/helm-charts"

--- a/charts/logging/alloy/test/default.yaml.out
+++ b/charts/logging/alloy/test/default.yaml.out
@@ -7,10 +7,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
@@ -22,10 +22,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: config
@@ -523,99 +523,127 @@ kind: ClusterRole
 metadata:
   name: release-name-alloy
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
 rules:
-  # Rules which allow discovery.kubernetes to function.
   - apiGroups:
-      - ""
-      - "discovery.k8s.io"
-      - "networking.k8s.io"
+    - ""
+    - discovery.k8s.io
+    - networking.k8s.io
     resources:
-      - endpoints
-      - endpointslices
-      - ingresses
-      - nodes
-      - nodes/proxy
-      - nodes/metrics
-      - pods
-      - services
+    - endpoints
+    - endpointslices
+    - ingresses
+    - pods
+    - services
     verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+    - get
+    - list
+    - watch
   - apiGroups:
-      - ""
+    - ""
     resources:
-      - pods
-      - pods/log
-      - namespaces
+    - pods
+    - pods/log
+    - namespaces
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
   - apiGroups:
-      - "monitoring.grafana.com"
+    - monitoring.grafana.com
     resources:
-      - podlogs
+    - podlogs
     verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow mimir.rules.kubernetes to work.
-  - apiGroups: ["monitoring.coreos.com"]
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
     resources:
-      - prometheusrules
+    - prometheusrules
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - alertmanagerconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - podmonitors
+    - servicemonitors
+    - probes
+    - scrapeconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/metrics
+    verbs:
+    - get
+    - list
+    - watch
   - nonResourceURLs:
-      - /metrics
+    - /metrics
     verbs:
-      - get
-  # Rules for prometheus.kubernetes.*
-  - apiGroups: ["monitoring.coreos.com"]
-    resources:
-      - podmonitors
-      - servicemonitors
-      - probes
-      - scrapeconfigs
-    verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow eventhandler to work.
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for remote.kubernetes.*
-  - apiGroups: [""]
-    resources:
-      - "configmaps"
-      - "secrets"
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for otelcol.processor.k8sattributes
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
+    - get
 ---
 # Source: grafana-alloy/charts/alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -623,10 +651,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-alloy
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
@@ -646,10 +674,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: networking
@@ -672,10 +700,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
 spec:
@@ -688,7 +716,6 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
-        checksum/config: 5cfc2433d2a9ad959997328d400fc6758c8b8da8c356d31a4b2bfde8ff51140
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: release-name
@@ -696,7 +723,7 @@ spec:
       serviceAccountName: release-name-alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.9.2
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run
@@ -709,6 +736,10 @@ spec:
             - name: ALLOY_DEPLOY_MODE
               value: "helm"
             - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -729,7 +760,8 @@ spec:
               mountPath: /var/log
               readOnly: true
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0@sha256:7d9e4eea5f1139e602508871f422b0116c60e87c662f3dcd234d5ab60cd0d8c1
+          imagePullPolicy: IfNotPresent
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/charts/logging/alloy/test/values.example.ce.yaml.out
+++ b/charts/logging/alloy/test/values.example.ce.yaml.out
@@ -7,10 +7,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
@@ -22,10 +22,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: config
@@ -523,99 +523,127 @@ kind: ClusterRole
 metadata:
   name: release-name-alloy
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
 rules:
-  # Rules which allow discovery.kubernetes to function.
   - apiGroups:
-      - ""
-      - "discovery.k8s.io"
-      - "networking.k8s.io"
+    - ""
+    - discovery.k8s.io
+    - networking.k8s.io
     resources:
-      - endpoints
-      - endpointslices
-      - ingresses
-      - nodes
-      - nodes/proxy
-      - nodes/metrics
-      - pods
-      - services
+    - endpoints
+    - endpointslices
+    - ingresses
+    - pods
+    - services
     verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+    - get
+    - list
+    - watch
   - apiGroups:
-      - ""
+    - ""
     resources:
-      - pods
-      - pods/log
-      - namespaces
+    - pods
+    - pods/log
+    - namespaces
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
   - apiGroups:
-      - "monitoring.grafana.com"
+    - monitoring.grafana.com
     resources:
-      - podlogs
+    - podlogs
     verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow mimir.rules.kubernetes to work.
-  - apiGroups: ["monitoring.coreos.com"]
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
     resources:
-      - prometheusrules
+    - prometheusrules
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - alertmanagerconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - podmonitors
+    - servicemonitors
+    - probes
+    - scrapeconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/metrics
+    verbs:
+    - get
+    - list
+    - watch
   - nonResourceURLs:
-      - /metrics
+    - /metrics
     verbs:
-      - get
-  # Rules for prometheus.kubernetes.*
-  - apiGroups: ["monitoring.coreos.com"]
-    resources:
-      - podmonitors
-      - servicemonitors
-      - probes
-      - scrapeconfigs
-    verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow eventhandler to work.
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for remote.kubernetes.*
-  - apiGroups: [""]
-    resources:
-      - "configmaps"
-      - "secrets"
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for otelcol.processor.k8sattributes
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
+    - get
 ---
 # Source: grafana-alloy/charts/alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -623,10 +651,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-alloy
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
@@ -646,10 +674,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: networking
@@ -672,10 +700,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
 spec:
@@ -688,7 +716,6 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
-        checksum/config: 5cfc2433d2a9ad959997328d400fc6758c8b8da8c356d31a4b2bfde8ff51140
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: release-name
@@ -696,7 +723,7 @@ spec:
       serviceAccountName: release-name-alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.9.2
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run
@@ -709,6 +736,10 @@ spec:
             - name: ALLOY_DEPLOY_MODE
               value: "helm"
             - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -729,7 +760,8 @@ spec:
               mountPath: /var/log
               readOnly: true
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0@sha256:7d9e4eea5f1139e602508871f422b0116c60e87c662f3dcd234d5ab60cd0d8c1
+          imagePullPolicy: IfNotPresent
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload

--- a/charts/logging/alloy/test/values.example.ee.yaml.out
+++ b/charts/logging/alloy/test/values.example.ee.yaml.out
@@ -7,10 +7,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
@@ -22,10 +22,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: config
@@ -523,99 +523,127 @@ kind: ClusterRole
 metadata:
   name: release-name-alloy
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
 rules:
-  # Rules which allow discovery.kubernetes to function.
   - apiGroups:
-      - ""
-      - "discovery.k8s.io"
-      - "networking.k8s.io"
+    - ""
+    - discovery.k8s.io
+    - networking.k8s.io
     resources:
-      - endpoints
-      - endpointslices
-      - ingresses
-      - nodes
-      - nodes/proxy
-      - nodes/metrics
-      - pods
-      - services
+    - endpoints
+    - endpointslices
+    - ingresses
+    - pods
+    - services
     verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+    - get
+    - list
+    - watch
   - apiGroups:
-      - ""
+    - ""
     resources:
-      - pods
-      - pods/log
-      - namespaces
+    - pods
+    - pods/log
+    - namespaces
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
   - apiGroups:
-      - "monitoring.grafana.com"
+    - monitoring.grafana.com
     resources:
-      - podlogs
+    - podlogs
     verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow mimir.rules.kubernetes to work.
-  - apiGroups: ["monitoring.coreos.com"]
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
     resources:
-      - prometheusrules
+    - prometheusrules
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - alertmanagerconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - podmonitors
+    - servicemonitors
+    - probes
+    - scrapeconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/metrics
+    verbs:
+    - get
+    - list
+    - watch
   - nonResourceURLs:
-      - /metrics
+    - /metrics
     verbs:
-      - get
-  # Rules for prometheus.kubernetes.*
-  - apiGroups: ["monitoring.coreos.com"]
-    resources:
-      - podmonitors
-      - servicemonitors
-      - probes
-      - scrapeconfigs
-    verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow eventhandler to work.
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for remote.kubernetes.*
-  - apiGroups: [""]
-    resources:
-      - "configmaps"
-      - "secrets"
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for otelcol.processor.k8sattributes
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
+    - get
 ---
 # Source: grafana-alloy/charts/alloy/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -623,10 +651,10 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-alloy
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
@@ -646,10 +674,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: networking
@@ -672,10 +700,10 @@ metadata:
   name: release-name-alloy
   namespace: default
   labels:
-    helm.sh/chart: alloy-1.1.2
+    helm.sh/chart: alloy-1.10.0
     app.kubernetes.io/name: alloy
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.17.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: alloy
 spec:
@@ -688,7 +716,6 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
-        checksum/config: 5cfc2433d2a9ad959997328d400fc6758c8b8da8c356d31a4b2bfde8ff51140
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: release-name
@@ -696,7 +723,7 @@ spec:
       serviceAccountName: release-name-alloy
       containers:
         - name: alloy
-          image: docker.io/grafana/alloy:v1.9.2
+          image: docker.io/grafana/alloy:v1.17.0
           imagePullPolicy: IfNotPresent
           args:
             - run
@@ -709,6 +736,10 @@ spec:
             - name: ALLOY_DEPLOY_MODE
               value: "helm"
             - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -729,7 +760,8 @@ spec:
               mountPath: /var/log
               readOnly: true
         - name: config-reloader
-          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.91.0@sha256:7d9e4eea5f1139e602508871f422b0116c60e87c662f3dcd234d5ab60cd0d8c1
+          imagePullPolicy: IfNotPresent
           args:
             - --watched-dir=/etc/alloy
             - --reload-url=http://localhost:12345/-/reload


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps Grafana Alloy from `v1.9.2` to `v1.17.0` and the upstream Helm chart  from `1.1.2` to `1.10.0` to pick up 8 minor releases worth of bug fixes, security patches, and new features.

The current chart config is unaffected — it uses only `discovery.kubernetes`, `discovery.relabel`, `local.file_match`, `loki.source.file`, `loki.source.journal`, `loki.process`, and `loki.write`, none of which have breaking changes in this range.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

The version jump is large (v1.9.2 → v1.17.0) but safe for this chart. The `values.example.ce.yaml.out` and `values.example.ee.yaml.out` test files has been regenerated and reflects the following changes from the helm chart upgrade:

- All resource labels updated: `alloy-1.1.2` → `alloy-1.10.0`,   `v1.9.2` → `v1.17.0`
- Alloy container image bumped: `alloy:v1.9.2` → `alloy:v1.17.0`
- config-reloader image bumped: `prometheus-config-reloader:v0.81.0` → `prometheus-config-reloader:v0.91.0@sha256:7d9e...` and `imagePullPolicy: IfNotPresent` added
- `checksum/config` pod annotation removed (chart 1.3.0 — avoids unnecessary pod restarts when config-reloader is enabled)
- New `K8S_NODE_NAME` env var injected into the Alloy container (chart 1.7.0 —  used by `otelcol.processor.resourcedetection`)
- ClusterRole restructured: YAML block style, inline comments removed, `nodes/proxy` replaced by `nodes/pods`, `nodes`/`nodes/metrics`/`/metrics`  split into dedicated rules, `alertmanagerconfigs` rule added, and the two  separate `otelcol.processor.k8sattributes` replicaset rules merged into one
- `config.alloy` ConfigMap content is **unchanged**

For anyone extending this chart with additional components in the future, the release note below documents every relevant breaking change introduced across this range.

Also note: `loki.source.file "kubernetes_pods_static"` continues to use `legacy_positions_file = "/run/promtail/positions.yaml"` — a leftover path from the Promtail migration, inconsistent with the `/run/alloy/` path used by all other sources. This is pre-existing and out of scope for this PR but should be addressed in a follow-up.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bumped Grafana Alloy from v1.9.2 to v1.17.0 (Helm chart 1.1.2 → 1.10.0). The current chart configuration is unaffected. If extending the helm chart with additional components, please review the https://github.com/grafana/alloy/blob/main/operations/helm/charts/alloy/CHANGELOG.md and https://grafana.com/docs/alloy/latest/release-notes/ for any upstream breaking changes.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
