### PR TITLE
Update metering to v1.4.0

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.3.1"
+	meteringVersion = "v1.4.0"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
 **What this PR does / why we need it**:
Bumps the metering image from v1.3.1 to v1.4.0. The v1.4.0 release is a dependency-only update (Go toolchain bump to 1.26.5 and routine dependency updates); no source, CLI flag, or report-schema changes that affect KKP integration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:
The metering image is pinned by a single hardcoded Go constant (`meteringVersion` in `pkg/ee/metering/reconcile.go`). The version-reporter reads this constant directly via `hack/versions.yaml`, so no chart or second edit is required. This matches the structure of the previous bump (#15353).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The metering version is upgraded to v1.4.0.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```