### PR TITLE
Add conformance release bump workflow and enhance trigger with labels

### DIFF
--- a/.github/workflows/conformance-release.yml
+++ b/.github/workflows/conformance-release.yml
@@ -1,0 +1,120 @@
+name: Conformance Release Bump
+
+# This workflow is triggered when a new KKP release is tagged, and it opens a tracking issue in the
+# conformance-ee repository to bump the KKP module dependencies and cut a new conformance-ee release.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to open the conformance-ee bump issue for (e.g. v2.30.5 or v2.30.0-rc.0)'
+        required: true
+        type: string
+
+jobs:
+  create-release-bump-issue:
+    runs-on: ubuntu-latest
+    environment:
+      name: KKP
+      deployment: false
+
+    steps:
+      - name: Parse tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          # Tag pushes set GITHUB_REF_NAME to the tag; manual runs pass it in.
+          TAG="${INPUT_TAG:-${GITHUB_REF_NAME}}"
+
+          # Manual runs accept a free-form tag, so validate the shape before
+          # deriving a release branch / module path from it.
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::'${TAG}' is not a valid vMAJOR.MINOR.PATCH[-prerelease] release tag."
+            exit 1
+          fi
+          
+          # A pre-release tag carries a hyphenated suffix (e.g. v2.30.0-rc.0).
+          if [[ "$TAG" == *-* ]]; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+          
+          MINOR="$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\..*/\1/')"
+          MAJOR="$(echo "$TAG" | sed -E 's/^v([0-9]+)\..*/\1/')"
+
+          {
+            echo "tag=${TAG}"
+            echo "minor=${MINOR}"
+            echo "major=${MAJOR}"
+            echo "release_branch=release/${MINOR}"
+            echo "prerelease=${PRERELEASE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create issue in conformance-ee
+        env:
+          GH_TOKEN: ${{ secrets.KKP_CONFORMANCE_CROSS_GH_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_BRANCH: ${{ steps.tag.outputs.release_branch }}
+          MAJOR: ${{ steps.tag.outputs.major }}
+          PRERELEASE: ${{ steps.tag.outputs.prerelease }}
+          SOURCE_REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            TITLE="Bump KKP to ${TAG} (pre-release) and cut a new conformance-ee release"
+            RELEASE_NOTE="This is a **pre-release** (\`${TAG}\`); mark the conformance-ee release as a pre-release too."
+          else
+            TITLE="Bump KKP to ${TAG} and cut a new conformance-ee release"
+            RELEASE_NOTE="Cut a new conformance-ee release for \`${TAG}\`."
+          fi
+
+          # Idempotency: a tag push is a one-time event, but a re-run (or a
+          # re-pushed tag) should not open a duplicate.
+          EXISTING=$(gh issue list \
+            --repo kubermatic/conformance-ee \
+            --state open \
+            --search "in:title \"${TITLE}\"" \
+            --json number \
+            --jq 'length')
+          if [ "${EXISTING:-0}" -gt 0 ]; then
+            echo "An open issue titled '${TITLE}' already exists; skipping."
+            exit 0
+          fi
+          
+          ISSUE_URL=$(gh issue create \
+            --repo kubermatic/conformance-ee \
+            --title "${TITLE}" \
+            --assignee "kubermatic-bot" \
+            --assignee "@copilot" \
+            --body "## Release Bump Tracking
+
+          A new KKP release tag has been created in [\`${SOURCE_REPO}\`](${SERVER_URL}/${SOURCE_REPO}).
+
+          | Field | Value |
+          |-------|-------|
+          | **Release tag** | [\`${TAG}\`](${SERVER_URL}/${SOURCE_REPO}/releases/tag/${TAG}) |
+          | **Release branch** | \`${RELEASE_BRANCH}\` |
+
+          ### Action required
+          On the \`${RELEASE_BRANCH}\` branch of this repository:
+          
+          1. Bump the KKP module dependencies in \`go.mod\` to \`${TAG}\`:
+             - \`k8c.io/kubermatic/v${MAJOR}@${TAG}\`
+             - \`k8c.io/kubermatic/sdk/v${MAJOR}@${TAG}\`
+          2. Run \`go mod tidy\` and commit the updated \`go.mod\`/\`go.sum\`.
+          3. Open a PR against \`${RELEASE_BRANCH}\`, get it merged.
+          4. ${RELEASE_NOTE}
+
+          <!-- SOURCE-METADATA
+          source-repo: ${SOURCE_REPO}
+          source-tag: ${TAG}
+          release-branch: ${RELEASE_BRANCH}
+          prerelease: ${PRERELEASE}
+          -->")
+
+          echo "Created conformance-ee issue: ${ISSUE_URL}"

--- a/.github/workflows/conformance-release.yml
+++ b/.github/workflows/conformance-release.yml
@@ -44,14 +44,16 @@ jobs:
             PRERELEASE=false
           fi
           
-          MINOR="$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\..*/\1/')"
+          # major.minor without the leading "v" (e.g. v2.30.5 -> 2.30). The
+          # conformance-ee release branches are named release/kkp-<major.minor>.
+          MAJOR_MINOR="$(echo "$TAG" | sed -E 's/^v([0-9]+\.[0-9]+)\..*/\1/')"
+          # Major version alone drives the Go module path suffix (kubermatic/vN).
           MAJOR="$(echo "$TAG" | sed -E 's/^v([0-9]+)\..*/\1/')"
 
           {
             echo "tag=${TAG}"
-            echo "minor=${MINOR}"
             echo "major=${MAJOR}"
-            echo "release_branch=release/${MINOR}"
+            echo "release_branch=release/kkp-${MAJOR_MINOR}"
             echo "prerelease=${PRERELEASE}"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/conformance-trigger.yml
+++ b/.github/workflows/conformance-trigger.yml
@@ -94,11 +94,15 @@ jobs:
           KIND_LABELS: ${{ steps.pr.outputs.kind_labels }}
         run: |
           LABEL_ARGS=()
+          KIND_DISPLAY="—"
           if [ -n "$KIND_LABELS" ]; then
+            KIND_DISPLAY=""
             IFS=',' read -ra LABELS <<< "$KIND_LABELS"
             for label in "${LABELS[@]}"; do
               gh label create "$label" --repo "kubermatic/conformance-ee" --force 2>/dev/null || true
               LABEL_ARGS+=(--label "$label")
+              [ -n "$KIND_DISPLAY" ] && KIND_DISPLAY="${KIND_DISPLAY}, "
+              KIND_DISPLAY="${KIND_DISPLAY}\`${label}\`"
             done
           fi
 
@@ -114,6 +118,7 @@ jobs:
           |-------|-------|
           | **KKP PR** | [#${PR_NUMBER} — ${PR_TITLE}](${PR_URL}) |
           | **KKP Issue** | [#${KKP_ISSUE_NUMBER}](${KKP_ISSUE_URL}) |
+          | **Kind labels** | ${KIND_DISPLAY} |
           
           ### PR Description
           ${PR_BODY}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Added `conformance-release` workflow to synchronize KKP and Conformance-ee releases.
- Updated `conformance-trigger` workflow to add labels in the issue description.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
