### PR TITLE
bump kube-state-metrics helm chart to 5.37.0

### DIFF
--- a/charts/monitoring/kube-state-metrics/Chart.lock
+++ b/charts/monitoring/kube-state-metrics/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
-  version: 5.30.0
-digest: sha256:d69fbab055710acbe8052c085a178510ecc9f0d70f2c24cbc165a47b57c2cee5
-generated: "2025-02-25T16:03:49.007961+01:00"
+  version: 5.37.0
+digest: sha256:a26f83d8f922b559856a9f07b720b50402c8deacb9dd64c2195c2dbba634cfb5
+generated: "2026-08-05T19:15:51.815138+03:00"

--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -32,5 +32,5 @@ maintainers:
 dependencies:
   - name: kube-state-metrics
     repository: https://prometheus-community.github.io/helm-charts
-    version: 5.30.0
+    version: 5.37.0
 

--- a/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
+++ b/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
@@ -1,12 +1,12 @@
 ---
 # Source: kube-state-metrics/charts/kube-state-metrics/templates/pdb.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -25,7 +25,7 @@ kind: ServiceAccount
 automountServiceAccountToken: false
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -42,7 +42,7 @@ metadata:
   name: kube-state-metrics-customresourcestate-config
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -86,7 +86,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -111,12 +111,12 @@ rules:
   - cronjobs
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   verbs: ["list", "watch"]
@@ -131,7 +131,7 @@ rules:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["networking.k8s.io"]
   resources:
   - ingresses
   verbs: ["list", "watch"]
@@ -191,7 +191,7 @@ rules:
   - pods
   verbs: ["list", "watch"]
 
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - replicasets
   verbs: ["list", "watch"]
@@ -254,7 +254,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -278,7 +278,7 @@ metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -311,7 +311,7 @@ metadata:
   name: kube-state-metrics
   namespace: default
   labels:    
-    helm.sh/chart: kube-state-metrics-5.30.0
+    helm.sh/chart: kube-state-metrics-5.37.0
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: metrics
     app.kubernetes.io/part-of: kube-state-metrics
@@ -330,7 +330,7 @@ spec:
   template:
     metadata:
       labels:        
-        helm.sh/chart: kube-state-metrics-5.30.0
+        helm.sh/chart: kube-state-metrics-5.37.0
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: metrics
         app.kubernetes.io/part-of: kube-state-metrics
@@ -347,6 +347,7 @@ spec:
       automountServiceAccountToken: true
       hostNetwork: false
       serviceAccountName: kube-state-metrics
+      dnsPolicy: ClusterFirst
       containers:
       - name: kube-state-metrics
         args:


### PR DESCRIPTION
**What this PR does / why we need it**:

The seed monitoring `kube-state-metrics` chart has been pinned to the upstream prometheus-community chart `5.30.0` since the wrapper migration in #14174. This bumps the dependency to `5.37.0`, the latest release on the 5.x line, and regenerates `Chart.lock` and the golden-master render fixture.

The chart stays on 5.x, so `appVersion` is unchanged at `2.15.0`. The kube-state-metrics binary is not upgraded and no metric series change, which means the Grafana dashboards under `charts/monitoring/grafana/dashboards/kubernetes/` and the rules in `charts/monitoring/prometheus/rules/general-kube-state-metrics.yaml` are unaffected.

**Which issue(s) this PR fixes**:
Fixes #16115

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

Rendering with KKP's own values changes in exactly four places, all of them no-ops on a real cluster:

- `helm.sh/chart` label version string.
- PDB `policy/v1beta1` to `policy/v1`. Upstream 5.34.0 dropped the `Capabilities` fallback. On any supported cluster 5.30.0 already selected `policy/v1`; only Helm's offline capability set produced v1beta1, which is why the fixture changes.
- ClusterRole loses the `extensions` apiGroup for daemonsets, deployments, replicasets and ingresses (upstream 5.34.1). `extensions/v1beta1` for these was removed in Kubernetes 1.16, and ClusterRole is mutable, so there is no upgrade path concern.
- Pod spec gains an explicit `dnsPolicy: ClusterFirst`, which was already the implicit default.

`spec.selector` on the Deployment is untouched, so this does not reintroduce the immutable-field upgrade failure from #14671 / #14357.

Nothing in `charts/monitoring/kube-state-metrics/values.yaml` collides with the upstream changes in this range. KKP does not set `env` (type changed `{}` to `[]` in 5.33.1), does not enable `kubeRBACProxy` (so both kube-rbac-proxy image bumps and the probe gating are unreachable, and the render still contains a single image, `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0`), and leaves `service.type` at ClusterIP with no nodePort. `customResourceState.config` is set without the new `.name` / `.key` values, so the ConfigMap name and key are reproduced exactly.

To verify:

```
cd charts/monitoring/kube-state-metrics && ./test/test.sh
```

Note that a newer kube-state-metrics binary needs a major chart bump, not a 5.x patch: `appVersion` is `2.15.0` across the whole 5.x line and also on chart 6.0.0, whose only breaking change is dropping PSP support. 7.x ships 2.17.0 and 8.x ships 2.19.1. Worth a follow-up ticket if the goal is a newer binary rather than template fixes.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Updated the seed monitoring kube-state-metrics Helm chart to 5.37.0.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
Prerequisites: a KKP seed with the monitoring stack installed.

Setup
1. Install or upgrade the seed monitoring stack from this branch.
2. Wait for the kube-state-metrics Deployment in the monitoring namespace
   to become ready.

Verify
3. Confirm the Deployment reports the new chart version:
   get deployment kube-state-metrics -n monitoring \
     -o jsonpath='{.metadata.labels.helm\.sh/chart}'
   Expected: kube-state-metrics-5.37.0
4. Confirm the pod is running and serving metrics on port 8080 at /metrics.
5. Open the Grafana "Kubernetes / Compute Resources / Cluster" dashboard and
   confirm the panels still populate.
6. Confirm no alerts from general-kube-state-metrics.yaml are firing.
```
