### PR TITLE
Bump prometheus-blackbox-exporter Helm chart to 11.16.0

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.lock
+++ b/charts/monitoring/blackbox-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus-blackbox-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 9.2.0
-digest: sha256:a91728b22064f8e7e42b2c61c72b9d12d3dab14de27572bc24159212c84800cb
-generated: "2025-02-25T13:54:42.31030274+01:00"
+  version: 11.16.0
+digest: sha256:e9f8f3790a89a841925a7dc0e62d69aea5902498a8136411147ac78be8638dbe
+generated: "2026-08-05T19:49:32.60279+03:00"

--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: blackbox-exporter
 version: 9.9.9-dev
-appVersion: v0.25.0
+appVersion: v0.28.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:
   - kubermatic
@@ -31,5 +31,5 @@ maintainers:
 dependencies:
   - name: prometheus-blackbox-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 9.2.0
+    version: 11.16.0
     alias: blackbox-exporter

--- a/charts/monitoring/blackbox-exporter/test/default.yaml.out
+++ b/charts/monitoring/blackbox-exporter/test/default.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: blackbox-exporter/charts/blackbox-exporter/templates/configmap.yaml
@@ -19,10 +19,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 data:
   blackbox.yaml: |
@@ -65,10 +65,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -109,8 +109,11 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: blackbox-exporter-11.16.0
         app.kubernetes.io/name: blackbox-exporter
         app.kubernetes.io/instance: release-name
+        app.kubernetes.io/version: "v0.28.0"
+        app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/config: aed63c39ba6a0479ad8af916a0afd097e20c80b4d9e35cb665b0f2fa5c17ddb8
         prometheus.io/port: "9115"
@@ -132,7 +135,7 @@ spec:
       containers:
       
       - name: blackbox-exporter
-        image: quay.io/prometheus/blackbox-exporter:v0.25.0
+        image: quay.io/prometheus/blackbox-exporter:v0.28.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/monitoring/blackbox-exporter/test/values.example.ce.yaml.out
+++ b/charts/monitoring/blackbox-exporter/test/values.example.ce.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: blackbox-exporter/charts/blackbox-exporter/templates/configmap.yaml
@@ -19,10 +19,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 data:
   blackbox.yaml: |
@@ -65,10 +65,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -109,8 +109,11 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: blackbox-exporter-11.16.0
         app.kubernetes.io/name: blackbox-exporter
         app.kubernetes.io/instance: release-name
+        app.kubernetes.io/version: "v0.28.0"
+        app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/config: aed63c39ba6a0479ad8af916a0afd097e20c80b4d9e35cb665b0f2fa5c17ddb8
         prometheus.io/port: "9115"
@@ -132,7 +135,7 @@ spec:
       containers:
       
       - name: blackbox-exporter
-        image: quay.io/prometheus/blackbox-exporter:v0.25.0
+        image: quay.io/prometheus/blackbox-exporter:v0.28.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/monitoring/blackbox-exporter/test/values.example.ee.yaml.out
+++ b/charts/monitoring/blackbox-exporter/test/values.example.ee.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: blackbox-exporter/charts/blackbox-exporter/templates/configmap.yaml
@@ -19,10 +19,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 data:
   blackbox.yaml: |
@@ -65,10 +65,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-11.16.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.28.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -109,8 +109,11 @@ spec:
   template:
     metadata:
       labels:
+        helm.sh/chart: blackbox-exporter-11.16.0
         app.kubernetes.io/name: blackbox-exporter
         app.kubernetes.io/instance: release-name
+        app.kubernetes.io/version: "v0.28.0"
+        app.kubernetes.io/managed-by: Helm
       annotations:
         checksum/config: aed63c39ba6a0479ad8af916a0afd097e20c80b4d9e35cb665b0f2fa5c17ddb8
         prometheus.io/port: "9115"
@@ -132,7 +135,7 @@ spec:
       containers:
       
       - name: blackbox-exporter
-        image: quay.io/prometheus/blackbox-exporter:v0.25.0
+        image: quay.io/prometheus/blackbox-exporter:v0.28.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Reference to upstream values.yaml:
-# https://github.com/prometheus-community/helm-charts/blob/prometheus-blackbox-exporter-9.2.0/charts/prometheus-blackbox-exporter/values.yaml
+# https://github.com/prometheus-community/helm-charts/blob/prometheus-blackbox-exporter-11.16.0/charts/prometheus-blackbox-exporter/values.yaml
 
 blackbox-exporter:
   fullnameOverride: blackbox-exporter


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the vendored `prometheus-blackbox-exporter` Helm chart dependency from `9.2.0` to `11.16.0`, which moves blackbox_exporter from `v0.25.0` to `v0.28.0`.

The issue scopes this to `9.8.0` (the last 9.x) and asks to skip the 10.x/11.x majors. `9.8.0` was released 2025-05-31 and is the end of the 9.x line; upstream has moved to 11.16.0. Going to `9.8.0` would land on an abandoned line and forfeit a year of blackbox_exporter fixes, requiring a second bump to get current. This PR goes to `11.16.0` instead because the 10.x/11.x breaking changes are inert for KKP's configuration (justification below), so there is no technical reason to stop at 9.x.

Changes:

- `charts/monitoring/blackbox-exporter/Chart.yaml`: dependency `version` `9.2.0` -> `11.16.0` and `appVersion` `v0.25.0` -> `v0.28.0`
- `charts/monitoring/blackbox-exporter/Chart.lock`: regenerated via `helm dependency update`
- `charts/monitoring/blackbox-exporter/test/{default,values.example.ce,values.example.ee}.yaml.out`: regenerated golden fixtures
- `charts/monitoring/blackbox-exporter/values.yaml`: updated the upstream reference-comment URL to the new tag

The complete rendered manifest delta under our values is:

- `helm.sh/chart` and `app.kubernetes.io/version` labels
- `blackbox-exporter` image `v0.25.0` -> `v0.28.0`
- three added pod labels (`helm.sh/chart`, `app.kubernetes.io/version`, `app.kubernetes.io/managed-by: Helm`)

No structural changes, no removed resources, no changed defaults. KKP's two probe modules (`https_2xx`, `https_2xx_skip_tls_verify`) render byte-identically.

**Which issue(s) this PR fixes**:
Fixes #16116

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:


Verification:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update the prometheus-blackbox-exporter Helm chart to 11.16.0 (blackbox_exporter v0.28.0).
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
TBD
```
