### PR TITLE
Add workflow to publish cis benchmark report

### DIFF
--- a/.github/workflows/cis-bench-trigger.yml
+++ b/.github/workflows/cis-bench-trigger.yml
@@ -1,0 +1,86 @@
+name: CIS Bench Trigger
+
+# Fires when a kubermatic issue is opened or labeled with `cis-bench-request`.
+# Parses the issue body for KKP version + Kubernetes versions and dispatches
+# the `cis-bench-run` event to kubermatic/conformance-ee, which runs the CIS
+# conformance suite and reports results back as comments + (on failure) a
+# follow-up issue here.
+#
+# Expected issue body format:
+#
+#   ## CIS-BENCH-REQUEST
+#   kkp-version: 2.30.0
+#   k8s-versions: 1.32.0,1.33.0
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  dispatch:
+    if: contains(github.event.issue.labels.*.name, 'cis-bench-request')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Parse issue body
+        id: parse
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json body --jq '.body')
+          ISSUE_BODY=${ISSUE_BODY//$'\r'/}
+
+          extract() {
+            echo "$ISSUE_BODY" | grep -E "^$1: " | head -1 | sed "s/^$1: *//"
+          }
+
+          KKP_VERSION=$(extract "kkp-version")
+          K8S_VERSIONS=$(extract "k8s-versions")
+
+          if [ -z "$KKP_VERSION" ] || [ -z "$K8S_VERSIONS" ]; then
+            echo "Missing kkp-version or k8s-versions in issue body — aborting"
+            exit 1
+          fi
+
+          echo "kkp_version=${KKP_VERSION}"   >> "$GITHUB_OUTPUT"
+          echo "k8s_versions=${K8S_VERSIONS}" >> "$GITHUB_OUTPUT"
+          echo "Parsed: kkp=${KKP_VERSION}, k8s=${K8S_VERSIONS}"
+
+      - name: Acknowledge on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          KKP_VERSION:  ${{ steps.parse.outputs.kkp_version }}
+          K8S_VERSIONS: ${{ steps.parse.outputs.k8s_versions }}
+          RUN_URL: ${{ github.server_url }}/kubermatic/conformance-ee/actions/workflows/cis-bench-run.yml
+        run: |
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "🛡️ CIS benchmark requested.
+
+          | Field | Value |
+          |-------|-------|
+          | **KKP version** | \`${KKP_VERSION}\` |
+          | **Kubernetes versions** | \`${K8S_VERSIONS}\` |
+          | **Runner** | [kubermatic/conformance-ee — cis-bench-run](${RUN_URL}) |
+
+          Dispatching to \`kubermatic/conformance-ee\`. Results will be posted as comments here when the run completes. A failure-tracking issue will be opened automatically if any control fails."
+
+      - name: Dispatch cis-bench-run
+        env:
+          GH_TOKEN: ${{ secrets.KKP_CONFORMANCE_CROSS_GH_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          KKP_VERSION:  ${{ steps.parse.outputs.kkp_version }}
+          K8S_VERSIONS: ${{ steps.parse.outputs.k8s_versions }}
+        run: |
+          gh api /repos/kubermatic/conformance-ee/dispatches -X POST \
+            -F event_type=cis-bench-run \
+            -F "client_payload[kkpVersion]=${KKP_VERSION}" \
+            -F "client_payload[k8sVersions]=${K8S_VERSIONS}" \
+            -F "client_payload[triggerIssueNumber]=${ISSUE_NUMBER}" \
+            -F "client_payload[triggerIssueRepo]=${{ github.repository }}"
+          echo "Dispatched cis-bench-run for kkp=${KKP_VERSION}, k8s=${K8S_VERSIONS}, issue=#${ISSUE_NUMBER}"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds `.github/workflows/cis-bench-trigger.yml` that fires when an issue is opened or labeled with `cis-bench-request`. The workflow parses the issue body for the requested KKP version and Kubernetes versions, posts an acknowledgement comment on the same issue, and dispatches a `cis-bench-run` `repository_dispatch` event to `kubermatic/conformance-ee` so the CIS Kubernetes Benchmark conformance suite executes there. Results (per-k8s status comments, failure-tracking issues, and the docs PR link) is commented back in the original issue.  

- Expected issue body shape:
```
CIS-BENCH-REQUEST

  kkp-version: 2.30.0
  k8s-versions: 1.34.5,1.33.5
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
ref #15692 , https://github.com/kubermatic/conformance-ee/pull/63

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a workflow to publish cis benchmark report based on kkp and k8s version mentioned in the issue with label `cis-bench-request`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
