### PR TITLE
Switch CI vSphere datastore to "vsan"

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -63,9 +63,10 @@ func (s *vSphereScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.VSphere.KKPDatacenter,
 			VSphere: &kubermaticv1.VSphereCloudSpec{
-				Username:  secrets.VSphere.Username,
-				Password:  secrets.VSphere.Password,
-				Datastore: s.datacenter.Spec.VSphere.DefaultDatastore,
+				Username:     secrets.VSphere.Username,
+				Password:     secrets.VSphere.Password,
+				Datastore:    s.datacenter.Spec.VSphere.DefaultDatastore,
+				ResourcePool: "Resources",
 			},
 		},
 		Version: s.clusterVersion,

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -186,6 +186,7 @@ timeout -s 9 "${maxDuration}m" ./_build/conformance-tester $EXTRA_ARGS \
   -node-ssh-pub-key="$E2E_SSH_PUBKEY" \
   -distributions="${DISTRIBUTIONS:-}" \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS:-}" \
+  -log-debug="true" \
   -exclude-tests="${EXCLUDE_TESTS:-}" \
   -scenario-options="${SCENARIO_OPTIONS:-}" \
   -pushgateway-endpoint="pushgateway.monitoring.svc.cluster.local.:9091" \

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -103,7 +103,7 @@ spec:
         vsphere:
           cluster: vSAN Cluster
           datacenter: Hamburg
-          datastore: Datastore0-truenas
+          datastore: vsan
           endpoint: https://10.10.0.100
           allowInsecure: true
           ipv6Enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the vSphere CI datacenter to use the `vsan` datastore, which is the shared datastore currently available in the CI vSphere environment. The previously referenced datastore is no longer available, causing vSphere e2e presubmits to fail during cluster creation.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:
vSphere e2e jobs will not auto-trigger on this PR (it does not touch `addons/csi/vsphere` or `pkg/provider/cloud/vsphere`), so they need a manual `/test` trigger to verify.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```