### PR TITLE
Bump cert-manager Helm chart to v1.20.3

### DIFF
--- a/charts/cert-manager/Chart.lock
+++ b/charts/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.19.4
-digest: sha256:0bc58732b03575b508819f5356502cf841e1a1146a403d50541bd71b3f212066
-generated: "2026-03-10T13:50:38.402488538+01:00"
+  version: v1.20.3
+digest: sha256:bae6dd079566575b0b7ce0ef21f7d4cb30152ac82214f35fd811b32729301f6e
+generated: "2026-07-06T19:26:16.117484+03:00"

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: cert-manager
 version: 9.9.9-dev
-appVersion: v1.19.4
+appVersion: v1.20.3
 description: A Helm chart for cert-manager
 keywords:
   - kubermatic
@@ -31,4 +31,4 @@ maintainers:
 dependencies:
   - repository: https://charts.jetstack.io
     name: cert-manager
-    version: 1.19.4
+    version: 1.20.3

--- a/charts/cert-manager/crd/cert-manager.crds.yaml
+++ b/charts/cert-manager/crd/cert-manager.crds.yaml
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: acme.cert-manager.io
   names:
@@ -301,6 +301,22 @@ spec:
                                 The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                 If set, ClientID and ClientSecret must also be set.
                               type: string
+                            zoneType:
+                              description: |-
+                                ZoneType determines which type of Azure DNS zone to use.
+
+                                Valid values are:
+                                  - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                  - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                If not specified, AzurePublicZone is used.
+
+                                Support for Azure Private DNS zones is currently
+                                experimental and may change in future releases.
+                              enum:
+                                - AzurePublicZone
+                                - AzurePrivateZone
+                              type: string
                           required:
                             - resourceGroupName
                             - subscriptionID
@@ -424,7 +440,7 @@ spec:
                               description: |-
                                 The IP address or hostname of an authoritative DNS server supporting
                                 RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                 This field is required.
                               type: string
                             protocol:
@@ -474,8 +490,8 @@ spec:
                               description: |-
                                 The AccessKeyID is used for authentication.
                                 Cannot be set when SecretAccessKeyID is set.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               type: string
                             accessKeyIDSecretRef:
@@ -483,8 +499,8 @@ spec:
                                 The SecretAccessKey is used for authentication. If set, pull the AWS
                                 access key ID from a key within a Kubernetes Secret.
                                 Cannot be set when AccessKeyID is set.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               properties:
                                 key:
@@ -573,8 +589,8 @@ spec:
                             secretAccessKeySecretRef:
                               description: |-
                                 The SecretAccessKey is used for authentication.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               properties:
                                 key:
@@ -1931,9 +1947,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -3142,9 +3159,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -3292,6 +3310,10 @@ spec:
             - metadata
             - spec
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3309,7 +3331,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: acme.cert-manager.io
   names:
@@ -3568,6 +3590,10 @@ spec:
             - metadata
             - spec
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3585,7 +3611,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -3889,6 +3915,10 @@ spec:
                   type: string
               type: object
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3906,7 +3936,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -4349,9 +4379,6 @@ spec:
                         will be generated whenever a re-issuance occurs.
                         Default is `Always`.
                         The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
-                        The new default can be disabled by setting the
-                        `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
-                        the controller component.
                       enum:
                         - Never
                         - Always
@@ -4707,6 +4734,10 @@ spec:
                   type: integer
               type: object
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -4724,7 +4755,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -5112,6 +5143,22 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                  zoneType:
+                                    description: |-
+                                      ZoneType determines which type of Azure DNS zone to use.
+
+                                      Valid values are:
+                                        - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                        - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                      If not specified, AzurePublicZone is used.
+
+                                      Support for Azure Private DNS zones is currently
+                                      experimental and may change in future releases.
+                                    enum:
+                                      - AzurePublicZone
+                                      - AzurePrivateZone
+                                    type: string
                                 required:
                                   - resourceGroupName
                                   - subscriptionID
@@ -5235,7 +5282,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:
@@ -5285,8 +5332,8 @@ spec:
                                     description: |-
                                       The AccessKeyID is used for authentication.
                                       Cannot be set when SecretAccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     type: string
                                   accessKeyIDSecretRef:
@@ -5294,8 +5341,8 @@ spec:
                                       The SecretAccessKey is used for authentication. If set, pull the AWS
                                       access key ID from a key within a Kubernetes Secret.
                                       Cannot be set when AccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -5384,8 +5431,8 @@ spec:
                                   secretAccessKeySecretRef:
                                     description: |-
                                       The SecretAccessKey is used for authentication.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -6742,9 +6789,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -7953,9 +8001,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -8212,8 +8261,8 @@ spec:
                               properties:
                                 audiences:
                                   description: |-
-                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
-                                    consisting of the issuer's namespace and name is always included.
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
                                   items:
                                     type: string
                                   type: array
@@ -8341,16 +8390,16 @@ spec:
                   type: object
                 venafi:
                   description: |-
-                    Venafi configures this issuer to sign certificates using a Venafi TPP
-                    or Venafi Cloud policy zone.
+                    Venafi configures this issuer to sign certificates using a CyberArk Certificate Manager Self-Hosted
+                    or SaaS policy zone.
                   properties:
                     cloud:
                       description: |-
-                        Cloud specifies the Venafi cloud configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        Cloud specifies the CyberArk Certificate Manager SaaS configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         apiTokenSecretRef:
-                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          description: APITokenSecretRef is a secret key selector for the CyberArk Certificate Manager SaaS API token.
                           properties:
                             key:
                               description: |-
@@ -8368,7 +8417,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for Venafi Cloud.
+                            URL is the base URL for CyberArk Certificate Manager SaaS.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
                       required:
@@ -8376,13 +8425,13 @@ spec:
                       type: object
                     tpp:
                       description: |-
-                        TPP specifies Trust Protection Platform configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         caBundle:
                           description: |-
                             Base64-encoded bundle of PEM CAs which will be used to validate the certificate
-                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            chain presented by the CyberArk Certificate Manager Self-Hosted server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
                           format: byte
@@ -8390,7 +8439,7 @@ spec:
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
-                            which will be used to validate the certificate chain presented by the TPP server.
+                            which will be used to validate the certificate chain presented by the CyberArk Certificate Manager Self-Hosted server.
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
@@ -8411,7 +8460,7 @@ spec:
                           type: object
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            CredentialsRef is a reference to a Secret containing the CyberArk Certificate Manager Self-Hosted API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
                           properties:
@@ -8425,7 +8474,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            URL is the base URL for the vedsdk endpoint of the CyberArk Certificate Manager Self-Hosted instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
                       required:
@@ -8434,8 +8483,8 @@ spec:
                       type: object
                     zone:
                       description: |-
-                        Zone is the Venafi Policy Zone to use for this issuer.
-                        All requests made to the Venafi platform will be restricted by the named
+                        Zone is the Certificate Manager Policy Zone to use for this issuer.
+                        All requests made to the Certificate Manager platform will be restricted by the named
                         zone policy.
                         This field is required.
                       type: string
@@ -8541,7 +8590,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
 spec:
   group: cert-manager.io
   names:
@@ -8928,6 +8977,22 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                  zoneType:
+                                    description: |-
+                                      ZoneType determines which type of Azure DNS zone to use.
+
+                                      Valid values are:
+                                        - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                        - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                      If not specified, AzurePublicZone is used.
+
+                                      Support for Azure Private DNS zones is currently
+                                      experimental and may change in future releases.
+                                    enum:
+                                      - AzurePublicZone
+                                      - AzurePrivateZone
+                                    type: string
                                 required:
                                   - resourceGroupName
                                   - subscriptionID
@@ -9051,7 +9116,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:
@@ -9101,8 +9166,8 @@ spec:
                                     description: |-
                                       The AccessKeyID is used for authentication.
                                       Cannot be set when SecretAccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     type: string
                                   accessKeyIDSecretRef:
@@ -9110,8 +9175,8 @@ spec:
                                       The SecretAccessKey is used for authentication. If set, pull the AWS
                                       access key ID from a key within a Kubernetes Secret.
                                       Cannot be set when AccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -9200,8 +9265,8 @@ spec:
                                   secretAccessKeySecretRef:
                                     description: |-
                                       The SecretAccessKey is used for authentication.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -10558,9 +10623,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -11769,9 +11835,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -12028,8 +12095,8 @@ spec:
                               properties:
                                 audiences:
                                   description: |-
-                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
-                                    consisting of the issuer's namespace and name is always included.
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
                                   items:
                                     type: string
                                   type: array
@@ -12157,16 +12224,16 @@ spec:
                   type: object
                 venafi:
                   description: |-
-                    Venafi configures this issuer to sign certificates using a Venafi TPP
-                    or Venafi Cloud policy zone.
+                    Venafi configures this issuer to sign certificates using a CyberArk Certificate Manager Self-Hosted
+                    or SaaS policy zone.
                   properties:
                     cloud:
                       description: |-
-                        Cloud specifies the Venafi cloud configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        Cloud specifies the CyberArk Certificate Manager SaaS configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         apiTokenSecretRef:
-                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          description: APITokenSecretRef is a secret key selector for the CyberArk Certificate Manager SaaS API token.
                           properties:
                             key:
                               description: |-
@@ -12184,7 +12251,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for Venafi Cloud.
+                            URL is the base URL for CyberArk Certificate Manager SaaS.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
                       required:
@@ -12192,13 +12259,13 @@ spec:
                       type: object
                     tpp:
                       description: |-
-                        TPP specifies Trust Protection Platform configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         caBundle:
                           description: |-
                             Base64-encoded bundle of PEM CAs which will be used to validate the certificate
-                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            chain presented by the CyberArk Certificate Manager Self-Hosted server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
                           format: byte
@@ -12206,7 +12273,7 @@ spec:
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
-                            which will be used to validate the certificate chain presented by the TPP server.
+                            which will be used to validate the certificate chain presented by the CyberArk Certificate Manager Self-Hosted server.
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
@@ -12227,7 +12294,7 @@ spec:
                           type: object
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            CredentialsRef is a reference to a Secret containing the CyberArk Certificate Manager Self-Hosted API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
                           properties:
@@ -12241,7 +12308,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            URL is the base URL for the vedsdk endpoint of the CyberArk Certificate Manager Self-Hosted instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
                       required:
@@ -12250,8 +12317,8 @@ spec:
                       type: object
                     zone:
                       description: |-
-                        Zone is the Venafi Policy Zone to use for this issuer.
-                        All requests made to the Venafi platform will be restricted by the named
+                        Zone is the Certificate Manager Policy Zone to use for this issuer.
+                        All requests made to the Certificate Manager platform will be restricted by the named
                         zone policy.
                         This field is required.
                       type: string

--- a/charts/cert-manager/test/default.yaml.out
+++ b/charts/cert-manager/test/default.yaml.out
@@ -5,15 +5,15 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: release-name-cert-manager-cainjector
-  namespace: sandbox
+  namespace: default
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -21,15 +21,15 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: release-name-cert-manager
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -37,15 +37,15 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: release-name-cert-manager-webhook
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,9 +57,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -91,9 +91,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -119,9 +119,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -147,9 +147,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -184,9 +184,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -206,6 +206,9 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders/finalizers"]
     verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers/finalizers", "issuers/finalizers"]
+    verbs: ["update"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
@@ -224,9 +227,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -286,9 +289,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -306,10 +309,10 @@ rules:
     resources: ["ingresses/finalizers"]
     verbs: ["update"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways", "httproutes"]
+    resources: ["gateways", "httproutes", "listenersets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways/finalizers", "httproutes/finalizers"]
+    resources: ["gateways/finalizers", "httproutes/finalizers", "listenersets/finalizers"]
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["events"]
@@ -325,9 +328,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -344,9 +347,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -369,9 +372,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -382,8 +385,11 @@ rules:
     resources: ["certificates/status"]
     verbs: ["update"]
   - apiGroups: ["acme.cert-manager.io"]
-    resources: ["challenges", "orders"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+    resources: ["challenges"]
+    verbs: ["delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["delete", "deletecollection"]
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
@@ -396,9 +402,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -420,9 +426,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -448,9 +454,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -466,16 +472,16 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-cainjector
 subjects:
   - name: release-name-cert-manager-cainjector
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -488,16 +494,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-issuers
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -510,16 +516,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-clusterissuers
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -532,16 +538,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-certificates
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -554,16 +560,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-orders
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -576,16 +582,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-challenges
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -598,16 +604,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-ingress-shim
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -620,16 +626,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-approve:cert-manager-io
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -642,16 +648,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-name-cert-manager-controller-certificatesigningrequests
 subjects:
   - name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-rbac.yaml
@@ -664,9 +670,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -674,7 +680,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: release-name-cert-manager-webhook
-  namespace: sandbox
+  namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 # leader election rules
@@ -688,9 +694,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -716,9 +722,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -733,15 +739,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-cert-manager-tokenrequest
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -753,15 +759,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-cert-manager-webhook:dynamic-serving
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -786,9 +792,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -796,7 +802,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: release-name-cert-manager-cainjector
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # grant cert-manager permission to manage the leaderelection configmap in the
@@ -811,9 +817,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -821,7 +827,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # grant cert-manager permission to create tokens for the serviceaccount
@@ -829,15 +835,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-cert-manager-tokenrequest
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -845,22 +851,22 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: release-name-cert-manager
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-cert-manager-webhook:dynamic-serving
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -868,22 +874,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: release-name-cert-manager-webhook
-  namespace: sandbox
+  namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: release-name-cert-manager-cainjector
-  namespace: sandbox
+  namespace: default
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -900,15 +906,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: release-name-cert-manager
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -926,15 +932,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: release-name-cert-manager-webhook
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -956,15 +962,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-cert-manager-cainjector
-  namespace: sandbox
+  namespace: default
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -979,9 +985,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -995,7 +1001,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1023,15 +1029,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-cert-manager
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -1046,9 +1052,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1062,13 +1068,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-controller:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.4
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.3
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -1109,15 +1115,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-cert-manager-webhook
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -1132,9 +1138,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1148,7 +1154,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1212,11 +1218,11 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
-    cert-manager.io/inject-ca-from-secret: "sandbox/release-name-cert-manager-webhook-ca"
+    cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
   - name: webhook.cert-manager.io
     rules:
@@ -1240,7 +1246,7 @@ webhooks:
     clientConfig:
       service:
         name: release-name-cert-manager-webhook
-        namespace: sandbox
+        namespace: default
         path: /mutate
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -1253,11 +1259,11 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
-    cert-manager.io/inject-ca-from-secret: "sandbox/release-name-cert-manager-webhook-ca"
+    cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
   - name: webhook.cert-manager.io
     namespaceSelector:
@@ -1288,7 +1294,7 @@ webhooks:
     clientConfig:
       service:
         name: release-name-cert-manager-webhook
-        namespace: sandbox
+        namespace: default
         path: /validate
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
@@ -1297,7 +1303,7 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: release-name-cert-manager-startupapicheck
-  namespace: sandbox
+  namespace: default
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1307,9 +1313,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-rbac.yaml
 # create certificate role
@@ -1317,15 +1323,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: release-name-cert-manager-startupapicheck:create-cert
-  namespace: sandbox
+  namespace: default
   labels:
     app: startupapicheck
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1340,15 +1346,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: release-name-cert-manager-startupapicheck:create-cert
-  namespace: sandbox
+  namespace: default
   labels:
     app: startupapicheck
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1360,22 +1366,22 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: release-name-cert-manager-startupapicheck
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-job.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: release-name-cert-manager-startupapicheck
-  namespace: sandbox
+  namespace: default
   labels:
     app: startupapicheck
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1389,9 +1395,9 @@ spec:
         app.kubernetes.io/name: startupapicheck
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "startupapicheck"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
     spec:
       restartPolicy: OnFailure
       serviceAccountName: release-name-cert-manager-startupapicheck
@@ -1402,7 +1408,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-startupapicheck
-          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - check

--- a/charts/cert-manager/test/override-controller-test.yaml.out
+++ b/charts/cert-manager/test/override-controller-test.yaml.out
@@ -5,15 +5,15 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: cert-manager-cainjector
-  namespace: sandbox
+  namespace: default
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -21,15 +21,15 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: cert-manager
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -37,15 +37,15 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: cert-manager-webhook
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,9 +57,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -91,9 +91,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -119,9 +119,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -147,9 +147,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -184,9 +184,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -206,6 +206,9 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders/finalizers"]
     verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers/finalizers", "issuers/finalizers"]
+    verbs: ["update"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
@@ -224,9 +227,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -286,9 +289,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -306,10 +309,10 @@ rules:
     resources: ["ingresses/finalizers"]
     verbs: ["update"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways", "httproutes"]
+    resources: ["gateways", "httproutes", "listenersets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways/finalizers", "httproutes/finalizers"]
+    resources: ["gateways/finalizers", "httproutes/finalizers", "listenersets/finalizers"]
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["events"]
@@ -325,9 +328,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -344,9 +347,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -369,9 +372,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -382,8 +385,11 @@ rules:
     resources: ["certificates/status"]
     verbs: ["update"]
   - apiGroups: ["acme.cert-manager.io"]
-    resources: ["challenges", "orders"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+    resources: ["challenges"]
+    verbs: ["delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["delete", "deletecollection"]
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
@@ -396,9 +402,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -420,9 +426,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -448,9 +454,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -466,16 +472,16 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-cainjector
 subjects:
   - name: cert-manager-cainjector
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -488,16 +494,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-issuers
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -510,16 +516,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-clusterissuers
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -532,16 +538,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-certificates
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -554,16 +560,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-orders
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -576,16 +582,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-challenges
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -598,16 +604,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-ingress-shim
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -620,16 +626,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-approve:cert-manager-io
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
@@ -642,16 +648,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cert-manager-controller-certificatesigningrequests
 subjects:
   - name: cert-manager
-    namespace: sandbox
+    namespace: default
     kind: ServiceAccount
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-rbac.yaml
@@ -664,9 +670,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -674,7 +680,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cert-manager-webhook
-  namespace: sandbox
+  namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 # leader election rules
@@ -688,9 +694,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -716,9 +722,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -733,15 +739,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-tokenrequest
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -753,15 +759,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-webhook:dynamic-serving
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -786,9 +792,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -796,7 +802,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cert-manager-cainjector
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # grant cert-manager permission to manage the leaderelection configmap in the
@@ -811,9 +817,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -821,7 +827,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cert-manager
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # grant cert-manager permission to create tokens for the serviceaccount
@@ -829,15 +835,15 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-tokenrequest
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -845,22 +851,22 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cert-manager
-    namespace: sandbox
+    namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-webhook:dynamic-serving
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -868,22 +874,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cert-manager-webhook
-  namespace: sandbox
+  namespace: default
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: cert-manager-cainjector
-  namespace: sandbox
+  namespace: default
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -900,15 +906,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cert-manager
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -926,15 +932,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cert-manager-webhook
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   type: ClusterIP
   ports:
@@ -956,15 +962,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager-cainjector
-  namespace: sandbox
+  namespace: default
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -979,9 +985,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -995,7 +1001,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1030,15 +1036,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager
-  namespace: sandbox
+  namespace: default
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -1053,9 +1059,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1069,13 +1075,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-controller:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.4
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.3
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -1122,15 +1128,15 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager-webhook
-  namespace: sandbox
+  namespace: default
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
 spec:
   replicas: 1
   selector:
@@ -1145,9 +1151,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.3"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.19.4
+        helm.sh/chart: cert-manager-v1.20.3
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -1161,7 +1167,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.20.3"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1231,11 +1237,11 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
-    cert-manager.io/inject-ca-from-secret: "sandbox/cert-manager-webhook-ca"
+    cert-manager.io/inject-ca-from-secret: "default/cert-manager-webhook-ca"
 webhooks:
   - name: webhook.cert-manager.io
     rules:
@@ -1259,7 +1265,7 @@ webhooks:
     clientConfig:
       service:
         name: cert-manager-webhook
-        namespace: sandbox
+        namespace: default
         path: /mutate
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -1272,11 +1278,11 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.3"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.19.4
+    helm.sh/chart: cert-manager-v1.20.3
   annotations:
-    cert-manager.io/inject-ca-from-secret: "sandbox/cert-manager-webhook-ca"
+    cert-manager.io/inject-ca-from-secret: "default/cert-manager-webhook-ca"
 webhooks:
   - name: webhook.cert-manager.io
     namespaceSelector:
@@ -1307,5 +1313,5 @@ webhooks:
     clientConfig:
       service:
         name: cert-manager-webhook
-        namespace: sandbox
+        namespace: default
         path: /validate


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the vendored cert-manager chart from v1.19.4 to v1.20.3. Chart.lock, the embedded CRDs, and the golden test fixtures are regenerated to match.

**Which issue(s) this PR fixes**:
Fixes #16103

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

No chart values KKP relies on were removed or renamed upstream in 1.20.x. A couple of behavioral notes worth flagging: cert-manager pods now run as 65532:65532 instead of 1000:0, and the `DefaultPrivateKeyRotationPolicyAlways` feature gate is GA so it can't be turned off. Neither affects our shipped config.

The ApplicationDefinition in `pkg/ee/default-application-catalog/` is left alone on purpose. It tracks a separate version line pulled from the OCI mirror, not this vendored chart, so it belongs in its own change.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The cert-manager chart shipped with KKP is bumped to v1.20.3.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
