### PR TITLE
bump blackbox-exporter helm chart to 9.8.0

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.lock
+++ b/charts/monitoring/blackbox-exporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus-blackbox-exporter
   repository: https://prometheus-community.github.io/helm-charts
-  version: 9.2.0
-digest: sha256:a91728b22064f8e7e42b2c61c72b9d12d3dab14de27572bc24159212c84800cb
-generated: "2025-02-25T13:54:42.31030274+01:00"
+  version: 9.8.0
+digest: sha256:c45078b13e7ebb4468ec7d7c43b3d8d086ca3641ab8acadc2a7c42fb001c6b97
+generated: "2026-08-05T19:49:02.107027+03:00"

--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -31,5 +31,5 @@ maintainers:
 dependencies:
   - name: prometheus-blackbox-exporter
     repository: https://prometheus-community.github.io/helm-charts
-    version: 9.2.0
+    version: 9.8.0
     alias: blackbox-exporter

--- a/charts/monitoring/blackbox-exporter/test/default.yaml.out
+++ b/charts/monitoring/blackbox-exporter/test/default.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: blackbox-exporter/charts/blackbox-exporter/templates/configmap.yaml
@@ -19,10 +19,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 data:
   blackbox.yaml: |
@@ -65,10 +65,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -132,7 +132,7 @@ spec:
       containers:
       
       - name: blackbox-exporter
-        image: quay.io/prometheus/blackbox-exporter:v0.25.0
+        image: quay.io/prometheus/blackbox-exporter:v0.26.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/monitoring/blackbox-exporter/test/values.example.ce.yaml.out
+++ b/charts/monitoring/blackbox-exporter/test/values.example.ce.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: blackbox-exporter/charts/blackbox-exporter/templates/configmap.yaml
@@ -19,10 +19,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 data:
   blackbox.yaml: |
@@ -65,10 +65,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -132,7 +132,7 @@ spec:
       containers:
       
       - name: blackbox-exporter
-        image: quay.io/prometheus/blackbox-exporter:v0.25.0
+        image: quay.io/prometheus/blackbox-exporter:v0.26.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/monitoring/blackbox-exporter/test/values.example.ee.yaml.out
+++ b/charts/monitoring/blackbox-exporter/test/values.example.ee.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: blackbox-exporter/charts/blackbox-exporter/templates/configmap.yaml
@@ -19,10 +19,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 data:
   blackbox.yaml: |
@@ -65,10 +65,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -89,10 +89,10 @@ metadata:
   name: blackbox-exporter
   namespace: default
   labels:
-    helm.sh/chart: blackbox-exporter-9.2.0
+    helm.sh/chart: blackbox-exporter-9.8.0
     app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v0.25.0"
+    app.kubernetes.io/version: "v0.26.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -132,7 +132,7 @@ spec:
       containers:
       
       - name: blackbox-exporter
-        image: quay.io/prometheus/blackbox-exporter:v0.25.0
+        image: quay.io/prometheus/blackbox-exporter:v0.26.0
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Reference to upstream values.yaml:
-# https://github.com/prometheus-community/helm-charts/blob/prometheus-blackbox-exporter-9.2.0/charts/prometheus-blackbox-exporter/values.yaml
+# https://github.com/prometheus-community/helm-charts/blob/prometheus-blackbox-exporter-9.8.0/charts/prometheus-blackbox-exporter/values.yaml
 
 blackbox-exporter:
   fullnameOverride: blackbox-exporter


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the seed monitoring `prometheus-blackbox-exporter` chart dependency from `9.2.0` to `9.8.0`, the latest release on the 9.x line, and regenerates `Chart.lock` and the three golden-master render fixtures.

The only substantive change in the 9.2.0 to 9.8.0 range is at chart 9.3.0, which upgrades the blackbox_exporter binary from `v0.25.0` to `v0.26.0`. Releases 9.4.0 through 9.8.0 each bump only the optional `configReloader` image (`prometheus-config-reloader`), which KKP does not enable, so they are unreachable. The upstream chart diff across the whole range touches only `Chart.yaml` and `values.yaml`; there are zero template changes.

**Which issue(s) this PR fixes**:
Fixes #16116

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

Unlike a pure template bump, this one moves the prober binary, so it is worth a quick smoke test. v0.26.0 has one `[CHANGE]` (adopt `log/slog`, drop `go-kit/log`) and three additive `[FEATURE]`s, with no metric removals or renames. I verified every blackbox metric KKP consumes still exists at the v0.26.0 tag:

- Alert rules in `charts/monitoring/prometheus/rules/src/general/blackbox-exporter.yaml`: `probe_success`, `probe_http_duration_seconds`, `probe_ssl_earliest_cert_expiry`
- Dashboard `charts/monitoring/grafana/dashboards/monitoring/blackbox-exporter.json`: additionally `probe_duration_seconds`, `probe_dns_lookup_time_seconds`, `probe_http_ssl`, `probe_http_status_code`, `probe_http_version`

The `log/slog` change is harmless here: nothing parses blackbox-exporter logs positionally. `charts/logging/` has no Fluent Bit parser keyed to it, and the chart's pod annotations set only `prometheus.io/scrape` and `prometheus.io/port` (no `fluentbit.io/parser`), unlike the kube-state-metrics chart which sets `fluentbit.io/parser: glog`.

The prober module config in `charts/monitoring/blackbox-exporter/values.yaml` (`https_2xx`, `https_2xx_skip_tls_verify`) uses only config keys that remain valid in v0.26.0. `https_2xx_skip_tls_verify` is the module referenced by `charts/monitoring/prometheus/config/scraping/blackbox-exporter.yaml` for probing user cluster apiservers at `/livez`.

The rendered output changes in exactly three places, identical across all three fixtures: the `helm.sh/chart` label, the `app.kubernetes.io/version` label, and the image tag `quay.io/prometheus/blackbox-exporter:v0.25.0` to `:v0.26.0`. The Deployment `spec.selector` is unchanged.

To verify locally:

```
cd charts/monitoring/blackbox-exporter && ./test/test.sh
```

Note that `hack/test-chart-rendering.sh` runs under `set +o errexit` and calls `helm dependency build`, which fails if `Chart.lock` is stale. Regenerate the lock with `helm dependency update` before running the test, otherwise the script swallows the build error and the fixtures get truncated to zero bytes.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Updated the seed monitoring blackbox-exporter Helm chart to 9.8.0 (blackbox_exporter v0.26.0).
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
Prerequisites: a KKP seed with the monitoring stack installed and at least
one user cluster whose apiserver is probed by blackbox-exporter.

Setup
1. Install or upgrade the seed monitoring stack from this branch.
2. Wait for the blackbox-exporter Deployment in the monitoring namespace
   to become ready.

Verify
3. Confirm the running image is v0.26.0:
   get deployment blackbox-exporter -n monitoring \
     -o jsonpath='{.spec.template.spec.containers[0].image}'
4. Confirm the user cluster apiserver probe is succeeding:
   query probe_success{job="blackbox-exporter-user-cluster-apiservers"}
   Expected: 1 for each target.
5. Open the Grafana blackbox-exporter dashboard and confirm the panels
   still populate.
6. Confirm no alerts from general-blackbox-exporter.yaml are firing that
   were not firing before the upgrade.
```
