### PR TITLE
[release/v2.30] Fix apiserver NetworkPolicy OIDC bug for LB backed issuers (like KubeLB)

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -326,7 +326,7 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 // It must cover every OIDC source handled by oidcIssuerDestinations; missing
 // one only delays policy updates until the next normal cluster reconcile.
 func (r *Reconciler) isOIDCIssuerClusterCandidate(cluster *kubermaticv1.Cluster) bool {
-	oidcSettings := cluster.Spec.OIDC //nolint:staticcheck
+	oidcSettings := cluster.Spec.OIDC
 	return oidcSettings.IssuerURL != "" ||
 		(r.features.KubernetesOIDCAuthentication && r.oidcIssuerURL != "")
 }

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -247,7 +247,7 @@ func Add(
 func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(e.Object)
+			return isOIDCIssuerLoadBalancerServiceCandidate(e.Object)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldSvc, oldOK := e.ObjectOld.(*corev1.Service)
@@ -256,8 +256,8 @@ func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 				return false
 			}
 
-			if !serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(oldSvc) &&
-				!serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(newSvc) {
+			if !isOIDCIssuerLoadBalancerServiceCandidate(oldSvc) &&
+				!isOIDCIssuerLoadBalancerServiceCandidate(newSvc) {
 				return false
 			}
 
@@ -267,7 +267,7 @@ func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 				!apiequality.Semantic.DeepEqual(oldSvc.Status.LoadBalancer.Ingress, newSvc.Status.LoadBalancer.Ingress)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(e.Object)
+			return isOIDCIssuerLoadBalancerServiceCandidate(e.Object)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
@@ -275,7 +275,9 @@ func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 	}
 }
 
-func serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(obj ctrlruntimeclient.Object) bool {
+// isOIDCIssuerLoadBalancerServiceCandidate only checks cheap Service fields.
+// Reconciliation performs the exact issuer IP/hostname and port match.
+func isOIDCIssuerLoadBalancerServiceCandidate(obj ctrlruntimeclient.Object) bool {
 	svc, ok := obj.(*corev1.Service)
 	if !ok {
 		return false
@@ -321,7 +323,7 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 			continue
 		}
 
-		if seedUnavailable || r.clusterMayUseOIDCIssuer(cluster, seed) {
+		if seedUnavailable || r.isOIDCIssuerClusterCandidate(cluster, seed) {
 			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: cluster.Name}})
 		}
 	}
@@ -333,9 +335,9 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 	return requests
 }
 
-// clusterMayUseOIDCIssuer is a cheap enqueue heuristic. Keep it aligned with
+// isOIDCIssuerClusterCandidate is a cheap enqueue heuristic. Keep it aligned with
 // oidcIssuerDestinations; false negatives only delay updates until the next reconcile.
-func (r *Reconciler) clusterMayUseOIDCIssuer(cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) bool {
+func (r *Reconciler) isOIDCIssuerClusterCandidate(cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) bool {
 	oidcSettings := cluster.Spec.OIDC //nolint:staticcheck
 	if oidcSettings.IssuerURL != "" ||
 		cluster.Spec.IsAuthenticationConfigurationEnabled() ||

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -335,8 +335,9 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 	return requests
 }
 
-// isOIDCIssuerClusterCandidate is a cheap enqueue heuristic. Keep it aligned with
-// oidcIssuerDestinations; false negatives only delay updates until the next reconcile.
+// isOIDCIssuerClusterCandidate is a cheap prefilter for Service watch events.
+// It must cover every OIDC source handled by oidcIssuerDestinations; missing
+// one only delays policy updates until the next normal cluster reconcile.
 func (r *Reconciler) isOIDCIssuerClusterCandidate(cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) bool {
 	oidcSettings := cluster.Spec.OIDC //nolint:staticcheck
 	if oidcSettings.IssuerURL != "" ||

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -247,7 +247,7 @@ func Add(
 func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return isOIDCIssuerLoadBalancerServiceCandidate(e.Object)
+			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldSvc, oldOK := e.ObjectOld.(*corev1.Service)

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -301,19 +301,6 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 		return nil
 	}
 
-	var seed *kubermaticv1.Seed
-	seedUnavailable := false
-	if r.seedGetter != nil {
-		var err error
-		seed, err = r.seedGetter()
-		if err != nil {
-			// Fail open for enqueueing so transient Seed read errors do not leave
-			// stale policies behind; reconciliation still applies normal guards.
-			seedUnavailable = true
-			utilruntime.HandleError(fmt.Errorf("failed to get Seed for OIDC issuer LoadBalancer Service change: %w", err))
-		}
-	}
-
 	requests := make([]reconcile.Request, 0, len(clusters.Items))
 	for i := range clusters.Items {
 		cluster := &clusters.Items[i]
@@ -323,7 +310,7 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 			continue
 		}
 
-		if seedUnavailable || r.isOIDCIssuerClusterCandidate(cluster, seed) {
+		if r.isOIDCIssuerClusterCandidate(cluster) {
 			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: cluster.Name}})
 		}
 	}
@@ -338,28 +325,10 @@ func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context
 // isOIDCIssuerClusterCandidate is a cheap prefilter for Service watch events.
 // It must cover every OIDC source handled by oidcIssuerDestinations; missing
 // one only delays policy updates until the next normal cluster reconcile.
-func (r *Reconciler) isOIDCIssuerClusterCandidate(cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) bool {
+func (r *Reconciler) isOIDCIssuerClusterCandidate(cluster *kubermaticv1.Cluster) bool {
 	oidcSettings := cluster.Spec.OIDC //nolint:staticcheck
-	if oidcSettings.IssuerURL != "" ||
-		cluster.Spec.IsAuthenticationConfigurationEnabled() ||
-		(r.features.KubernetesOIDCAuthentication && r.oidcIssuerURL != "") {
-		return true
-	}
-
-	if seed == nil {
-		return false
-	}
-
-	if dc, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]; found &&
-		authenticationConfigurationRefConfigured(dc.Spec.AuthenticationConfiguration) {
-		return true
-	}
-
-	return authenticationConfigurationRefConfigured(seed.Spec.AuthenticationConfiguration)
-}
-
-func authenticationConfigurationRefConfigured(ref *kubermaticv1.AuthenticationConfiguration) bool {
-	return ref != nil && ref.SecretName != "" && ref.SecretKey != ""
+	return oidcSettings.IssuerURL != "" ||
+		(r.features.KubernetesOIDCAuthentication && r.oidcIssuerURL != "")
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -43,6 +43,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -261,9 +262,9 @@ func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 			}
 
 			return oldSvc.Spec.Type != newSvc.Spec.Type ||
-				!reflect.DeepEqual(oldSvc.Spec.Selector, newSvc.Spec.Selector) ||
-				!reflect.DeepEqual(oldSvc.Spec.Ports, newSvc.Spec.Ports) ||
-				!reflect.DeepEqual(oldSvc.Status.LoadBalancer.Ingress, newSvc.Status.LoadBalancer.Ingress)
+				!apiequality.Semantic.DeepEqual(oldSvc.Spec.Selector, newSvc.Spec.Selector) ||
+				!apiequality.Semantic.DeepEqual(oldSvc.Spec.Ports, newSvc.Spec.Ports) ||
+				!apiequality.Semantic.DeepEqual(oldSvc.Status.LoadBalancer.Ingress, newSvc.Status.LoadBalancer.Ingress)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			return serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(e.Object)

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"go.uber.org/zap"
@@ -52,8 +53,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -229,9 +232,130 @@ func Add(
 		bldr.Watches(t, inNamespaceHandler, builder.WithPredicates(predicateutil.SkipCreateEvents()))
 	}
 
+	bldr.Watches(
+		&corev1.Service{},
+		handler.EnqueueRequestsFromMapFunc(reconciler.enqueueClustersForOIDCIssuerLoadBalancerService),
+		builder.WithPredicates(oidcIssuerLoadBalancerServicePredicate()),
+	)
+
 	_, err := bldr.Build(reconciler)
 
 	return err
+}
+
+func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSvc, oldOK := e.ObjectOld.(*corev1.Service)
+			newSvc, newOK := e.ObjectNew.(*corev1.Service)
+			if !oldOK || !newOK {
+				return false
+			}
+
+			if !serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(oldSvc) &&
+				!serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(newSvc) {
+				return false
+			}
+
+			return oldSvc.Spec.Type != newSvc.Spec.Type ||
+				!reflect.DeepEqual(oldSvc.Spec.Selector, newSvc.Spec.Selector) ||
+				!reflect.DeepEqual(oldSvc.Spec.Ports, newSvc.Spec.Ports) ||
+				!reflect.DeepEqual(oldSvc.Status.LoadBalancer.Ingress, newSvc.Status.LoadBalancer.Ingress)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(e.Object)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func serviceMayProvideOIDCIssuerLoadBalancerBackendPeers(obj ctrlruntimeclient.Object) bool {
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		return false
+	}
+
+	return svc.Spec.Type == corev1.ServiceTypeLoadBalancer &&
+		len(svc.Spec.Selector) > 0 &&
+		len(svc.Status.LoadBalancer.Ingress) > 0
+}
+
+func (r *Reconciler) enqueueClustersForOIDCIssuerLoadBalancerService(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+	if _, ok := obj.(*corev1.Service); !ok {
+		return nil
+	}
+
+	// A LoadBalancer Service can back an issuer used by any user cluster, so the
+	// handler enqueues cheap OIDC candidates and lets reconciliation recompute the exact peers.
+	clusters := &kubermaticv1.ClusterList{}
+	if err := r.List(ctx, clusters); err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list Clusters for OIDC issuer LoadBalancer Service change: %w", err))
+		return nil
+	}
+
+	var seed *kubermaticv1.Seed
+	seedUnavailable := false
+	if r.seedGetter != nil {
+		var err error
+		seed, err = r.seedGetter()
+		if err != nil {
+			// Fail open for enqueueing so transient Seed read errors do not leave
+			// stale policies behind; reconciliation still applies normal guards.
+			seedUnavailable = true
+			utilruntime.HandleError(fmt.Errorf("failed to get Seed for OIDC issuer LoadBalancer Service change: %w", err))
+		}
+	}
+
+	requests := make([]reconcile.Request, 0, len(clusters.Items))
+	for i := range clusters.Items {
+		cluster := &clusters.Items[i]
+		if cluster.DeletionTimestamp != nil ||
+			cluster.Status.NamespaceName == "" ||
+			!cluster.Spec.Features[kubermaticv1.ApiserverNetworkPolicy] {
+			continue
+		}
+
+		if seedUnavailable || r.clusterMayUseOIDCIssuer(cluster, seed) {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: cluster.Name}})
+		}
+	}
+
+	sort.Slice(requests, func(i, j int) bool {
+		return requests[i].Name < requests[j].Name
+	})
+
+	return requests
+}
+
+// clusterMayUseOIDCIssuer is a cheap enqueue heuristic. Keep it aligned with
+// oidcIssuerDestinations; false negatives only delay updates until the next reconcile.
+func (r *Reconciler) clusterMayUseOIDCIssuer(cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed) bool {
+	oidcSettings := cluster.Spec.OIDC //nolint:staticcheck
+	if oidcSettings.IssuerURL != "" ||
+		cluster.Spec.IsAuthenticationConfigurationEnabled() ||
+		(r.features.KubernetesOIDCAuthentication && r.oidcIssuerURL != "") {
+		return true
+	}
+
+	if seed == nil {
+		return false
+	}
+
+	if dc, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]; found &&
+		authenticationConfigurationRefConfigured(dc.Spec.AuthenticationConfiguration) {
+		return true
+	}
+
+	return authenticationConfigurationRefConfigured(seed.Spec.AuthenticationConfiguration)
+}
+
+func authenticationConfigurationRefConfigured(ref *kubermaticv1.AuthenticationConfiguration) bool {
+	return ref != nil && ref.SecretName != "" && ref.SecretKey != ""
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
@@ -37,29 +37,16 @@ import (
 func TestOIDCIssuerLoadBalancerServicePredicate(t *testing.T) {
 	predicate := oidcIssuerLoadBalancerServicePredicate()
 
-	t.Run("create matching service", func(t *testing.T) {
-		require.True(t, predicate.Create(event.CreateEvent{Object: oidcIssuerLoadBalancerService()}))
+	t.Run("ignore create event", func(t *testing.T) {
+		require.False(t, predicate.Create(event.CreateEvent{Object: oidcIssuerLoadBalancerService()}))
 	})
 
-	t.Run("create service without ingress", func(t *testing.T) {
-		svc := oidcIssuerLoadBalancerService()
-		svc.Status.LoadBalancer.Ingress = nil
+	t.Run("update when load balancer ingress is assigned", func(t *testing.T) {
+		oldSvc := oidcIssuerLoadBalancerService()
+		newSvc := oldSvc.DeepCopy()
+		oldSvc.Status.LoadBalancer.Ingress = nil
 
-		require.False(t, predicate.Create(event.CreateEvent{Object: svc}))
-	})
-
-	t.Run("create service without selector", func(t *testing.T) {
-		svc := oidcIssuerLoadBalancerService()
-		svc.Spec.Selector = nil
-
-		require.False(t, predicate.Create(event.CreateEvent{Object: svc}))
-	})
-
-	t.Run("create non LoadBalancer service", func(t *testing.T) {
-		svc := oidcIssuerLoadBalancerService()
-		svc.Spec.Type = corev1.ServiceTypeClusterIP
-
-		require.False(t, predicate.Create(event.CreateEvent{Object: svc}))
+		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
 	})
 
 	t.Run("update when ingress changes", func(t *testing.T) {
@@ -84,6 +71,15 @@ func TestOIDCIssuerLoadBalancerServicePredicate(t *testing.T) {
 		newSvc.Spec.Type = corev1.ServiceTypeClusterIP
 
 		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
+	})
+
+	t.Run("ignore update when neither service is a candidate", func(t *testing.T) {
+		oldSvc := oidcIssuerLoadBalancerService()
+		oldSvc.Status.LoadBalancer.Ingress = nil
+		newSvc := oldSvc.DeepCopy()
+		newSvc.Labels = map[string]string{"changed": "true"}
+
+		require.False(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
 	})
 
 	t.Run("ignore unrelated update", func(t *testing.T) {

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
@@ -146,7 +146,7 @@ func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
 			name: "enqueue OIDC candidates",
 			objects: []ctrlruntimeclient.Object{
 				clusterWithNetworkPolicy("legacy-oidc", "cluster-legacy-oidc", "dc-a", func(cluster *kubermaticv1.Cluster) {
-					cluster.Spec.OIDC.IssuerURL = "https://issuer.example.com" //nolint:staticcheck
+					cluster.Spec.OIDC.IssuerURL = "https://issuer.example.com"
 				}),
 				clusterWithNetworkPolicy("no-oidc", "cluster-no-oidc", "dc-a", nil),
 				&kubermaticv1.Cluster{

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestOIDCIssuerLoadBalancerServicePredicate(t *testing.T) {
+	predicate := oidcIssuerLoadBalancerServicePredicate()
+
+	t.Run("create matching service", func(t *testing.T) {
+		require.True(t, predicate.Create(event.CreateEvent{Object: oidcIssuerLoadBalancerService()}))
+	})
+
+	t.Run("create service without ingress", func(t *testing.T) {
+		svc := oidcIssuerLoadBalancerService()
+		svc.Status.LoadBalancer.Ingress = nil
+
+		require.False(t, predicate.Create(event.CreateEvent{Object: svc}))
+	})
+
+	t.Run("create service without selector", func(t *testing.T) {
+		svc := oidcIssuerLoadBalancerService()
+		svc.Spec.Selector = nil
+
+		require.False(t, predicate.Create(event.CreateEvent{Object: svc}))
+	})
+
+	t.Run("create non LoadBalancer service", func(t *testing.T) {
+		svc := oidcIssuerLoadBalancerService()
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+
+		require.False(t, predicate.Create(event.CreateEvent{Object: svc}))
+	})
+
+	t.Run("update when ingress changes", func(t *testing.T) {
+		oldSvc := oidcIssuerLoadBalancerService()
+		newSvc := oldSvc.DeepCopy()
+		newSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.10.45.1"}}
+
+		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
+	})
+
+	t.Run("update when ports change", func(t *testing.T) {
+		oldSvc := oidcIssuerLoadBalancerService()
+		newSvc := oldSvc.DeepCopy()
+		newSvc.Spec.Ports = []corev1.ServicePort{{Port: 443}}
+
+		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
+	})
+
+	t.Run("update when service stops matching", func(t *testing.T) {
+		oldSvc := oidcIssuerLoadBalancerService()
+		newSvc := oldSvc.DeepCopy()
+		newSvc.Spec.Type = corev1.ServiceTypeClusterIP
+
+		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
+	})
+
+	t.Run("ignore unrelated update", func(t *testing.T) {
+		oldSvc := oidcIssuerLoadBalancerService()
+		newSvc := oldSvc.DeepCopy()
+		newSvc.Labels = map[string]string{"changed": "true"}
+
+		require.False(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
+	})
+
+	t.Run("delete matching service", func(t *testing.T) {
+		require.True(t, predicate.Delete(event.DeleteEvent{Object: oidcIssuerLoadBalancerService()}))
+	})
+
+	t.Run("ignore generic event", func(t *testing.T) {
+		require.False(t, predicate.Generic(event.GenericEvent{Object: oidcIssuerLoadBalancerService()}))
+	})
+}
+
+func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
+	ctx := context.Background()
+
+	objects := []ctrlruntimeclient.Object{
+		clusterWithNetworkPolicy("legacy-oidc", "cluster-legacy-oidc", "dc-a", func(cluster *kubermaticv1.Cluster) {
+			cluster.Spec.OIDC.IssuerURL = "https://issuer.example.com" //nolint:staticcheck
+		}),
+		clusterWithNetworkPolicy("cluster-auth", "cluster-auth", "dc-a", func(cluster *kubermaticv1.Cluster) {
+			cluster.Spec.AuthenticationConfiguration = &kubermaticv1.AuthenticationConfiguration{
+				SecretName: "auth-config",
+				SecretKey:  "config.yaml",
+			}
+		}),
+		clusterWithNetworkPolicy("dc-auth", "cluster-dc-auth", "dc-auth", nil),
+		clusterWithNetworkPolicy("no-oidc", "cluster-no-oidc", "dc-a", nil),
+		&kubermaticv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "no-network-policy",
+			},
+			Spec: kubermaticv1.ClusterSpec{
+				Features: map[string]bool{},
+			},
+			Status: kubermaticv1.ClusterStatus{
+				NamespaceName: "cluster-no-network-policy",
+			},
+		},
+	}
+
+	r := &Reconciler{
+		Client: fake.NewClientBuilder().WithObjects(objects...).Build(),
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return &kubermaticv1.Seed{
+				Spec: kubermaticv1.SeedSpec{
+					Datacenters: map[string]kubermaticv1.Datacenter{
+						"dc-auth": {
+							Spec: kubermaticv1.DatacenterSpec{
+								AuthenticationConfiguration: &kubermaticv1.AuthenticationConfiguration{
+									SecretName: "dc-auth-config",
+									SecretKey:  "config.yaml",
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
+
+	require.Equal(t, []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: "cluster-auth"}},
+		{NamespacedName: types.NamespacedName{Name: "dc-auth"}},
+		{NamespacedName: types.NamespacedName{Name: "legacy-oidc"}},
+	}, requests)
+}
+
+func TestEnqueueClustersForOIDCIssuerLoadBalancerServiceWithDefaultIssuer(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := clusterWithNetworkPolicy("default-issuer", "cluster-default-issuer", "dc-a", nil)
+	r := &Reconciler{
+		Client:        fake.NewClientBuilder().WithObjects(cluster).Build(),
+		oidcIssuerURL: "https://issuer.example.com",
+		features: Features{
+			KubernetesOIDCAuthentication: true,
+		},
+	}
+
+	requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
+
+	require.Equal(t, []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: "default-issuer"}},
+	}, requests)
+}
+
+func TestEnqueueClustersForOIDCIssuerLoadBalancerServiceWithUnavailableSeed(t *testing.T) {
+	ctx := context.Background()
+
+	cluster := clusterWithNetworkPolicy("candidate", "cluster-candidate", "dc-a", nil)
+	r := &Reconciler{
+		Client: fake.NewClientBuilder().WithObjects(cluster).Build(),
+		seedGetter: func() (*kubermaticv1.Seed, error) {
+			return nil, errors.New("seed unavailable")
+		},
+	}
+
+	requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
+
+	require.Equal(t, []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: "candidate"}},
+	}, requests)
+}
+
+func clusterWithNetworkPolicy(name, namespace, datacenter string, mutate func(*kubermaticv1.Cluster)) *kubermaticv1.Cluster {
+	cluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: kubermaticv1.ClusterSpec{
+			Cloud: kubermaticv1.CloudSpec{
+				DatacenterName: datacenter,
+			},
+			Features: map[string]bool{
+				kubermaticv1.ApiserverNetworkPolicy: true,
+			},
+		},
+		Status: kubermaticv1.ClusterStatus{
+			NamespaceName: namespace,
+		},
+	}
+
+	if mutate != nil {
+		mutate(cluster)
+	}
+
+	return cluster
+}
+
+func oidcIssuerLoadBalancerService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "issuer-gateway",
+			Namespace: "issuer",
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{
+				"app": "issuer",
+			},
+			Ports: []corev1.ServicePort{
+				{Port: 80},
+			},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{IP: "10.10.45.0"}},
+			},
+		},
+	}
+}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
@@ -18,7 +18,6 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -139,7 +138,6 @@ func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
 	tests := []struct {
 		name          string
 		objects       []ctrlruntimeclient.Object
-		seedGetter    func() (*kubermaticv1.Seed, error)
 		oidcIssuerURL string
 		features      Features
 		expected      []reconcile.Request
@@ -150,13 +148,6 @@ func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
 				clusterWithNetworkPolicy("legacy-oidc", "cluster-legacy-oidc", "dc-a", func(cluster *kubermaticv1.Cluster) {
 					cluster.Spec.OIDC.IssuerURL = "https://issuer.example.com" //nolint:staticcheck
 				}),
-				clusterWithNetworkPolicy("cluster-auth", "cluster-auth", "dc-a", func(cluster *kubermaticv1.Cluster) {
-					cluster.Spec.AuthenticationConfiguration = &kubermaticv1.AuthenticationConfiguration{
-						SecretName: "auth-config",
-						SecretKey:  "config.yaml",
-					}
-				}),
-				clusterWithNetworkPolicy("dc-auth", "cluster-dc-auth", "dc-auth", nil),
 				clusterWithNetworkPolicy("no-oidc", "cluster-no-oidc", "dc-a", nil),
 				&kubermaticv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
@@ -170,25 +161,7 @@ func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
 					},
 				},
 			},
-			seedGetter: func() (*kubermaticv1.Seed, error) {
-				return &kubermaticv1.Seed{
-					Spec: kubermaticv1.SeedSpec{
-						Datacenters: map[string]kubermaticv1.Datacenter{
-							"dc-auth": {
-								Spec: kubermaticv1.DatacenterSpec{
-									AuthenticationConfiguration: &kubermaticv1.AuthenticationConfiguration{
-										SecretName: "dc-auth-config",
-										SecretKey:  "config.yaml",
-									},
-								},
-							},
-						},
-					},
-				}, nil
-			},
 			expected: []reconcile.Request{
-				{NamespacedName: types.NamespacedName{Name: "cluster-auth"}},
-				{NamespacedName: types.NamespacedName{Name: "dc-auth"}},
 				{NamespacedName: types.NamespacedName{Name: "legacy-oidc"}},
 			},
 		},
@@ -203,23 +176,12 @@ func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
 				{NamespacedName: types.NamespacedName{Name: "default-issuer"}},
 			},
 		},
-		{
-			name:    "enqueue network policy clusters when seed is unavailable",
-			objects: []ctrlruntimeclient.Object{clusterWithNetworkPolicy("candidate", "cluster-candidate", "dc-a", nil)},
-			seedGetter: func() (*kubermaticv1.Seed, error) {
-				return nil, errors.New("seed unavailable")
-			},
-			expected: []reconcile.Request{
-				{NamespacedName: types.NamespacedName{Name: "candidate"}},
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
 				Client:        fake.NewClientBuilder().WithObjects(tt.objects...).Build(),
-				seedGetter:    tt.seedGetter,
 				oidcIssuerURL: tt.oidcIssuerURL,
 				features:      tt.features,
 			}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
@@ -37,160 +37,198 @@ import (
 func TestOIDCIssuerLoadBalancerServicePredicate(t *testing.T) {
 	predicate := oidcIssuerLoadBalancerServicePredicate()
 
-	t.Run("ignore create event", func(t *testing.T) {
-		require.False(t, predicate.Create(event.CreateEvent{Object: oidcIssuerLoadBalancerService()}))
-	})
+	eventTests := []struct {
+		name     string
+		matches  func() bool
+		expected bool
+	}{
+		{
+			name: "ignore create event",
+			matches: func() bool {
+				return predicate.Create(event.CreateEvent{Object: oidcIssuerLoadBalancerService()})
+			},
+			expected: false,
+		},
+		{
+			name: "delete matching service",
+			matches: func() bool {
+				return predicate.Delete(event.DeleteEvent{Object: oidcIssuerLoadBalancerService()})
+			},
+			expected: true,
+		},
+		{
+			name: "ignore generic event",
+			matches: func() bool {
+				return predicate.Generic(event.GenericEvent{Object: oidcIssuerLoadBalancerService()})
+			},
+			expected: false,
+		},
+	}
 
-	t.Run("update when load balancer ingress is assigned", func(t *testing.T) {
-		oldSvc := oidcIssuerLoadBalancerService()
-		newSvc := oldSvc.DeepCopy()
-		oldSvc.Status.LoadBalancer.Ingress = nil
+	for _, tt := range eventTests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.matches())
+		})
+	}
 
-		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
-	})
+	updateTests := []struct {
+		name     string
+		mutate   func(oldSvc, newSvc *corev1.Service)
+		expected bool
+	}{
+		{
+			name: "update when load balancer ingress is assigned",
+			mutate: func(oldSvc, newSvc *corev1.Service) {
+				oldSvc.Status.LoadBalancer.Ingress = nil
+			},
+			expected: true,
+		},
+		{
+			name: "update when ingress changes",
+			mutate: func(oldSvc, newSvc *corev1.Service) {
+				newSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.10.45.1"}}
+			},
+			expected: true,
+		},
+		{
+			name: "update when ports change",
+			mutate: func(oldSvc, newSvc *corev1.Service) {
+				newSvc.Spec.Ports = []corev1.ServicePort{{Port: 443}}
+			},
+			expected: true,
+		},
+		{
+			name: "update when service stops matching",
+			mutate: func(oldSvc, newSvc *corev1.Service) {
+				newSvc.Spec.Type = corev1.ServiceTypeClusterIP
+			},
+			expected: true,
+		},
+		{
+			name: "ignore update when neither service is a candidate",
+			mutate: func(oldSvc, newSvc *corev1.Service) {
+				oldSvc.Status.LoadBalancer.Ingress = nil
+				newSvc.Status.LoadBalancer.Ingress = nil
+				newSvc.Labels = map[string]string{"changed": "true"}
+			},
+			expected: false,
+		},
+		{
+			name: "ignore unrelated update",
+			mutate: func(oldSvc, newSvc *corev1.Service) {
+				newSvc.Labels = map[string]string{"changed": "true"}
+			},
+			expected: false,
+		},
+	}
 
-	t.Run("update when ingress changes", func(t *testing.T) {
-		oldSvc := oidcIssuerLoadBalancerService()
-		newSvc := oldSvc.DeepCopy()
-		newSvc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "10.10.45.1"}}
+	for _, tt := range updateTests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSvc := oidcIssuerLoadBalancerService()
+			newSvc := oldSvc.DeepCopy()
+			tt.mutate(oldSvc, newSvc)
 
-		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
-	})
-
-	t.Run("update when ports change", func(t *testing.T) {
-		oldSvc := oidcIssuerLoadBalancerService()
-		newSvc := oldSvc.DeepCopy()
-		newSvc.Spec.Ports = []corev1.ServicePort{{Port: 443}}
-
-		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
-	})
-
-	t.Run("update when service stops matching", func(t *testing.T) {
-		oldSvc := oidcIssuerLoadBalancerService()
-		newSvc := oldSvc.DeepCopy()
-		newSvc.Spec.Type = corev1.ServiceTypeClusterIP
-
-		require.True(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
-	})
-
-	t.Run("ignore update when neither service is a candidate", func(t *testing.T) {
-		oldSvc := oidcIssuerLoadBalancerService()
-		oldSvc.Status.LoadBalancer.Ingress = nil
-		newSvc := oldSvc.DeepCopy()
-		newSvc.Labels = map[string]string{"changed": "true"}
-
-		require.False(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
-	})
-
-	t.Run("ignore unrelated update", func(t *testing.T) {
-		oldSvc := oidcIssuerLoadBalancerService()
-		newSvc := oldSvc.DeepCopy()
-		newSvc.Labels = map[string]string{"changed": "true"}
-
-		require.False(t, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
-	})
-
-	t.Run("delete matching service", func(t *testing.T) {
-		require.True(t, predicate.Delete(event.DeleteEvent{Object: oidcIssuerLoadBalancerService()}))
-	})
-
-	t.Run("ignore generic event", func(t *testing.T) {
-		require.False(t, predicate.Generic(event.GenericEvent{Object: oidcIssuerLoadBalancerService()}))
-	})
+			require.Equal(t, tt.expected, predicate.Update(event.UpdateEvent{ObjectOld: oldSvc, ObjectNew: newSvc}))
+		})
+	}
 }
 
 func TestEnqueueClustersForOIDCIssuerLoadBalancerService(t *testing.T) {
 	ctx := context.Background()
 
-	objects := []ctrlruntimeclient.Object{
-		clusterWithNetworkPolicy("legacy-oidc", "cluster-legacy-oidc", "dc-a", func(cluster *kubermaticv1.Cluster) {
-			cluster.Spec.OIDC.IssuerURL = "https://issuer.example.com" //nolint:staticcheck
-		}),
-		clusterWithNetworkPolicy("cluster-auth", "cluster-auth", "dc-a", func(cluster *kubermaticv1.Cluster) {
-			cluster.Spec.AuthenticationConfiguration = &kubermaticv1.AuthenticationConfiguration{
-				SecretName: "auth-config",
-				SecretKey:  "config.yaml",
-			}
-		}),
-		clusterWithNetworkPolicy("dc-auth", "cluster-dc-auth", "dc-auth", nil),
-		clusterWithNetworkPolicy("no-oidc", "cluster-no-oidc", "dc-a", nil),
-		&kubermaticv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "no-network-policy",
+	tests := []struct {
+		name          string
+		objects       []ctrlruntimeclient.Object
+		seedGetter    func() (*kubermaticv1.Seed, error)
+		oidcIssuerURL string
+		features      Features
+		expected      []reconcile.Request
+	}{
+		{
+			name: "enqueue OIDC candidates",
+			objects: []ctrlruntimeclient.Object{
+				clusterWithNetworkPolicy("legacy-oidc", "cluster-legacy-oidc", "dc-a", func(cluster *kubermaticv1.Cluster) {
+					cluster.Spec.OIDC.IssuerURL = "https://issuer.example.com" //nolint:staticcheck
+				}),
+				clusterWithNetworkPolicy("cluster-auth", "cluster-auth", "dc-a", func(cluster *kubermaticv1.Cluster) {
+					cluster.Spec.AuthenticationConfiguration = &kubermaticv1.AuthenticationConfiguration{
+						SecretName: "auth-config",
+						SecretKey:  "config.yaml",
+					}
+				}),
+				clusterWithNetworkPolicy("dc-auth", "cluster-dc-auth", "dc-auth", nil),
+				clusterWithNetworkPolicy("no-oidc", "cluster-no-oidc", "dc-a", nil),
+				&kubermaticv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "no-network-policy",
+					},
+					Spec: kubermaticv1.ClusterSpec{
+						Features: map[string]bool{},
+					},
+					Status: kubermaticv1.ClusterStatus{
+						NamespaceName: "cluster-no-network-policy",
+					},
+				},
 			},
-			Spec: kubermaticv1.ClusterSpec{
-				Features: map[string]bool{},
-			},
-			Status: kubermaticv1.ClusterStatus{
-				NamespaceName: "cluster-no-network-policy",
-			},
-		},
-	}
-
-	r := &Reconciler{
-		Client: fake.NewClientBuilder().WithObjects(objects...).Build(),
-		seedGetter: func() (*kubermaticv1.Seed, error) {
-			return &kubermaticv1.Seed{
-				Spec: kubermaticv1.SeedSpec{
-					Datacenters: map[string]kubermaticv1.Datacenter{
-						"dc-auth": {
-							Spec: kubermaticv1.DatacenterSpec{
-								AuthenticationConfiguration: &kubermaticv1.AuthenticationConfiguration{
-									SecretName: "dc-auth-config",
-									SecretKey:  "config.yaml",
+			seedGetter: func() (*kubermaticv1.Seed, error) {
+				return &kubermaticv1.Seed{
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							"dc-auth": {
+								Spec: kubermaticv1.DatacenterSpec{
+									AuthenticationConfiguration: &kubermaticv1.AuthenticationConfiguration{
+										SecretName: "dc-auth-config",
+										SecretKey:  "config.yaml",
+									},
 								},
 							},
 						},
 					},
-				},
-			}, nil
+				}, nil
+			},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "cluster-auth"}},
+				{NamespacedName: types.NamespacedName{Name: "dc-auth"}},
+				{NamespacedName: types.NamespacedName{Name: "legacy-oidc"}},
+			},
+		},
+		{
+			name:          "enqueue cluster using default issuer",
+			objects:       []ctrlruntimeclient.Object{clusterWithNetworkPolicy("default-issuer", "cluster-default-issuer", "dc-a", nil)},
+			oidcIssuerURL: "https://issuer.example.com",
+			features: Features{
+				KubernetesOIDCAuthentication: true,
+			},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "default-issuer"}},
+			},
+		},
+		{
+			name:    "enqueue network policy clusters when seed is unavailable",
+			objects: []ctrlruntimeclient.Object{clusterWithNetworkPolicy("candidate", "cluster-candidate", "dc-a", nil)},
+			seedGetter: func() (*kubermaticv1.Seed, error) {
+				return nil, errors.New("seed unavailable")
+			},
+			expected: []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: "candidate"}},
+			},
 		},
 	}
 
-	requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				Client:        fake.NewClientBuilder().WithObjects(tt.objects...).Build(),
+				seedGetter:    tt.seedGetter,
+				oidcIssuerURL: tt.oidcIssuerURL,
+				features:      tt.features,
+			}
 
-	require.Equal(t, []reconcile.Request{
-		{NamespacedName: types.NamespacedName{Name: "cluster-auth"}},
-		{NamespacedName: types.NamespacedName{Name: "dc-auth"}},
-		{NamespacedName: types.NamespacedName{Name: "legacy-oidc"}},
-	}, requests)
-}
+			requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
 
-func TestEnqueueClustersForOIDCIssuerLoadBalancerServiceWithDefaultIssuer(t *testing.T) {
-	ctx := context.Background()
-
-	cluster := clusterWithNetworkPolicy("default-issuer", "cluster-default-issuer", "dc-a", nil)
-	r := &Reconciler{
-		Client:        fake.NewClientBuilder().WithObjects(cluster).Build(),
-		oidcIssuerURL: "https://issuer.example.com",
-		features: Features{
-			KubernetesOIDCAuthentication: true,
-		},
+			require.Equal(t, tt.expected, requests)
+		})
 	}
-
-	requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
-
-	require.Equal(t, []reconcile.Request{
-		{NamespacedName: types.NamespacedName{Name: "default-issuer"}},
-	}, requests)
-}
-
-func TestEnqueueClustersForOIDCIssuerLoadBalancerServiceWithUnavailableSeed(t *testing.T) {
-	ctx := context.Background()
-
-	cluster := clusterWithNetworkPolicy("candidate", "cluster-candidate", "dc-a", nil)
-	r := &Reconciler{
-		Client: fake.NewClientBuilder().WithObjects(cluster).Build(),
-		seedGetter: func() (*kubermaticv1.Seed, error) {
-			return nil, errors.New("seed unavailable")
-		},
-	}
-
-	requests := r.enqueueClustersForOIDCIssuerLoadBalancerService(ctx, oidcIssuerLoadBalancerService())
-
-	require.Equal(t, []reconcile.Request{
-		{NamespacedName: types.NamespacedName{Name: "candidate"}},
-	}, requests)
 }
 
 func clusterWithNetworkPolicy(name, namespace, datacenter string, mutate func(*kubermaticv1.Cluster)) *kubermaticv1.Cluster {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -18,6 +18,7 @@ package kubernetes
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -1470,19 +1471,10 @@ func urlsToOIDCIssuerDestinationsWithResolver(ctx context.Context, urls []string
 
 	destinations := make([]oidcIssuerDestination, 0, len(destinationKeys))
 	for _, key := range slices.SortedFunc(maps.Keys(destinationKeys), func(a, b oidcIssuerDestinationKey) int {
-		if a.hostname < b.hostname {
-			return -1
+		if result := cmp.Compare(a.hostname, b.hostname); result != 0 {
+			return result
 		}
-		if a.hostname > b.hostname {
-			return 1
-		}
-		if a.port < b.port {
-			return -1
-		}
-		if a.port > b.port {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a.port, b.port)
 	}) {
 		destinations = append(destinations, oidcIssuerDestination{
 			hostname: key.hostname,

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -68,6 +68,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
@@ -744,10 +746,11 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			)
 		}
 
-		// allow egress traffic to OIDC issuer's external IPs
+		// Resolve OIDC issuer destinations for the legacy IPBlock rule and
+		// optional selector-backed LoadBalancer backend peers.
 		oidcDestinations, err := oidcIssuerDestinations(resolverCtx, c, data, r.features.KubernetesOIDCAuthentication)
 		if err != nil {
-			return fmt.Errorf("failed to fetch OIDC issuer IPs: %w", err)
+			return fmt.Errorf("failed to fetch OIDC issuer destinations: %w", err)
 		}
 		oidcIPs := oidcIssuerDestinationIPs(oidcDestinations)
 
@@ -810,6 +813,8 @@ type oidcIssuerDestinationKey struct {
 	hostname string
 	port     int32
 }
+
+type oidcIssuerDestinationPortLookup map[string]sets.Set[int32]
 
 type hostnameResolver func(context.Context, string) ([]net.IP, error)
 
@@ -899,7 +904,7 @@ func (r *Reconciler) oidcIssuerLoadBalancerBackendPeers(ctx context.Context, des
 
 	for i := range services.Items {
 		svc := &services.Items[i]
-		if !oidcIssuerLoadBalancerServiceMatchesDestination(svc, destinationIPs, destinationHostnames) {
+		if !oidcIssuerLoadBalancerServiceMatchesIssuerDestination(svc, destinationIPs, destinationHostnames) {
 			continue
 		}
 		if len(svc.Spec.Selector) == 0 {
@@ -932,9 +937,9 @@ func (r *Reconciler) oidcIssuerLoadBalancerBackendPeers(ctx context.Context, des
 	return peers, nil
 }
 
-func oidcIssuerDestinationLookups(destinations []oidcIssuerDestination) (map[string]map[int32]struct{}, map[string]map[int32]struct{}) {
-	ips := make(map[string]map[int32]struct{}, len(destinations))
-	hostnames := make(map[string]map[int32]struct{}, len(destinations))
+func oidcIssuerDestinationLookups(destinations []oidcIssuerDestination) (oidcIssuerDestinationPortLookup, oidcIssuerDestinationPortLookup) {
+	ips := make(oidcIssuerDestinationPortLookup, len(destinations))
+	hostnames := make(oidcIssuerDestinationPortLookup, len(destinations))
 
 	for _, destination := range destinations {
 		if destination.hostname != "" {
@@ -955,26 +960,20 @@ func oidcIssuerDestinationLookups(destinations []oidcIssuerDestination) (map[str
 	return ips, hostnames
 }
 
-func addOIDCIssuerDestinationLookup(lookups map[string]map[int32]struct{}, key string, port int32) {
+func addOIDCIssuerDestinationLookup(lookups oidcIssuerDestinationPortLookup, key string, port int32) {
 	if key == "" || port <= 0 {
 		return
 	}
 
 	ports, exists := lookups[key]
 	if !exists {
-		ports = map[int32]struct{}{}
+		ports = sets.New[int32]()
 		lookups[key] = ports
 	}
-	ports[port] = struct{}{}
+	ports.Insert(port)
 }
 
-func oidcIssuerLoadBalancerServiceMatches(svc *corev1.Service, destinationIPs, destinationHostnames map[string]map[int32]struct{}) bool {
-	// Only selector-backed LoadBalancer Services can be represented as
-	// NetworkPolicy pod peers.
-	return len(svc.Spec.Selector) > 0 && oidcIssuerLoadBalancerServiceMatchesDestination(svc, destinationIPs, destinationHostnames)
-}
-
-func oidcIssuerLoadBalancerServiceMatchesDestination(svc *corev1.Service, destinationIPs, destinationHostnames map[string]map[int32]struct{}) bool {
+func oidcIssuerLoadBalancerServiceMatchesIssuerDestination(svc *corev1.Service, destinationIPs, destinationHostnames oidcIssuerDestinationPortLookup) bool {
 	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 		return false
 	}
@@ -1017,18 +1016,18 @@ func oidcIssuerLoadBalancerServiceMatchesDestination(svc *corev1.Service, destin
 	return false
 }
 
-func loadBalancerServicePorts(svc *corev1.Service) map[int32]struct{} {
-	ports := make(map[int32]struct{}, len(svc.Spec.Ports))
+func loadBalancerServicePorts(svc *corev1.Service) sets.Set[int32] {
+	ports := sets.New[int32]()
 	for _, port := range svc.Spec.Ports {
 		if port.Port > 0 && (port.Protocol == "" || port.Protocol == corev1.ProtocolTCP) {
-			ports[port.Port] = struct{}{}
+			ports.Insert(port.Port)
 		}
 	}
 
 	return ports
 }
 
-func servicePortsMatchAnyDestination(servicePorts map[int32]struct{}, destinationLookups ...map[string]map[int32]struct{}) bool {
+func servicePortsMatchAnyDestination(servicePorts sets.Set[int32], destinationLookups ...oidcIssuerDestinationPortLookup) bool {
 	for _, lookups := range destinationLookups {
 		for _, destinationPorts := range lookups {
 			if servicePortsMatch(servicePorts, destinationPorts) {
@@ -1040,9 +1039,9 @@ func servicePortsMatchAnyDestination(servicePorts map[int32]struct{}, destinatio
 	return false
 }
 
-func servicePortsMatch(servicePorts, destinationPorts map[int32]struct{}) bool {
+func servicePortsMatch(servicePorts, destinationPorts sets.Set[int32]) bool {
 	for port := range destinationPorts {
-		if _, exists := servicePorts[port]; exists {
+		if servicePorts.Has(port) {
 			return true
 		}
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -829,7 +829,7 @@ const networkPolicyHostnameResolutionTimeout = 10 * time.Second
 
 // oidcIssuerDestinations returns the resolved OIDC issuer destination configured for the cluster.
 func oidcIssuerDestinations(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData, enableOIDCAuthentication bool) ([]oidcIssuerDestination, error) {
-	issuerURL := c.Spec.OIDC.IssuerURL //nolint:staticcheck
+	issuerURL := c.Spec.OIDC.IssuerURL
 	if issuerURL == "" && enableOIDCAuthentication {
 		issuerURL = data.OIDCIssuerURL()
 	}

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -67,6 +67,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -816,6 +817,11 @@ type oidcIssuerDestinationKey struct {
 
 type oidcIssuerDestinationPortLookup map[string]sets.Set[int32]
 
+type serviceNetworkPolicyPeerKey struct {
+	namespace string
+	selector  string
+}
+
 type hostnameResolver func(context.Context, string) ([]net.IP, error)
 
 const networkPolicyHostnameResolutionTimeout = 10 * time.Second
@@ -900,7 +906,7 @@ func (r *Reconciler) oidcIssuerLoadBalancerBackendPeers(ctx context.Context, des
 	})
 
 	peers := []networkingv1.NetworkPolicyPeer{}
-	seenPeers := map[string]struct{}{}
+	seenPeers := map[serviceNetworkPolicyPeerKey]struct{}{}
 
 	for i := range services.Items {
 		svc := &services.Items[i]
@@ -916,7 +922,7 @@ func (r *Reconciler) oidcIssuerLoadBalancerBackendPeers(ctx context.Context, des
 
 		// Shared external VIPs can match more than one Service on the same port.
 		// Keep all matching backend selectors; each peer remains namespace/pod-scoped.
-		peerKey := serviceNetworkPolicyPeerKey(svc.Namespace, svc.Spec.Selector)
+		peerKey := newServiceNetworkPolicyPeerKey(svc.Namespace, svc.Spec.Selector)
 		if _, exists := seenPeers[peerKey]; exists {
 			continue
 		}
@@ -1049,13 +1055,11 @@ func servicePortsMatch(servicePorts, destinationPorts sets.Set[int32]) bool {
 	return false
 }
 
-func serviceNetworkPolicyPeerKey(namespace string, selector map[string]string) string {
-	parts := []string{namespace}
-	for _, key := range slices.Sorted(maps.Keys(selector)) {
-		parts = append(parts, key+"="+selector[key])
+func newServiceNetworkPolicyPeerKey(namespace string, selector map[string]string) serviceNetworkPolicyPeerKey {
+	return serviceNetworkPolicyPeerKey{
+		namespace: namespace,
+		selector:  labels.FormatLabels(selector),
 	}
-
-	return strings.Join(parts, "\x00")
 }
 
 // GetConfigMapReconcilers returns all ConfigMapReconcilers that are currently in use.

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -72,6 +72,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
 	certutil "k8s.io/client-go/util/cert"
@@ -1488,8 +1489,8 @@ func urlsToOIDCIssuerDestinationsWithResolver(ctx context.Context, urls []string
 
 func oidcIssuerURLPort(u *url.URL) (int32, error) {
 	if port := u.Port(); port != "" {
-		parsedPort, err := strconv.ParseInt(port, 10, 32)
-		if err != nil || parsedPort < 1 || parsedPort > 65535 {
+		parsedPort, err := strconv.Atoi(port)
+		if err != nil || len(validation.IsValidPortNum(parsedPort)) > 0 {
 			return 0, fmt.Errorf("invalid port %q", port)
 		}
 		return int32(parsedPort), nil

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -70,7 +70,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -20,9 +20,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
+	"slices"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -727,8 +731,8 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			apiserver.KyvernoWebhookAllowReconciler(c),
 		}
 
-		// one shared limited context for all hostname resolutions
-		resolverCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		// one shared limited context for required hostname resolutions
+		resolverCtx, cancel := context.WithTimeout(ctx, networkPolicyHostnameResolutionTimeout)
 		defer cancel()
 
 		if data.IsKonnectivityEnabled() {
@@ -740,24 +744,12 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			)
 		}
 
-		issuerURL := c.Spec.OIDC.IssuerURL
-		if issuerURL == "" && r.features.KubernetesOIDCAuthentication {
-			issuerURL = data.OIDCIssuerURL()
+		// allow egress traffic to OIDC issuer's external IPs
+		oidcDestinations, err := oidcIssuerDestinations(resolverCtx, c, data, r.features.KubernetesOIDCAuthentication)
+		if err != nil {
+			return fmt.Errorf("failed to fetch OIDC issuer IPs: %w", err)
 		}
-
-		if issuerURL != "" {
-			u, err := url.Parse(issuerURL)
-			if err != nil {
-				return fmt.Errorf("failed to parse OIDC issuer URL %q: %w", issuerURL, err)
-			}
-
-			// allow egress traffic to OIDC issuer's external IPs
-			ipList, err := hostnameToIPList(resolverCtx, u.Hostname())
-			if err != nil {
-				return fmt.Errorf("failed to resolve OIDC issuer URL %q: %w", issuerURL, err)
-			}
-			namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.OIDCIssuerAllowReconciler(ipList, cfg.Spec.Ingress.NamespaceOverride))
-		}
+		oidcIPs := oidcIssuerDestinationIPs(oidcDestinations)
 
 		if c.Spec.IsWebhookAuthorizationEnabled() {
 			webhookURL, err := r.extractAuthorizationWebhookURL(ctx, c)
@@ -786,12 +778,285 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 
 		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.SeedApiserverAllowReconciler(apiIPs))
 
+		if len(oidcIPs) > 0 {
+			// Match optional LoadBalancer backend peers after required DNS lookups.
+			// This must not perform additional DNS resolution during Service matching.
+			loadBalancerBackendPeers, err := r.oidcIssuerLoadBalancerBackendPeers(ctx, oidcDestinations)
+			if err != nil {
+				return fmt.Errorf("failed to fetch OIDC issuer LoadBalancer backend peers: %w", err)
+			}
+			if len(loadBalancerBackendPeers) == 0 && r.log != nil {
+				r.log.Debugw("No OIDC issuer LoadBalancer Service backends matched", "cluster", c.Name)
+			}
+
+			namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.OIDCIssuerAllowReconciler(oidcIPs, loadBalancerBackendPeers, cfg.Spec.Ingress.NamespaceOverride))
+		}
+
 		if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, c.Status.NamespaceName, r); err != nil {
 			return fmt.Errorf("failed to ensure Network Policies: %w", err)
 		}
 	}
 
 	return nil
+}
+
+type oidcIssuerDestination struct {
+	hostname string
+	port     int32
+	ips      []net.IP
+}
+
+type oidcIssuerDestinationKey struct {
+	hostname string
+	port     int32
+}
+
+type hostnameResolver func(context.Context, string) ([]net.IP, error)
+
+const networkPolicyHostnameResolutionTimeout = 10 * time.Second
+
+// oidcIssuerDestinations returns the resolved OIDC issuer destination configured for the cluster.
+func oidcIssuerDestinations(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData, enableOIDCAuthentication bool) ([]oidcIssuerDestination, error) {
+	issuerURL := c.Spec.OIDC.IssuerURL //nolint:staticcheck
+	if issuerURL == "" && enableOIDCAuthentication {
+		issuerURL = data.OIDCIssuerURL()
+	}
+
+	if issuerURL == "" {
+		return nil, nil
+	}
+
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OIDC issuer URL %q: %w", issuerURL, err)
+	}
+	issuerPort, err := oidcIssuerURLPort(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OIDC issuer URL %q: %w", issuerURL, err)
+	}
+
+	// resolve OIDC issuer IPs
+	ipList, err := hostnameToIPList(ctx, u.Hostname())
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve OIDC issuer URL %q: %w", issuerURL, err)
+	}
+
+	return []oidcIssuerDestination{
+		{
+			hostname: normalizeHostname(u.Hostname()),
+			port:     issuerPort,
+			ips:      ipList,
+		},
+	}, nil
+}
+
+func oidcIssuerDestinationIPs(destinations []oidcIssuerDestination) []net.IP {
+	ipList := make([]net.IP, 0, len(destinations))
+	ipSet := make(map[string]struct{}, len(destinations))
+
+	for _, destination := range destinations {
+		for _, ip := range destination.ips {
+			if ip == nil {
+				continue
+			}
+
+			if _, exists := ipSet[ip.String()]; !exists {
+				ipSet[ip.String()] = struct{}{}
+				ipList = append(ipList, ip)
+			}
+		}
+	}
+
+	return ipList
+}
+
+func (r *Reconciler) oidcIssuerLoadBalancerBackendPeers(ctx context.Context, destinations []oidcIssuerDestination) ([]networkingv1.NetworkPolicyPeer, error) {
+	if len(destinations) == 0 {
+		return nil, nil
+	}
+
+	destinationIPs, destinationHostnames := oidcIssuerDestinationLookups(destinations)
+	if len(destinationIPs) == 0 && len(destinationHostnames) == 0 {
+		return nil, nil
+	}
+
+	// This is intentionally a cache-backed linear scan for now. If this becomes
+	// hot on large seeds, we can add an index for LoadBalancer ingress values.
+	services := &corev1.ServiceList{}
+	if err := r.List(ctx, services); err != nil {
+		return nil, fmt.Errorf("failed to list Services: %w", err)
+	}
+
+	sort.Slice(services.Items, func(i, j int) bool {
+		if services.Items[i].Namespace != services.Items[j].Namespace {
+			return services.Items[i].Namespace < services.Items[j].Namespace
+		}
+		return services.Items[i].Name < services.Items[j].Name
+	})
+
+	peers := []networkingv1.NetworkPolicyPeer{}
+	seenPeers := map[string]struct{}{}
+
+	for i := range services.Items {
+		svc := &services.Items[i]
+		if !oidcIssuerLoadBalancerServiceMatchesDestination(svc, destinationIPs, destinationHostnames) {
+			continue
+		}
+		if len(svc.Spec.Selector) == 0 {
+			if r.log != nil {
+				r.log.Debugw("Skipping selector-less OIDC issuer LoadBalancer Service backend", "namespace", svc.Namespace, "service", svc.Name)
+			}
+			continue
+		}
+
+		// Shared external VIPs can match more than one Service on the same port.
+		// Keep all matching backend selectors; each peer remains namespace/pod-scoped.
+		peerKey := serviceNetworkPolicyPeerKey(svc.Namespace, svc.Spec.Selector)
+		if _, exists := seenPeers[peerKey]; exists {
+			continue
+		}
+		seenPeers[peerKey] = struct{}{}
+
+		peers = append(peers, networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					corev1.LabelMetadataName: svc.Namespace,
+				},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: maps.Clone(svc.Spec.Selector),
+			},
+		})
+	}
+
+	return peers, nil
+}
+
+func oidcIssuerDestinationLookups(destinations []oidcIssuerDestination) (map[string]map[int32]struct{}, map[string]map[int32]struct{}) {
+	ips := make(map[string]map[int32]struct{}, len(destinations))
+	hostnames := make(map[string]map[int32]struct{}, len(destinations))
+
+	for _, destination := range destinations {
+		if destination.hostname != "" {
+			if ip := net.ParseIP(destination.hostname); ip != nil {
+				addOIDCIssuerDestinationLookup(ips, ip.String(), destination.port)
+			} else {
+				addOIDCIssuerDestinationLookup(hostnames, normalizeHostname(destination.hostname), destination.port)
+			}
+		}
+
+		for _, ip := range destination.ips {
+			if ip != nil {
+				addOIDCIssuerDestinationLookup(ips, ip.String(), destination.port)
+			}
+		}
+	}
+
+	return ips, hostnames
+}
+
+func addOIDCIssuerDestinationLookup(lookups map[string]map[int32]struct{}, key string, port int32) {
+	if key == "" || port <= 0 {
+		return
+	}
+
+	ports, exists := lookups[key]
+	if !exists {
+		ports = map[int32]struct{}{}
+		lookups[key] = ports
+	}
+	ports[port] = struct{}{}
+}
+
+func oidcIssuerLoadBalancerServiceMatches(svc *corev1.Service, destinationIPs, destinationHostnames map[string]map[int32]struct{}) bool {
+	// Only selector-backed LoadBalancer Services can be represented as
+	// NetworkPolicy pod peers.
+	return len(svc.Spec.Selector) > 0 && oidcIssuerLoadBalancerServiceMatchesDestination(svc, destinationIPs, destinationHostnames)
+}
+
+func oidcIssuerLoadBalancerServiceMatchesDestination(svc *corev1.Service, destinationIPs, destinationHostnames map[string]map[int32]struct{}) bool {
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return false
+	}
+
+	servicePorts := loadBalancerServicePorts(svc)
+	if len(servicePorts) == 0 {
+		return false
+	}
+	// Match the issuer URL port against the Service port. The generated policy
+	// intentionally does not restrict the translated backend targetPort.
+	if !servicePortsMatchAnyDestination(servicePorts, destinationIPs, destinationHostnames) {
+		return false
+	}
+
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" {
+			if ip := net.ParseIP(ingress.IP); ip != nil {
+				if ports, exists := destinationIPs[ip.String()]; exists && servicePortsMatch(servicePorts, ports) {
+					return true
+				}
+			}
+		}
+
+		if ingress.Hostname != "" {
+			if ip := net.ParseIP(ingress.Hostname); ip != nil {
+				if ports, exists := destinationIPs[ip.String()]; exists && servicePortsMatch(servicePorts, ports) {
+					return true
+				}
+			}
+
+			// Hostname ingress matching is best-effort by name only. We do not
+			// resolve Service LoadBalancer hostnames during reconciliation.
+			hostname := normalizeHostname(ingress.Hostname)
+			if ports, exists := destinationHostnames[hostname]; exists && servicePortsMatch(servicePorts, ports) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func loadBalancerServicePorts(svc *corev1.Service) map[int32]struct{} {
+	ports := make(map[int32]struct{}, len(svc.Spec.Ports))
+	for _, port := range svc.Spec.Ports {
+		if port.Port > 0 && (port.Protocol == "" || port.Protocol == corev1.ProtocolTCP) {
+			ports[port.Port] = struct{}{}
+		}
+	}
+
+	return ports
+}
+
+func servicePortsMatchAnyDestination(servicePorts map[int32]struct{}, destinationLookups ...map[string]map[int32]struct{}) bool {
+	for _, lookups := range destinationLookups {
+		for _, destinationPorts := range lookups {
+			if servicePortsMatch(servicePorts, destinationPorts) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func servicePortsMatch(servicePorts, destinationPorts map[int32]struct{}) bool {
+	for port := range destinationPorts {
+		if _, exists := servicePorts[port]; exists {
+			return true
+		}
+	}
+
+	return false
+}
+
+func serviceNetworkPolicyPeerKey(namespace string, selector map[string]string) string {
+	parts := []string{namespace}
+	for _, key := range slices.Sorted(maps.Keys(selector)) {
+		parts = append(parts, key+"="+selector[key])
+	}
+
+	return strings.Join(parts, "\x00")
 }
 
 // GetConfigMapReconcilers returns all ConfigMapReconcilers that are currently in use.
@@ -1161,6 +1426,87 @@ func (r *Reconciler) listAPIServerAlternateNames(ctx context.Context, cluster *k
 	}, nil
 }
 
+func urlsToOIDCIssuerDestinations(ctx context.Context, urls []string) ([]oidcIssuerDestination, error) {
+	return urlsToOIDCIssuerDestinationsWithResolver(ctx, urls, hostnameToIPList)
+}
+
+func urlsToOIDCIssuerDestinationsWithResolver(ctx context.Context, urls []string, resolve hostnameResolver) ([]oidcIssuerDestination, error) {
+	hostnames := make(map[string]string, len(urls))
+	destinationKeys := make(map[oidcIssuerDestinationKey]struct{}, len(urls))
+	for _, u := range urls {
+		parsedURL, err := url.Parse(u)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
+		}
+		port, err := oidcIssuerURLPort(parsedURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URL %q: %w", u, err)
+		}
+
+		lookupHostname := parsedURL.Hostname()
+		normalizedHostname := normalizeHostname(lookupHostname)
+		existingLookupHostname, exists := hostnames[normalizedHostname]
+		if !exists || (!strings.HasSuffix(existingLookupHostname, ".") && strings.HasSuffix(lookupHostname, ".")) {
+			hostnames[normalizedHostname] = lookupHostname
+		}
+		destinationKeys[oidcIssuerDestinationKey{
+			hostname: normalizedHostname,
+			port:     port,
+		}] = struct{}{}
+	}
+
+	resolvedHostnames := make(map[string][]net.IP, len(hostnames))
+	for _, hostname := range slices.Sorted(maps.Keys(hostnames)) {
+		lookupHostname := hostnames[hostname]
+		hostIPs, err := resolve(ctx, lookupHostname)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve hostname %q: %w", lookupHostname, err)
+		}
+		resolvedHostnames[hostname] = hostIPs
+	}
+
+	destinations := make([]oidcIssuerDestination, 0, len(destinationKeys))
+	for _, key := range slices.SortedFunc(maps.Keys(destinationKeys), func(a, b oidcIssuerDestinationKey) int {
+		if a.hostname < b.hostname {
+			return -1
+		}
+		if a.hostname > b.hostname {
+			return 1
+		}
+		if a.port < b.port {
+			return -1
+		}
+		if a.port > b.port {
+			return 1
+		}
+		return 0
+	}) {
+		destinations = append(destinations, oidcIssuerDestination{
+			hostname: key.hostname,
+			port:     key.port,
+			ips:      resolvedHostnames[key.hostname],
+		})
+	}
+
+	return destinations, nil
+}
+
+func oidcIssuerURLPort(u *url.URL) (int32, error) {
+	if port := u.Port(); port != "" {
+		parsedPort, err := strconv.ParseInt(port, 10, 32)
+		if err != nil || parsedPort < 1 || parsedPort > 65535 {
+			return 0, fmt.Errorf("invalid port %q", port)
+		}
+		return int32(parsedPort), nil
+	}
+
+	if strings.EqualFold(u.Scheme, "http") {
+		return 80, nil
+	}
+
+	return 443, nil
+}
+
 // hostnameToIPList returns a list of IP addresses used to reach the provided hostname.
 // If it is an IP address, returns it. If it is a domain name, resolves it.
 // The returned list of IPs is always sorted to produce the same result on each resolution attempt.
@@ -1185,6 +1531,10 @@ func hostnameToIPList(ctx context.Context, hostname string) ([]net.IP, error) {
 	})
 
 	return ipList, nil
+}
+
+func normalizeHostname(hostname string) string {
+	return strings.TrimSuffix(strings.ToLower(hostname), ".")
 }
 
 func (r *Reconciler) ensureAuditWebhook(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -18,7 +18,10 @@ package kubernetes
 
 import (
 	"context"
+	"net"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -30,8 +33,10 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestCloudControllerManagerDeployment(t *testing.T) {
@@ -366,4 +371,379 @@ func (k KCMDeploymentConfig) Create(td *resources.TemplateData) *appsv1.Deployme
 	}
 	d.Spec.Template, _ = apiserver.IsRunningWrapper(td, d.Spec.Template, sets.New(resources.ControllerManagerDeploymentName))
 	return &d
+}
+
+func TestOIDCIssuerLoadBalancerBackendPeers(t *testing.T) {
+	ctx := context.Background()
+
+	objects := []ctrlruntimeclient.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "issuer-gateway",
+				Namespace: "tenant-a",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-a",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 443},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "issuer-gateway-duplicate",
+				Namespace: "tenant-a",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-a",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 443},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "issuer-hostname",
+				Namespace: "tenant-b",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-b",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 443},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{Hostname: "oidc.example.com"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-ip",
+				Namespace: "tenant-c",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-c",
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-ip-unrelated-port",
+				Namespace: "tenant-c",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-c",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 80},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-ip-udp-issuer-port",
+				Namespace: "tenant-c",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-c-udp",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 443, Protocol: corev1.ProtocolUDP},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-ip-sctp-issuer-port",
+				Namespace: "tenant-c",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-c-sctp",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 443, Protocol: corev1.ProtocolSCTP},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "missing-selector",
+				Namespace: "tenant-d",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{Port: 443},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "10.10.45.0"},
+					},
+				},
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unrelated",
+				Namespace: "tenant-e",
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Selector: map[string]string{
+					"app.kubernetes.io/name": "tenant-e",
+				},
+				Ports: []corev1.ServicePort{
+					{Port: 443},
+				},
+			},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{
+						{IP: "192.0.2.1"},
+					},
+				},
+			},
+		},
+	}
+
+	r := &Reconciler{
+		Client: fake.NewClientBuilder().WithObjects(objects...).Build(),
+	}
+
+	peers, err := r.oidcIssuerLoadBalancerBackendPeers(ctx, []oidcIssuerDestination{
+		{
+			hostname: "issuer.example.com",
+			port:     443,
+			ips: []net.IP{
+				net.ParseIP("10.10.45.0"),
+			},
+		},
+		{
+			hostname: "oidc.example.com",
+			port:     443,
+			ips: []net.IP{
+				net.ParseIP("203.0.113.10"),
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []networkingv1.NetworkPolicyPeer{
+		{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					corev1.LabelMetadataName: "tenant-a",
+				},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": "tenant-a",
+				},
+			},
+		},
+		{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					corev1.LabelMetadataName: "tenant-b",
+				},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name": "tenant-b",
+				},
+			},
+		},
+	}, peers)
+}
+
+func TestURLsToOIDCIssuerDestinationsPreservesAbsoluteHostnameLookup(t *testing.T) {
+	ctx := context.Background()
+	resolvedHostnames := []string{}
+
+	destinations, err := urlsToOIDCIssuerDestinationsWithResolver(
+		ctx,
+		[]string{
+			"https://issuer.example.com/path-a",
+			"https://Issuer.Example.com./path-b",
+		},
+		func(ctx context.Context, hostname string) ([]net.IP, error) {
+			resolvedHostnames = append(resolvedHostnames, hostname)
+			return []net.IP{net.ParseIP("198.51.100.25")}, nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"Issuer.Example.com."}, resolvedHostnames)
+	require.Equal(t, []oidcIssuerDestination{
+		{
+			hostname: "issuer.example.com",
+			port:     443,
+			ips: []net.IP{
+				net.ParseIP("198.51.100.25"),
+			},
+		},
+	}, destinations)
+}
+
+func TestURLsToOIDCIssuerDestinations(t *testing.T) {
+	tests := []struct {
+		name                 string
+		urls                 []string
+		expectedDestinations []oidcIssuerDestination
+		expectError          string
+	}{
+		{
+			name: "deduplicates repeated hosts",
+			urls: []string{
+				"https://10.10.10.10/path-a",
+				"https://10.10.10.10/path-b",
+				"https://20.20.20.20",
+			},
+			expectedDestinations: []oidcIssuerDestination{
+				{
+					hostname: "10.10.10.10",
+					port:     443,
+					ips: []net.IP{
+						net.ParseIP("10.10.10.10"),
+					},
+				},
+				{
+					hostname: "20.20.20.20",
+					port:     443,
+					ips: []net.IP{
+						net.ParseIP("20.20.20.20"),
+					},
+				},
+			},
+		},
+		{
+			name: "supports ipv6 hosts",
+			urls: []string{
+				"https://[2001:db8::1]",
+				"https://[2001:db8::2]",
+			},
+			expectedDestinations: []oidcIssuerDestination{
+				{
+					hostname: "2001:db8::1",
+					port:     443,
+					ips: []net.IP{
+						net.ParseIP("2001:db8::1"),
+					},
+				},
+				{
+					hostname: "2001:db8::2",
+					port:     443,
+					ips: []net.IP{
+						net.ParseIP("2001:db8::2"),
+					},
+				},
+			},
+		},
+		{
+			name: "keeps explicit ports distinct",
+			urls: []string{
+				"https://10.10.10.10",
+				"https://10.10.10.10:8443",
+			},
+			expectedDestinations: []oidcIssuerDestination{
+				{
+					hostname: "10.10.10.10",
+					port:     443,
+					ips: []net.IP{
+						net.ParseIP("10.10.10.10"),
+					},
+				},
+				{
+					hostname: "10.10.10.10",
+					port:     8443,
+					ips: []net.IP{
+						net.ParseIP("10.10.10.10"),
+					},
+				},
+			},
+		},
+		{
+			name:        "invalid URL returns error",
+			urls:        []string{"://not-a-url"},
+			expectError: "failed to parse URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destinations, err := urlsToOIDCIssuerDestinations(context.Background(), tt.urls)
+			if tt.expectError != "" {
+				require.ErrorContains(t, err, tt.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedDestinations, destinations)
+		})
+	}
 }

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -326,7 +326,7 @@ func ApiserverInternalAllowReconciler() reconciling.NamedNetworkPolicyReconciler
 }
 
 // OIDCIssuerAllowReconciler returns a func to create/update the apiserver oidc-issuer-allow egress policy.
-func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) reconciling.NamedNetworkPolicyReconcilerFactory {
+func OIDCIssuerAllowReconciler(egressIPs []net.IP, loadBalancerBackendPeers []networkingv1.NetworkPolicyPeer, namespaceOverride string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		ingressNamespace := stackscommon.NginxIngressControllerNamespace
 		if namespaceOverride != "" {
@@ -342,6 +342,12 @@ func OIDCIssuerAllowReconciler(egressIPs []net.IP, namespaceOverride string) rec
 				{
 					To: ipListToPeers(egressIPs),
 				},
+			}
+
+			if len(loadBalancerBackendPeers) > 0 {
+				egressRules = append(egressRules, networkingv1.NetworkPolicyEgressRule{
+					To: loadBalancerBackendPeers,
+				})
 			}
 
 			for _, ns := range ingressNamespaces {

--- a/pkg/resources/apiserver/networkpolicy_test.go
+++ b/pkg/resources/apiserver/networkpolicy_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	stackscommon "k8c.io/kubermatic/v2/pkg/install/stack/common"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestOIDCIssuerAllowReconciler(t *testing.T) {
+	loadBalancerBackendPeer := networkingv1.NetworkPolicyPeer{
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				corev1.LabelMetadataName: "tenant-a",
+			},
+		},
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "tenant-a",
+			},
+		},
+	}
+
+	policyName, reconciler := OIDCIssuerAllowReconciler(
+		[]net.IP{net.ParseIP("10.10.45.0")},
+		[]networkingv1.NetworkPolicyPeer{loadBalancerBackendPeer},
+		"",
+	)()
+	require.Equal(t, resources.NetworkPolicyOIDCIssuerAllow, policyName)
+
+	networkPolicy, err := reconciler(&networkingv1.NetworkPolicy{})
+	require.NoError(t, err)
+
+	require.Equal(t, networkingv1.NetworkPolicySpec{
+		PolicyTypes: []networkingv1.PolicyType{
+			networkingv1.PolicyTypeEgress,
+		},
+		PodSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				resources.AppLabelKey: name,
+			},
+		},
+		Egress: []networkingv1.NetworkPolicyEgressRule{
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "10.10.45.0/32",
+						},
+					},
+				},
+			},
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					loadBalancerBackendPeer,
+				},
+			},
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								corev1.LabelMetadataName: stackscommon.NginxIngressControllerNamespace,
+							},
+						},
+					},
+				},
+			},
+			{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								corev1.LabelMetadataName: stackscommon.EnvoyGatewayControllerNamespace,
+							},
+						},
+					},
+				},
+			},
+		},
+	}, networkPolicy.Spec)
+}

--- a/pkg/resources/apiserver/networkpolicy_test.go
+++ b/pkg/resources/apiserver/networkpolicy_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is a manual backport of #16014, which fixes #15939.

The automatic backport failed because of #15740, which added AuthenticationConfiguration support and changed the OIDC issuer resolution logic, so the fix had to be adapted manually for release/v2.30.

/assign adoi

```release-note
Fixed apiserver OIDC issuer NetworkPolicies for OIDC issuers exposed through selector backed seed side LoadBalancer Services, like KubeLB, when the CNI enforces egress against translated backend pod identities.
```