### PR TITLE
Add in-cluster LB/PV cleanup finalizers in e2e ClusterJig to stop clo…

### DIFF
--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -27,6 +27,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/sdk/v2/semver"
 	"k8c.io/kubermatic/v2/pkg/cluster/client"
+	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -302,6 +303,16 @@ func (j *ClusterJig) Create(ctx context.Context, waitForHealthy bool) (*kubermat
 		if err = j.WaitForHealthyControlPlane(ctx, 5*time.Minute); err != nil {
 			return nil, fmt.Errorf("failed to wait for cluster to become healthy: %w", err)
 		}
+	}
+
+	// opt into KKP deleting user-cluster LoadBalancer and PVC resources on
+	// cluster deletion. Without these finalizers the clusterdeletion controller
+	// skips in-cluster LB/PV cleanup, which leaks cloud LBs for tests that
+	// install type=LoadBalancer services (e.g. ingress-nginx via apps).
+	if err := kuberneteshelper.TryAddFinalizer(ctx, j.client,
+		&kubermaticv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: j.clusterName}},
+		kubermaticv1.InClusterLBCleanupFinalizer, kubermaticv1.InClusterPVCleanupFinalizer); err != nil {
+		return nil, fmt.Errorf("failed to add in-cluster LB/PV cleanup finalizers: %w", err)
 	}
 
 	if err := j.installAddons(ctx); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The e2e `ClusterJig` misses `InClusterLBCleanupFinalizer` / `InClusterPVCleanupFinalizer` to the clusters it creates. Those finalizers are opt-in; KKP seed controllers do not add them, so `clusterdeletion.cleanupInClusterResources` skips in-cluster LB/PV cleanup when they are missing. Tests that install a `type=LoadBalancer` service (cilium and canal install ingress-nginx via an `ApplicationInstallation` - that's a bit tricky) leaked the cloud load balancer on cleanup: the user-cluster service was never deleted, the namespace went away, and the AWS ELB stayed. This adds the finalizers in `ClusterJig.Create` via `TryAddFinalizer`, the same approach the conformance-tester uses.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
