### PR TITLE
Mirror Cilium 1.17.17, 1.18.11, and 1.19.5 charts to Kubermatic mirror

### DIFF
--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -55,7 +55,7 @@ declare -A CHART_URLS=(
 # Default versions for each chart
 declare -A CHART_VERSIONS=(
   ["cluster-autoscaler"]="9.46.6"
-  ["cilium"]="1.19.4"
+  ["cilium"]="1.19.5"
   # Add more default versions here as needed
   ["aikit"]="0.18.0"
   ["argo-cd"]="8.0.0"
@@ -82,7 +82,7 @@ declare -A CHART_VERSIONS=(
 # above. Values are comma-separated version lists. This is consumed by the
 # postsubmit wrapper; direct script callers can still pass explicit versions.
 declare -A CHART_ADDITIONAL_VERSIONS=(
-  ["cilium"]="1.17.16"
+  ["cilium"]="1.17.17,1.18.11"
 )
 
 # Re-enable unset variable checking after array declarations


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Cilium mirror configuration so the latest maintained Cilium patches are mirrored to the Kubermatic mirror registry: `1.17.17`, `1.18.11`, and `1.19.5`. These will be needed for us to add as extra supported versions in KKP with the new KKP minor.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #15808 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
