### PR TITLE
Bump d3fk/s3cmd image to Alpine 3.24 digest

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -409,7 +409,7 @@ spec:
     backupStoreContainer: |2
 
       name: store-container
-      image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
+      image: d3fk/s3cmd@sha256:426f98fdc8a2c7d7a879eb0da57131e6eec4d239881448f23946216fe801b614
       command:
       - /bin/sh
       - -c

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -383,7 +383,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd --debug $SSL_FLAGS \
+        s3cmd $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \
@@ -421,7 +421,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd --debug $SSL_FLAGS \
+        s3cmd $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -373,7 +373,7 @@ spec:
     backupDeleteContainer: |2
 
       name: delete-container
-      image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
+      image: d3fk/s3cmd@sha256:426f98fdc8a2c7d7a879eb0da57131e6eec4d239881448f23946216fe801b614
       command:
       - /bin/sh
       - -c
@@ -383,7 +383,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd $SSL_FLAGS \
+        s3cmd --debug SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \
@@ -421,7 +421,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd $SSL_FLAGS \
+        s3cmd --debug $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -383,7 +383,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd --debug SSL_FLAGS \
+        s3cmd --debug $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -409,7 +409,7 @@ spec:
     backupStoreContainer: |2
 
       name: store-container
-      image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
+      image: d3fk/s3cmd@sha256:426f98fdc8a2c7d7a879eb0da57131e6eec4d239881448f23946216fe801b614
       command:
       - /bin/sh
       - -c

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -383,7 +383,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd --debug $SSL_FLAGS \
+        s3cmd $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \
@@ -421,7 +421,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd --debug $SSL_FLAGS \
+        s3cmd $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -373,7 +373,7 @@ spec:
     backupDeleteContainer: |2
 
       name: delete-container
-      image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
+      image: d3fk/s3cmd@sha256:426f98fdc8a2c7d7a879eb0da57131e6eec4d239881448f23946216fe801b614
       command:
       - /bin/sh
       - -c
@@ -383,7 +383,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd $SSL_FLAGS \
+        s3cmd --debug SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \
@@ -421,7 +421,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd $SSL_FLAGS \
+        s3cmd --debug $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -383,7 +383,7 @@ spec:
           SSL_FLAGS="--no-ssl"
         fi
 
-        s3cmd --debug SSL_FLAGS \
+        s3cmd --debug $SSL_FLAGS \
           --access_key=$ACCESS_KEY_ID \
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -138,7 +138,7 @@ MINIO_TLS_CERT=$(mktemp)
 
 # create CA certificate
 openssl genrsa -out "$CUSTOM_CA_KEY" 2048
-openssl req -x509 -new -nodes -subj "/C=DE/O=Kubermatic CI/CN=kubermatic-e2e-ca" -key "$CUSTOM_CA_KEY" -sha256 -days 30 -out "$CUSTOM_CA_CERT"
+openssl req -x509 -new -nodes -subj "/C=DE/O=Kubermatic CI/CN=kubermatic-e2e-ca" -key "$CUSTOM_CA_KEY" -sha256 -days 30 -addext "basicConstraints=critical,CA:TRUE" -addext "keyUsage=critical,keyCertSign,cRLSign" -out "$CUSTOM_CA_CERT"
 
 # create private key, CSR and signed certificate for minio TLS
 openssl genrsa -out "$MINIO_TLS_KEY" 2048

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -736,7 +736,7 @@ command:
     SSL_FLAGS="--no-ssl"
   fi
 
-  s3cmd $SSL_FLAGS \
+  s3cmd --debug $SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \
@@ -749,7 +749,7 @@ volumeMounts:
 
 const DefaultBackupDeleteContainer = `
 name: delete-container
-image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
+image: d3fk/s3cmd@sha256:426f98fdc8a2c7d7a879eb0da57131e6eec4d239881448f23946216fe801b614
 command:
 - /bin/sh
 - -c
@@ -759,7 +759,7 @@ command:
     SSL_FLAGS="--no-ssl"
   fi
 
-  s3cmd $SSL_FLAGS \
+  s3cmd --debug SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -724,7 +724,7 @@ func defaultExternalClusterVersioning(settings *kubermaticv1.KubermaticVersionin
 
 const DefaultBackupStoreContainer = `
 name: store-container
-image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
+image: d3fk/s3cmd@sha256:426f98fdc8a2c7d7a879eb0da57131e6eec4d239881448f23946216fe801b614
 command:
 - /bin/sh
 - -c

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -759,7 +759,7 @@ command:
     SSL_FLAGS="--no-ssl"
   fi
 
-  s3cmd --debug SSL_FLAGS \
+  s3cmd --debug $SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -736,7 +736,7 @@ command:
     SSL_FLAGS="--no-ssl"
   fi
 
-  s3cmd --debug $SSL_FLAGS \
+  s3cmd $SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \
@@ -759,7 +759,7 @@ command:
     SSL_FLAGS="--no-ssl"
   fi
 
-  s3cmd --debug $SSL_FLAGS \
+  s3cmd $SSL_FLAGS \
     --access_key=$ACCESS_KEY_ID \
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the `d3fk/s3cmd` image from `sha256:fb4c4dc…` to `sha256:426f98f…`. The old digest was built on Alpine 3.17.1, which is end-of-life and no longer receives security updates; the new digest is built on Alpine 3.24.1. The upgrade resolves 62 CVEs carried by the outdated Alpine base packages. Full list under "Special notes" below.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
Internal reference: 9392

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
Base image moves off EOL Alpine 3.17.1 → 3.24.1 (package count 34 → 62). CVE list below is from a Trivy diff (present in old digest, absent in new). Severity breakdown was not captured in this scan.

<details>
<summary>62 CVEs resolved by this bump</summary>

CVE-2022-4203, CVE-2022-4304, CVE-2022-4450, CVE-2023-0215, CVE-2023-0216, CVE-2023-0217, CVE-2023-0286, CVE-2023-0401, CVE-2023-0464, CVE-2023-0465, CVE-2023-0466, CVE-2023-1255, CVE-2023-2650, CVE-2023-27043, CVE-2023-29491, CVE-2023-2975, CVE-2023-3446, CVE-2023-3817, CVE-2023-40217, CVE-2023-42363, CVE-2023-42364, CVE-2023-42365, CVE-2023-42366, CVE-2023-52425, CVE-2023-52426, CVE-2023-5363, CVE-2023-5678, CVE-2023-6129, CVE-2023-6237, CVE-2023-6597, CVE-2023-7104, CVE-2024-0450, CVE-2024-0727, CVE-2024-13176, CVE-2024-2511, CVE-2024-28757, CVE-2024-4032, CVE-2024-45490, CVE-2024-45491, CVE-2024-45492, CVE-2024-4603, CVE-2024-4741, CVE-2024-50602, CVE-2024-5535, CVE-2024-6119, CVE-2024-6232, CVE-2024-6345, CVE-2024-6923, CVE-2024-7592, CVE-2024-8088, CVE-2024-9143, CVE-2025-15467, CVE-2025-26519, CVE-2025-68160, CVE-2025-69418, CVE-2025-69419, CVE-2025-69420, CVE-2025-69421, CVE-2025-9230, CVE-2025-9232, CVE-2026-22795, CVE-2026-22796
</details>

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bumped the d3fk/s3cmd image to a current digest built on Alpine 3.24, resolving 62 CVEs inherited from the previously used end-of-life Alpine 3.17 base.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
