### PR TITLE
Enable server-side apply with conflict forcing when the installer runs with Helm 4

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -177,6 +177,16 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 		"--timeout", c.timeout.String(),
 	}
 
+	if c.version.Major() >= 4 {
+		// Helm 4 defaults --server-side to "auto", which follows the apply method of the
+		// previous release revision. KKP components legitimately co-own fields of some
+		// chart-managed objects (e.g. the operator reconciles .dockerconfigjson of the
+		// dockercfg secret), so a plain server-side apply upgrade fails with field
+		// conflicts. Force SSA and conflict resolution so the installer always converges
+		// on the chart-defined state.
+		command = append(command, "--server-side=true", "--force-conflicts")
+	}
+
 	if valuesFile != "" {
 		command = append(command, "--values", valuesFile)
 	} else {
@@ -184,12 +194,31 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 	}
 
 	command = append(command, valuesToFlags(values)...)
-	command = append(command, flags...)
+	command = append(command, c.translateFlags(flags)...)
 	command = append(command, releaseName, chartDirectory)
 
 	_, err := c.run(namespace, command...)
 
 	return err
+}
+
+// translateFlags maps Helm-3-era flags to their Helm 4 replacements.
+func (c *cli) translateFlags(flags []string) []string {
+	if c.version.Major() < 4 {
+		return flags
+	}
+
+	result := make([]string, 0, len(flags))
+	for _, flag := range flags {
+		// deprecated in Helm 4
+		if flag == "--atomic" {
+			flag = "--rollback-on-failure"
+		}
+
+		result = append(result, flag)
+	}
+
+	return result
 }
 
 func (c *cli) GetRelease(namespace string, name string) (*Release, error) {

--- a/pkg/install/helm/cli_test.go
+++ b/pkg/install/helm/cli_test.go
@@ -144,3 +144,83 @@ func TestListReleasesUsesCorrectFlagsForHelmVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
+	testcases := []struct {
+		name         string
+		helmVersion  string
+		flags        []string
+		expectedArgs []string
+	}{
+		{
+			name:        "helm v3 does not enable server-side apply and keeps --atomic",
+			helmVersion: "3.19.0",
+			flags:       []string{"--atomic"},
+			expectedArgs: []string{
+				"helm",
+				"--namespace", "test-namespace",
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--values", "values.yaml",
+				"--atomic",
+				"release", "chart-dir",
+			},
+		},
+		{
+			name:        "helm v4.0 enables server-side apply and translates --atomic",
+			helmVersion: "4.0.0",
+			flags:       []string{"--atomic"},
+			expectedArgs: []string{
+				"helm",
+				"--namespace", "test-namespace",
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--server-side=true", "--force-conflicts",
+				"--values", "values.yaml",
+				"--rollback-on-failure",
+				"release", "chart-dir",
+			},
+		},
+		{
+			name:        "helm v4.1 enables server-side apply without extra flags",
+			helmVersion: "4.1.1",
+			flags:       nil,
+			expectedArgs: []string{
+				"helm",
+				"--namespace", "test-namespace",
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--server-side=true", "--force-conflicts",
+				"--values", "values.yaml",
+				"release", "chart-dir",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalRunCmd := runCmd
+			t.Cleanup(func() {
+				runCmd = originalRunCmd
+			})
+
+			capturedArgs := []string{}
+			runCmd = func(cmd *exec.Cmd) ([]byte, error) {
+				capturedArgs = append([]string{}, cmd.Args...)
+				return nil, nil
+			}
+
+			c := &cli{
+				binary:     "helm",
+				kubeconfig: "test-kubeconfig",
+				timeout:    30 * time.Second,
+				version:    *semverlib.MustParse(tc.helmVersion),
+				logger:     logrus.New(),
+			}
+
+			err := c.InstallChart("test-namespace", "release", "chart-dir", "values.yaml", nil, tc.flags)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedArgs, capturedArgs)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Helm 4 defaults `--server-side` to "auto" and uses server-side apply for releases that were installed by Helm 4. KKP components legitimately co-own fields of some chart-managed objects, for example the kubermatic-operator reconciles `.dockerconfigjson` of the `dockercfg` Secret from `KubermaticConfiguration.spec.imagePullSecret`. When such a field diverges from the chart-rendered value, `helm upgrade` fails with "Apply failed with 1 conflict" and the installer `deploy` aborts.

This change makes the installer's helm wrapper pass `--server-side=true` and `--force-conflicts` on the `upgrade --install` path when the detected Helm binary is major version 4, so the installer always converges on the chart-defined state. It also translates the deprecated `--atomic` flag to `--rollback-on-failure` for Helm 4. Helm 3 invocations are unchanged. The version gating mirrors the existing Helm 3/4 handling of `--all` in `ListReleases`.

Verified on a kind cluster: with a release installed by Helm 4 and `dockercfg` co-owned by the operator with diverged content, a plain `helm upgrade` reproduces the conflict from the issue; the patched installer deploys successfully, reclaims the field for Helm, and repeated runs stay successful. Helm 3 deploys emit the previous command unchanged.

**Which issue(s) this PR fixes**:
Fixes #16063

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
The forced apply covers every chart the installer deploys, so fields of chart-managed objects that were modified out-of-band are reset to chart-defined content on deploy. Custom CA bundles belong in a separately named ConfigMap referenced by `spec.caBundle`, per the existing documentation.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
kubermatic-installer now enables server-side apply with conflict forcing when running with Helm 4, fixing `deploy` failures caused by field-ownership conflicts (for example on the dockercfg Secret). With Helm 4 the deprecated `--atomic` flag is replaced by `--rollback-on-failure`.
```

**Documentation**:
```documentation
NONE (no documentation needed for this PR)
```

**Test issue**:
```test-issue
NONE
```
