### PR TITLE
Always pass the OIDC issuer flags to the kubermatic-api Deployment

### DIFF
--- a/charts/kubermatic.example.ce.yaml
+++ b/charts/kubermatic.example.ce.yaml
@@ -47,11 +47,15 @@ spec:
 
     # This must match the secret configured for the kubermaticIssuer client from
     # the dex clients in values.yaml.
-    # Needed if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting
+    # Required for logging into the KKP dashboard and for the OIDC kubeconfig
+    # endpoints ("enableOIDCKubeconfig: true" in KubermaticSetting).
     issuerClientSecret: <dex-kubermatic-issuer-oauth-secret-here>
 
     # these need to be randomly generated. Those can be generated on the
     # shell using:
     # cat /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c32
+    #
+    # issuerCookieKey signs the short-lived cookie that carries the OAuth state
+    # during login and is required for logging into the KKP dashboard.
     issuerCookieKey: <a-random-key>
     serviceAccountKey: <another-random-key>

--- a/charts/kubermatic.example.ee.yaml
+++ b/charts/kubermatic.example.ee.yaml
@@ -58,11 +58,15 @@ spec:
 
     # This must match the secret configured for the kubermaticIssuer client from
     # the dex clients in values.yaml.
-    # Needed if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting
+    # Required for logging into the KKP dashboard and for the OIDC kubeconfig
+    # endpoints ("enableOIDCKubeconfig: true" in KubermaticSetting).
     issuerClientSecret: <dex-kubermatic-issuer-oauth-secret-here>
 
     # these need to be randomly generated. Those can be generated on the
     # shell using:
     # cat /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c32
+    #
+    # issuerCookieKey signs the short-lived cookie that carries the OAuth state
+    # during login and is required for logging into the KKP dashboard.
     issuerCookieKey: <a-random-key>
     serviceAccountKey: <another-random-key>

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -21,7 +21,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
-	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -224,22 +223,16 @@ func APIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerNa
 				fmt.Sprintf("-expose-strategy=%s", cfg.Spec.ExposeStrategy),
 				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.API.PProfEndpoint),
+				fmt.Sprintf("-oidc-issuer-redirect-uri=%s", cfg.Spec.Auth.IssuerRedirectURL),
+				fmt.Sprintf("-oidc-issuer-client-id=%s", cfg.Spec.Auth.IssuerClientID),
+				fmt.Sprintf("-oidc-issuer-client-secret=%s", cfg.Spec.Auth.IssuerClientSecret),
+				fmt.Sprintf("-oidc-issuer-cookie-hash-key=%s", cfg.Spec.Auth.IssuerCookieKey),
 			}
 
 			if cfg.Spec.API.DebugLog {
 				args = append(args, "-v=4", "-log-debug=true")
 			} else {
 				args = append(args, "-v=2")
-			}
-
-			if cfg.Spec.FeatureGates[features.OIDCKubeCfgEndpoint] {
-				args = append(
-					args,
-					fmt.Sprintf("-oidc-issuer-redirect-uri=%s", cfg.Spec.Auth.IssuerRedirectURL),
-					fmt.Sprintf("-oidc-issuer-client-id=%s", cfg.Spec.Auth.IssuerClientID),
-					fmt.Sprintf("-oidc-issuer-client-secret=%s", cfg.Spec.Auth.IssuerClientSecret),
-					fmt.Sprintf("-oidc-issuer-cookie-hash-key=%s", cfg.Spec.Auth.IssuerCookieKey),
-				)
 			}
 
 			if workerName != "" {

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -274,10 +274,8 @@ func validateKubermaticConfiguration(config *kubermaticv1.KubermaticConfiguratio
 			failures = append(failures, fmt.Errorf("spec.auth.serviceAccountKey is invalid: %w", err))
 		}
 
-		if config.Spec.FeatureGates[features.OIDCKubeCfgEndpoint] {
-			failures = validateRandomSecret(config, config.Spec.Auth.IssuerClientSecret, "spec.auth.issuerClientSecret", failures)
-			failures = validateRandomSecret(config, config.Spec.Auth.IssuerCookieKey, "spec.auth.issuerCookieKey", failures)
-		}
+		failures = validateRandomSecret(config, config.Spec.Auth.IssuerClientSecret, "spec.auth.issuerClientSecret", failures)
+		failures = validateRandomSecret(config, config.Spec.Auth.IssuerCookieKey, "spec.auth.issuerCookieKey", failures)
 	}
 
 	return failures


### PR DESCRIPTION
**What this PR does / why we need it**:
The four `-oidc-issuer-*` flags were only passed to the `kubermatic-api`
  Deployment when the `OIDCKubeCfgEndpoint` feature gate was enabled. That gate is
  off by default, and the dashboard's new authorization code flow needs them — so
  on a default install login fails with `500 securecookie: hash key is not set`.

  The issuer client is no longer used only by the OIDC kubeconfig endpoints, so
  the flags become unconditional, along with the installer validation for
  `issuerClientSecret` and `issuerCookieKey`. The gate still disables the
  kubeconfig routes, which are registered separately inside the API.
**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
