### PR TITLE
Add enableImageDiscovery to OpenStack settings

### DIFF
--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -307,10 +307,8 @@ spec:
                       properties:
                         enableImageDiscovery:
                           description: |-
-                            EnableImageDiscovery will make the dashboard dynamically discover and list the images
-                            available to the OpenStack project (identified by their os_distro metadata) in the
-                            image dropdown. If disabled, the dropdown only offers the default images configured
-                            in the datacenter. Disabled by default.
+                            EnableImageDiscovery enables listing the OpenStack project's images (matched by their
+                            os_distro metadata) in the dashboard's image dropdown.
                           type: boolean
                         enforceCustomDisk:
                           description: EnforceCustomDisk will enforce the custom disk option for machines for the dashboard.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -305,6 +305,13 @@ spec:
                     openStack:
                       description: OpenStack are the configurations for openstack provider.
                       properties:
+                        enableImageDiscovery:
+                          description: |-
+                            EnableImageDiscovery will make the dashboard dynamically discover and list the images
+                            available to the OpenStack project (identified by their os_distro metadata) in the
+                            image dropdown. If disabled, the dropdown only offers the default images configured
+                            in the datacenter. Disabled by default.
+                          type: boolean
                         enforceCustomDisk:
                           description: EnforceCustomDisk will enforce the custom disk option for machines for the dashboard.
                           type: boolean

--- a/sdk/apis/kubermatic/v1/settings.go
+++ b/sdk/apis/kubermatic/v1/settings.go
@@ -231,6 +231,12 @@ type WebTerminalOptions struct {
 type OpenStack struct {
 	// EnforceCustomDisk will enforce the custom disk option for machines for the dashboard.
 	EnforceCustomDisk bool `json:"enforceCustomDisk,omitempty"`
+
+	// EnableImageDiscovery will make the dashboard dynamically discover and list the images
+	// available to the OpenStack project (identified by their os_distro metadata) in the
+	// image dropdown. If disabled, the dropdown only offers the default images configured
+	// in the datacenter. Disabled by default.
+	EnableImageDiscovery bool `json:"enableImageDiscovery,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=DHCP;POOL

--- a/sdk/apis/kubermatic/v1/settings.go
+++ b/sdk/apis/kubermatic/v1/settings.go
@@ -232,10 +232,8 @@ type OpenStack struct {
 	// EnforceCustomDisk will enforce the custom disk option for machines for the dashboard.
 	EnforceCustomDisk bool `json:"enforceCustomDisk,omitempty"`
 
-	// EnableImageDiscovery will make the dashboard dynamically discover and list the images
-	// available to the OpenStack project (identified by their os_distro metadata) in the
-	// image dropdown. If disabled, the dropdown only offers the default images configured
-	// in the datacenter. Disabled by default.
+	// EnableImageDiscovery enables listing the OpenStack project's images (matched by their
+	// os_distro metadata) in the dashboard's image dropdown.
 	EnableImageDiscovery bool `json:"enableImageDiscovery,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an enableImageDiscovery option to OpenStack settings so the dashboard can list project-scoped OpenStack images.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref: https://github.com/kubermatic/dashboard/issues/3024

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:



**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add enableImageDiscovery option to OpenStack settings for listing project-scoped images in the dashboard.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
