### PR TITLE
user-cluster prometheus: second set of memory optimization

### DIFF
--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -229,6 +229,14 @@ scrape_configs:
     replacement: $1
     target_label: instance
 
+  # drop etcd's gRPC server request-count metrics; not referenced by any
+  # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+  # newer etcd versions no longer even expose that histogram)
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: 'grpc_server_.*'
+    action: drop
+
 # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
 - job_name: kubernetes-control-plane
   scheme: https
@@ -293,6 +301,10 @@ scrape_configs:
   - source_labels: [__name__]
     regex: 'workqueue_.*'
     action: drop
+  # instance (pod IP:port) is redundant with the pod label set above, since
+  # each pod maps to exactly one instance here
+  - action: labeldrop
+    regex: instance
 
 # scrape other cluster control plane components,
 # except kube-state-metrics (handled separately below), DNS resolver,
@@ -331,6 +343,12 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: pod
+
+  # instance (pod IP:port) is redundant with the pod label set above, since
+  # each pod maps to exactly one instance here
+  metric_relabel_configs:
+  - action: labeldrop
+    regex: instance
 
 # Dedicated, highly-filtered job for KSM
 - job_name: kube-state-metrics
@@ -409,6 +427,12 @@ scrape_configs:
     target_label: pod
   - target_label: job
     replacement: konnectivity-server
+
+  # instance (pod IP:port) is redundant with the pod label set above, since
+  # each pod maps to exactly one instance here
+  metric_relabel_configs:
+  - action: labeldrop
+    regex: instance
 {{- end }}
 
 #######################################################################
@@ -578,6 +602,12 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: pod
+
+  # instance (pod IP:port) is redundant with the pod label set above, since
+  # each pod maps to exactly one instance here
+  metric_relabel_configs:
+  - action: labeldrop
+    regex: instance
 {{- end }}
 {{- end }}
 {{- with .CustomScrapingConfigs -}}

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-aws-1.35.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.35.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-aws-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-azure-1.35.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.35.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-azure-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-baremetal-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-baremetal-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.35.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.35.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-edge-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-edge-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-gcp-1.35.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.35.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-gcp-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-openstack-1.35.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.35.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-openstack-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vcd-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vcd-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.33.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.34.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.35.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.35.0-prometheus-externalCloudProvider.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.35.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.35.0-prometheus.yaml
@@ -46,6 +46,14 @@ data:
         replacement: $1
         target_label: instance
 
+      # drop etcd's gRPC server request-count metrics; not referenced by any
+      # alert/recording rule (only grpc_server_handling_seconds_bucket is, and
+      # newer etcd versions no longer even expose that histogram)
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grpc_server_.*'
+        action: drop
+
     # scrape the cluster's control plane (apiserver, controller-manager, scheduler)
     - job_name: kubernetes-control-plane
       scheme: https
@@ -112,6 +120,10 @@ data:
       - source_labels: [__name__]
         regex: 'workqueue_.*'
         action: drop
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      - action: labeldrop
+        regex: instance
 
     # scrape other cluster control plane components,
     # except kube-state-metrics (handled separately below), DNS resolver,
@@ -150,6 +162,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     # Dedicated, highly-filtered job for KSM
     - job_name: kube-state-metrics
@@ -225,6 +243,12 @@ data:
         target_label: pod
       - target_label: job
         replacement: konnectivity-server
+
+      # instance (pod IP:port) is redundant with the pod label set above, since
+      # each pod maps to exactly one instance here
+      metric_relabel_configs:
+      - action: labeldrop
+        regex: instance
 
     #######################################################################
     # These rules will scrape pods running inside the user cluster itself.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR builds upon #15861 to add more optimization for unused metrics

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # NA

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
/kind chore

**Special notes for your reviewer**:
This screenshot shows impact of this change on a "bare" cluster with zero workload. 1st line shows memory usage by default prometheus and 2nd series shows after 2nd level optimized configmap was deployed.

<img width="657" height="614" alt="image" src="https://github.com/user-attachments/assets/ac7ff858-5a89-43b0-b386-73b5d4ef65b7" />

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Along with #15861, this PR reduces amount of memory utilization by the prometheus component of each user-cluster. But if you had bumped up the prometheus memory requests via componentsOverride, you would not get benefit of memory optimizations. So please review actual memory usage of user-xxxx/prometheus pods and adjust componentsOverride, as needed.
action required: If you had written custom alert rules / grafana dashboards on seed which uses metrics from job="nodes", you would need to update job name to kubelet instead. If you had written alerts / dashboards which use "instance" attribute, you will need to rewire your alerts / dahboards with pod attribute for some of the metrics.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/kubermatic/issues/15909
```
