### PR TITLE
apply kubevirt netpol first when apiserver ip is available

### DIFF
--- a/pkg/ee/kubevirt-network-controller/controller.go
+++ b/pkg/ee/kubevirt-network-controller/controller.go
@@ -27,6 +27,7 @@ package kubevirtnetworkcontroller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -57,6 +58,12 @@ const (
 	NetworkPolicyPodSelectorLabel = "kubermatic.k8c.io/cluster-id"
 	NetworkPolicyCleanupFinalizer = "kubermatic.k8c.io/cleanup-kubevirt-infra-network-policy"
 )
+
+// clusterIPUnknownRetryTimeout mirrors the retry timeout used in the seed-controller-manager's
+// kubernetes controller (see pkg/controller/seed-controller-manager/kubernetes/resources.go) for the
+// same reason: the apiserver address is only known once a LoadBalancer/NodePort address has been
+// allocated, which can take a moment after cluster creation.
+const clusterIPUnknownRetryTimeout = 5 * time.Second
 
 type Reconciler struct {
 	ctrlruntimeclient.Client
@@ -195,8 +202,19 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, kube
 
 	switch dc.ProviderNetwork.NetworkPolicy.Mode {
 	case kubermaticv1.NetworkPolicyModeDeny:
+		// The apiserver address is only populated once the control plane's LoadBalancer/NodePort address
+		// has been allocated. Reconciling before that happens would create the NetworkPolicy without the
+		// apiserver rule, only to update it again a moment later, so wait until the address is known.
+		if cluster.Status.Address.IP == "" && cluster.Spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling {
+			log.Debugf("Cluster IP address not known yet, retrying in %s", clusterIPUnknownRetryTimeout)
+			return &reconcile.Result{RequeueAfter: clusterIPUnknownRetryTimeout}, nil
+		}
 		log.Debug("Setting up cluster-isolation NetworkPolicy for the tenant cluster in default deny mode")
-		if err := reconcileNamespacedClusterIsolationNetworkPolicyDefaultDeny(ctx, kubeVirtInfraClient, cluster, dc.NamespacedMode.Namespace, dc.DNSConfig.Nameservers); err != nil {
+		var nameservers []string
+		if dc.DNSConfig != nil {
+			nameservers = dc.DNSConfig.Nameservers
+		}
+		if err := reconcileNamespacedClusterIsolationNetworkPolicyDefaultDeny(ctx, kubeVirtInfraClient, cluster, dc.NamespacedMode.Namespace, nameservers); err != nil {
 			return &reconcile.Result{}, err
 		}
 	case kubermaticv1.NetworkPolicyModeAllow:

--- a/pkg/ee/kubevirt-network-controller/controller_test.go
+++ b/pkg/ee/kubevirt-network-controller/controller_test.go
@@ -61,6 +61,7 @@ func TestReconcile(t *testing.T) {
 		seedGetter                 func() (*kubermaticv1.Seed, error)
 		wantErr                    error
 		wantNetPolicy              *networkingv1.NetworkPolicy
+		wantRequeue                bool
 	}{
 		{
 			name:        "scenario 1: reconcile with network policy feature enabled in default allow mode",
@@ -282,6 +283,166 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:        "scenario 2b: reconcile with network policy feature enabled in default deny mode before the apiserver address is populated",
+			requestName: clusterName,
+			seedClient: fake.
+				NewClientBuilder().
+				WithObjects(generator.GenDefaultProject(), generator.GenCluster(clusterName, clusterName, "projectName", time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC), func(cluster *kubermaticv1.Cluster) {
+					cluster.Spec.Cloud.DatacenterName = datacenterName
+					// The apiserver address is only populated once the control plane has been initialized.
+					cluster.Status.Address.IP = ""
+				})).
+				Build(),
+			seedGetter: func() (*kubermaticv1.Seed, error) {
+				return &kubermaticv1.Seed{
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							datacenterName: {
+								Country:  "D",
+								Location: "Hamburg",
+								Spec: kubermaticv1.DatacenterSpec{
+									Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+										NamespacedMode: &kubermaticv1.NamespacedMode{
+											Enabled:   true,
+											Namespace: "test",
+										},
+										DNSConfig: &corev1.PodDNSConfig{
+											Nameservers: []string{"1.1.1.1"},
+										},
+										ProviderNetwork: &kubermaticv1.ProviderNetwork{
+											Name:                 "test",
+											NetworkPolicyEnabled: true,
+											NetworkPolicy: &kubermaticv1.NetworkPolicy{
+												Enabled: true,
+												Mode:    kubermaticv1.NetworkPolicyModeDeny,
+											},
+											VPCs: []kubermaticv1.VPC{
+												{
+													Name: "dev",
+													Subnets: []kubermaticv1.Subnet{
+														{Name: "subnet-1"}, {Name: "subnet-2"},
+													},
+												},
+											},
+										},
+									},
+									RequiredEmails: []string{"example.com"},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			// Reconciliation should wait until the apiserver address is known rather than create a
+			// NetworkPolicy without the apiserver rule.
+			wantNetPolicy: nil,
+			wantRequeue:   true,
+		},
+		{
+			// Regression test: DNSConfig is optional (omitempty) on DatacenterSpecKubevirt, so
+			// reconciling in default deny mode must not panic with a nil pointer dereference when
+			// it's unset, and should simply produce a NetworkPolicy without a nameserver egress rule.
+			name:        "scenario 2c: reconcile with network policy feature enabled in default deny mode without DNSConfig configured",
+			requestName: clusterName,
+			seedClient: fake.
+				NewClientBuilder().
+				WithObjects(generator.GenDefaultProject(), generator.GenCluster(clusterName, clusterName, "projectName", time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC), func(cluster *kubermaticv1.Cluster) {
+					cluster.Spec.Cloud.DatacenterName = datacenterName
+				})).
+				Build(),
+			seedGetter: func() (*kubermaticv1.Seed, error) {
+				return &kubermaticv1.Seed{
+					Spec: kubermaticv1.SeedSpec{
+						Datacenters: map[string]kubermaticv1.Datacenter{
+							datacenterName: {
+								Country:  "D",
+								Location: "Hamburg",
+								Spec: kubermaticv1.DatacenterSpec{
+									Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+										NamespacedMode: &kubermaticv1.NamespacedMode{
+											Enabled:   true,
+											Namespace: "test",
+										},
+										ProviderNetwork: &kubermaticv1.ProviderNetwork{
+											Name:                 "test",
+											NetworkPolicyEnabled: true,
+											NetworkPolicy: &kubermaticv1.NetworkPolicy{
+												Enabled: true,
+												Mode:    kubermaticv1.NetworkPolicyModeDeny,
+											},
+											VPCs: []kubermaticv1.VPC{
+												{
+													Name: "dev",
+													Subnets: []kubermaticv1.Subnet{
+														{Name: "subnet-1"}, {Name: "subnet-2"},
+													},
+												},
+											},
+										},
+									},
+									RequiredEmails: []string{"example.com"},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+			wantNetPolicy: &networkingv1.NetworkPolicy{
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							NetworkPolicyPodSelectorLabel: clusterName,
+						},
+					},
+					Egress: []networkingv1.NetworkPolicyEgressRule{
+						{
+							Ports: []networkingv1.NetworkPolicyPort{},
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											NetworkPolicyPodSelectorLabel: clusterName,
+										},
+									},
+								},
+							},
+						},
+						{
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "35.194.142.199/32",
+									},
+								},
+							},
+						},
+					},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{
+						{
+							From: []networkingv1.NetworkPolicyPeer{
+								{
+									PodSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											NetworkPolicyPodSelectorLabel: clusterName,
+										},
+									},
+								},
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "35.194.142.199/32",
+									},
+								},
+							},
+						},
+					},
+					PolicyTypes: []networkingv1.PolicyType{
+						networkingv1.PolicyTypeEgress,
+						networkingv1.PolicyTypeIngress,
+					},
+				},
+			},
+		},
+		{
 			name:        "scenario 3: reconcile with network policy feature disabled",
 			requestName: clusterName,
 			seedClient: fake.
@@ -425,9 +586,13 @@ func TestReconcile(t *testing.T) {
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
-			_, err := r.Reconcile(ctx, request)
+			result, err := r.Reconcile(ctx, request)
 			if !errors.Is(tc.wantErr, err) {
 				t.Fatalf("unexpected error occurred: %v, want error: %v", err, tc.wantErr)
+			}
+
+			if tc.wantRequeue && result.RequeueAfter == 0 {
+				t.Fatalf("expected reconciliation to be requeued, but got: %+v", result)
 			}
 
 			currentNetPol := &networkingv1.NetworkPolicy{}

--- a/pkg/ee/kubevirt-network-controller/network_policy.go
+++ b/pkg/ee/kubevirt-network-controller/network_policy.go
@@ -102,6 +102,9 @@ func namespacedClusterIsolationNetworkPolicyDefaultAllowReconciler(clusterName s
 // namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler creates a network policy that restrict Egress traffic between clusters deployed in the namespaced mode within the same VPC network.
 func namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler(cluster *kubermaticv1.Cluster, nameservers []string) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
+		// The apiserver address is only populated once the control plane has been initialized. Until then we must
+		// not emit an IPBlock for it, since an empty address would result in an invalid "/32" CIDR being rejected
+		// by the apiserver. The policy gets updated with the apiserver rules once the address becomes available.
 		apiserverAddress := cluster.Status.Address.IP
 		return fmt.Sprintf("cluster-isolation-%s", cluster.Name), func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -127,15 +130,6 @@ func namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler(cluster *kuber
 							},
 						},
 					},
-					{
-						To: []networkingv1.NetworkPolicyPeer{
-							{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", apiserverAddress),
-								},
-							},
-						},
-					},
 				},
 				Ingress: []networkingv1.NetworkPolicyIngressRule{
 					{
@@ -147,16 +141,33 @@ func namespacedClusterIsolationNetworkPolicyDefaultDenyReconciler(cluster *kuber
 									},
 								},
 							},
-							{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: fmt.Sprintf("%s/32", apiserverAddress),
-								},
-							},
 						},
 					},
 				},
 			}
+
+			if apiserverAddress != "" {
+				apiserverCIDR := fmt.Sprintf("%s/32", apiserverAddress)
+				np.Spec.Egress = append(np.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							IPBlock: &networkingv1.IPBlock{
+								CIDR: apiserverCIDR,
+							},
+						},
+					},
+				})
+				np.Spec.Ingress[0].From = append(np.Spec.Ingress[0].From, networkingv1.NetworkPolicyPeer{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: apiserverCIDR,
+					},
+				})
+			}
+
 			for _, nameserver := range nameservers {
+				if nameserver == "" {
+					continue
+				}
 				np.Spec.Egress = append(np.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
 					To: []networkingv1.NetworkPolicyPeer{
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:

When cluster isolation is enabled in default-deny mode for a namespaced KubeVirt datacenter, the `kubevirt-network-controller` had two bugs:

1. It built the apiserver `IPBlock` CIDR from `cluster.Status.Address.IP` before that field is populated (it's only set once the control plane's LoadBalancer/NodePort address is allocated). This produced an invalid `"/32"` CIDR, which the apiserver rejects, surfacing as a `Warning`/`ReconcilingError` event on every newly created cluster until the address became available -  a false-positive that caused user confusion and support requests.
2. It unconditionally dereferenced `dc.DNSConfig.Nameservers`, but `DNSConfig` is an optional (`omitempty`) field on `DatacenterSpecKubevirt`. Any datacenter without `dnsConfig` configured caused a nil-pointer panic on every default-deny reconcile, crashing the controller goroutine repeatedly.

Fix:
- Wait (`RequeueAfter`) until `cluster.Status.Address.IP` is known before reconciling the default-deny NetworkPolicy, mirroring the same wait-for-address pattern already used in `pkg/controller/seed-controller-manager/kubernetes/resources.go`.
- Defensively omit the apiserver/nameserver `IPBlock` entries if the address/nameserver strings are still empty, matching the guard pattern already used for subnet gateways in default-allow mode and in `pkg/provider/cloud/kubevirt/network_policy.go`.
- Guard `dc.DNSConfig` for nil before reading `.Nameservers`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15667

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed the kubevirt-network-controller emitting spurious "invalid NetworkPolicy" warning events and potentially panicking when reconciling cluster-isolation NetworkPolicies in default-deny mode before the cluster's apiserver address or DNS configuration were available.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
