### PR TITLE
WIP: add list-images subcommand and -c/--concurrency for helm charts

### DIFF
--- a/cmd/kubermatic-installer/cmd_list_images.go
+++ b/cmd/kubermatic-installer/cmd_list_images.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8c.io/kubermatic/v2/pkg/install/images"
+	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type ListImagesOptions struct {
+	Options
+	ImageCollectionOptions
+
+	Format string
+}
+
+const (
+	formatPlain = "plain"
+	formatJSON  = "json"
+)
+
+func ListImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *cobra.Command {
+	opt := ListImagesOptions{
+		ImageCollectionOptions: ImageCollectionOptions{
+			HelmTimeout: 5 * time.Minute,
+			HelmBinary:  "helm",
+		},
+		Format: formatPlain,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list-images",
+		Short: "List all container images and OCI Helm chart references used by KKP",
+		Long: `Lists every container image and OCI Helm chart reference that KKP would deploy,
+without mirroring anything. The output goes to stdout (one ref per line by default),
+progress and diagnostic logs go to stderr.
+
+Discovery works by rendering the same deployments, addons, Helm charts and
+applications that mirror-images uses, so the list is best-effort complete for the
+code paths exercised with the given configuration and defaults; it is not a
+guaranteed exhaustive inventory.
+
+Network access is required: application charts are always downloaded, and vendored
+charts under --charts-directory fetch their dependencies unless they are packaged
+(tgz) with the dependencies bundled. When --addons-path is set, the addons Docker
+image is not pulled. Runtime is dominated by chart downloads and rendering and is
+typically measured in minutes, not seconds.
+
+Use --format json to get per-image source attribution (reconciler, addon, chart,
+application, etc.) and to distinguish container images from OCI Helm chart refs.`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			options.CopyInto(&opt.Options)
+
+			if opt.Config == "" {
+				opt.Config = os.Getenv("CONFIG_YAML")
+			}
+
+			if opt.HelmValuesFile == "" {
+				opt.HelmValuesFile = os.Getenv("HELM_VALUES")
+			}
+
+			if opt.HelmBinary == "" {
+				opt.HelmBinary = os.Getenv("HELM_BINARY")
+			}
+
+			opt.Versions = versions
+		},
+
+		RunE:         ListImagesFunc(logger, versions, &opt),
+		SilenceUsage: true,
+	}
+
+	cmd.PersistentFlags().StringVar(&opt.Config, "config", "", "Path to the KubermaticConfiguration YAML file")
+	cmd.PersistentFlags().StringVar(&opt.VersionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
+	cmd.PersistentFlags().StringArrayVar(&opt.ProviderFilter, "provider-filter", nil, fmt.Sprintf("Cloud providers to list images for. Valid values are: %s. Can be specified multiple times. If not specified, images for all providers will be listed", strings.Join(allSupportedProviderNames(), ", ")))
+	cmd.PersistentFlags().StringVar(&opt.RegistryPrefix, "registry-prefix", "", "Check source registries against this prefix and only include images that match it")
+	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides and tag suffixes in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that the development-only dockerTag override is still observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
+
+	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image and avoids pulling the addons Docker image")
+	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
+
+	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
+	cmd.PersistentFlags().StringVar(&opt.HelmValuesFile, "helm-values", "", "Use this values.yaml when rendering Helm charts")
+	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "Helm 3.x or 4.x binary to use for rendering charts")
+
+	cmd.PersistentFlags().IntVarP(&opt.Concurrency, "concurrency", "c", defaultHelmConcurrency(), "Number of Helm charts to render in parallel. Set to 1 for the historical sequential behavior. Chart dependency registration is serialized internally, so this is safe for concurrent helm repo add.")
+
+	cmd.PersistentFlags().StringVar(&opt.Format, "format", opt.Format, fmt.Sprintf("Output format. Supported formats: %q (one ref per line on stdout), %q (array of objects with ref, type and sources)", formatPlain, formatJSON))
+
+	return cmd
+}
+
+func ListImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions, options *ListImagesOptions) cobraFuncE {
+	return handleErrors(logger, func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		if err := validateListImagesFormat(options.Format); err != nil {
+			return err
+		}
+
+		collection, err := collectAllImages(ctx, logger, versions, &options.ImageCollectionOptions, options.ChartsDirectory)
+		if err != nil {
+			return err
+		}
+
+		return printCollection(cmd.OutOrStdout(), collection, options.Format)
+	})
+}
+
+func validateListImagesFormat(format string) error {
+	switch format {
+	case formatPlain, formatJSON:
+		return nil
+	default:
+		return fmt.Errorf("invalid --format %q, supported formats are %q and %q", format, formatPlain, formatJSON)
+	}
+}
+
+// printCollection writes the collection to out in the requested format. plain
+// emits one ref per line with no decoration; json emits a deterministically
+// ordered array of {ref, type, sources} objects.
+func printCollection(out io.Writer, collection *images.Collection, format string) error {
+	switch format {
+	case formatPlain:
+		for _, ref := range collection.RefList() {
+			if _, err := fmt.Fprintln(out, ref); err != nil {
+				return fmt.Errorf("failed to write output: %w", err)
+			}
+		}
+		return nil
+	case formatJSON:
+		entries := collection.Sorted()
+		output := make([]listImageEntry, 0, len(entries))
+		for _, entry := range entries {
+			sources := sets.List(entry.Sources)
+			if len(sources) == 0 {
+				sources = nil
+			}
+			output = append(output, listImageEntry{
+				Ref:     entry.Ref,
+				Type:    string(entry.Type),
+				Sources: sources,
+			})
+		}
+
+		encoder := json.NewEncoder(out)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(output); err != nil {
+			return fmt.Errorf("failed to write JSON output: %w", err)
+		}
+		return nil
+	default:
+		// format is validated before collection runs; reaching here is a programming error
+		return fmt.Errorf("unsupported format %q", format)
+	}
+}
+
+// listImageEntry is the JSON representation of a single collected ref.
+type listImageEntry struct {
+	Ref     string   `json:"ref"`
+	Type    string   `json:"type"`
+	Sources []string `json:"sources"`
+}

--- a/cmd/kubermatic-installer/cmd_list_images_test.go
+++ b/cmd/kubermatic-installer/cmd_list_images_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"k8c.io/kubermatic/v2/pkg/install/images"
+)
+
+func TestValidateListImagesFormat(t *testing.T) {
+	testCases := []struct {
+		format    string
+		expectErr bool
+	}{
+		{format: "plain", expectErr: false},
+		{format: "json", expectErr: false},
+		{format: "", expectErr: true},
+		{format: "yaml", expectErr: true},
+		{format: "PLAIN", expectErr: true},
+		{format: "csv", expectErr: true},
+	}
+
+	for _, tc := range testCases {
+		err := validateListImagesFormat(tc.format)
+		if tc.expectErr && err == nil {
+			t.Errorf("format %q expected an error, got nil", tc.format)
+		}
+		if !tc.expectErr && err != nil {
+			t.Errorf("format %q expected no error, got %v", tc.format, err)
+		}
+	}
+}
+
+func newTestCollection() *images.Collection {
+	c := images.NewCollection()
+	c.Insert("docker.io/nginxinc/nginx-unprivileged:1.20.1-alpine", images.RefTypeImage, "reconciler:mla-gateway")
+	c.Insert("quay.io/kubermatic-mirror/helm-charts/cilium:1.18.10", images.RefTypeHelmChart, "application:cilium@1.18.10")
+	// shared ref discovered by two sources, exercising dedup + source merging
+	c.Insert("registry.example/shared:1.0", images.RefTypeImage, "reconciler:foo")
+	c.Insert("registry.example/shared:1.0", images.RefTypeImage, "addon:bar")
+	return c
+}
+
+func TestPrintCollectionPlain(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printCollection(&buf, newTestCollection(), formatPlain); err != nil {
+		t.Fatalf("printCollection failed: %v", err)
+	}
+
+	// plain output: sorted refs, one per line, nothing else
+	want := strings.Join([]string{
+		"docker.io/nginxinc/nginx-unprivileged:1.20.1-alpine",
+		"quay.io/kubermatic-mirror/helm-charts/cilium:1.18.10",
+		"registry.example/shared:1.0",
+	}, "\n") + "\n"
+
+	if got := buf.String(); got != want {
+		t.Errorf("plain output mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPrintCollectionJSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printCollection(&buf, newTestCollection(), formatJSON); err != nil {
+		t.Fatalf("printCollection failed: %v", err)
+	}
+
+	var entries []listImageEntry
+	if err := json.Unmarshal(buf.Bytes(), &entries); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw:\n%s", err, buf.String())
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// every entry must have a ref, a type and at least one source
+	for _, e := range entries {
+		if e.Ref == "" {
+			t.Errorf("entry with empty ref: %+v", e)
+		}
+		if e.Type == "" {
+			t.Errorf("entry %q has empty type", e.Ref)
+		}
+		if len(e.Sources) == 0 {
+			t.Errorf("entry %q has no sources", e.Ref)
+		}
+	}
+
+	// refs are emitted sorted; assert the ordering the consumers rely on
+	refs := []string{entries[0].Ref, entries[1].Ref, entries[2].Ref}
+	wantRefs := []string{
+		"docker.io/nginxinc/nginx-unprivileged:1.20.1-alpine",
+		"quay.io/kubermatic-mirror/helm-charts/cilium:1.18.10",
+		"registry.example/shared:1.0",
+	}
+	for i := range wantRefs {
+		if refs[i] != wantRefs[i] {
+			t.Errorf("entry %d ref = %q, want %q", i, refs[i], wantRefs[i])
+		}
+	}
+
+	// the helm-chart entry keeps its type
+	if entries[1].Type != string(images.RefTypeHelmChart) {
+		t.Errorf("cilium entry type = %q, want %q", entries[1].Type, images.RefTypeHelmChart)
+	}
+
+	// the shared entry merged both sources
+	if entries[2].Ref != "registry.example/shared:1.0" {
+		t.Fatalf("expected shared entry at index 2, got %q", entries[2].Ref)
+	}
+	wantSources := []string{"addon:bar", "reconciler:foo"}
+	if len(entries[2].Sources) != 2 || entries[2].Sources[0] != wantSources[0] || entries[2].Sources[1] != wantSources[1] {
+		t.Errorf("shared entry sources = %v, want %v", entries[2].Sources, wantSources)
+	}
+}
+
+func TestPrintCollectionInvalidFormat(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printCollection(&buf, images.NewCollection(), "bogus"); err == nil {
+		t.Errorf("expected an error for bogus format, got nil")
+	}
+}

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -49,21 +50,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type MirrorImagesOptions struct {
-	Options
-
-	Registry                  string
+// ImageCollectionOptions holds the flags shared between mirror-images and
+// list-images: config loading, version/provider/registry filters, addon source,
+// and helm settings. Mirror/Archive/LoadFrom/DryRun/Insecure stay on
+// MirrorImagesOptions because list-images does not mirror anything.
+type ImageCollectionOptions struct {
 	Config                    string
 	Versions                  kubermaticversion.Versions
 	VersionFilter             string
 	ProviderFilter            []string
 	RegistryPrefix            string
 	IgnoreRepositoryOverrides bool
-	Archive                   bool
-	ArchivePath               string
-	LoadFrom                  string
-	DryRun                    bool
-	Insecure                  bool
 
 	AddonsPath  string
 	AddonsImage string
@@ -71,12 +68,31 @@ type MirrorImagesOptions struct {
 	HelmValuesFile string
 	HelmTimeout    time.Duration
 	HelmBinary     string
+
+	// Concurrency limits parallel Helm chart rendering in the charts loop. 0
+	// means sequential (the historical behavior).
+	Concurrency int
+}
+
+type MirrorImagesOptions struct {
+	Options
+
+	ImageCollectionOptions
+
+	Registry    string
+	Archive     bool
+	ArchivePath string
+	LoadFrom    string
+	DryRun      bool
+	Insecure    bool
 }
 
 func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *cobra.Command {
 	opt := MirrorImagesOptions{
-		HelmTimeout: 5 * time.Minute,
-		HelmBinary:  "helm",
+		ImageCollectionOptions: ImageCollectionOptions{
+			HelmTimeout: 5 * time.Minute,
+			HelmBinary:  "helm",
+		},
 	}
 
 	cmd := &cobra.Command{
@@ -132,14 +148,19 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().StringVar(&opt.HelmValuesFile, "helm-values", "", "Use this values.yaml when rendering Helm charts")
 	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "Helm 3.x or 4.x binary to use for rendering charts")
 
+	cmd.PersistentFlags().IntVarP(&opt.Concurrency, "concurrency", "c", defaultHelmConcurrency(), "Number of Helm charts to render in parallel. Set to 1 for the historical sequential behavior. Chart dependency registration is serialized internally, so this is safe for concurrent helm repo add.")
+
 	return cmd
 }
 
-func getKubermaticConfiguration(options *MirrorImagesOptions) (*kubermaticv1.KubermaticConfiguration, error) {
-	if !options.Archive && options.Registry == "" {
-		return nil, errors.New("no target registry was passed")
-	}
+// defaultHelmConcurrency caps parallel chart rendering at 8 even on many-core
+// hosts: each chart spawns helm subprocesses and pulls dependencies, so an
+// unbounded worker count thrashes the registry and file descriptors.
+func defaultHelmConcurrency() int {
+	return min(runtime.GOMAXPROCS(0), 8)
+}
 
+func getKubermaticConfiguration(options *ImageCollectionOptions) (*kubermaticv1.KubermaticConfiguration, error) {
 	if options.AddonsImage != "" && options.AddonsPath != "" {
 		return nil, errors.New("--addons-image and --addons-path must not be set at the same time")
 	}
@@ -202,7 +223,7 @@ func clearRepositoryOverrides(config *kubermaticv1.KubermaticConfiguration) {
 	config.Spec.UserCluster.Addons.DockerTagSuffix = ""
 }
 
-func getAddonsPath(ctx context.Context, logger *logrus.Logger, options *MirrorImagesOptions, kubermaticConfig *kubermaticv1.KubermaticConfiguration) (string, error) {
+func getAddonsPath(ctx context.Context, logger *logrus.Logger, options *ImageCollectionOptions, kubermaticConfig *kubermaticv1.KubermaticConfiguration) (string, error) {
 	// if no local addons path is given, use the configured addons
 	// Docker image and extract the addons from there
 	addonsImage := options.AddonsImage
@@ -274,8 +295,8 @@ func CollectImageMatrix(
 	caBundle resources.CABundle,
 	registryPrefix string,
 	cloudSpecs []kubermaticv1.CloudSpec,
-) ([]string, error) {
-	var imageList []string
+) (*images.Collection, error) {
+	collection := images.NewCollection()
 	for _, clusterVersion := range clusterVersions {
 		for _, cloudSpec := range cloudSpecs {
 			for _, cniPlugin := range images.GetCNIPlugins() {
@@ -302,11 +323,11 @@ func CollectImageMatrix(
 				if err != nil {
 					return nil, fmt.Errorf("failed to get images: %w", err)
 				}
-				imageList = append(imageList, imagesWithKonnectivity...)
+				collection.Merge(imagesWithKonnectivity)
 			}
 		}
 	}
-	return imageList, nil
+	return collection, nil
 }
 
 func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions, options *MirrorImagesOptions) cobraFuncE {
@@ -329,38 +350,55 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 }
 
 func mirrorImages(ctx context.Context, logger *logrus.Logger, versions kubermaticversion.Versions, options *MirrorImagesOptions, userAgent string) error {
+	if !options.Archive && options.Registry == "" {
+		return errors.New("no target registry was passed")
+	}
+
+	collection, err := collectAllImages(ctx, logger, versions, &options.ImageCollectionOptions, options.ChartsDirectory)
+	if err != nil {
+		return err
+	}
+
+	return archiveOrCopyImages(ctx, logger, collection.RefList(), options, userAgent)
+}
+
+// collectAllImages runs the full discovery pipeline shared by mirror-images and
+// list-images. It never touches a target registry; that concern belongs to the
+// caller. chartsDirectory is passed separately because it lives on the global
+// Options struct rather than on ImageCollectionOptions.
+func collectAllImages(ctx context.Context, logger *logrus.Logger, versions kubermaticversion.Versions, options *ImageCollectionOptions, chartsDirectory string) (*images.Collection, error) {
 	kubermaticConfig, err := getKubermaticConfiguration(options)
 	if err != nil {
-		return fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
+		return nil, fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
 	}
 
 	clusterVersions, err := images.GetVersions(logger, kubermaticConfig, options.VersionFilter)
 	if err != nil {
-		return fmt.Errorf("failed to load versions: %w", err)
+		return nil, fmt.Errorf("failed to load versions: %w", err)
 	}
 
-	caBundle, err := certificates.NewCABundleFromFile(filepath.Join(options.ChartsDirectory, "kubermatic-operator/static/ca-bundle.pem"))
+	caBundle, err := certificates.NewCABundleFromFile(filepath.Join(chartsDirectory, "kubermatic-operator/static/ca-bundle.pem"))
 	if err != nil {
-		return fmt.Errorf("failed to load CA bundle: %w", err)
+		return nil, fmt.Errorf("failed to load CA bundle: %w", err)
 	}
 
 	if options.AddonsPath == "" {
 		options.AddonsPath, err = getAddonsPath(ctx, logger, options, kubermaticConfig)
 		if err != nil {
-			return fmt.Errorf("failed to get addons path: %w", err)
+			return nil, fmt.Errorf("failed to get addons path: %w", err)
 		}
 		defer os.RemoveAll(options.AddonsPath)
 	}
 
 	allAddons, err := addonutil.LoadAddonsFromDirectory(options.AddonsPath)
 	if err != nil {
-		return fmt.Errorf("failed to load addons: %w", err)
+		return nil, fmt.Errorf("failed to load addons: %w", err)
 	}
 
 	// Parse and validate the provider filter
 	providerFilter, err := parseProviderFilter(options.ProviderFilter)
 	if err != nil {
-		return fmt.Errorf("failed to parse provider filter: %w", err)
+		return nil, fmt.Errorf("failed to parse provider filter: %w", err)
 	}
 
 	// Filter cloud specs based on the provider filter
@@ -374,45 +412,42 @@ func mirrorImages(ctx context.Context, logger *logrus.Logger, versions kubermati
 
 	logger.Info("🚀 Collecting images…")
 
-	// Using a set here for deduplication
-	imageSet := sets.New[string]()
+	collection := images.NewCollection()
 
-	imageList, err := CollectImageMatrix(logger, clusterVersions, kubermaticConfig, allAddons, versions, caBundle, options.RegistryPrefix, cloudSpecs)
+	matrixCollection, err := CollectImageMatrix(logger, clusterVersions, kubermaticConfig, allAddons, versions, caBundle, options.RegistryPrefix, cloudSpecs)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	imageSet.Insert(imageList...)
+	collection.Merge(matrixCollection)
 
-	// Populate the imageSet with images specified in the KubermaticConfiguration's MirrorImages field.
-	// This ensures that all required images for mirroring are included in the set for further processing.
-	if len(kubermaticConfig.Spec.MirrorImages) > 0 {
-		imageSet.Insert(kubermaticConfig.Spec.MirrorImages...)
-	}
+	// Add images explicitly listed in the KubermaticConfiguration's MirrorImages field.
+	collection.InsertAll(kubermaticConfig.Spec.MirrorImages, images.RefTypeImage, "config:mirrorImages")
 
 	// if we have a charts directory, we try to render the charts and add the images to our list
-	helmChartImages, err := collectHelmChartImages(ctx, logger, kubermaticConfig, clusterVersions, options)
+	helmChartImages, err := collectHelmChartImages(ctx, logger, kubermaticConfig, clusterVersions, options, chartsDirectory)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	imageSet.Insert(sets.List(helmChartImages)...)
+	collection.Merge(helmChartImages)
 
 	// get images from system and default applications
 	applicationImages, err := collectApplicationImages(logger, kubermaticConfig, options)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	imageSet.Insert(sets.List(applicationImages)...)
+	collection.Merge(applicationImages)
 
 	// finally, add some static images that are not covered by any of the above
-	imageSet.Insert(staticImages()...)
-	return archiveOrCopyImages(ctx, logger, imageSet, options, userAgent)
+	collection.InsertAll(staticImages(), images.RefTypeImage, "static")
+
+	return collection, nil
 }
 
-func collectHelmChartImages(ctx context.Context, logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, clusterVersions []*version.Version, options *MirrorImagesOptions) (sets.Set[string], error) {
-	imageSet := sets.New[string]()
+func collectHelmChartImages(ctx context.Context, logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, clusterVersions []*version.Version, options *ImageCollectionOptions, chartsDirectory string) (*images.Collection, error) {
+	collection := images.NewCollection()
 
-	if options.ChartsDirectory == "" {
-		return imageSet, nil
+	if chartsDirectory == "" {
+		return collection, nil
 	}
 
 	helmClient, err := helm.NewCLI(options.HelmBinary, "", "", options.HelmTimeout, logger)
@@ -420,24 +455,24 @@ func collectHelmChartImages(ctx context.Context, logger *logrus.Logger, kubermat
 		return nil, fmt.Errorf("failed to create Helm client: %w", err)
 	}
 
-	chartsLogger := logger.WithField("charts-directory", options.ChartsDirectory)
+	chartsLogger := logger.WithField("charts-directory", chartsDirectory)
 	chartsLogger.Info("🚀 Rendering Helm charts…")
 
 	// Because charts can specify a desired kubeVersion and the helm render default is hardcoded to 1.20, we need to set a custom kubeVersion.
 	// Otherwise some charts would fail to render (e.g. consul).
 	// Since we are just rendering from the client-side, it makes sense to use the latest kubeVersion we support.
 	latestClusterVersion := clusterVersions[len(clusterVersions)-1]
-	images, err := images.GetImagesForHelmCharts(ctx, chartsLogger, kubermaticConfig, helmClient, options.ChartsDirectory, options.HelmValuesFile, options.RegistryPrefix, latestClusterVersion.Version.Original())
+	chartCollection, err := images.GetImagesForHelmCharts(ctx, chartsLogger, kubermaticConfig, helmClient, chartsDirectory, options.HelmValuesFile, options.RegistryPrefix, latestClusterVersion.Version.Original(), options.Concurrency)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images from helm charts: %w", err)
 	}
-	imageSet.Insert(images...)
+	collection.Merge(chartCollection)
 
-	return imageSet, nil
+	return collection, nil
 }
 
-func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, options *MirrorImagesOptions) (sets.Set[string], error) {
-	imageSet := sets.New[string]()
+func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermaticv1.KubermaticConfiguration, options *ImageCollectionOptions) (*images.Collection, error) {
+	collection := images.NewCollection()
 
 	helmClient, err := helm.NewCLI(options.HelmBinary, "", "", options.HelmTimeout, logger)
 	if err != nil {
@@ -451,13 +486,9 @@ func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermati
 		if err != nil {
 			return nil, err
 		}
-		chartImage := fmt.Sprintf("%s/%s:%s", sysChart.Template.Source.Helm.URL, sysChart.Template.Source.Helm.ChartName, sysChart.Template.Source.Helm.ChartVersion)
-		// Check if the chartImage starts with "oci://"
-		if strings.HasPrefix(chartImage, "oci://") {
-			// remove oci:// prefix and insert the chartImage into imageSet.
-			imageSet.Insert(chartImage[len("oci://"):])
-		}
-		imageSet.Insert(sysChart.WorkloadImages...)
+		source := fmt.Sprintf("application:%s@%s", sysChart.Template.Source.Helm.ChartName, sysChart.Template.Source.Helm.ChartVersion)
+		insertAppChartRef(collection, sysChart.Template.Source.Helm, source)
+		collection.InsertAll(sysChart.WorkloadImages, images.RefTypeImage, source)
 	}
 
 	if kubermaticConfig.Spec.FeatureGates[features.ExternalApplicationCatalogManager] {
@@ -476,22 +507,18 @@ func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermati
 			}
 			defer os.RemoveAll(chartPath)
 
-			chartImages, renderErr := images.GetImagesForHelmChart(logger, nil, helmClient, chartPath, "", options.RegistryPrefix, "")
+			chartImages, renderErr := images.GetImagesForHelmChart(logger, nil, helmClient, chartPath, "", options.RegistryPrefix, "", nil)
 			if renderErr != nil {
 				return nil, fmt.Errorf("failed to render Helm chart %s: %w", catalogChart.Template.Source.Helm.ChartName, renderErr)
 			}
 
-			// extract OCI chart image if present
-			chartImage := fmt.Sprintf("%s/%s:%s",
-				catalogChart.Template.Source.Helm.URL,
+			source := fmt.Sprintf("application:%s@%s",
 				catalogChart.Template.Source.Helm.ChartName,
 				catalogChart.Template.Source.Helm.ChartVersion)
-			if strings.HasPrefix(chartImage, "oci://") {
-				imageSet.Insert(chartImage[len("oci://"):])
-			}
+			insertAppChartRef(collection, catalogChart.Template.Source.Helm, source)
 
 			// add workload images from rendered chart
-			imageSet.Insert(chartImages...)
+			collection.InsertAll(chartImages, images.RefTypeImage, source)
 		}
 	} else {
 		// legacy approach: use embedded default application catalog
@@ -500,23 +527,31 @@ func collectApplicationImages(logger *logrus.Logger, kubermaticConfig *kubermati
 			if err != nil {
 				return nil, err
 			}
-			chartImage := fmt.Sprintf("%s/%s:%s",
-				defaultChart.Template.Source.Helm.URL,
+			source := fmt.Sprintf("application:%s@%s",
 				defaultChart.Template.Source.Helm.ChartName,
 				defaultChart.Template.Source.Helm.ChartVersion)
-			// Check if the chartImage starts with "oci://"
-			if strings.HasPrefix(chartImage, "oci://") {
-				// remove oci:// prefix and insert the chartImage into imageSet.
-				imageSet.Insert(chartImage[len("oci://"):])
-			}
-			imageSet.Insert(defaultChart.WorkloadImages...)
+			insertAppChartRef(collection, defaultChart.Template.Source.Helm, source)
+			collection.InsertAll(defaultChart.WorkloadImages, images.RefTypeImage, source)
 		}
 	}
 
-	return imageSet, nil
+	return collection, nil
 }
 
-func archiveOrCopyImages(ctx context.Context, logger *logrus.Logger, imageSet sets.Set[string], options *MirrorImagesOptions, userAgent string) error {
+// insertAppChartRef inserts the OCI chart reference for an application when its
+// source is an OCI registry. Non-OCI (http) chart sources have no chart ref to
+// mirror, so nothing is inserted.
+func insertAppChartRef(collection *images.Collection, helmSource *appskubermaticv1.HelmSource, source string) {
+	if helmSource == nil {
+		return
+	}
+	chartImage := fmt.Sprintf("%s/%s:%s", helmSource.URL, helmSource.ChartName, helmSource.ChartVersion)
+	if strings.HasPrefix(chartImage, "oci://") {
+		collection.Insert(chartImage[len("oci://"):], images.RefTypeHelmChart, source)
+	}
+}
+
+func archiveOrCopyImages(ctx context.Context, logger *logrus.Logger, imageList []string, options *MirrorImagesOptions, userAgent string) error {
 	if options.Archive && options.ArchivePath == "" {
 		currentPath, err := os.Getwd()
 		if err != nil {
@@ -531,7 +566,7 @@ func archiveOrCopyImages(ctx context.Context, logger *logrus.Logger, imageSet se
 
 	if options.Archive {
 		logger.WithField("archive-path", options.ArchivePath).Info("🚀 Archiving images…")
-		count, fullCount, err = images.ArchiveImages(ctx, logger, options.ArchivePath, options.DryRun, sets.List(imageSet))
+		count, fullCount, err = images.ArchiveImages(ctx, logger, options.ArchivePath, options.DryRun, imageList)
 		if err != nil {
 			return fmt.Errorf("failed to export images: %w", err)
 		}
@@ -541,7 +576,7 @@ func archiveOrCopyImages(ctx context.Context, logger *logrus.Logger, imageSet se
 		}
 	} else {
 		logger.WithField("registry", options.Registry).Info("🚀 Mirroring images…")
-		count, fullCount, err = images.CopyImages(ctx, logger, options.DryRun, options.Insecure, sets.List(imageSet), options.Registry, userAgent)
+		count, fullCount, err = images.CopyImages(ctx, logger, options.DryRun, options.Insecure, imageList, options.Registry, userAgent)
 		if err != nil {
 			return fmt.Errorf("failed to mirror all images (successfully copied %d/%d): %w", count, fullCount, err)
 		}

--- a/cmd/kubermatic-installer/main_ce.go
+++ b/cmd/kubermatic-installer/main_ce.go
@@ -40,6 +40,7 @@ func addCommands(cmd *cobra.Command, logger *logrus.Logger, versions kubermatic.
 		PrintCommand(),
 		VersionCommand(logger, versions),
 		MirrorImagesCommand(logger, versions),
+		ListImagesCommand(logger, versions),
 		MirrorBinariesCommand(logger, versions),
 		LocalCommand(logger),
 	)

--- a/cmd/kubermatic-installer/main_ee.go
+++ b/cmd/kubermatic-installer/main_ee.go
@@ -40,6 +40,7 @@ func addCommands(cmd *cobra.Command, logger *logrus.Logger, versions kubermatic.
 		PrintCommand(),
 		VersionCommand(logger, versions),
 		MirrorImagesCommand(logger, versions),
+		ListImagesCommand(logger, versions),
 		MirrorBinariesCommand(logger, versions),
 		LocalCommand(logger),
 	)

--- a/pkg/install/images/addons.go
+++ b/pkg/install/images/addons.go
@@ -32,7 +32,7 @@ import (
 
 var serializer = json.NewSerializerWithOptions(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, json.SerializerOptions{})
 
-func getImagesFromAddons(log logrus.FieldLogger, addons map[string]*addon.Addon, cluster *kubermaticv1.Cluster) ([]string, error) {
+func getImagesFromAddons(log logrus.FieldLogger, addons map[string]*addon.Addon, cluster *kubermaticv1.Cluster) (*Collection, error) {
 	credentials := resources.Credentials{}
 
 	addonData, err := addon.NewTemplateData(cluster, credentials, "", "", "", nil, nil)
@@ -40,16 +40,16 @@ func getImagesFromAddons(log logrus.FieldLogger, addons map[string]*addon.Addon,
 		return nil, fmt.Errorf("failed to create addon template data: %w", err)
 	}
 
-	var images []string
+	collection := NewCollection()
 	for addonName, addonObj := range addons {
 		addonImages, err := getImagesFromAddon(log.WithField("addon", addonName), addonObj, serializer, addonData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get images for addon %s: %w", addonName, err)
 		}
-		images = append(images, addonImages...)
+		collection.InsertAll(addonImages, RefTypeImage, "addon:"+addonName)
 	}
 
-	return images, nil
+	return collection, nil
 }
 
 func getImagesFromAddon(log logrus.FieldLogger, addonObj *addon.Addon, decoder runtime.Decoder, data *addon.TemplateData) ([]string, error) {

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -228,7 +228,7 @@ func getHelmChartRenderFunc(config *kubermaticv1.KubermaticConfiguration,
 							}
 						}
 
-						chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, versionValuesFile, registryPrefix, "")
+						chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, versionValuesFile, registryPrefix, "", nil)
 						if err != nil {
 							yield(nil, fmt.Errorf("failed to get images for cluster-autoscaler (k8s %s): %w", majorMinor, err))
 							return
@@ -242,7 +242,7 @@ func getHelmChartRenderFunc(config *kubermaticv1.KubermaticConfiguration,
 				}
 
 				// get images
-				chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, valuesFile, registryPrefix, "") // since we don't have the version constraints in AppDefs yet, we can leave kubeVersion parameter empty
+				chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, valuesFile, registryPrefix, "", nil) // since we don't have the version constraints in AppDefs yet, we can leave kubeVersion parameter empty
 				if err != nil {
 					yield(nil, fmt.Errorf("failed to get images for chart: %w", err))
 

--- a/pkg/install/images/collection.go
+++ b/pkg/install/images/collection.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// RefType tells whether a collected reference is a container image or an OCI
+// Helm chart reference that mirror-images / list-images would copy.
+type RefType string
+
+const (
+	RefTypeImage     RefType = "image"
+	RefTypeHelmChart RefType = "helm-chart"
+)
+
+// CollectedRef is a container image or OCI Helm chart reference together with
+// the deduplicated set of sources it was discovered in.
+//
+// Source labels use a "<kind>:<name>" vocabulary:
+//   - "reconciler:<name>"          - Go reconciler factory (e.g. "reconciler:etcd")
+//   - "addon:<name>"               - rendered addon manifest (e.g. "addon:canal")
+//   - "etcd-backup:store" / "etcd-backup:delete"
+//   - "chart:<name>"               - vendored Helm chart under --charts-directory
+//   - "application:<chart>@<ver>"  - system/default/external catalog application
+//   - "config:mirrorImages"        - KubermaticConfig spec.mirrorImages
+//   - "static"                     - hardcoded extras (web terminal)
+type CollectedRef struct {
+	Ref     string
+	Type    RefType
+	Sources sets.Set[string]
+}
+
+// Collection aggregates refs, deduplicating by ref string and merging the
+// source labels of duplicates.
+type Collection struct {
+	refs map[string]*CollectedRef
+}
+
+func NewCollection() *Collection {
+	return &Collection{refs: map[string]*CollectedRef{}}
+}
+
+// Insert adds a ref with one source label. If the ref already exists, the
+// source is merged into the existing entry. An entry already typed as a Helm
+// chart is never downgraded to a plain image by a later Insert.
+func (c *Collection) Insert(ref string, t RefType, source string) {
+	if ref == "" {
+		return
+	}
+
+	if existing, ok := c.refs[ref]; ok {
+		existing.Sources.Insert(source)
+		// a helm-chart ref must stay a helm-chart even if a later insert sees it as an image
+		if existing.Type == RefTypeHelmChart {
+			return
+		}
+		if t == RefTypeHelmChart {
+			existing.Type = RefTypeHelmChart
+		}
+		return
+	}
+
+	entry := &CollectedRef{
+		Ref:     ref,
+		Type:    t,
+		Sources: sets.New(source),
+	}
+	c.refs[ref] = entry
+}
+
+// InsertAll adds many refs that share a type and a single source label.
+func (c *Collection) InsertAll(refs []string, t RefType, source string) {
+	for _, ref := range refs {
+		c.Insert(ref, t, source)
+	}
+}
+
+// Merge folds another collection into this one, merging source labels.
+func (c *Collection) Merge(other *Collection) {
+	if other == nil {
+		return
+	}
+	for _, entry := range other.refs {
+		for source := range entry.Sources {
+			c.Insert(entry.Ref, entry.Type, source)
+		}
+	}
+}
+
+// FilterPrefix drops entries whose ref does not begin with prefix. When prefix
+// is empty the collection is left unchanged.
+func (c *Collection) FilterPrefix(prefix string) {
+	if prefix == "" {
+		return
+	}
+	for ref := range c.refs {
+		if !strings.HasPrefix(ref, prefix) {
+			delete(c.refs, ref)
+		}
+	}
+}
+
+// RefList returns all ref strings, sorted. Use this for the mirror/archive
+// path that only cares about which refs to copy.
+func (c *Collection) RefList() []string {
+	refs := make([]string, 0, len(c.refs))
+	for ref := range c.refs {
+		refs = append(refs, ref)
+	}
+	slices.Sort(refs)
+	return refs
+}
+
+// Sorted returns all entries sorted by ref, each with a sorted Sources slice,
+// for deterministic output.
+func (c *Collection) Sorted() []CollectedRef {
+	refs := c.RefList()
+	out := make([]CollectedRef, 0, len(refs))
+	for _, ref := range refs {
+		entry := c.refs[ref]
+		out = append(out, CollectedRef{
+			Ref:     entry.Ref,
+			Type:    entry.Type,
+			Sources: sets.New(sets.List(entry.Sources)...),
+		})
+	}
+	return out
+}

--- a/pkg/install/images/collection_test.go
+++ b/pkg/install/images/collection_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestCollectionInsertDedup(t *testing.T) {
+	c := NewCollection()
+	c.Insert("registry.example/foo:1.0", RefTypeImage, "reconciler:foo")
+	c.Insert("registry.example/foo:1.0", RefTypeImage, "addon:bar")
+
+	entries := c.Sorted()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 deduped entry, got %d", len(entries))
+	}
+
+	want := []string{"addon:bar", "reconciler:foo"}
+	if got := sets.List(entries[0].Sources); !reflect.DeepEqual(got, want) {
+		t.Errorf("expected sources %v, got %v", want, got)
+	}
+}
+
+func TestCollectionHelmChartNotDowngraded(t *testing.T) {
+	c := NewCollection()
+	// a chart ref is seen first as a helm-chart
+	c.Insert("registry.example/charts/cilium:1.18.10", RefTypeHelmChart, "application:cilium@1.18.10")
+	// later the same ref shows up as a plain image; it must stay a helm-chart
+	c.Insert("registry.example/charts/cilium:1.18.10", RefTypeImage, "reconciler:weird")
+
+	entries := c.Sorted()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Type != RefTypeHelmChart {
+		t.Errorf("helm-chart entry was downgraded to %q", entries[0].Type)
+	}
+}
+
+func TestCollectionUpgradeToHelmChart(t *testing.T) {
+	c := NewCollection()
+	c.Insert("registry.example/charts/x:1.0", RefTypeImage, "reconciler:x")
+	c.Insert("registry.example/charts/x:1.0", RefTypeHelmChart, "application:x@1.0")
+
+	entries := c.Sorted()
+	if entries[0].Type != RefTypeHelmChart {
+		t.Errorf("expected type upgraded to helm-chart, got %q", entries[0].Type)
+	}
+}
+
+func TestCollectionMerge(t *testing.T) {
+	a := NewCollection()
+	a.Insert("a:1", RefTypeImage, "reconciler:a")
+	a.Insert("shared:1", RefTypeImage, "reconciler:a")
+
+	b := NewCollection()
+	b.Insert("b:1", RefTypeImage, "addon:b")
+	b.Insert("shared:1", RefTypeImage, "addon:shared")
+
+	a.Merge(b)
+
+	refs := a.RefList()
+	want := []string{"a:1", "b:1", "shared:1"}
+	if !reflect.DeepEqual(refs, want) {
+		t.Errorf("RefList = %v, want %v", refs, want)
+	}
+
+	for _, entry := range a.Sorted() {
+		if entry.Ref == "shared:1" {
+			want := []string{"addon:shared", "reconciler:a"}
+			if got := sets.List(entry.Sources); !reflect.DeepEqual(got, want) {
+				t.Errorf("merged sources = %v, want %v", got, want)
+			}
+		}
+	}
+}
+
+func TestCollectionFilterPrefix(t *testing.T) {
+	c := NewCollection()
+	c.Insert("quay.io/foo:1", RefTypeImage, "reconciler:foo")
+	c.Insert("docker.io/bar:1", RefTypeImage, "reconciler:bar")
+	c.FilterPrefix("quay.io")
+
+	refs := c.RefList()
+	if !reflect.DeepEqual(refs, []string{"quay.io/foo:1"}) {
+		t.Errorf("FilterPrefix left %v, want only [quay.io/foo:1]", refs)
+	}
+}
+
+func TestCollectionDeterministicOrdering(t *testing.T) {
+	c := NewCollection()
+	c.Insert("z:1", RefTypeImage, "src:z")
+	c.Insert("a:1", RefTypeImage, "src:a")
+	c.Insert("m:1", RefTypeImage, "src:m")
+
+	first := c.RefList()
+	// run again to ensure stability across calls
+	second := c.RefList()
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("RefList not stable: %v vs %v", first, second)
+	}
+
+	want := []string{"a:1", "m:1", "z:1"}
+	if !reflect.DeepEqual(first, want) {
+		t.Errorf("RefList = %v, want sorted %v", first, want)
+	}
+}
+
+func TestCollectionInsertEmptyRef(t *testing.T) {
+	c := NewCollection()
+	c.Insert("", RefTypeImage, "src:empty")
+	if got := c.RefList(); len(got) != 0 {
+		t.Errorf("empty ref should be ignored, got %v", got)
+	}
+}

--- a/pkg/install/images/helm.go
+++ b/pkg/install/images/helm.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
 
@@ -35,7 +36,14 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func GetImagesForHelmCharts(ctx context.Context, log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, chartsPath string, valuesFile string, registryPrefix string, kubeVersion string) ([]string, error) {
+// helmDepBuildMu serializes BuildChartDependencies across concurrent chart
+// renders. helm writes registered repositories to a single shared file
+// (~/.config/helm/repositories.yaml); concurrent `helm repo add` calls race on
+// it and can corrupt or lose entries. The dependency download and template
+// render themselves write to per-chart directories and stay concurrent.
+var helmDepBuildMu sync.Mutex
+
+func GetImagesForHelmCharts(ctx context.Context, log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, chartsPath string, valuesFile string, registryPrefix string, kubeVersion string, concurrency int) (*Collection, error) {
 	if info, err := os.Stat(chartsPath); err != nil || !info.IsDir() {
 		return nil, fmt.Errorf("%s is not a valid directory", chartsPath)
 	}
@@ -45,19 +53,94 @@ func GetImagesForHelmCharts(ctx context.Context, log logrus.FieldLogger, config 
 		return nil, fmt.Errorf("failed to find Helm charts: %w", err)
 	}
 
-	images := []string{}
-	for _, chartPath := range chartPaths {
-		chartImages, err := GetImagesForHelmChart(log, config, helmClient, chartPath, valuesFile, registryPrefix, kubeVersion)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get images for Helm chart: %w", err)
-		}
-		images = append(images, chartImages...)
+	// findHelmCharts returns sorted paths, so the per-chart results stay
+	// deterministic regardless of worker scheduling.
+	type chartResult struct {
+		chartPath string
+		images    []string
 	}
 
-	return images, nil
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	jobs := make(chan string)
+	results := make(chan chartResult)
+	errCh := make(chan error, 1)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	workerCount := concurrency
+	if workerCount > len(chartPaths) {
+		workerCount = len(chartPaths)
+	}
+	for range workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for chartPath := range jobs {
+				// a sibling worker hit an error; stop pulling new work
+				if ctx.Err() != nil {
+					return
+				}
+
+				chartImages, err := GetImagesForHelmChart(log, config, helmClient, chartPath, valuesFile, registryPrefix, kubeVersion, &helmDepBuildMu)
+				if err != nil {
+					select {
+					case errCh <- fmt.Errorf("failed to get images for Helm chart %q: %w", filepath.Base(chartPath), err):
+					default:
+					}
+					cancel()
+					return
+				}
+
+				results <- chartResult{chartPath: chartPath, images: chartImages}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, chartPath := range chartPaths {
+			if ctx.Err() != nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- chartPath:
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	collected := make(map[string][]string, len(chartPaths))
+	for res := range results {
+		collected[res.chartPath] = res.images
+	}
+
+	select {
+	case err := <-errCh:
+		return nil, err
+	default:
+	}
+
+	collection := NewCollection()
+	// iterate in the original sorted order for deterministic output
+	for _, chartPath := range chartPaths {
+		collection.InsertAll(collected[chartPath], RefTypeImage, "chart:"+filepath.Base(chartPath))
+	}
+
+	return collection, nil
 }
 
-func GetImagesForHelmChart(log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, chartPath string, valuesFile string, registryPrefix string, kubeVersion string) ([]string, error) {
+func GetImagesForHelmChart(log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, chartPath string, valuesFile string, registryPrefix string, kubeVersion string, depBuildMu *sync.Mutex) ([]string, error) {
 	images := []string{}
 	serializer := json.NewSerializer(&json.SimpleMetaFactory{}, scheme.Scheme, scheme.Scheme, false)
 
@@ -83,7 +166,18 @@ func GetImagesForHelmChart(log logrus.FieldLogger, config *kubermaticv1.Kubermat
 	}
 	if chartFI.IsDir() {
 		chartLog.Debug("Fetching chart dependencies…")
-		if err := helmClient.BuildChartDependencies(chartPath, nil); err != nil {
+		// BuildChartDependencies runs `helm repo add` which mutates the shared
+		// repositories.yaml; serialize it across concurrent renders when a mutex
+		// is provided. The dependency download and template render that follow
+		// are per-chart and stay concurrent.
+		if depBuildMu != nil {
+			depBuildMu.Lock()
+		}
+		err := helmClient.BuildChartDependencies(chartPath, nil)
+		if depBuildMu != nil {
+			depBuildMu.Unlock()
+		}
+		if err != nil {
 			return nil, fmt.Errorf("failed to download chart dependencies: %w", err)
 		}
 	}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -398,7 +398,7 @@ func copyImage(ctx context.Context, log logrus.FieldLogger, image ImageSourceDes
 	})
 }
 
-func GetImagesForVersion(log logrus.FieldLogger, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, config *kubermaticv1.KubermaticConfiguration, addons map[string]*addon.Addon, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle, registryPrefix string) (images []string, err error) {
+func GetImagesForVersion(log logrus.FieldLogger, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, config *kubermaticv1.KubermaticConfiguration, addons map[string]*addon.Addon, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle, registryPrefix string) (*Collection, error) {
 	seed, err := defaulting.DefaultSeed(&kubermaticv1.Seed{}, config, zap.NewNop().Sugar())
 	if err != nil {
 		return nil, fmt.Errorf("failed to default Seed: %w", err)
@@ -409,41 +409,31 @@ func GetImagesForVersion(log logrus.FieldLogger, clusterVersion *version.Version
 		return nil, err
 	}
 
-	creatorImages, err := getImagesFromReconcilers(log, templateData, config, kubermaticVersions, seed)
+	collection, err := getImagesFromReconcilers(log, templateData, config, kubermaticVersions, seed)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images from internal creator functions: %w", err)
 	}
-
-	images = append(images, creatorImages...)
 
 	addonImages, err := getImagesFromAddons(log, addons, templateData.Cluster())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get images from addons: %w", err)
 	}
 
-	images = append(images, addonImages...)
-	if backupImages, err := etcdBackupImages(config.Spec.SeedController); err != nil {
+	collection.Merge(addonImages)
+
+	backupImages, err := etcdBackupImages(config.Spec.SeedController)
+	if err != nil {
 		return nil, fmt.Errorf("failed to get images from etcd backups: %w", err)
-	} else {
-		images = append(images, backupImages...)
 	}
+	collection.Merge(backupImages)
 
-	if registryPrefix != "" {
-		var filteredImages []string
-		for _, image := range images {
-			if strings.HasPrefix(image, registryPrefix) {
-				filteredImages = append(filteredImages, image)
-			}
-		}
+	collection.FilterPrefix(registryPrefix)
 
-		images = filteredImages
-	}
-
-	return images, nil
+	return collection, nil
 }
 
-func etcdBackupImages(configuration kubermaticv1.KubermaticSeedControllerConfiguration) ([]string, error) {
-	var images []string
+func etcdBackupImages(configuration kubermaticv1.KubermaticSeedControllerConfiguration) (*Collection, error) {
+	collection := NewCollection()
 
 	if configuration.BackupStoreContainer == "" {
 		configuration.BackupStoreContainer = defaulting.DefaultBackupStoreContainer
@@ -452,7 +442,7 @@ func etcdBackupImages(configuration kubermaticv1.KubermaticSeedControllerConfigu
 	if image, err := kubernetes.ContainerFromString(configuration.BackupStoreContainer); err != nil {
 		return nil, fmt.Errorf("failed to get backup store image: %w", err)
 	} else {
-		images = append(images, image.Image)
+		collection.Insert(image.Image, RefTypeImage, "etcd-backup:store")
 	}
 
 	if configuration.BackupDeleteContainer == "" {
@@ -462,13 +452,15 @@ func etcdBackupImages(configuration kubermaticv1.KubermaticSeedControllerConfigu
 	if image, err := kubernetes.ContainerFromString(configuration.BackupDeleteContainer); err != nil {
 		return nil, fmt.Errorf("failed to get backup delete image: %w", err)
 	} else {
-		images = append(images, image.Image)
+		collection.Insert(image.Image, RefTypeImage, "etcd-backup:delete")
 	}
 
-	return images, nil
+	return collection, nil
 }
 
-func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.TemplateData, config *kubermaticv1.KubermaticConfiguration, kubermaticVersions kubermatic.Versions, seed *kubermaticv1.Seed) (images []string, err error) {
+func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.TemplateData, config *kubermaticv1.KubermaticConfiguration, kubermaticVersions kubermatic.Versions, seed *kubermaticv1.Seed) (*Collection, error) {
+	collection := NewCollection()
+
 	statefulsetReconcilers := kubernetescontroller.GetStatefulSetReconcilers(templateData, false, false, 0)
 	statefulsetReconcilers = append(statefulsetReconcilers, monitoring.GetStatefulSetReconcilers(templateData)...)
 
@@ -516,39 +508,39 @@ func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.Temp
 	daemonsetReconcilers = append(daemonsetReconcilers, envoyagent.DaemonSetReconciler(templateData.Cluster(), net.IPv4(0, 0, 0, 0), kubermaticVersions, "", templateData.RewriteImage))
 
 	for _, creatorGetter := range statefulsetReconcilers {
-		_, creator := creatorGetter()
+		name, creator := creatorGetter()
 		statefulset, err := creator(&appsv1.StatefulSet{})
 		if err != nil {
 			return nil, err
 		}
-		images = append(images, getImagesFromPodSpec(statefulset.Spec.Template.Spec)...)
+		collection.InsertAll(getImagesFromPodSpec(statefulset.Spec.Template.Spec), RefTypeImage, "reconciler:"+name)
 	}
 
 	for _, createFunc := range deploymentReconcilers {
-		_, creator := createFunc()
+		name, creator := createFunc()
 		deployment, err := creator(&appsv1.Deployment{})
 		if err != nil {
 			return nil, err
 		}
-		images = append(images, getImagesFromPodSpec(deployment.Spec.Template.Spec)...)
+		collection.InsertAll(getImagesFromPodSpec(deployment.Spec.Template.Spec), RefTypeImage, "reconciler:"+name)
 	}
 
 	for _, createFunc := range cronjobReconcilers {
-		_, creator := createFunc()
+		name, creator := createFunc()
 		cronJob, err := creator(&batchv1.CronJob{})
 		if err != nil {
 			return nil, err
 		}
-		images = append(images, getImagesFromPodSpec(cronJob.Spec.JobTemplate.Spec.Template.Spec)...)
+		collection.InsertAll(getImagesFromPodSpec(cronJob.Spec.JobTemplate.Spec.Template.Spec), RefTypeImage, "reconciler:"+name)
 	}
 
 	for _, createFunc := range daemonsetReconcilers {
-		_, creator := createFunc()
+		name, creator := createFunc()
 		daemonset, err := creator(&appsv1.DaemonSet{})
 		if err != nil {
 			return nil, err
 		}
-		images = append(images, getImagesFromPodSpec(daemonset.Spec.Template.Spec)...)
+		collection.InsertAll(getImagesFromPodSpec(daemonset.Spec.Template.Spec), RefTypeImage, "reconciler:"+name)
 	}
 
 	// Add images for Enterprise Edition addons/components.
@@ -557,8 +549,8 @@ func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.Temp
 		return nil, err
 	}
 
-	images = append(images, additionalImages...)
-	return images, nil
+	collection.Merge(additionalImages)
+	return collection, nil
 }
 
 func getImagesFromPodSpec(spec corev1.PodSpec) (images []string) {

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -81,7 +81,16 @@ func TestRetagImageForAllVersions(t *testing.T) {
 				if err != nil {
 					t.Errorf("Error calling getImagesForVersion for %s / %s / %s: %v", cloudSpec.ProviderName, clusterVersion.Version.String(), cni, err)
 				}
-				imageSet.Insert(images...)
+				imageSet.Insert(images.RefList()...)
+
+				// every discovered ref must carry at least one source label so
+				// that list-images can attribute it; an unlabeled ref is a bug
+				// in the discovery pipeline, not just missing metadata.
+				for _, entry := range images.Sorted() {
+					if entry.Sources.Len() == 0 {
+						t.Errorf("ref %q for %s / %s / %s has no source label", entry.Ref, cloudSpec.ProviderName, clusterVersion.Version.String(), cni)
+					}
+				}
 			}
 		}
 	}

--- a/pkg/install/images/integration/images_integration_test.go
+++ b/pkg/install/images/integration/images_integration_test.go
@@ -67,11 +67,11 @@ func TestProcessImagesFromHelmChartsAndSystemAppsAndDefaultApps(t *testing.T) {
 	}
 
 	var containerImages []string
-	chartImages, err := images.GetImagesForHelmCharts(context.Background(), log, config, helmClient, "../../../../charts/monitoring", "", "", "")
+	chartImages, err := images.GetImagesForHelmCharts(context.Background(), log, config, helmClient, "../../../../charts/monitoring", "", "", "", 1)
 	if err != nil {
 		t.Errorf("error calling GetImagesForHelmCharts: %v", err)
 	}
-	containerImages = append(containerImages, chartImages...)
+	containerImages = append(containerImages, chartImages.RefList()...)
 
 	appImages, err := images.GetImagesFromSystemApplicationDefinitions(log, config, helmClient, helmCommandTimeout, "")
 	if err != nil {

--- a/pkg/install/images/wrappers_ce.go
+++ b/pkg/install/images/wrappers_ce.go
@@ -30,9 +30,9 @@ import (
 )
 
 // getAdditionalImagesFromReconcilers returns the images used by the reconcilers for Enterprise Edition addons/components.
-// Since this is the Community Edition, this function is no-op and would always return nil,nil.
-func getAdditionalImagesFromReconcilers(_ *resources.TemplateData) ([]string, error) {
-	return nil, nil
+// Since this is the Community Edition, this function is no-op and returns an empty collection.
+func getAdditionalImagesFromReconcilers(_ *resources.TemplateData) (*Collection, error) {
+	return NewCollection(), nil
 }
 
 func DefaultAppsHelmCharts(

--- a/pkg/install/images/wrappers_ee.go
+++ b/pkg/install/images/wrappers_ee.go
@@ -40,7 +40,9 @@ import (
 )
 
 // getAdditionalImagesFromReconcilers returns the images used by the reconcilers for Enterprise Edition addons/components.
-func getAdditionalImagesFromReconcilers(templateData *resources.TemplateData) (images []string, err error) {
+func getAdditionalImagesFromReconcilers(templateData *resources.TemplateData) (*Collection, error) {
+	collection := NewCollection()
+
 	deploymentReconcilers := []reconciling.NamedDeploymentReconcilerFactory{
 		kubelb.DeploymentReconciler(templateData),
 		velero.DeploymentReconciler(templateData),
@@ -49,29 +51,29 @@ func getAdditionalImagesFromReconcilers(templateData *resources.TemplateData) (i
 	deploymentReconcilers = append(deploymentReconcilers, kyverno.GetDeploymentReconcilers(templateData)...)
 
 	for _, createFunc := range deploymentReconcilers {
-		_, dpCreator := createFunc()
+		name, dpCreator := createFunc()
 		deployment, err := dpCreator(&appsv1.Deployment{})
 		if err != nil {
 			return nil, err
 		}
-		images = append(images, getImagesFromPodSpec(deployment.Spec.Template.Spec)...)
+		collection.InsertAll(getImagesFromPodSpec(deployment.Spec.Template.Spec), RefTypeImage, "reconciler:"+name)
 	}
 
-	_, dsCreator := velero.DaemonSetReconciler(templateData)()
+	dsName, dsCreator := velero.DaemonSetReconciler(templateData)()
 	daemonset, err := dsCreator(&appsv1.DaemonSet{})
 	if err != nil {
 		return nil, err
 	}
-	images = append(images, getImagesFromPodSpec(daemonset.Spec.Template.Spec)...)
+	collection.InsertAll(getImagesFromPodSpec(daemonset.Spec.Template.Spec), RefTypeImage, "reconciler:"+dsName)
 
-	_, stsCreator := metering.MeteringPrometheusReconciler(templateData.RewriteImage, templateData.Seed())()
+	stsName, stsCreator := metering.MeteringPrometheusReconciler(templateData.RewriteImage, templateData.Seed())()
 	statefulset, err := stsCreator(&appsv1.StatefulSet{})
 	if err != nil {
 		return nil, err
 	}
-	images = append(images, getImagesFromPodSpec(statefulset.Spec.Template.Spec)...)
+	collection.InsertAll(getImagesFromPodSpec(statefulset.Spec.Template.Spec), RefTypeImage, "reconciler:"+stsName)
 
-	return images, err
+	return collection, nil
 }
 
 func DefaultAppsHelmCharts(


### PR DESCRIPTION
add `kubermatic-installer list-images`. it lists the container images and OCI chart refs KKP would deploy, running the same discovery as mirror-images but with no target registry. output is plain (one ref per line on stdout) or json with per-image source attribution.

add --concurrency/-c to render helm charts in parallel (default min(GOMAXPROCS, 8)). chart dependency setup is serialized with a mutex since `helm repo add` writes the shared repositories.yaml; dep download and template stay concurrent.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue

```
