### PR TITLE
Pull KubeVirt conformance test image from quay 

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	kubevirtImageHTTPServerSvc      = "http://image-repo.kube-system.svc/images"
+	kubevirtUbuntuImage             = "docker://quay.io/kubermatic-virt-disks/ubuntu:24.04-amd64"
 	kubevirtVCPUs                   = 2
 	kubevirtMemory                  = "4Gi"
 	kubevirtDiskSize                = "25Gi"
@@ -110,7 +110,7 @@ func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secret
 func (s *kubevirtScenario) getOSImage() (string, error) {
 	switch s.operatingSystem {
 	case providerconfig.OperatingSystemUbuntu:
-		return kubevirtImageHTTPServerSvc + "/ubuntu-22.04.img", nil
+		return kubevirtUbuntuImage, nil
 	default:
 		return "", fmt.Errorf("unsupported OS %q selected", s.operatingSystem)
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

The conformance-tester hardcoded the Ubuntu disk image to http://image-repo.kube-system.svc/images/ubuntu-22.04.img, which requires an in-cluster image server that is not present in all test environments and fails DNS resolution otherwise. Point it at the quay docker source instead.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
