### PR TITLE
Update Azure CCM, cloud-node-manager and CSI drivers to latest versions and move to the maintained `/oss/v2` registry

### DIFF
--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -18,13 +18,13 @@
 {{ if eq .Cluster.CloudProviderName "azure" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.32.4" }}
+{{ $version = "v1.33.16" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.33.1" }}
+{{ $version = "v1.34.13" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.34.3" }}
+{{ $version = "v1.35.8" }}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 apiVersion: v1
@@ -111,7 +111,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cloud-node-manager
-        image: {{ Image (print "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:" $version) }}
+        image: {{ Image (print "mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:" $version) }}
         imagePullPolicy: IfNotPresent
         command:
         - cloud-node-manager
@@ -168,7 +168,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cloud-node-manager
-        image: {{ Image (print "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:" $version) }}
+        image: {{ Image (print "mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:" $version) }}
         imagePullPolicy: IfNotPresent
         command:
         - /cloud-node-manager.exe

--- a/addons/csi/azure-disk/Makefile
+++ b/addons/csi/azure-disk/Makefile
@@ -16,7 +16,7 @@
 
 OUTPUT_FILE = driver.yaml
 REPO_NAME = kkp-addons-csi-azure-disk
-CHART_VERSION = 1.34.3
+CHART_VERSION = 1.34.4
 
 .PHONY: default
 default: setup-helm build clean-helm

--- a/addons/csi/azure-disk/_header.txt
+++ b/addons/csi/azure-disk/_header.txt
@@ -24,11 +24,11 @@
 {{ $version = "v1.32.11" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}

--- a/addons/csi/azure-disk/customizations.patch
+++ b/addons/csi/azure-disk/customizations.patch
@@ -1,14 +1,11 @@
 --- a/addons/csi/azure-disk/driver.yaml
 +++ b/addons/csi/azure-disk/driver.yaml
-@@ -560,8 +561,12 @@ spec:
-             - --vmss-cache-ttl-seconds=-1
-             - --enable-traffic-manager=false
+@@ -560,7 +560,9 @@ spec:
              - --traffic-manager-port=7788
-+            {{- if semverCompare .Cluster.Version ">= 1.29" }}
              - --enable-otel-tracing=false
-+            {{- end }}
-+            {{- if semverCompare .Cluster.Version ">= 1.30" }}
              - --check-disk-lun-collision=true
++            {{- if semverCompare .Cluster.Version ">= 1.34" }}
+             - --vmss-detach-timeout-seconds=20
 +            {{- end }}
            env:
              - name: AZURE_CREDENTIAL_FILE

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -560,7 +560,9 @@ spec:
             - --traffic-manager-port=7788
             - --enable-otel-tracing=false
             - --check-disk-lun-collision=true
+            {{- if semverCompare .Cluster.Version ">= 1.34" }}
             - --vmss-detach-timeout-seconds=20
+            {{- end }}
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: /etc/kubernetes/azure.json

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -24,13 +24,13 @@
 {{ $version = "v1.32.11" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}
 apiVersion: v1
 kind: ServiceAccount

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -39,8 +39,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-controller-sa
   namespace: kube-system
 ---
@@ -51,8 +51,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-node-sa
   namespace: kube-system
 ---
@@ -63,8 +63,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-attacher-role
 rules:
   - apiGroups:
@@ -138,8 +138,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-provisioner-role
 rules:
   - apiGroups:
@@ -231,8 +231,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-resizer-role
 rules:
   - apiGroups:
@@ -306,8 +306,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-snapshotter-role
 rules:
   - apiGroups:
@@ -419,8 +419,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -438,8 +438,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -457,8 +457,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -476,8 +476,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -521,8 +521,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-controller
   namespace: kube-system
 spec:
@@ -539,8 +539,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.3
-        helm.sh/chart: azuredisk-csi-driver-1.34.3
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
     spec:
       containers:
         - args:
@@ -556,13 +556,13 @@ spec:
             - --user-agent-suffix=OSS-helm
             - --allow-empty-cloud-config=false
             - --vmss-cache-ttl-seconds=-1
+            - --kube-api-qps=0
+            - --kube-api-burst=0
             - --enable-traffic-manager=false
             - --traffic-manager-port=7788
             - --enable-otel-tracing=false
             - --check-disk-lun-collision=true
-            {{- if semverCompare .Cluster.Version ">= 1.34" }}
             - --vmss-detach-timeout-seconds=20
-            {{- end }}
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: /etc/kubernetes/azure.json
@@ -770,8 +770,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.3
-    helm.sh/chart: azuredisk-csi-driver-1.34.3
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-node
   namespace: kube-system
 spec:
@@ -785,8 +785,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.3
-        helm.sh/chart: azuredisk-csi-driver-1.34.3
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
     spec:
       affinity:
         nodeAffinity:
@@ -985,7 +985,7 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.34.3
+    csiDriver: v1.34.4
     snapshot: v8.5.0
   name: disk.csi.azure.com
 spec:

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -556,8 +556,6 @@ spec:
             - --user-agent-suffix=OSS-helm
             - --allow-empty-cloud-config=false
             - --vmss-cache-ttl-seconds=-1
-            - --kube-api-qps=0
-            - --kube-api-burst=0
             - --enable-traffic-manager=false
             - --traffic-manager-port=7788
             - --enable-otel-tracing=false

--- a/addons/csi/azure-file/Makefile
+++ b/addons/csi/azure-file/Makefile
@@ -16,7 +16,7 @@
 
 OUTPUT_FILE = driver.yaml
 REPO_NAME = kkp-addons-csi-azure-file
-CHART_VERSION = 1.35.0
+CHART_VERSION = 1.35.6
 
 .PHONY: default
 default: setup-helm build clean-helm

--- a/addons/csi/azure-file/_header.txt
+++ b/addons/csi/azure-file/_header.txt
@@ -24,11 +24,11 @@
 {{ $version = "v1.32.9" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.3" }}
+{{ $version = "v1.34.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.35.0" }}
+{{ $version = "v1.35.6" }}
 {{ end }}

--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -41,8 +41,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller-sa
   namespace: kube-system
 ---
@@ -55,8 +55,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node-sa
   namespace: kube-system
 ---
@@ -69,8 +69,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-attacher-role
 rules:
   - apiGroups:
@@ -140,8 +140,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-provisioner-role
 rules:
   - apiGroups:
@@ -235,8 +235,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-resizer-role
 rules:
   - apiGroups:
@@ -275,6 +275,14 @@ rules:
       - update
       - patch
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattributesclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -296,8 +304,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-snapshotter-role
 rules:
   - apiGroups:
@@ -365,8 +373,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller-secret-role
 rules:
   - apiGroups:
@@ -386,8 +394,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node-secret-role
 rules:
   - apiGroups:
@@ -406,8 +414,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -427,8 +435,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -448,8 +456,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -469,8 +477,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -490,8 +498,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller-secret-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -511,8 +519,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node-secret-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -533,8 +541,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller
   namespace: kube-system
 spec:
@@ -557,8 +565,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azurefile-csi-driver
         app.kubernetes.io/part-of: azurefile-csi-driver
-        app.kubernetes.io/version: 1.35.0
-        helm.sh/chart: azurefile-csi-driver-1.35.0
+        app.kubernetes.io/version: 1.35.6
+        helm.sh/chart: azurefile-csi-driver-1.35.6
     spec:
       containers:
         - args:
@@ -627,12 +635,12 @@ spec:
             - --extra-create-metadata=true
             - --kube-api-qps=50
             - --kube-api-burst=100
-            - --feature-gates=HonorPVReclaimPolicy=true
             - --retry-interval-max=30m
+            - --feature-gates=VolumeAttributesClass=true
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.1" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.3.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
           resources:
@@ -654,6 +662,8 @@ spec:
             - -leader-election
             - --leader-election-namespace=kube-system
             - -v=2
+            - --kube-api-qps=100
+            - --kube-api-burst=200
             - --retry-interval-max=30m
           env:
             - name: ADDRESS
@@ -681,12 +691,12 @@ spec:
             - --leader-election-namespace=kube-system
             - -handle-volume-inuse-error=false
             - -timeout=120s
-            - -feature-gates=RecoverVolumeExpansionFailure=true
+            - -feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true
             - --retry-interval-max=30m
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.2.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-resizer
           resources:
@@ -708,7 +718,7 @@ spec:
             - --probe-timeout=3s
             - --http-endpoint=localhost:29612
             - --v=2
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -768,8 +778,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node
   namespace: kube-system
 spec:
@@ -787,8 +797,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azurefile-csi-driver
         app.kubernetes.io/part-of: azurefile-csi-driver
-        app.kubernetes.io/version: 1.35.0
-        helm.sh/chart: azurefile-csi-driver-1.35.0
+        app.kubernetes.io/version: 1.35.6
+        helm.sh/chart: azurefile-csi-driver-1.35.6
     spec:
       affinity:
         nodeAffinity:
@@ -803,10 +813,8 @@ spec:
         - args:
             - --v=5
             - --endpoint=$(CSI_ENDPOINT)
-            {{- if semverCompare .Cluster.Version ">= 1.33" }}
             - --azurefile-proxy-endpoint=$(AZUREFILE_PROXY_ENDPOINT)
             - --enable-azurefile-proxy=true
-            {{- end }}
             - --nodeid=$(KUBE_NODE_NAME)
             - --kubeconfig=
             - --drivername=file.csi.azure.com
@@ -834,10 +842,8 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: AZURE_GO_SDK_LOG_LEVEL
-            {{- if semverCompare .Cluster.Version ">= 1.33" }}
             - name: AZUREFILE_PROXY_ENDPOINT
               value: unix:///csi/azurefile-proxy.sock
-            {{- end }}
           image: '{{ Image (print "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:" $version) }}'
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -880,7 +886,7 @@ spec:
             - --probe-timeout=10s
             - --http-endpoint=localhost:29613
             - --v=2
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -896,14 +902,28 @@ spec:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=2
+            - --http-endpoint=localhost:29617
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/file.csi.azure.com/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.17.0" }}'
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 10
           name: node-driver-registrar
+          ports:
+            - containerPort: 29617
+              name: healthz
+              protocol: TCP
           resources:
             limits:
               memory: 100Mi
@@ -915,7 +935,6 @@ spec:
               name: socket-dir
             - mountPath: /registration
               name: registration-dir
-        {{- if semverCompare .Cluster.Version ">= 1.34" }}
         - command:
             - azfilesrefresh
           image: '{{ Image (print "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:" $version) }}'
@@ -935,10 +954,8 @@ spec:
               name: azfilesauth
             - mountPath: /var/log/
               name: log-dir
-        {{- end }}
       dnsPolicy: Default
       hostNetwork: true
-      {{- if semverCompare .Cluster.Version ">= 1.33" }}
       hostPID: true
       initContainers:
         - command:
@@ -956,10 +973,8 @@ spec:
               value: /var/lib/kubelet
             - name: MIGRATE_K8S_REPO
               value: "false"
-            {{- if semverCompare .Cluster.Version ">= 1.34" }}
             - name: ENABLE_MI_AUTH
               value: "true"
-            {{- end }}
           image: '{{ Image (print "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:" $version) }}'
           imagePullPolicy: IfNotPresent
           name: install-azurefile-proxy
@@ -976,7 +991,6 @@ spec:
             - mountPath: /var/lib/kubelet
               mountPropagation: Bidirectional
               name: mountpoint-dir
-      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1032,7 +1046,7 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.35.0
+    csiDriver: v1.35.6
     snapshot: v8.5.0
   labels:
     app.kubernetes.io/component: csi-driver
@@ -1040,13 +1054,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: file.csi.azure.com
 spec:
   attachRequired: false
   fsGroupPolicy: ReadWriteOnceWithFSType
   podInfoOnMount: true
+  requiresRepublish: true
   tokenRequests:
     - audience: api://AzureADTokenExchange
   volumeLifecycleModes:

--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -24,13 +24,13 @@
 {{ $version = "v1.32.9" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.3" }}
+{{ $version = "v1.34.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.35.0" }}
+{{ $version = "v1.35.6" }}
 {{ end }}
 apiVersion: v1
 kind: ServiceAccount

--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -935,6 +935,7 @@ spec:
               name: socket-dir
             - mountPath: /registration
               name: registration-dir
+        {{- if semverCompare .Cluster.Version ">= 1.34" }}
         - command:
             - azfilesrefresh
           image: '{{ Image (print "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:" $version) }}'
@@ -954,6 +955,7 @@ spec:
               name: azfilesauth
             - mountPath: /var/log/
               name: log-dir
+        {{- end }}
       dnsPolicy: Default
       hostNetwork: true
       hostPID: true
@@ -973,8 +975,10 @@ spec:
               value: /var/lib/kubelet
             - name: MIGRATE_K8S_REPO
               value: "false"
+            {{- if semverCompare .Cluster.Version ">= 1.34" }}
             - name: ENABLE_MI_AUTH
               value: "true"
+            {{- end }}
           image: '{{ Image (print "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:" $version) }}'
           imagePullPolicy: IfNotPresent
           name: install-azurefile-proxy

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -71,7 +71,7 @@ func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDe
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        registry.Must(data.RewriteImage("mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v" + version)),
+					Image:        registry.Must(data.RewriteImage("mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v" + version)),
 					Command:      []string{"cloud-controller-manager"},
 					Args:         getAzureFlags(data),
 					Env:          getEnvVars(),
@@ -111,19 +111,19 @@ func AzureCCMVersion(version semver.Semver) (string, error) {
 	// reminder: do not forget to update addons/azure-cloud-node-manager as well!
 
 	// https://github.com/kubernetes-sigs/cloud-provider-azure/releases
-	// gcrane ls --json mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager | jq -r '.tags[]'
+	// gcrane ls --json mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager | jq -r '.tags[]'
 
 	switch version.MajorMinor() {
 	case v132:
-		return "1.32.4", nil
+		return "1.32.20", nil
 	case v133:
-		return "1.33.6", nil
+		return "1.33.16", nil
 	case v134:
-		fallthrough
+		return "1.34.13", nil
 	case v135:
 		fallthrough
 	default:
-		return "1.34.3", nil
+		return "1.35.8", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.33.6
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.33.16
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.34.13
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.35.8
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates all four Azure components to current, maintained images and moves the two that were on a frozen registry path onto the maintained one.

- Azure cloud-controller-manager: switch from `mcr.microsoft.com/oss/kubernetes/…` (frozen at v1.34.3) to `/oss/v2/…`, pinning the latest upstream patch per minor (v1.32.20, v1.33.16, v1.34.13, v1.35.8) with a dedicated 1.35 entry (no more 1.35→1.34 fallthrough).
- Azure cloud-node-manager: same `/oss/` → `/oss/v2/` move, and corrects a version skew where each cluster was served a node-manager a full minor behind (1.33→v1.32.4, 1.34→v1.33.1, 1.35→v1.34.3); now aligned (1.33→v1.33.16, 1.34→v1.34.13, 1.35→v1.35.8).
- Azure Disk CSI: per-minor images bumped (1.33 v1.33.7→v1.33.10, 1.34/1.35 v1.34.1→v1.34.4).
- Azure File CSI: per-minor images bumped (1.33 v1.33.7→v1.33.10, 1.34 v1.34.3→v1.34.7, 1.35 v1.35.0→v1.35.6).

Both the Disk and File addons pin a CSI image per Kubernetes minor, so a cluster runs its own minor's patch (e.g. a 1.33 cluster runs azurefile v1.33.10), not a single version everywhere.

**Security impact (Trivy diff, old tag vs new, point-in-time):**

| Component | k8s | old → new | CVEs resolved | residual | introduced |
|---|---|---|---|---|---|
| cloud-controller-manager | 1.32 | v1.32.4 → v1.32.20 | 121 | 0 | 0 |
| cloud-controller-manager | 1.33 | v1.33.6 → v1.33.16 | 100 | 0 | 0 |
| cloud-controller-manager | 1.34 | v1.34.3 → v1.34.13 | 101 | 0 | 0 |
| cloud-controller-manager | 1.35 | v1.34.3 → v1.35.8 | 101 | 0 | 0 |
| cloud-node-manager | 1.33 | v1.32.4 → v1.33.16 | 121 | 0 | 0 |
| cloud-node-manager | 1.34 | v1.33.1 → v1.34.13 | 120 | 0 | 0 |
| cloud-node-manager | 1.35 | v1.34.3 → v1.35.8 | 101 | 0 | 0 |
| azuredisk-csi | 1.33 | v1.33.7 → v1.33.10 | 3 | 0 | 0 |
| azuredisk-csi | 1.34/1.35 | v1.34.1 → v1.34.4 | 3 | 0 | 0 |
| azurefile-csi | 1.33 | v1.33.7 → v1.33.10 | 112 | 3 | 0 |
| azurefile-csi | 1.34 | v1.34.3 → v1.34.7 | 115 | 3 | 0 |
| azurefile-csi | 1.35 | v1.35.0 → v1.35.6 | 96 | 3 | 0 |

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
Internal reference: 9394

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated the Azure cloud-controller-manager, cloud-node-manager, and the Azure Disk and Azure File CSI drivers to their latest upstream versions per supported Kubernetes minor. The controller-manager and node-manager images now come from the maintained mcr.microsoft.com/oss/v2 registry path (the previous /oss path was frozen at v1.34.3), clearing the base-image CVEs those stale images carried. Kubernetes 1.35 clusters now receive matching 1.35 controller-manager and node-manager images instead of 1.34 ones.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
