### PR TITLE
[release/v2.29] Add changelogs for KKP patch releases v2.29.10/v2.28.13

### DIFF
--- a/docs/changelogs/CHANGELOG-2.28.md
+++ b/docs/changelogs/CHANGELOG-2.28.md
@@ -13,6 +13,20 @@
 - [v2.28.10](#v22810)
 - [v2.28.11](#v22811)
 - [v2.28.12](#v22812)
+- [v2.28.13](#v22813)
+
+## v2.28.13
+
+**GitHub release: [v2.28.13](https://github.com/kubermatic/kubermatic/releases/tag/v2.28.13)**
+
+### Bugfixes
+
+- Fix UserProjectBindings being deleted before their User logs in for the first time ([#16131](https://github.com/kubermatic/kubermatic/pull/16131))
+- Fix KubeLB option precedence so enforced datacenters always show the option regardless of the enabled flag ([#8175](https://github.com/kubermatic/dashboard/pull/8175))
+
+### Updates
+
+- Update MLA Gateway nginx image to v1.31.2-alpine ([#16084](https://github.com/kubermatic/kubermatic/pull/16084))
 
 ## v2.28.12
 

--- a/docs/changelogs/CHANGELOG-2.29.md
+++ b/docs/changelogs/CHANGELOG-2.29.md
@@ -10,6 +10,25 @@
 - [v2.29.7](#v2297)
 - [v2.29.8](#v2298)
 - [v2.29.9](#v2299)
+- [v2.29.10](#v22910)
+
+## v2.29.10
+
+**GitHub release: [v2.29.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.10)**
+
+### Bugfixes
+
+- Fix a bug where multiple GroupProjectBindings with the same group and project could be created. The admission webhook now rejects duplicate bindings at creation time and prevents  an existing binding from being updated into a conflicting group/project pair ([#16162](https://github.com/kubermatic/kubermatic/pull/16162))
+- Fix nodeport-proxy-envoy Prometheus annotations to include the standard `prometheus.io/path` metrics path annotation ([#16092](https://github.com/kubermatic/kubermatic/pull/16092))
+- Fix the kubevirt-network-controller emitting spurious "invalid NetworkPolicy" warning events and potentially panicking when reconciling cluster-isolation NetworkPolicies in default-deny mode before the cluster's apiserver address or DNS configuration were available ([#16074](https://github.com/kubermatic/kubermatic/pull/16074))
+- Fix UserProjectBindings being deleted before their User logs in for the first time ([#16131](https://github.com/kubermatic/kubermatic/pull/16131))
+- Fix KubeLB option precedence so enforced datacenters always show the option regardless of the enabled flag ([#8174](https://github.com/kubermatic/dashboard/pull/8174))
+
+### Updates
+
+- Add support for k8s patch release v1.34.10 ([#16167](https://github.com/kubermatic/kubermatic/pull/16167))
+- Update machine-controller to v1.64.3 ([#16176](https://github.com/kubermatic/kubermatic/pull/16176))
+- Update MLA Gateway nginx image to v1.31.2-alpine ([#16084](https://github.com/kubermatic/kubermatic/pull/16084))
 
 ## v2.29.9
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add changelogs for KKP patch releases v2.29.10/v2.28.13

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
