### PR TITLE
Bump MLA Gateway nginx image and add data-plane e2e coverage

### DIFF
--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -47,9 +47,11 @@ export KUBERMATIC_YAML=hack/ci/testdata/kubermatic.yaml
 
 source hack/ci/setup-kind-cluster.sh
 
-# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+# gather the logs of all things in the cluster control plane, the Kubermatic namespace
+# and the seed MLA stack (consul/cortex/loki), whose health the data-plane checks depend on
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/mla" --namespace mla > /dev/null 2>&1 &
 
 source hack/ci/setup-kubermatic-mla-in-kind.sh
 

--- a/hack/ci/setup-kubermatic-mla-in-kind.sh
+++ b/hack/ci/setup-kubermatic-mla-in-kind.sh
@@ -172,6 +172,14 @@ echodate "Starting the deployment of User Cluster MLA..."
 MLA_HELM_VALUES_FILE="$(mktemp)"
 cat > "${MLA_HELM_VALUES_FILE}" << EOF
 cortex:
+  # a single ingester cannot satisfy the default replication factor of 3
+  # (writes need a quorum of 2 and fail with "at least 2 live replicas
+  # required"), so scale the factor down together with the replicas
+  config:
+    ingester:
+      lifecycler:
+        ring:
+          replication_factor: 1
   ingester:
     replicas: 1
   distributor:
@@ -182,6 +190,12 @@ cortex:
     replicas: 1
 
 loki-distributed:
+  loki:
+    structuredConfig:
+      ingester:
+        lifecycler:
+          ring:
+            replication_factor: 1
   ingester:
     replicas: 1
   distributor:

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -302,7 +302,7 @@ func GatewayExternalServiceReconciler(c *kubermaticv1.Cluster) reconciling.Named
 
 const (
 	image   = "nginxinc/nginx-unprivileged"
-	version = "1.20.1-alpine"
+	version = "1.31.2-alpine"
 
 	nginxScript = `
 set -e

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -24,7 +24,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -46,8 +48,11 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -96,7 +101,7 @@ func TestMLAIntegration(t *testing.T) {
 		t.Fatalf("Failed to get credentials: %v", err)
 	}
 
-	seedClient, _, err := utils.GetClients()
+	seedClient, seedConfig, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}
@@ -175,6 +180,10 @@ func TestMLAIntegration(t *testing.T) {
 
 	if err := verifyRateLimits(ctx, logger, seedClient, p, cluster); err != nil {
 		t.Errorf("failed to verify rate limits: %v", err)
+	}
+
+	if err := verifyGatewayWritePath(ctx, logger, seedClient, seedConfig, testJig, cluster); err != nil {
+		t.Errorf("failed to verify MLA Gateway write path: %v", err)
 	}
 
 	logger.Info("Disabling MLA...")
@@ -672,4 +681,284 @@ func createRuleGroup(ctx context.Context, client ctrlruntimeclient.Client, clust
 	}
 
 	return expected, nil
+}
+
+// gatewayWriteProbeImage is agnhost, which ships curl and is already used by
+// other e2e suites for in-cluster HTTP checks.
+const (
+	gatewayWriteProbeImage = "registry.k8s.io/e2e-test-images/agnhost:2.53"
+	gatewayProbePodName    = "mla-gateway-probe"
+	gatewayProbeContainer  = "probe"
+
+	// gatewayName matches the unexported constant in
+	// pkg/controller/seed-controller-manager/mla/resources.go and the value of
+	// the app.kubernetes.io/name label on the gateway pods.
+	gatewayName = "mla-gateway"
+
+	// lokiPushJob is the log stream label the probe writes and later queries,
+	// so it can be told apart from real agent traffic.
+	lokiPushJob = "mla-gateway-e2e-probe"
+)
+
+// verifyGatewayWritePath exercises the MLA Gateway data plane directly, which
+// the rest of the suite never does (it talks to the Cortex/Loki backends over
+// port-forwards, bypassing the gateway). It confirms three NGINX behaviors that
+// an image bump could regress: that a real mTLS push round-trips to storage
+// (W1), that a client without a cert is rejected (W2, ssl_verify_client on),
+// and that TLS 1.2 is rejected while TLS 1.3 works (W3, ssl_protocols TLSv1.3).
+//
+// The gateway write port (8080) has no in-cluster Service (mla-gateway ClusterIP
+// fronts only the read port 8081), so the probe curls a gateway pod IP on 8080
+// directly. This covers the gateway's NGINX behavior across all expose
+// strategies; the nodeport-proxy layer in front is out of scope.
+func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, seedConfig *rest.Config, testJig *jig.TestJig, cluster *kubermaticv1.Cluster) error {
+	clusterNS := cluster.Status.NamespaceName
+	if clusterNS == "" {
+		return errors.New("cluster has no namespace yet (Status.NamespaceName empty)")
+	}
+
+	// the agent mTLS client cert is reconciled into the user cluster and signed
+	// by the seed-side mla-gateway-ca, the CA the gateway verifies clients
+	// against. The CA itself is not needed here: the probe curls a pod IP, so
+	// server cert verification is skipped (-k) and only the client cert matters.
+	log.Info("Waiting for MLA Gateway mTLS material...")
+	var clientCert, clientKey []byte
+	if err := wait.Poll(ctx, 2*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
+		clusterClient, err := testJig.ClusterJig.ClusterClient(ctx)
+		if err != nil {
+			return err, nil
+		}
+
+		certSecret := &corev1.Secret{}
+		if err := clusterClient.Get(ctx, types.NamespacedName{Namespace: resources.UserClusterMLANamespace, Name: resources.MLAMonitoringAgentCertificatesSecretName}, certSecret); err != nil {
+			if apierrors.IsNotFound(err) {
+				return err, nil
+			}
+
+			return nil, fmt.Errorf("failed to get monitoring agent cert secret: %w", err)
+		}
+
+		clientCert = certSecret.Data[resources.MLAMonitoringAgentClientCertSecretKey]
+		clientKey = certSecret.Data[resources.MLAMonitoringAgentClientKeySecretKey]
+
+		if len(clientCert) == 0 || len(clientKey) == 0 {
+			return errors.New("mla material not yet populated"), nil
+		}
+
+		return nil, nil
+	}); err != nil {
+		return fmt.Errorf("failed to gather mTLS material: %w", err)
+	}
+
+	// stage the cert/key/CA in the seed cluster-namespace as a Secret the probe
+	// pod mounts, so curl can present them without writing them to a command line.
+	probeSecretName := gatewayProbePodName + "-tls"
+	probeSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      probeSecretName,
+			Namespace: clusterNS,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			resources.MLAMonitoringAgentClientCertSecretKey: clientCert,
+			resources.MLAMonitoringAgentClientKeySecretKey:  clientKey,
+		},
+	}
+
+	err := seedClient.Create(ctx, probeSecret)
+	if err != nil {
+		return fmt.Errorf("failed to create probe TLS secret: %w", err)
+	}
+	defer func() { _ = seedClient.Delete(context.Background(), probeSecret) }()
+
+	log.Info("Waiting for MLA Gateway pod to be ready...")
+
+	gatewayPodIP, err := waitGatewayPodReady(ctx, seedClient, clusterNS)
+	if err != nil {
+		return fmt.Errorf("failed to find ready gateway pod: %w", err)
+	}
+
+	log.Infof("Gateway pod IP: %s", gatewayPodIP)
+
+	probe := &utils.TestPodConfig{
+		Log:       log,
+		Namespace: clusterNS,
+		Client:    seedClient,
+		Config:    seedConfig,
+		CreatePodFunc: func(ns string) *corev1.Pod {
+			return newGatewayProbePod(ns, probeSecretName)
+		},
+	}
+
+	if err := probe.DeployTestPod(ctx, log); err != nil {
+		return fmt.Errorf("failed to deploy gateway probe pod: %w", err)
+	}
+
+	defer func() { _ = probe.CleanUp(context.Background()) }()
+
+	const (
+		certPath = "/etc/ssl/mla/client.crt"
+		keyPath  = "/etc/ssl/mla/client.key"
+	)
+	// -k: the server cert SAN does not cover a pod IP, but client-cert
+	// verification (ssl_verify_client on) still runs server-side regardless.
+	baseCurl := []string{
+		"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+		"--connect-timeout", "3", "--max-time", "15",
+		"--cert", certPath, "--key", keyPath, "-k",
+	}
+
+	var problems []string
+
+	// a real mTLS push round-trips to storage. Push a log stream, then read
+	// it back through the gateway read path (port 80 -> 8081, no TLS) and assert
+	// the stream is visible. Proves proxy_pass on both ports plus the
+	// X-Scope-OrgID tenant injection end to end.
+	pushBody := fmt.Sprintf(
+		`{"streams":[{"stream":{"job":%q},"values":[[%q,"probe"]]}]}`,
+		lokiPushJob, strconv.FormatInt(time.Now().UnixNano(), 10),
+	)
+	pushURL := fmt.Sprintf("https://%s/loki/api/v1/push", net.JoinHostPort(gatewayPodIP, "8080"))
+	pushCode, _, err := probe.Exec(
+		ctx, gatewayProbeContainer,
+		append(baseCurl, "-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL)...,
+	)
+	if err != nil {
+		problems = append(problems, fmt.Sprintf("W1 push request failed to execute: %v", err))
+	} else if !isSuccessPushCode(pushCode) {
+		problems = append(problems, fmt.Sprintf("W1 push did not succeed, got HTTP %s", pushCode))
+	}
+
+	readURL := fmt.Sprintf(
+		"http://%s/loki/api/v1/query?query=%s",
+		net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", gatewayName, clusterNS), "80"),
+		url.QueryEscape(fmt.Sprintf("{job=%q}", lokiPushJob)),
+	)
+	// deliberately no X-Scope-OrgID header: the gateway read server overwrites
+	// it with the cluster name (proxy_set_header at server scope), so getting
+	// the pushed stream back proves the gateway's tenant injection works on
+	// both paths, not just that loki honors a header the test set itself.
+	readCmd := []string{
+		"curl", "-s", "--connect-timeout", "3", "--max-time", "15", readURL,
+	}
+
+	// give loki a moment to index the just-pushed stream before reading back
+	streamVisible := false
+	if readErr := wait.Poll(ctx, 2*time.Second, 90*time.Second, func(ctx context.Context) (error, error) {
+		stdout, _, execErr := probe.Exec(ctx, gatewayProbeContainer, readCmd...)
+		if execErr != nil {
+			return execErr, nil
+		}
+
+		if strings.Contains(stdout, lokiPushJob) {
+			streamVisible = true
+			return nil, nil
+		}
+
+		return errors.New("stream not yet visible"), nil
+	}); readErr != nil || !streamVisible {
+		problems = append(problems, fmt.Sprintf("W1 pushed stream not readable via gateway read path (visible=%v): %v", streamVisible, readErr))
+	}
+
+	noCertCurl := []string{
+		"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+		"--connect-timeout", "3", "--max-time", "15", "-k",
+		"-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL,
+	}
+
+	noCertCode, noCertStderr, noCertErr := probe.Exec(ctx, gatewayProbeContainer, noCertCurl...)
+	if noCertErr == nil && isSuccessPushCode(noCertCode) {
+		problems = append(problems, fmt.Sprintf("W2 push without client cert unexpectedly succeeded (HTTP %s, stderr=%q); mTLS enforcement broken", noCertCode, noCertStderr))
+	}
+
+	log.Info("MLA Gateway write path verified.")
+	return nil
+}
+
+// waitGatewayPodReady returns the pod IP of a ready mla-gateway pod in the
+// cluster namespace.
+func waitGatewayPodReady(ctx context.Context, client ctrlruntimeclient.Client, namespace string) (string, error) {
+	var gatewayPodIP string
+	if err := wait.Poll(ctx, 2*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
+		pods := &corev1.PodList{}
+		if err := client.List(ctx, pods,
+			ctrlruntimeclient.InNamespace(namespace),
+			ctrlruntimeclient.MatchingLabels{"app.kubernetes.io/name": gatewayName}); err != nil {
+			return nil, fmt.Errorf("failed to list gateway pods: %w", err)
+		}
+
+		for i := range pods.Items {
+			p := &pods.Items[i]
+			if p.Status.PodIP != "" && isPodReady(p) {
+				gatewayPodIP = p.Status.PodIP
+				return nil, nil
+			}
+		}
+
+		return errors.New("no ready gateway pod yet"), nil
+	}); err != nil {
+		return "", err
+	}
+
+	return gatewayPodIP, nil
+}
+
+func isPodReady(p *corev1.Pod) bool {
+	for _, c := range p.Status.ContainerStatuses {
+		if c.Name != "nginx" {
+			continue
+		}
+
+		if c.Ready {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isSuccessPushCode treats 2xx (and 204 no-content, the normal Loki push
+// response) as a successful write. An empty code means curl bailed before any
+// HTTP response (TLS handshake failure), which is a failure for positive
+// assertions and a pass for the mTLS-negative one.
+func isSuccessPushCode(code string) bool {
+	return len(code) == 3 && code[0] == '2'
+}
+
+// newGatewayProbePod returns an agnhost pod that stays alive (pause) and mounts
+// the staged TLS material so curl inside it can present the client cert.
+func newGatewayProbePod(ns, tlsSecretName string) *corev1.Pod {
+	const mountPath = "/etc/ssl/mla"
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayProbePodName,
+			Namespace: ns,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:            gatewayProbeContainer,
+					Image:           gatewayWriteProbeImage,
+					Args:            []string{"pause"},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "tls", MountPath: mountPath, ReadOnly: true},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "tls",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName:  tlsSecretName,
+							DefaultMode: ptr.To[int32](0400),
+						},
+					},
+				},
+			},
+			TerminationGracePeriodSeconds: ptr.To[int64](0),
+		},
+	}
 }

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -47,6 +47,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/generator"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -831,12 +832,21 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 		`{"streams":[{"stream":{"job":%q},"values":[[%q,"probe"]]}]}`,
 		lokiPushJob, strconv.FormatInt(pushTime.UnixNano(), 10),
 	)
-	pushURL := fmt.Sprintf("https://%s/loki/api/v1/push", net.JoinHostPort(gatewayPodIP, "8080"))
-	pushCurl := append(baseCurl, "-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL)
+	pushURLFor := func(podIP string) string {
+		return fmt.Sprintf("https://%s/loki/api/v1/push", net.JoinHostPort(podIP, "8080"))
+	}
 
 	// pod readiness only proves the 8081 probe endpoint, so the first push can
-	// still hit a transient distributor or resolver blip; retry briefly.
+	// still hit a transient distributor or resolver blip; retry briefly. The
+	// pod IP is re-resolved per attempt in case a gateway rollout replaces the
+	// pod mid-check.
 	if pushErr := wait.Poll(ctx, 2*time.Second, 60*time.Second, func(ctx context.Context) (error, error) {
+		podIP, err := readyGatewayPodIP(ctx, seedClient, clusterNS)
+		if err != nil {
+			return err, nil
+		}
+
+		pushCurl := append(append([]string{}, baseCurl...), "-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURLFor(podIP))
 		pushCode, _, err := probe.Exec(ctx, gatewayProbeContainer, pushCurl...)
 		if err != nil {
 			return fmt.Errorf("push failed to execute: %w", err), nil
@@ -884,25 +894,31 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 		problems = append(problems, fmt.Sprintf("W1 pushed stream not readable via gateway read path: %v", readErr))
 	}
 
-	noCertCurl := []string{
-		"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-		"--connect-timeout", "3", "--max-time", "15", "-k",
-		"-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL,
-	}
+	// the write-path checks above can outlive the pod resolved at the start,
+	// so pick a live pod again for the no-cert probe.
+	if noCertPodIP, err := readyGatewayPodIP(ctx, seedClient, clusterNS); err != nil {
+		problems = append(problems, fmt.Sprintf("W2 could not resolve a ready gateway pod: %v", err))
+	} else {
+		noCertCurl := []string{
+			"curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+			"--connect-timeout", "3", "--max-time", "15", "-k",
+			"-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURLFor(noCertPodIP),
+		}
 
-	noCertCode, _, noCertErr := probe.Exec(ctx, gatewayProbeContainer, noCertCurl...)
-	switch {
-	case noCertErr == nil && isSuccessPushCode(noCertCode):
-		problems = append(problems, fmt.Sprintf("W2 push without client cert unexpectedly succeeded (HTTP %s); mTLS enforcement broken", noCertCode))
-	case noCertErr == nil:
-		// handshake completed but nginx refused the request at the HTTP level
-		// (400 "No required SSL certificate was sent"); mTLS enforced.
-	case isTLSRejection(noCertErr):
-		// curl bailed during or right after the handshake; mTLS enforced.
-	default:
-		// an infrastructure failure (timeout, pod gone) must not pass as
-		// proof of mTLS enforcement.
-		problems = append(problems, fmt.Sprintf("W2 push without client cert failed for a non-TLS reason, cannot prove mTLS enforcement: %v", noCertErr))
+		noCertCode, _, noCertErr := probe.Exec(ctx, gatewayProbeContainer, noCertCurl...)
+		switch {
+		case noCertErr == nil && isSuccessPushCode(noCertCode):
+			problems = append(problems, fmt.Sprintf("W2 push without client cert unexpectedly succeeded (HTTP %s); mTLS enforcement broken", noCertCode))
+		case noCertErr == nil:
+			// handshake completed but nginx refused the request at the HTTP level
+			// (400 "No required SSL certificate was sent"); mTLS enforced.
+		case isTLSRejection(noCertErr):
+			// curl bailed during or right after the handshake; mTLS enforced.
+		default:
+			// an infrastructure failure (timeout, pod gone) must not pass as
+			// proof of mTLS enforcement.
+			problems = append(problems, fmt.Sprintf("W2 push without client cert failed for a non-TLS reason, cannot prove mTLS enforcement: %v", noCertErr))
+		}
 	}
 
 	if len(problems) > 0 {
@@ -928,31 +944,65 @@ func isTLSRejection(err error) bool {
 }
 
 // waitGatewayPodReady returns the pod IP of a ready mla-gateway pod in the
-// cluster namespace.
+// cluster namespace. It first waits for the gateway Deployment rollout to be
+// complete: the rate-limit checks that run just before rewrite the gateway
+// nginx ConfigMap, and the checksum annotation forces a rolling update. A pod
+// picked mid-rollout can belong to the losing ReplicaSet and be deleted while
+// the write-path checks are still curling its IP.
 func waitGatewayPodReady(ctx context.Context, client ctrlruntimeclient.Client, namespace string) (string, error) {
 	var gatewayPodIP string
 	if err := wait.Poll(ctx, 2*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
-		pods := &corev1.PodList{}
-		if err := client.List(ctx, pods,
-			ctrlruntimeclient.InNamespace(namespace),
-			ctrlruntimeclient.MatchingLabels{"app.kubernetes.io/name": gatewayName}); err != nil {
-			return fmt.Errorf("failed to list gateway pods: %w", err), nil
+		deployment := &appsv1.Deployment{}
+		if err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: gatewayName}, deployment); err != nil {
+			return fmt.Errorf("failed to get gateway deployment: %w", err), nil
 		}
 
-		for i := range pods.Items {
-			p := &pods.Items[i]
-			if p.Status.PodIP != "" && isPodReady(p) {
-				gatewayPodIP = p.Status.PodIP
-				return nil, nil
-			}
+		replicas := int32(1)
+		if deployment.Spec.Replicas != nil {
+			replicas = *deployment.Spec.Replicas
 		}
 
-		return errors.New("no ready gateway pod yet"), nil
+		if deployment.Status.ObservedGeneration < deployment.Generation ||
+			deployment.Status.UpdatedReplicas != replicas ||
+			deployment.Status.ReadyReplicas != replicas ||
+			deployment.Status.Replicas != replicas {
+			return errors.New("gateway deployment rollout not complete yet"), nil
+		}
+
+		ip, err := readyGatewayPodIP(ctx, client, namespace)
+		if err != nil {
+			return err, nil
+		}
+
+		gatewayPodIP = ip
+		return nil, nil
 	}); err != nil {
 		return "", err
 	}
 
 	return gatewayPodIP, nil
+}
+
+// readyGatewayPodIP returns the pod IP of a ready, non-terminating mla-gateway
+// pod. Callers that curl the gateway over a longer period re-resolve the IP
+// per attempt so a rollout between attempts does not leave them talking to a
+// deleted pod.
+func readyGatewayPodIP(ctx context.Context, client ctrlruntimeclient.Client, namespace string) (string, error) {
+	pods := &corev1.PodList{}
+	if err := client.List(ctx, pods,
+		ctrlruntimeclient.InNamespace(namespace),
+		ctrlruntimeclient.MatchingLabels{"app.kubernetes.io/name": gatewayName}); err != nil {
+		return "", fmt.Errorf("failed to list gateway pods: %w", err)
+	}
+
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.DeletionTimestamp == nil && p.Status.PodIP != "" && isPodReady(p) {
+			return p.Status.PodIP, nil
+		}
+	}
+
+	return "", errors.New("no ready gateway pod")
 }
 
 func isPodReady(p *corev1.Pod) bool {

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -702,10 +702,9 @@ const (
 
 // verifyGatewayWritePath exercises the MLA Gateway data plane directly, which
 // the rest of the suite never does (it talks to the Cortex/Loki backends over
-// port-forwards, bypassing the gateway). It confirms three NGINX behaviors that
+// port-forwards, bypassing the gateway). It confirms two NGINX behaviors that
 // an image bump could regress: that a real mTLS push round-trips to storage
-// (W1), that a client without a cert is rejected (W2, ssl_verify_client on),
-// and that TLS 1.2 is rejected while TLS 1.3 works (W3, ssl_protocols TLSv1.3).
+// (W1) and that a client without a cert is rejected (W2, ssl_verify_client on).
 //
 // The gateway write port (8080) has no in-cluster Service (mla-gateway ClusterIP
 // fronts only the read port 8081), so the probe curls a gateway pod IP on 8080
@@ -765,11 +764,20 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 		},
 	}
 
+	// best-effort removal of leftovers from a previous aborted run so the
+	// Create calls below do not fail with AlreadyExists.
+	_ = seedClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: probeSecretName, Namespace: clusterNS}})
+	_ = seedClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: gatewayProbePodName, Namespace: clusterNS}})
+
 	err := seedClient.Create(ctx, probeSecret)
 	if err != nil {
 		return fmt.Errorf("failed to create probe TLS secret: %w", err)
 	}
-	defer func() { _ = seedClient.Delete(context.Background(), probeSecret) }()
+	defer func() {
+		if err := seedClient.Delete(context.Background(), probeSecret); err != nil && !apierrors.IsNotFound(err) {
+			log.Warnw("Failed to clean up probe TLS secret", zap.Error(err))
+		}
+	}()
 
 	log.Info("Waiting for MLA Gateway pod to be ready...")
 
@@ -794,7 +802,11 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 		return fmt.Errorf("failed to deploy gateway probe pod: %w", err)
 	}
 
-	defer func() { _ = probe.CleanUp(context.Background()) }()
+	defer func() {
+		if err := probe.CleanUp(context.Background()); err != nil {
+			log.Warnw("Failed to clean up gateway probe pod", zap.Error(err))
+		}
+	}()
 
 	const (
 		certPath = "/etc/ssl/mla/client.crt"
@@ -814,25 +826,37 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 	// it back through the gateway read path (port 80 -> 8081, no TLS) and assert
 	// the stream is visible. Proves proxy_pass on both ports plus the
 	// X-Scope-OrgID tenant injection end to end.
+	pushTime := time.Now()
 	pushBody := fmt.Sprintf(
 		`{"streams":[{"stream":{"job":%q},"values":[[%q,"probe"]]}]}`,
-		lokiPushJob, strconv.FormatInt(time.Now().UnixNano(), 10),
+		lokiPushJob, strconv.FormatInt(pushTime.UnixNano(), 10),
 	)
 	pushURL := fmt.Sprintf("https://%s/loki/api/v1/push", net.JoinHostPort(gatewayPodIP, "8080"))
-	pushCode, _, err := probe.Exec(
-		ctx, gatewayProbeContainer,
-		append(baseCurl, "-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL)...,
-	)
-	if err != nil {
-		problems = append(problems, fmt.Sprintf("W1 push request failed to execute: %v", err))
-	} else if !isSuccessPushCode(pushCode) {
-		problems = append(problems, fmt.Sprintf("W1 push did not succeed, got HTTP %s", pushCode))
+	pushCurl := append(baseCurl, "-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL)
+
+	// pod readiness only proves the 8081 probe endpoint, so the first push can
+	// still hit a transient distributor or resolver blip; retry briefly.
+	if pushErr := wait.Poll(ctx, 2*time.Second, 60*time.Second, func(ctx context.Context) (error, error) {
+		pushCode, _, err := probe.Exec(ctx, gatewayProbeContainer, pushCurl...)
+		if err != nil {
+			return fmt.Errorf("push failed to execute: %w", err), nil
+		}
+
+		if !isSuccessPushCode(pushCode) {
+			return fmt.Errorf("push returned HTTP %s", pushCode), nil
+		}
+
+		return nil, nil
+	}); pushErr != nil {
+		problems = append(problems, fmt.Sprintf("W1 push did not succeed: %v", pushErr))
 	}
 
 	readURL := fmt.Sprintf(
-		"http://%s/loki/api/v1/query?query=%s",
+		"http://%s/loki/api/v1/query_range?query=%s&start=%d&end=%d",
 		net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", gatewayName, clusterNS), "80"),
 		url.QueryEscape(fmt.Sprintf("{job=%q}", lokiPushJob)),
+		pushTime.Add(-time.Minute).UnixNano(),
+		pushTime.Add(10*time.Minute).UnixNano(),
 	)
 	// deliberately no X-Scope-OrgID header: the gateway read server overwrites
 	// it with the cluster name (proxy_set_header at server scope), so getting
@@ -843,21 +867,21 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 	}
 
 	// give loki a moment to index the just-pushed stream before reading back
-	streamVisible := false
 	if readErr := wait.Poll(ctx, 2*time.Second, 90*time.Second, func(ctx context.Context) (error, error) {
 		stdout, _, execErr := probe.Exec(ctx, gatewayProbeContainer, readCmd...)
 		if execErr != nil {
 			return execErr, nil
 		}
 
-		if strings.Contains(stdout, lokiPushJob) {
-			streamVisible = true
+		// the label alone is not enough, loki error bodies can echo the query;
+		// require a successful response that contains the pushed stream.
+		if strings.Contains(stdout, `"status":"success"`) && strings.Contains(stdout, lokiPushJob) {
 			return nil, nil
 		}
 
 		return errors.New("stream not yet visible"), nil
-	}); readErr != nil || !streamVisible {
-		problems = append(problems, fmt.Sprintf("W1 pushed stream not readable via gateway read path (visible=%v): %v", streamVisible, readErr))
+	}); readErr != nil {
+		problems = append(problems, fmt.Sprintf("W1 pushed stream not readable via gateway read path: %v", readErr))
 	}
 
 	noCertCurl := []string{
@@ -866,13 +890,41 @@ func verifyGatewayWritePath(ctx context.Context, log *zap.SugaredLogger, seedCli
 		"-XPOST", "-H", "Content-Type: application/json", "-d", pushBody, pushURL,
 	}
 
-	noCertCode, noCertStderr, noCertErr := probe.Exec(ctx, gatewayProbeContainer, noCertCurl...)
-	if noCertErr == nil && isSuccessPushCode(noCertCode) {
-		problems = append(problems, fmt.Sprintf("W2 push without client cert unexpectedly succeeded (HTTP %s, stderr=%q); mTLS enforcement broken", noCertCode, noCertStderr))
+	noCertCode, _, noCertErr := probe.Exec(ctx, gatewayProbeContainer, noCertCurl...)
+	switch {
+	case noCertErr == nil && isSuccessPushCode(noCertCode):
+		problems = append(problems, fmt.Sprintf("W2 push without client cert unexpectedly succeeded (HTTP %s); mTLS enforcement broken", noCertCode))
+	case noCertErr == nil:
+		// handshake completed but nginx refused the request at the HTTP level
+		// (400 "No required SSL certificate was sent"); mTLS enforced.
+	case isTLSRejection(noCertErr):
+		// curl bailed during or right after the handshake; mTLS enforced.
+	default:
+		// an infrastructure failure (timeout, pod gone) must not pass as
+		// proof of mTLS enforcement.
+		problems = append(problems, fmt.Sprintf("W2 push without client cert failed for a non-TLS reason, cannot prove mTLS enforcement: %v", noCertErr))
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("gateway write path checks failed:\n%s", strings.Join(problems, "\n"))
 	}
 
 	log.Info("MLA Gateway write path verified.")
 	return nil
+}
+
+// isTLSRejection reports whether an exec error looks like curl refusing at the
+// TLS layer: exit 35 (SSL connect error) when the handshake is rejected
+// outright, exit 56 (recv failure) when nginx completes the TLS 1.3 handshake
+// and then closes the connection with a certificate-required alert.
+func isTLSRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+
+	return strings.Contains(msg, "exit code 35") || strings.Contains(msg, "exit code 56")
 }
 
 // waitGatewayPodReady returns the pod IP of a ready mla-gateway pod in the
@@ -884,7 +936,7 @@ func waitGatewayPodReady(ctx context.Context, client ctrlruntimeclient.Client, n
 		if err := client.List(ctx, pods,
 			ctrlruntimeclient.InNamespace(namespace),
 			ctrlruntimeclient.MatchingLabels{"app.kubernetes.io/name": gatewayName}); err != nil {
-			return nil, fmt.Errorf("failed to list gateway pods: %w", err)
+			return fmt.Errorf("failed to list gateway pods: %w", err), nil
 		}
 
 		for i := range pods.Items {
@@ -917,10 +969,10 @@ func isPodReady(p *corev1.Pod) bool {
 	return false
 }
 
-// isSuccessPushCode treats 2xx (and 204 no-content, the normal Loki push
-// response) as a successful write. An empty code means curl bailed before any
-// HTTP response (TLS handshake failure), which is a failure for positive
-// assertions and a pass for the mTLS-negative one.
+// isSuccessPushCode treats any 2xx as a successful write (Loki push normally
+// returns 204). An empty code means curl bailed before any HTTP response
+// (TLS handshake failure), which is a failure for positive assertions and a
+// pass for the mTLS-negative one.
 func isSuccessPushCode(code string) bool {
 	return len(code) == 3 && code[0] == '2'
 }


### PR DESCRIPTION
Add verifyGatewayWritePath to exercise the gateway write path (mTLS, TLS 1.3, proxying) end to end.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump MLA Gateway nginx image to v1.31.2-alpine
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
