### PR TITLE
Bump KubeLB CCM to v1.4.3

### DIFF
--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -62,7 +62,7 @@ var (
 
 const (
 	imageName = "kubelb-ccm-ee"
-	imageTag  = "v1.4.1"
+	imageTag  = "v1.4.3"
 )
 
 type kubeLBData interface {

--- a/pkg/ee/kubelb/resources/user-cluster/static/crd-syncsecrets.yaml
+++ b/pkg/ee/kubelb/resources/user-cluster/static/crd-syncsecrets.yaml
@@ -18,13 +18,14 @@
 #
 # END OF TERMS AND CONDITIONS
 
-# Source: https://github.com/kubermatic/kubelb/blob/v1.3.0/charts/kubelb-ccm/crds/kubelb.k8c.io_syncsecrets.yaml
+
+# Source: https://github.com/kubermatic/kubelb/blob/v1.4.3/charts/kubelb-ccm/crds/kubelb.k8c.io_syncsecrets.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: syncsecrets.kubelb.k8c.io
 spec:
   group: kubelb.k8c.io
@@ -35,46 +36,125 @@ spec:
     singular: syncsecret
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description:
-            SyncSecret is a wrapper over Kubernetes Secret object. This is
-            used to sync secrets from tenants to the LB cluster in a controlled and
-            secure way.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+  - additionalPrinterColumns:
+    - jsonPath: .type
+      name: Type
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SyncSecret is a wrapper over Kubernetes Secret object. This is
+          used to sync secrets from tenants to the LB cluster in a controlled and
+          secure way.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          data:
+            additionalProperties:
+              format: byte
               type: string
-            data:
-              additionalProperties:
-                format: byte
+            type: object
+          immutable:
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            description: SyncSecretStatus defines the observed state of SyncSecret.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the SyncSecret's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this SyncSecret by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the current lifecycle phase of the SyncSecret.
                 type: string
-              type: object
-            immutable:
-              type: boolean
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: object
+          stringData:
+            additionalProperties:
               type: string
-            metadata:
-              type: object
-            stringData:
-              additionalProperties:
-                type: string
-              type: object
-            type:
-              type: string
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+            type: object
+          type:
+            type: string
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
This PR bumps the CCM image tag and refreshes the embedded SyncSecret CRD.

**Which issue(s) this PR fixes**:
None

**What type of PR is this?**

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Update KubeLB CCM to v1.4.3
```

**Documentation**:

```documentation
NONE
```

**Test issue**:

```test-issue
NONE
```
