### PR TITLE
Change pull_request to pull_request_target 

### DIFF
--- a/.github/workflows/conformance-trigger.yml
+++ b/.github/workflows/conformance-trigger.yml
@@ -1,7 +1,7 @@
 name: Conformance Issue Trigger
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
     paths:
@@ -12,10 +12,20 @@ on:
       - 'pkg/ee/kubevirt-network-controller/**'
       - 'addons/csi/kubevirt/**'
       - 'sdk/apis/kubermatic/v1/cluster.go'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to create conformance tracking issues for'
+        required: true
+        type: string
 
 jobs:
   create-issues:
-    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'kind/feature') || contains(github.event.pull_request.labels.*.name, 'kind/bug'))
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+        (contains(github.event.pull_request.labels.*.name, 'kind/feature') ||
+         contains(github.event.pull_request.labels.*.name, 'kind/bug')))
     runs-on: ubuntu-latest
     environment:
       name: KKP
@@ -28,21 +38,26 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
-          PR_BODY=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body --jq '.body')
-          KIND_LABELS=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name | select(startswith("kind/"))] | join(",")')
+          PR=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json title,url,body,labels,mergedAt)
+
+          # workflow_dispatch can't check merge state/labels in the job "if", so enforce it here.
+          if [ "$(jq -r '.mergedAt != null and ([.labels[].name] | any(. == "kind/feature" or . == "kind/bug"))' <<<"$PR")" != "true" ]; then
+            echo "::error::PR #${PR_NUMBER} must be merged and labeled kind/feature or kind/bug."
+            exit 1
+          fi
 
           {
-            echo "pr_title=${{ github.event.pull_request.title }}"
             echo "pr_number=${PR_NUMBER}"
-            echo "pr_url=${{ github.event.pull_request.html_url }}"
-            echo "kind_labels=${KIND_LABELS}"
+            echo "pr_title=$(jq -r .title <<<"$PR")"
+            echo "pr_url=$(jq -r .url <<<"$PR")"
+            echo "kind_labels=$(jq -r '[.labels[].name | select(startswith("kind/"))] | join(",")' <<<"$PR")"
             echo "pr_body<<PR_BODY_EOF"
-            echo "${PR_BODY}"
+            jq -r .body <<<"$PR"
             echo "PR_BODY_EOF"
           } >> "$GITHUB_OUTPUT"
-
+      
       - name: Create issue in kubermatic
         id: kkp-issue
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Change workflow trigger from `pull_request` to `pull_request_target`, because `pull_request_target` runs in the base repository's context, so the `GITHUB_TOKEN` gets full write permissions and access to secrets, which `pull_request` denies for PRs coming from forks.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
