### PR TITLE
[release/v2.29] Add support for k8s patch release v1.34.10

### DIFF
--- a/.prow/applications-catalog.yaml
+++ b/.prow/applications-catalog.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -73,7 +73,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -120,7 +120,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -167,7 +167,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -257,7 +257,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -302,7 +302,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -347,7 +347,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -482,7 +482,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -527,7 +527,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -572,7 +572,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -617,7 +617,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -662,7 +662,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-default-application-e2e-test.sh"
           env:
@@ -752,7 +752,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-application-definitions-e2e-test.sh"
           env:

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -198,7 +198,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -231,7 +231,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -258,7 +258,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -291,7 +291,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -321,7 +321,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -357,7 +357,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-cluster-backup-e2e-tests.sh"
           env:
@@ -388,7 +388,7 @@ presubmits:
       preset-docker-push: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-argocd-e2e-tests.sh"
           env:
@@ -410,7 +410,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-encryption-at-rest-tests.sh"
           env:
@@ -446,7 +446,7 @@ presubmits:
       preset-vault: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-user-ssh-key-agent-e2e-tests.sh"
           env:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ce
@@ -118,7 +118,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -166,7 +166,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -159,7 +159,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -117,7 +117,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -160,7 +160,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -204,7 +204,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -248,7 +248,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -291,7 +291,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -330,7 +330,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -166,7 +166,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -118,7 +118,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -162,7 +162,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -206,7 +206,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -301,7 +301,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-11
           command:
             - make
           args:
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - make
             - test-integration
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-11
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-11
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-11
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -202,7 +202,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - ./hack/ci/trivy-scan.sh
           env:
@@ -225,7 +225,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/release-utility-images.sh"
           env:
@@ -252,7 +252,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-11
           command:
             - "./hack/ci/run-addons-integration-test.sh"
           resources:

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -186,7 +186,7 @@ func (e *Cluster) DeleteUnwantedDeadMembers(ctx context.Context, log *zap.Sugare
 		return true, nil
 	}
 
-	// to avoide race conditions, we will run only on the cluster leader
+	// to avoid race conditions, we will run only on the cluster leader
 	leader, err := e.isLeader(ctx, log)
 	if err != nil {
 		log.Warnw("failed to determine if member is cluster leader", zap.Error(err))

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.25.11 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.25.11 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.25.11 AS builder
 
 # import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -687,6 +687,7 @@ spec:
       - v1.34.7
       - v1.34.8
       - v1.34.9
+      - v1.34.10
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -687,6 +687,7 @@ spec:
       - v1.34.7
       - v1.34.8
       - v1.34.9
+      - v1.34.10
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-11 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/update-docs.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-11 containerize ./hack/update-docs.sh
 
 (
   cd docs

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-11 containerize ./hack/update-fixtures.sh
 
 echodate "Updating fixtures..."
 make test-update &> /dev/null

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-11 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-11 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -277,6 +277,7 @@ var (
 			newSemver("v1.34.7"),
 			newSemver("v1.34.8"),
 			newSemver("v1.34.9"),
+			newSemver("v1.34.10"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.31 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for k8s patch release v1.34.10. Also bump Go build version to latest version v1.25.11. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for k8s patch release v1.34.10
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
