### PR TITLE
Prevent deleting pending UserProjectBindings before their User exists

### DIFF
--- a/pkg/controller/master-controller-manager/user-project-binding/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller.go
@@ -43,6 +43,10 @@ const (
 	controllerName = "kkp-user-project-binding-controller"
 
 	userProjectBindingEmailKey = ".spec.userEmail"
+
+	// userResolvedAnnotation is set on a UserProjectBinding once its referenced
+	// User has been found at least once.
+	userResolvedAnnotation = "userprojectbinding.kubermatic.k8c.io/user-resolved"
 )
 
 // reconcileSyncProjectBinding reconciles UserProjectBinding objects.
@@ -113,6 +117,11 @@ func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.Su
 	user, err := r.getUserForBinding(ctx, projectBinding)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			if projectBinding.Annotations[userResolvedAnnotation] != "true" {
+				log.Debug("user for binding not found yet, binding is pending")
+				return nil
+			}
+
 			if err := r.removeFinalizerFromBinding(ctx, projectBinding); err != nil {
 				return fmt.Errorf("failed to remove finalizer from orphaned binding %s: %w", projectBinding.Name, err)
 			}
@@ -123,6 +132,10 @@ func (r *reconcileSyncProjectBinding) reconcile(ctx context.Context, log *zap.Su
 		}
 
 		return fmt.Errorf("failed to get user from binding: %w", err)
+	}
+
+	if err := r.markUserResolved(ctx, projectBinding); err != nil {
+		return fmt.Errorf("failed to mark binding %s as resolved: %w", projectBinding.Name, err)
 	}
 
 	if projectBinding.DeletionTimestamp != nil {
@@ -189,6 +202,24 @@ func (r *reconcileSyncProjectBinding) ensureNotProjectOwnerForBinding(ctx contex
 	}
 
 	return r.removeFinalizerFromBinding(ctx, projectBinding)
+}
+
+// markUserResolved records that this binding's User has been found, so that a
+// later NotFound for the same binding can be recognized as orphaned rather
+// than pending.
+func (r *reconcileSyncProjectBinding) markUserResolved(ctx context.Context, projectBinding *kubermaticv1.UserProjectBinding) error {
+	if projectBinding.Annotations[userResolvedAnnotation] == "true" {
+		return nil
+	}
+
+	oldBinding := projectBinding.DeepCopy()
+
+	if projectBinding.Annotations == nil {
+		projectBinding.Annotations = map[string]string{}
+	}
+	projectBinding.Annotations[userResolvedAnnotation] = "true"
+
+	return r.Patch(ctx, projectBinding, ctrlruntimeclient.MergeFrom(oldBinding))
 }
 
 func (r *reconcileSyncProjectBinding) addFinalizerToBinding(ctx context.Context, projectBinding *kubermaticv1.UserProjectBinding) error {

--- a/pkg/controller/master-controller-manager/user-project-binding/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -212,5 +213,80 @@ func TestEnsureProjectOwnerForBinding(t *testing.T) {
 				t.Fatalf("Objects differ:\n%v", diff.ObjectDiff(test.expectedProject, updatedProject))
 			}
 		})
+	}
+}
+
+func TestReconcilePendingBindingIsNotDeleted(t *testing.T) {
+	ctx := context.Background()
+
+	binding := test.CreateExpectedEditorBinding("James Bond", thunderball)
+
+	kubermaticFakeClient := fake.
+		NewClientBuilder().
+		WithObjects(binding, thunderball). // no matching User exists
+		Build()
+
+	target := reconcileSyncProjectBinding{Client: kubermaticFakeClient}
+
+	if err := target.reconcile(ctx, zap.NewNop().Sugar(), binding); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedBinding := &kubermaticv1.UserProjectBinding{}
+	if err := kubermaticFakeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: binding.Name}, updatedBinding); err != nil {
+		t.Fatalf("expected pending binding to still exist, but got: %v", err)
+	}
+
+	if updatedBinding.Annotations[userResolvedAnnotation] == "true" {
+		t.Fatal("expected pending binding to not be marked as resolved")
+	}
+}
+
+func TestReconcileOrphanedBindingIsDeleted(t *testing.T) {
+	ctx := context.Background()
+
+	binding := test.CreateExpectedEditorBinding("James Bond", thunderball)
+	binding.Annotations = map[string]string{userResolvedAnnotation: "true"}
+
+	kubermaticFakeClient := fake.
+		NewClientBuilder().
+		WithObjects(binding, thunderball). // no matching User exists anymore
+		Build()
+
+	target := reconcileSyncProjectBinding{Client: kubermaticFakeClient}
+
+	if err := target.reconcile(ctx, zap.NewNop().Sugar(), binding); err != nil {
+		t.Fatal(err)
+	}
+
+	err := kubermaticFakeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: binding.Name}, &kubermaticv1.UserProjectBinding{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected orphaned binding to be deleted, but got err: %v", err)
+	}
+}
+
+func TestReconcileMarksBindingAsResolved(t *testing.T) {
+	ctx := context.Background()
+
+	binding := test.CreateExpectedEditorBinding("James Bond", thunderball)
+
+	kubermaticFakeClient := fake.
+		NewClientBuilder().
+		WithObjects(binding, thunderball, jamesBond).
+		Build()
+
+	target := reconcileSyncProjectBinding{Client: kubermaticFakeClient}
+
+	if err := target.reconcile(ctx, zap.NewNop().Sugar(), binding); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedBinding := &kubermaticv1.UserProjectBinding{}
+	if err := kubermaticFakeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: binding.Name}, updatedBinding); err != nil {
+		t.Fatal(err)
+	}
+
+	if updatedBinding.Annotations[userResolvedAnnotation] != "true" {
+		t.Fatal("expected binding to be marked as resolved")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the `UserProjectBinding` controller deleting bindings immediately when their User didn't exist yet (e.g. before first login), instead of only deleting ones that were truly
  orphaned (e.g. a removed service account).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15949 

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed UserProjectBindings being deleted before their User logs in for the first time.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/kubermatic/issues/16150
```
