### PR TITLE
Fix the KubeVirt LB tests

### DIFF
--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -114,6 +114,11 @@ func mergeServiceAnnotations(traceability map[string]string, cluster *kubermatic
 		ann[awsAdditionalTagsKey] = awsAdditionalResourceTags(traceability)
 	}
 
+	if cluster.Spec.Cloud.Kubevirt != nil {
+		ann["metallb.io/allow-shared-ip"] = "true"
+		ann["metallb.io/loadBalancerIPs"] = "91.98.176.168"
+	}
+
 	return ann
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that when we run the tests for KubeV, we choose the right IP Pool and IP address to connect to during the testing as the KubeV staging env has multiple pools and not all of them are public. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
None
```
