### PR TITLE
Fix/duplicate project groups

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -233,7 +233,7 @@ func main() {
 	// /////////////////////////////////////////
 	// setup GroupProjectBinding webhook
 
-	groupProjectBindingValidator := groupprojectbinding.NewValidator()
+	groupProjectBindingValidator := groupprojectbinding.NewValidator(mgr.GetClient())
 	if err := builder.WebhookManagedBy(mgr, &kubermaticv1.GroupProjectBinding{}).WithValidator(groupProjectBindingValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup GroupProjectBinding validation webhook", zap.Error(err))
 	}

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -74,7 +74,7 @@ func WebhookClusterRoleReconciler(cfg *kubermaticv1.KubermaticConfiguration) rec
 			r.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"kubermatic.k8c.io"},
-					Resources: []string{"clustertemplates", "projects", "ipamallocations", "resourcequotas", "users"},
+					Resources: []string{"clustertemplates", "projects", "ipamallocations", "resourcequotas", "users", "groupprojectbindings"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 				{

--- a/pkg/ee/validation/groupprojectbinding/groupprojectbinding.go
+++ b/pkg/ee/validation/groupprojectbinding/groupprojectbinding.go
@@ -25,10 +25,29 @@
 package groupprojectbinding
 
 import (
+	"context"
 	"errors"
+	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func ValidateCreate(ctx context.Context, binding *kubermaticv1.GroupProjectBinding, client ctrlruntimeclient.Client) error {
+	existingBindings := &kubermaticv1.GroupProjectBindingList{}
+	if err := client.List(ctx, existingBindings); err != nil {
+		return fmt.Errorf("failed to list GroupProjectBindings: %w", err)
+	}
+
+	for _, existing := range existingBindings.Items {
+		if existing.Spec.Group == binding.Spec.Group && existing.Spec.ProjectID == binding.Spec.ProjectID {
+			return fmt.Errorf("group %q is already bound to project %q", binding.Spec.Group, binding.Spec.ProjectID)
+		}
+	}
+
+	return nil
+}
 
 func ValidateUpdate(oldGroupProjectBinding *kubermaticv1.GroupProjectBinding, newGroupProjectBinding *kubermaticv1.GroupProjectBinding) error {
 	if oldGroupProjectBinding.Spec.ProjectID != newGroupProjectBinding.Spec.ProjectID {

--- a/pkg/ee/validation/groupprojectbinding/groupprojectbinding.go
+++ b/pkg/ee/validation/groupprojectbinding/groupprojectbinding.go
@@ -35,24 +35,47 @@ import (
 )
 
 func ValidateCreate(ctx context.Context, binding *kubermaticv1.GroupProjectBinding, client ctrlruntimeclient.Client) error {
-	existingBindings := &kubermaticv1.GroupProjectBindingList{}
-	if err := client.List(ctx, existingBindings); err != nil {
-		return fmt.Errorf("failed to list GroupProjectBindings: %w", err)
+	duplicate, err := hasDuplicateGroupProjectBinding(ctx, client, binding, binding.Name)
+	if err != nil {
+		return err
 	}
-
-	for _, existing := range existingBindings.Items {
-		if existing.Spec.Group == binding.Spec.Group && existing.Spec.ProjectID == binding.Spec.ProjectID {
-			return fmt.Errorf("group %q is already bound to project %q", binding.Spec.Group, binding.Spec.ProjectID)
-		}
+	if duplicate {
+		return fmt.Errorf("group %q is already bound to project %q", binding.Spec.Group, binding.Spec.ProjectID)
 	}
 
 	return nil
 }
 
-func ValidateUpdate(oldGroupProjectBinding *kubermaticv1.GroupProjectBinding, newGroupProjectBinding *kubermaticv1.GroupProjectBinding) error {
+func ValidateUpdate(ctx context.Context, oldGroupProjectBinding *kubermaticv1.GroupProjectBinding, newGroupProjectBinding *kubermaticv1.GroupProjectBinding, client ctrlruntimeclient.Client) error {
 	if oldGroupProjectBinding.Spec.ProjectID != newGroupProjectBinding.Spec.ProjectID {
 		return errors.New("attribute \"projectID\" cannot be updated for existing GroupProjectBinding resource")
 	}
 
+	duplicate, err := hasDuplicateGroupProjectBinding(ctx, client, newGroupProjectBinding, newGroupProjectBinding.Name)
+	if err != nil {
+		return err
+	}
+	if duplicate {
+		return fmt.Errorf("group %q is already bound to project %q", newGroupProjectBinding.Spec.Group, newGroupProjectBinding.Spec.ProjectID)
+	}
+
 	return nil
+}
+
+func hasDuplicateGroupProjectBinding(ctx context.Context, client ctrlruntimeclient.Client, binding *kubermaticv1.GroupProjectBinding, excludeName string) (bool, error) {
+	existingBindings := &kubermaticv1.GroupProjectBindingList{}
+	if err := client.List(ctx, existingBindings); err != nil {
+		return false, fmt.Errorf("failed to list GroupProjectBindings: %w", err)
+	}
+
+	for _, existing := range existingBindings.Items {
+		if existing.Name == excludeName {
+			continue
+		}
+		if existing.Spec.Group == binding.Spec.Group && existing.Spec.ProjectID == binding.Spec.ProjectID {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/ee/validation/groupprojectbinding/groupprojectbinding_test.go
+++ b/pkg/ee/validation/groupprojectbinding/groupprojectbinding_test.go
@@ -25,6 +25,7 @@
 package groupprojectbinding_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -32,9 +33,80 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/ee/validation/groupprojectbinding"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func TestValidateCreate(t *testing.T) {
+	testCases := []struct {
+		name            string
+		existingBinding *kubermaticv1.GroupProjectBinding
+		newBinding      *kubermaticv1.GroupProjectBinding
+		errExpected     bool
+	}{
+		{
+			name: "no existing binding, create succeeds",
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			errExpected: false,
+		},
+		{
+			name: "same group and project already bound, create fails",
+			existingBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "existing-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "editors"},
+			},
+			errExpected: true,
+		},
+		{
+			name: "same group different project, create succeeds",
+			existingBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "existing-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project2", Role: "viewers"},
+			},
+			errExpected: false,
+		},
+		{
+			name: "different group same project, create succeeds",
+			existingBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "existing-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group1", ProjectID: "project1", Role: "viewers"},
+			},
+			newBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-binding"},
+				Spec:       kubermaticv1.GroupProjectBindingSpec{Group: "group2", ProjectID: "project1", Role: "viewers"},
+			},
+			errExpected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []ctrlruntimeclient.Object
+			if tc.existingBinding != nil {
+				objs = append(objs, tc.existingBinding)
+			}
+			client := fake.NewClientBuilder().WithObjects(objs...).Build()
+
+			err := groupprojectbinding.ValidateCreate(context.Background(), tc.newBinding, client)
+			if (err != nil) != tc.errExpected {
+				t.Fatalf("expected error: %v, got: %v", tc.errExpected, err)
+			}
+		})
+	}
+}
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := []struct {

--- a/pkg/ee/validation/groupprojectbinding/groupprojectbinding_test.go
+++ b/pkg/ee/validation/groupprojectbinding/groupprojectbinding_test.go
@@ -27,6 +27,7 @@ package groupprojectbinding_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,6 +114,7 @@ func TestValidateUpdate(t *testing.T) {
 		name                   string
 		oldGroupProjectBinding *kubermaticv1.GroupProjectBinding
 		newGroupProjectBinding *kubermaticv1.GroupProjectBinding
+		otherBindings          []ctrlruntimeclient.Object
 		expectedError          error
 	}{
 		{
@@ -163,11 +165,74 @@ func TestValidateUpdate(t *testing.T) {
 			},
 			expectedError: errors.New("attribute \"projectID\" cannot be updated for existing GroupProjectBinding resource"),
 		},
+		{
+			name: "not allowed update: changing group collides with another binding",
+			oldGroupProjectBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "binding2",
+				},
+				Spec: kubermaticv1.GroupProjectBindingSpec{
+					Group:     "group2",
+					Role:      "role2",
+					ProjectID: "project1",
+				},
+			},
+			newGroupProjectBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "binding2",
+				},
+				Spec: kubermaticv1.GroupProjectBindingSpec{
+					Group:     "group1",
+					Role:      "role2",
+					ProjectID: "project1",
+				},
+			},
+			otherBindings: []ctrlruntimeclient.Object{
+				&kubermaticv1.GroupProjectBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "binding1",
+					},
+					Spec: kubermaticv1.GroupProjectBindingSpec{
+						Group:     "group1",
+						Role:      "role1",
+						ProjectID: "project1",
+					},
+				},
+			},
+			expectedError: fmt.Errorf("group %q is already bound to project %q", "group1", "project1"),
+		},
+		{
+			name: "allowed no-op update: unchanged group and project do not collide with self",
+			oldGroupProjectBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "binding1",
+				},
+				Spec: kubermaticv1.GroupProjectBindingSpec{
+					Group:     "group1",
+					Role:      "role1",
+					ProjectID: "project1",
+				},
+			},
+			newGroupProjectBinding: &kubermaticv1.GroupProjectBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "binding1",
+				},
+				Spec: kubermaticv1.GroupProjectBindingSpec{
+					Group:     "group1",
+					Role:      "role2",
+					ProjectID: "project1",
+				},
+			},
+			expectedError: nil,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := groupprojectbinding.ValidateUpdate(tc.oldGroupProjectBinding, tc.newGroupProjectBinding)
+			objs := append([]ctrlruntimeclient.Object{tc.oldGroupProjectBinding}, tc.otherBindings...)
+			client := fake.NewClientBuilder().WithObjects(objs...).Build()
+
+			err := groupprojectbinding.ValidateUpdate(context.Background(), tc.oldGroupProjectBinding, tc.newGroupProjectBinding, client)
 			assert.Equal(t, tc.expectedError, err)
 		})
 	}

--- a/pkg/webhook/groupprojectbinding/validation/validation.go
+++ b/pkg/webhook/groupprojectbinding/validation/validation.go
@@ -21,22 +21,26 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // validator for validating GroupProjectBinding CRD.
 type validator struct {
+	client ctrlruntimeclient.Client
 }
 
 // NewValidator returns a new GroupProjectBinding validator.
-func NewValidator() *validator {
-	return &validator{}
+func NewValidator(client ctrlruntimeclient.Client) *validator {
+	return &validator{
+		client: client,
+	}
 }
 
 var _ admission.Validator[*kubermaticv1.GroupProjectBinding] = &validator{}
 
 func (v *validator) ValidateCreate(ctx context.Context, obj *kubermaticv1.GroupProjectBinding) (admission.Warnings, error) {
-	return nil, validateCreate(ctx, obj)
+	return nil, validateCreate(ctx, obj, v.client)
 }
 
 func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj *kubermaticv1.GroupProjectBinding) (admission.Warnings, error) {

--- a/pkg/webhook/groupprojectbinding/validation/validation.go
+++ b/pkg/webhook/groupprojectbinding/validation/validation.go
@@ -44,7 +44,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj *kubermaticv1.GroupP
 }
 
 func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj *kubermaticv1.GroupProjectBinding) (admission.Warnings, error) {
-	return nil, validateUpdate(ctx, oldObj, newObj)
+	return nil, validateUpdate(ctx, oldObj, newObj, v.client)
 }
 
 func (v *validator) ValidateDelete(ctx context.Context, obj *kubermaticv1.GroupProjectBinding) (admission.Warnings, error) {

--- a/pkg/webhook/groupprojectbinding/validation/wrappers_ce.go
+++ b/pkg/webhook/groupprojectbinding/validation/wrappers_ce.go
@@ -23,10 +23,13 @@ import (
 	"errors"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func validateCreate(_ context.Context,
 	_ *kubermaticv1.GroupProjectBinding,
+	_ ctrlruntimeclient.Client,
 ) error {
 	return errors.New("this resource is disabled for the Community Edition")
 }

--- a/pkg/webhook/groupprojectbinding/validation/wrappers_ce.go
+++ b/pkg/webhook/groupprojectbinding/validation/wrappers_ce.go
@@ -37,6 +37,7 @@ func validateCreate(_ context.Context,
 func validateUpdate(_ context.Context,
 	_ *kubermaticv1.GroupProjectBinding,
 	_ *kubermaticv1.GroupProjectBinding,
+	_ ctrlruntimeclient.Client,
 ) error {
 	return errors.New("this resource is disabled for the Community Edition")
 }

--- a/pkg/webhook/groupprojectbinding/validation/wrappers_ee.go
+++ b/pkg/webhook/groupprojectbinding/validation/wrappers_ee.go
@@ -23,12 +23,15 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	eegroupprojectbindingvalidation "k8c.io/kubermatic/v2/pkg/ee/validation/groupprojectbinding"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateCreate(_ context.Context,
-	_ *kubermaticv1.GroupProjectBinding,
+func validateCreate(ctx context.Context,
+	obj *kubermaticv1.GroupProjectBinding,
+	client ctrlruntimeclient.Client,
 ) error {
-	return nil
+	return eegroupprojectbindingvalidation.ValidateCreate(ctx, obj, client)
 }
 
 func validateUpdate(_ context.Context,

--- a/pkg/webhook/groupprojectbinding/validation/wrappers_ee.go
+++ b/pkg/webhook/groupprojectbinding/validation/wrappers_ee.go
@@ -34,11 +34,12 @@ func validateCreate(ctx context.Context,
 	return eegroupprojectbindingvalidation.ValidateCreate(ctx, obj, client)
 }
 
-func validateUpdate(_ context.Context,
+func validateUpdate(ctx context.Context,
 	oldObj *kubermaticv1.GroupProjectBinding,
 	newObj *kubermaticv1.GroupProjectBinding,
+	client ctrlruntimeclient.Client,
 ) error {
-	return eegroupprojectbindingvalidation.ValidateUpdate(oldObj, newObj)
+	return eegroupprojectbindingvalidation.ValidateUpdate(ctx, oldObj, newObj, client)
 }
 
 func validateDelete(_ context.Context,


### PR DESCRIPTION
**What this PR does / why we need it**:
The `GroupProjectBinding` admission webhook's `validateCreate` was previously a no-op, allowing multiple bindings with the same group and projectID to be created. This continues #15809  (by @itsBaivab), which added a create-time uniqueness check. This PR adds the missing piece flagged in review: the same check on update, since `Spec.Group` and `Spec.Role` were still mutable and could be changed to collide with another existing binding's (group, projectID) pair, bypassing the create-time check entirely.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #15778 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where multiple GroupProjectBindings with the same group and project could be created. The admission webhook now rejects duplicate bindings at creation time and prevents
  an existing binding from being updated into a conflicting group/project pair.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/kubermatic/issues/16163
```
