### PR TITLE
Pass --force-conflicts only when Helm applies server-side

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -33,6 +33,17 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 )
 
+// applyMethodServerSide is the value helm records on a release whose objects
+// were applied server-side.
+//
+// Helm's own constant is release.ApplyMethodServerSideApply in
+// helm.sh/helm/v4/pkg/release/v1, but this repo pins helm.sh/helm/v3, which has
+// no apply-method concept at all, and the installer drives the helm binary
+// rather than importing the SDK. Hence the mirror. Helm documents an empty value
+// as meaning client-side apply, so only ever compare against this value, never
+// against the client-side one.
+const applyMethodServerSide = "ssa"
+
 var (
 	minHelmVersionMajor uint64 = 3
 	maxHelmVersionMajor uint64 = 4
@@ -177,17 +188,16 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 		"--timeout", c.timeout.String(),
 	}
 
+	forcingConflicts := false
+
 	if c.version.Major() >= 4 {
-		// Helm 4 defaults --server-side to "auto" and already applies chart objects
-		// server-side. KKP components legitimately co-own fields of some chart-managed
-		// objects (e.g. the operator reconciles .dockerconfigjson of the dockercfg
-		// secret), so a plain server-side apply upgrade fails with field conflicts.
-		// --force-conflicts resolves those in helm's favor without forcing the apply
-		// method to "true", which would rewrite the full object body of every managed
-		// resource on every deploy and overwhelm loaded apiservers (e.g. the large
-		// user-cluster MLA stack). The conflict resolution is driven by --force-conflicts,
-		// not by forcing --server-side=true.
-		command = append(command, "--force-conflicts")
+		// --force-conflicts is only valid under server-side apply, which Helm 4
+		// decides per release (see serverSideApplyActive). Passing it unconditionally
+		// makes Helm reject releases installed by Helm 3.
+		forcingConflicts = c.serverSideApplyActive(namespace, releaseName)
+		if forcingConflicts {
+			command = append(command, "--server-side=true", "--force-conflicts")
+		}
 	}
 
 	if valuesFile != "" {
@@ -200,9 +210,72 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 	command = append(command, c.translateFlags(flags)...)
 	command = append(command, releaseName, chartDirectory)
 
-	_, err := c.run(namespace, command...)
+	if _, err := c.run(namespace, command...); err != nil {
+		// A field-ownership conflict is the one failure the operator cannot act on
+		// without knowing the release applies client-side, and therefore that the
+		// installer deliberately did not force conflicts. Say so, but only on the
+		// path where it is relevant.
+		if c.version.Major() >= 4 && !forcingConflicts {
+			return fmt.Errorf("%w (release %q applies client-side, so field conflicts were not forced; check `helm get metadata %s --namespace %s`)", err, releaseName, releaseName, namespace)
+		}
 
-	return err
+		return err
+	}
+
+	return nil
+}
+
+// releaseMetadata is the subset of `helm get metadata` output that decides how
+// the next operation on a release will be applied.
+type releaseMetadata struct {
+	Status string `json:"status"`
+	// ApplyMethod is empty when helm never recorded one, which is the case for
+	// every release installed by Helm 3.
+	ApplyMethod string `json:"applyMethod"`
+}
+
+// serverSideApplyActive reports whether the next Helm 4 operation on the given
+// release will apply server-side, and therefore whether --force-conflicts is a
+// legal flag to pass alongside it.
+func (c *cli) serverSideApplyActive(namespace string, releaseName string) bool {
+	metadata, err := c.releaseMetadata(namespace, releaseName)
+	if err != nil {
+		// The release cannot be read. Tell "not installed yet", where helm applies
+		// server-side, apart from a genuine read failure, where assuming an install
+		// would silently migrate a client-side release onto server-side apply and
+		// rewrite the full body of every object it manages.
+		release, listErr := c.GetRelease(namespace, releaseName)
+		if listErr == nil && release == nil {
+			return true
+		}
+
+		c.logger.Warnf("Cannot determine the apply method of release %q; deploying without field conflict resolution, so ownership conflicts will surface as errors: %v", releaseName, err)
+
+		return false
+	}
+
+	if ReleaseStatus(metadata.Status) == ReleaseStatusDeleted {
+		return true
+	}
+
+	c.logger.Debugf("Release %q has status %q and apply method %q", releaseName, metadata.Status, metadata.ApplyMethod)
+
+	return metadata.ApplyMethod == applyMethodServerSide
+}
+
+// releaseMetadata returns helm's record for the newest revision of a release.
+func (c *cli) releaseMetadata(namespace string, releaseName string) (*releaseMetadata, error) {
+	output, err := c.run(namespace, "get", "metadata", releaseName, "-o", "json")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get release metadata: %w", err)
+	}
+
+	metadata := releaseMetadata{}
+	if err := json.NewDecoder(bytes.NewReader(output)).Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse Helm output: %w", err)
+	}
+
+	return &metadata, nil
 }
 
 // translateFlags maps Helm-3-era flags to their Helm 4 replacements.

--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -192,7 +192,7 @@ func (c *cli) InstallChart(namespace string, releaseName string, chartDirectory 
 
 	if c.version.Major() >= 4 {
 		// --force-conflicts is only valid under server-side apply, which Helm 4
-		// decides per release (see serverSideApplyActive). Passing it unconditionally
+		// decides per release (see `serverSideApplyActive`). Passing it unconditionally
 		// makes Helm reject releases installed by Helm 3.
 		forcingConflicts = c.serverSideApplyActive(namespace, releaseName)
 		if forcingConflicts {

--- a/pkg/install/helm/cli_test.go
+++ b/pkg/install/helm/cli_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package helm
 
 import (
+	"encoding/json"
+	"errors"
 	"os/exec"
+	"slices"
 	"testing"
 	"time"
 
@@ -146,54 +149,204 @@ func TestListReleasesUsesCorrectFlagsForHelmVersion(t *testing.T) {
 }
 
 func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
+	const (
+		namespace   = "test-namespace"
+		releaseName = "release"
+	)
+
+	// Helm rejects --force-conflicts unless server-side apply is enabled, and
+	// --server-side defaults to "auto", which inherits the apply method from the
+	// release's newest revision. So the flags depend on release state, not just on
+	// the helm version.
 	testcases := []struct {
-		name         string
-		helmVersion  string
-		flags        []string
+		name        string
+		helmVersion string
+		flags       []string
+
+		// metadataStatus and metadataApplyMethod are what `helm get metadata`
+		// reports. An empty apply method means helm never recorded one, which is the
+		// case for every release installed by Helm 3.
+		metadataStatus      string
+		metadataApplyMethod string
+		// metadataFails simulates a release helm cannot report on, either because it
+		// does not exist or because the read failed. releaseListed then decides
+		// which of the two the fallback `helm list` sees.
+		metadataFails bool
+		releaseListed bool
+		listFails     bool
+
 		expectedArgs []string
+		// expectMetadataProbe guards against probing with a helm that has no such
+		// subcommand. expectListProbe guards against listing when the metadata call
+		// already answered the question.
+		expectMetadataProbe bool
+		expectListProbe     bool
 	}{
 		{
-			name:        "helm v3 does not enable server-side apply and keeps --atomic",
-			helmVersion: "3.19.0",
-			flags:       []string{"--atomic"},
+			name:                "helm 3 never enables server-side apply and keeps --atomic",
+			helmVersion:         "3.19.0",
+			flags:               []string{"--atomic"},
+			metadataStatus:      "deployed",
+			metadataApplyMethod: "csa",
 			expectedArgs: []string{
 				"helm",
-				"--namespace", "test-namespace",
+				"--namespace", namespace,
 				"upgrade", "--install",
 				"--timeout", "30s",
 				"--values", "values.yaml",
 				"--atomic",
-				"release", "chart-dir",
+				releaseName, "chart-dir",
 			},
+			expectMetadataProbe: false,
+			expectListProbe:     false,
 		},
 		{
-			name:        "helm v4.0 forces conflict resolution and translates --atomic",
-			helmVersion: "4.0.0",
-			flags:       []string{"--atomic"},
+			name:          "helm 4 forces conflicts on a fresh install and translates --atomic",
+			helmVersion:   "4.0.0",
+			flags:         []string{"--atomic"},
+			metadataFails: true,
+			releaseListed: false,
 			expectedArgs: []string{
 				"helm",
-				"--namespace", "test-namespace",
+				"--namespace", namespace,
 				"upgrade", "--install",
 				"--timeout", "30s",
-				"--force-conflicts",
+				"--server-side=true", "--force-conflicts",
 				"--values", "values.yaml",
 				"--rollback-on-failure",
-				"release", "chart-dir",
+				releaseName, "chart-dir",
 			},
+			expectMetadataProbe: true,
+			expectListProbe:     true,
 		},
 		{
-			name:        "helm v4.1 forces conflict resolution without extra flags",
-			helmVersion: "4.1.1",
-			flags:       nil,
+			// --server-side=true is load-bearing next to --rollback-on-failure: helm
+			// forwards both values into the rollback, which resolves the apply method
+			// against the rollback target's revision. Leaving --server-side at auto
+			// there can make the rollback itself fail on the invalid flag pair and
+			// mask the real upgrade error.
+			name:                "helm 4 keeps the full pair alongside the rollback flag",
+			helmVersion:         "4.1.1",
+			flags:               []string{"--atomic"},
+			metadataStatus:      "deployed",
+			metadataApplyMethod: "ssa",
 			expectedArgs: []string{
 				"helm",
-				"--namespace", "test-namespace",
+				"--namespace", namespace,
 				"upgrade", "--install",
 				"--timeout", "30s",
-				"--force-conflicts",
+				"--server-side=true", "--force-conflicts",
 				"--values", "values.yaml",
-				"release", "chart-dir",
+				"--rollback-on-failure",
+				releaseName, "chart-dir",
 			},
+			expectMetadataProbe: true,
+			expectListProbe:     false,
+		},
+		{
+			name:                "helm 4 forces conflicts when the release already applies server-side",
+			helmVersion:         "4.1.1",
+			metadataStatus:      "deployed",
+			metadataApplyMethod: "ssa",
+			expectedArgs: []string{
+				"helm",
+				"--namespace", namespace,
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--server-side=true", "--force-conflicts",
+				"--values", "values.yaml",
+				releaseName, "chart-dir",
+			},
+			expectMetadataProbe: true,
+			expectListProbe:     false,
+		},
+		{
+			name:                "helm 4 leaves a client-side release alone",
+			helmVersion:         "4.1.1",
+			metadataStatus:      "deployed",
+			metadataApplyMethod: "csa",
+			expectedArgs: []string{
+				"helm",
+				"--namespace", namespace,
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--values", "values.yaml",
+				releaseName, "chart-dir",
+			},
+			expectMetadataProbe: true,
+			expectListProbe:     false,
+		},
+		{
+			// The regression that shipped in v2.30.6: a release installed by Helm 3
+			// has no recorded apply method, so helm resolves "auto" to client-side and
+			// refuses --force-conflicts.
+			name:                "helm 4 leaves a release with no recorded apply method alone",
+			helmVersion:         "4.1.1",
+			metadataStatus:      "deployed",
+			metadataApplyMethod: "",
+			expectedArgs: []string{
+				"helm",
+				"--namespace", namespace,
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--values", "values.yaml",
+				releaseName, "chart-dir",
+			},
+			expectMetadataProbe: true,
+			expectListProbe:     false,
+		},
+		{
+			// helm treats a release whose newest revision is uninstalled as a fresh
+			// install, which applies server-side no matter what that revision
+			// recorded. Deciding on the apply method alone would withhold
+			// --force-conflicts exactly where a conflict can occur.
+			name:                "helm 4 forces conflicts on an uninstalled release with a client-side revision",
+			helmVersion:         "4.1.1",
+			metadataStatus:      "uninstalled",
+			metadataApplyMethod: "csa",
+			expectedArgs: []string{
+				"helm",
+				"--namespace", namespace,
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--server-side=true", "--force-conflicts",
+				"--values", "values.yaml",
+				releaseName, "chart-dir",
+			},
+			expectMetadataProbe: true,
+			expectListProbe:     false,
+		},
+		{
+			name:          "helm 4 does not force conflicts when an existing release cannot be read",
+			helmVersion:   "4.1.1",
+			metadataFails: true,
+			releaseListed: true,
+			expectedArgs: []string{
+				"helm",
+				"--namespace", namespace,
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--values", "values.yaml",
+				releaseName, "chart-dir",
+			},
+			expectMetadataProbe: true,
+			expectListProbe:     true,
+		},
+		{
+			name:          "helm 4 does not force conflicts when releases cannot be listed either",
+			helmVersion:   "4.1.1",
+			metadataFails: true,
+			listFails:     true,
+			expectedArgs: []string{
+				"helm",
+				"--namespace", namespace,
+				"upgrade", "--install",
+				"--timeout", "30s",
+				"--values", "values.yaml",
+				releaseName, "chart-dir",
+			},
+			expectMetadataProbe: true,
+			expectListProbe:     true,
 		},
 	}
 
@@ -204,10 +357,44 @@ func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
 				runCmd = originalRunCmd
 			})
 
-			capturedArgs := []string{}
+			upgradeCalls := [][]string{}
+			metadataArgs := []string{}
+			listProbed := false
+
 			runCmd = func(cmd *exec.Cmd) ([]byte, error) {
-				capturedArgs = append([]string{}, cmd.Args...)
-				return nil, nil
+				switch {
+				case containsArg(cmd.Args, "metadata"):
+					metadataArgs = append([]string{}, cmd.Args...)
+					if tc.metadataFails {
+						return nil, errors.New("simulated helm get metadata failure")
+					}
+					payload := map[string]any{
+						"name":     releaseName,
+						"revision": 1,
+						"status":   tc.metadataStatus,
+					}
+					// helm omits the field entirely when it was never recorded
+					if tc.metadataApplyMethod != "" {
+						payload["applyMethod"] = tc.metadataApplyMethod
+					}
+					encoded, err := json.Marshal(payload)
+					require.NoError(t, err)
+					return encoded, nil
+
+				case containsArg(cmd.Args, "list"):
+					listProbed = true
+					if tc.listFails {
+						return nil, errors.New("simulated helm list failure")
+					}
+					if !tc.releaseListed {
+						return []byte(`[]`), nil
+					}
+					return []byte(`[{"name":"` + releaseName + `","namespace":"` + namespace + `","chart":"test-chart-1.2.3"}]`), nil
+
+				default:
+					upgradeCalls = append(upgradeCalls, append([]string{}, cmd.Args...))
+					return nil, nil
+				}
 			}
 
 			c := &cli{
@@ -218,9 +405,95 @@ func TestInstallChartUsesCorrectFlagsForHelmVersion(t *testing.T) {
 				logger:     logrus.New(),
 			}
 
-			err := c.InstallChart("test-namespace", "release", "chart-dir", "values.yaml", nil, tc.flags)
+			err := c.InstallChart(namespace, releaseName, "chart-dir", "values.yaml", nil, tc.flags)
 			require.NoError(t, err)
-			require.Equal(t, tc.expectedArgs, capturedArgs)
+
+			require.Len(t, upgradeCalls, 1, "expected exactly one helm upgrade invocation")
+			upgradeArgs := upgradeCalls[0]
+			require.Equal(t, tc.expectedArgs, upgradeArgs)
+
+			require.Equal(t, tc.expectMetadataProbe, len(metadataArgs) > 0,
+				"unexpected `helm get metadata` probing behaviour")
+			require.Equal(t, tc.expectListProbe, listProbed,
+				"unexpected `helm list` probing behaviour")
+
+			if len(metadataArgs) > 0 {
+				// The probe must read the same revision helm's own upgrade reads, which
+				// means no --revision, and it must be namespaced and JSON.
+				require.Equal(t, []string{
+					"helm",
+					"--namespace", namespace,
+					"get", "metadata", releaseName, "-o", "json",
+				}, metadataArgs)
+			}
+
+			// The invariant the v2.30.6 regression violated: helm rejects
+			// --force-conflicts unless server-side apply is enabled alongside it.
+			if containsArg(upgradeArgs, "--force-conflicts") {
+				require.Contains(t, upgradeArgs, "--server-side=true",
+					"--force-conflicts must never be emitted without --server-side=true")
+			}
 		})
 	}
+}
+
+func TestInstallChartPropagatesUpgradeFailure(t *testing.T) {
+	testcases := []struct {
+		name        string
+		applyMethod string
+		// expectHint asserts the error names the apply method, which is the only way
+		// an operator can tell a field conflict apart from any other failure.
+		expectHint bool
+	}{
+		{
+			name:        "server-side release fails without the client-side hint",
+			applyMethod: "ssa",
+			expectHint:  false,
+		},
+		{
+			name:        "client-side release explains that conflicts were not forced",
+			applyMethod: "csa",
+			expectHint:  true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalRunCmd := runCmd
+			t.Cleanup(func() {
+				runCmd = originalRunCmd
+			})
+
+			runCmd = func(cmd *exec.Cmd) ([]byte, error) {
+				if containsArg(cmd.Args, "metadata") {
+					return []byte(`{"name":"release","revision":1,"status":"deployed","applyMethod":"` + tc.applyMethod + `"}`), nil
+				}
+				return nil, errors.New("conflict occurred while applying object")
+			}
+
+			c := &cli{
+				binary:     "helm",
+				kubeconfig: "test-kubeconfig",
+				timeout:    30 * time.Second,
+				version:    *semverlib.MustParse("4.1.1"),
+				logger:     logrus.New(),
+			}
+
+			err := c.InstallChart("test-namespace", "release", "chart-dir", "values.yaml", nil, nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "conflict occurred while applying object",
+				"the underlying helm error must survive wrapping")
+
+			if tc.expectHint {
+				require.Contains(t, err.Error(), "applies client-side")
+				require.Contains(t, err.Error(), "helm get metadata release --namespace test-namespace")
+			} else {
+				require.NotContains(t, err.Error(), "applies client-side")
+			}
+		})
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	return slices.Contains(args, want)
 }

--- a/pkg/install/util/helm.go
+++ b/pkg/install/util/helm.go
@@ -120,6 +120,11 @@ func DeployHelmChart(
 		return err
 	}
 
+	// Note that the installer's own --force (the `force` argument above) selects the
+	// re-install branch in the switch above and must never be forwarded to helm as
+	// --force: Helm 4 marks its --force mutually exclusive with --force-conflicts,
+	// which the helm client emits for server-side releases, so passing both would
+	// make every such deploy fail before it starts.
 	flags := []string{}
 	if atomic {
 		flags = append(flags, "--atomic")


### PR DESCRIPTION
**What this PR does / why we need it**:

The installer passed `--force-conflicts` to Helm 4 without enabling server-side apply. Helm validates the two as a pair and rejects the invocation, so every deploy that upgrades a release originally installed with Helm 3 fails:

```
Error: UPGRADE FAILED: invalid client update option(s): forceConflicts enabled when serverSideApply disabled
```

`--server-side` defaults to `auto`, which inherits the apply method from the release's newest revision. Releases written by Helm 3 recorded no method, so `auto` resolves to client-side for them and the flag is invalid. `--force` is not needed to reach this.

The helm client now decides per release. It reads `helm get metadata` and passes `--server-side=true --force-conflicts` only where Helm applies server-side: the release does not exist, its newest revision recorded `ssa`, or its newest revision is `uninstalled` (which Helm treats as a fresh install). Client-side releases get no apply-related flags, which is the v2.30.5 behaviour and cannot conflict, because client-side apply performs no field-ownership checks. Helm 3 is unchanged.

This keeps #16063 fixed for the releases that can hit it, and does not migrate client-side releases onto server-side apply, which is what overloaded the dev apiserver in #16138.

**Which issue(s) this PR fixes**:
No separate issue was filed. This fixes a regression introduced by #16148.

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
kubermatic-installer now passes --force-conflicts to Helm 4 only for releases that Helm applies server-side, fixing deploy failures on releases that were originally installed with Helm 3.
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/2293
```

**Test issue**:
```test-issue
https://github.com/kubermatic/kubermatic/issues/16209
```

