### PR TITLE
Bump dex chart to 0.24.1

### DIFF
--- a/charts/dex/Chart.lock
+++ b/charts/dex/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: dex
   repository: https://charts.dexidp.io
-  version: 0.24.0
-digest: sha256:edc13197d17a4f57be57b6276617398b55c40748b01ff09c800f93a7d344cf05
-generated: "2025-09-12T02:16:26.274458989+05:30"
+  version: 0.24.1
+digest: sha256:844f2761a4adb252b2cb4cdaeef3fe016e850c89996602806575b9c83fe4a1ab
+generated: "2026-07-06T19:18:00.721322+03:00"

--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 dependencies:
   - repository: https://charts.dexidp.io
     name: dex
-    version: 0.24.0
+    version: 0.24.1

--- a/charts/dex/test/default.yaml.out
+++ b/charts/dex/test/default.yaml.out
@@ -6,7 +6,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -19,7 +19,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -61,7 +61,7 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -77,7 +77,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -98,7 +98,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -115,7 +115,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -136,7 +136,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -165,7 +165,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: c9d19a62d710c06e36b31c1a8676051aabffbe7575de361b74c3c2e93a65b9dc
+        checksum/config: cf65f5eff074e784e4c7f7cd2cc68d57ef3dcade877e927ba7488f88d551c499
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -259,7 +259,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"

--- a/charts/dex/test/values.example.ce.yaml.out
+++ b/charts/dex/test/values.example.ce.yaml.out
@@ -6,7 +6,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -19,7 +19,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -61,7 +61,7 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -77,7 +77,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -98,7 +98,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -115,7 +115,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -136,7 +136,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -165,7 +165,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 31b3f09a3753ade9252c083cc916642e19907a16de86789904b8f5cf3745a864
+        checksum/config: 9bc28c9be29d99ee7989cbc1c17b7ee54e9527f99c9d3dc937445cf5d11482d5
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -259,7 +259,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"

--- a/charts/dex/test/values.example.ee.yaml.out
+++ b/charts/dex/test/values.example.ee.yaml.out
@@ -6,7 +6,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -19,7 +19,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -61,7 +61,7 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -77,7 +77,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -98,7 +98,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -115,7 +115,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -136,7 +136,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -165,7 +165,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: 31b3f09a3753ade9252c083cc916642e19907a16de86789904b8f5cf3745a864
+        checksum/config: 9bc28c9be29d99ee7989cbc1c17b7ee54e9527f99c9d3dc937445cf5d11482d5
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name
@@ -259,7 +259,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"

--- a/charts/dex/test/values.httproute.yaml.out
+++ b/charts/dex/test/values.httproute.yaml.out
@@ -6,7 +6,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -19,7 +19,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -61,7 +61,7 @@ kind: ClusterRole
 metadata:
   name: release-name-dex
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -77,7 +77,7 @@ kind: ClusterRoleBinding
 metadata:
   name: release-name-dex-cluster
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -98,7 +98,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -115,7 +115,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -136,7 +136,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -165,7 +165,7 @@ metadata:
   name: release-name-dex
   namespace: default
   labels:
-    helm.sh/chart: dex-0.24.0
+    helm.sh/chart: dex-0.24.1
     app.kubernetes.io/name: dex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "2.44.0"
@@ -183,7 +183,7 @@ spec:
     metadata:
       annotations:
       
-        checksum/config: c9d19a62d710c06e36b31c1a8676051aabffbe7575de361b74c3c2e93a65b9dc
+        checksum/config: cf65f5eff074e784e4c7f7cd2cc68d57ef3dcade877e927ba7488f88d551c499
       labels:
         app.kubernetes.io/name: dex
         app.kubernetes.io/instance: release-name


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the vendored dex chart from 0.24.0 to 0.24.1. The appVersion stays at 2.44.0, so this is just a chart patch bump. The 0.24.1 release adds an optional Gateway API HTTPRoute template that is off by default.

**Which issue(s) this PR fixes**:
Fixes #16104

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```