### PR TITLE
installer: keep --force-conflicts but stop forcing --server-side=true for Helm 4

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -178,13 +178,16 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 	}
 
 	if c.version.Major() >= 4 {
-		// Helm 4 defaults --server-side to "auto", which follows the apply method of the
-		// previous release revision. KKP components legitimately co-own fields of some
-		// chart-managed objects (e.g. the operator reconciles .dockerconfigjson of the
-		// dockercfg secret), so a plain server-side apply upgrade fails with field
-		// conflicts. Force SSA and conflict resolution so the installer always converges
-		// on the chart-defined state.
-		command = append(command, "--server-side=true", "--force-conflicts")
+		// Helm 4 defaults --server-side to "auto" and already applies chart objects
+		// server-side. KKP components legitimately co-own fields of some chart-managed
+		// objects (e.g. the operator reconciles .dockerconfigjson of the dockercfg
+		// secret), so a plain server-side apply upgrade fails with field conflicts.
+		// --force-conflicts resolves those in helm's favor without forcing the apply
+		// method to "true", which would rewrite the full object body of every managed
+		// resource on every deploy and overwhelm loaded apiservers (e.g. the large
+		// user-cluster MLA stack). The conflict resolution is driven by --force-conflicts,
+		// not by forcing --server-side=true.
+		command = append(command, "--force-conflicts")
 	}
 
 	if valuesFile != "" {

--- a/pkg/install/helm/cli_test.go
+++ b/pkg/install/helm/cli_test.go
@@ -167,7 +167,7 @@ func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
 			},
 		},
 		{
-			name:        "helm v4.0 enables server-side apply and translates --atomic",
+			name:        "helm v4.0 forces conflict resolution and translates --atomic",
 			helmVersion: "4.0.0",
 			flags:       []string{"--atomic"},
 			expectedArgs: []string{
@@ -175,14 +175,14 @@ func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
 				"--namespace", "test-namespace",
 				"upgrade", "--install",
 				"--timeout", "30s",
-				"--server-side=true", "--force-conflicts",
+				"--force-conflicts",
 				"--values", "values.yaml",
 				"--rollback-on-failure",
 				"release", "chart-dir",
 			},
 		},
 		{
-			name:        "helm v4.1 enables server-side apply without extra flags",
+			name:        "helm v4.1 forces conflict resolution without extra flags",
 			helmVersion: "4.1.1",
 			flags:       nil,
 			expectedArgs: []string{
@@ -190,7 +190,7 @@ func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
 				"--namespace", "test-namespace",
 				"upgrade", "--install",
 				"--timeout", "30s",
-				"--server-side=true", "--force-conflicts",
+				"--force-conflicts",
 				"--values", "values.yaml",
 				"release", "chart-dir",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

#16138 made the installer pass `--server-side=true --force-conflicts` on the upgrade path when Helm 4 is detected, to fix the #16063 server-side-apply field-manager conflict on the `dockercfg` Secret (co-owned by the kubermatic-operator).

Forcing `--server-side=true` was unnecessary and harmful. Helm 4 already defaults `--server-side` to `auto` and applies chart objects server-side, so the conflict is resolved by `--force-conflicts` alone. Forcing `true` instead made the installer rewrite the full object body of every managed resource on every deploy, which overwhelmed the user-cluster MLA apiserver in post-kubermatic-deploy-dev (`etcdserver: request timed out` patching PodDisruptionBudgets/Secrets).

This keeps `--force-conflicts` (so #16063 stays fixed) and drops `--server-side=true` (so Helm keeps its lighter `auto` apply method). The `--atomic` to `--rollback-on-failure` translation for Helm 4 is unchanged.

Verified locally: reproduced the #16063 conflict on kind and confirmed `--server-side=auto --force-conflicts` resolves it on both the upgrade and fresh-install paths, same as `--server-side=true --force-conflicts`. Unit tests updated.

**Which issue(s) this PR fixes**:
Fixes #16162

**What type of PR is this**:
/kind bug

**Special notes for your reviewer**:
Regression introduced by #16138 (merged). The dev pipeline went red at that revision and stayed red; this restores the green baseline while preserving the #16063 fix.

**Does this PR introduce a user-facing change? Then add the Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```