### PR TITLE
Add standard Prometheus path annotation to nodeport proxy

### DIFF
--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments.go
@@ -74,6 +74,7 @@ func EnvoyDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, seed *
 				"prometheus.io/scrape":                                  "true",
 				"prometheus.io/port":                                    strconv.Itoa(EnvoyPort),
 				"prometheus.io/metrics_path":                            "/stats/prometheus",
+				"prometheus.io/path":                                    "/stats/prometheus",
 				"fluentbit.io/parser":                                   "json_iso",
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "envoy-config",
 			})

--- a/pkg/controller/operator/seed/resources/nodeportproxy/deployments_test.go
+++ b/pkg/controller/operator/seed/resources/nodeportproxy/deployments_test.go
@@ -74,6 +74,35 @@ func TestEnvoyDeploymentReconcilerReplicas(t *testing.T) {
 	}
 }
 
+func TestEnvoyDeploymentReconcilerPrometheusAnnotations(t *testing.T) {
+	t.Parallel()
+
+	seed := &kubermaticv1.Seed{}
+
+	_, reconcile := EnvoyDeploymentReconciler(&kubermaticv1.KubermaticConfiguration{}, seed, false, kubermatic.Versions{
+		KubermaticContainerTag: "v0.0.0-test",
+	})()
+
+	reconciled, err := reconcile(&appsv1.Deployment{})
+	if err != nil {
+		t.Fatalf("failed to reconcile deployment: %v", err)
+	}
+
+	annotations := reconciled.Spec.Template.Annotations
+	if annotations["prometheus.io/scrape"] != "true" {
+		t.Fatalf("expected prometheus scrape annotation to be true, got %q", annotations["prometheus.io/scrape"])
+	}
+	if annotations["prometheus.io/port"] != "8002" {
+		t.Fatalf("expected prometheus port annotation to be 8002, got %q", annotations["prometheus.io/port"])
+	}
+	if annotations["prometheus.io/path"] != "/stats/prometheus" {
+		t.Fatalf("expected prometheus path annotation to be /stats/prometheus, got %q", annotations["prometheus.io/path"])
+	}
+	if annotations["prometheus.io/metrics_path"] != "/stats/prometheus" {
+		t.Fatalf("expected prometheus metrics_path annotation to be /stats/prometheus, got %q", annotations["prometheus.io/metrics_path"])
+	}
+}
+
 func TestEnvoyDeploymentReconcilerAffinityUsesNameLabel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`nodeport-proxy-envoy` exposes metrics on `/stats/prometheus`, but only annotated this via `prometheus.io/metrics_path`. Scrape configs that only use the common `prometheus.io/path` annotation (which multiple kkp components already use) fall back to `/metrics` and receive `404`.

This PR fixes it and keeps `prometheus.io/metrics_path` annotation for compatibility.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/16091

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed nodeport-proxy-envoy Prometheus annotations to include the standard `prometheus.io/path` metrics path annotation.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
