### PR TITLE
[release/v2.30] Update Azure CCM, cloud-node-manager and CSI drivers to latest versions and move to the maintained `/oss/v2` registry

### DIFF
--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -24,13 +24,13 @@
 {{ $version = "v1.30.5" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.32.4" }}
+{{ $version = "v1.33.16" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.33.1" }}
+{{ $version = "v1.34.13" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.34.3" }}
+{{ $version = "v1.35.8" }}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 apiVersion: v1
@@ -117,7 +117,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cloud-node-manager
-        image: {{ Image (print "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:" $version) }}
+        image: {{ Image (print "mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:" $version) }}
         imagePullPolicy: IfNotPresent
         command:
         - cloud-node-manager
@@ -174,7 +174,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cloud-node-manager
-        image: {{ Image (print "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:" $version) }}
+        image: {{ Image (print "mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-node-manager:" $version) }}
         imagePullPolicy: IfNotPresent
         command:
         - /cloud-node-manager.exe

--- a/addons/csi/azure-disk/Makefile
+++ b/addons/csi/azure-disk/Makefile
@@ -16,7 +16,7 @@
 
 OUTPUT_FILE = driver.yaml
 REPO_NAME = kkp-addons-csi-azure-disk
-CHART_VERSION = 1.34.1
+CHART_VERSION = 1.34.4
 
 .PHONY: default
 default: setup-helm build clean-helm

--- a/addons/csi/azure-disk/_header.txt
+++ b/addons/csi/azure-disk/_header.txt
@@ -27,11 +27,11 @@
 {{ $version = "v1.32.11" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}

--- a/addons/csi/azure-disk/customizations.patch
+++ b/addons/csi/azure-disk/customizations.patch
@@ -1,14 +1,11 @@
 --- a/addons/csi/azure-disk/driver.yaml
 +++ b/addons/csi/azure-disk/driver.yaml
-@@ -560,8 +561,12 @@ spec:
-             - --vmss-cache-ttl-seconds=-1
-             - --enable-traffic-manager=false
+@@ -560,7 +560,9 @@ spec:
              - --traffic-manager-port=7788
-+            {{- if semverCompare .Cluster.Version ">= 1.29" }}
              - --enable-otel-tracing=false
-+            {{- end }}
-+            {{- if semverCompare .Cluster.Version ">= 1.30" }}
              - --check-disk-lun-collision=true
++            {{- if semverCompare .Cluster.Version ">= 1.34" }}
+             - --vmss-detach-timeout-seconds=20
 +            {{- end }}
            env:
              - name: AZURE_CREDENTIAL_FILE

--- a/addons/csi/azure-disk/driver.yaml
+++ b/addons/csi/azure-disk/driver.yaml
@@ -27,13 +27,13 @@
 {{ $version = "v1.32.11" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.34.1" }}
+{{ $version = "v1.34.4" }}
 {{ end }}
 apiVersion: v1
 kind: ServiceAccount
@@ -42,8 +42,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-controller-sa
   namespace: kube-system
 ---
@@ -54,8 +54,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-node-sa
   namespace: kube-system
 ---
@@ -66,8 +66,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-attacher-role
 rules:
   - apiGroups:
@@ -141,8 +141,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-provisioner-role
 rules:
   - apiGroups:
@@ -234,8 +234,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-resizer-role
 rules:
   - apiGroups:
@@ -309,8 +309,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-external-snapshotter-role
 rules:
   - apiGroups:
@@ -422,8 +422,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -441,8 +441,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -460,8 +460,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -479,8 +479,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: azuredisk-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -524,8 +524,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-controller
   namespace: kube-system
 spec:
@@ -542,8 +542,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.1
-        helm.sh/chart: azuredisk-csi-driver-1.34.1
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
     spec:
       containers:
         - args:
@@ -604,7 +604,7 @@ spec:
             - mountPath: /etc/kubernetes/
               name: azure-cred
         - args:
-            - --feature-gates=Topology=true,HonorPVReclaimPolicy=true,VolumeAttributesClass=true
+            - --feature-gates=Topology=true,VolumeAttributesClass=true
             - --csi-address=$(ADDRESS)
             - --v=2
             - --timeout=30s
@@ -619,7 +619,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.2.0" }}'
           name: csi-provisioner
           resources:
             limits:
@@ -646,7 +646,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.10.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-attacher:v4.11.0" }}'
           name: csi-attacher
           resources:
             limits:
@@ -673,7 +673,7 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0" }}'
           name: csi-snapshotter
           resources:
             limits:
@@ -694,13 +694,13 @@ spec:
             - -leader-election
             - --leader-election-namespace=kube-system
             - -handle-volume-inuse-error=false
-            - -feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true
+            - --feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true
             - -timeout=240s
             - --retry-interval-max=30m
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.1.0" }}'
           name: csi-resizer
           resources:
             limits:
@@ -720,7 +720,7 @@ spec:
             - --probe-timeout=3s
             - --http-endpoint=localhost:29602
             - --v=2
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0" }}'
           name: liveness-probe
           resources:
             limits:
@@ -773,8 +773,8 @@ metadata:
     app.kubernetes.io/instance: azuredisk-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azuredisk-csi-driver
-    app.kubernetes.io/version: 1.34.1
-    helm.sh/chart: azuredisk-csi-driver-1.34.1
+    app.kubernetes.io/version: 1.34.4
+    helm.sh/chart: azuredisk-csi-driver-1.34.4
   name: csi-azuredisk-node
   namespace: kube-system
 spec:
@@ -788,8 +788,8 @@ spec:
         app.kubernetes.io/instance: azuredisk-csi-driver
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azuredisk-csi-driver
-        app.kubernetes.io/version: 1.34.1
-        helm.sh/chart: azuredisk-csi-driver-1.34.1
+        app.kubernetes.io/version: 1.34.4
+        helm.sh/chart: azuredisk-csi-driver-1.34.4
     spec:
       affinity:
         nodeAffinity:
@@ -882,7 +882,7 @@ spec:
             - --probe-timeout=10s
             - --health-port=29603
             - --v=2
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.18.0" }}'
           name: liveness-probe
           resources:
             limits:
@@ -901,13 +901,27 @@ spec:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=2
+            - --http-endpoint=localhost:29607
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/disk.csi.azure.com/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.16.0" }}'
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 10
           name: node-driver-registrar
+          ports:
+            - containerPort: 29607
+              name: healthz
+              protocol: TCP
           resources:
             limits:
               memory: 100Mi
@@ -974,8 +988,8 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.34.1
-    snapshot: v8.4.0
+    csiDriver: v1.34.4
+    snapshot: v8.5.0
   name: disk.csi.azure.com
 spec:
   attachRequired: true

--- a/addons/csi/azure-file/Makefile
+++ b/addons/csi/azure-file/Makefile
@@ -16,7 +16,7 @@
 
 OUTPUT_FILE = driver.yaml
 REPO_NAME = kkp-addons-csi-azure-file
-CHART_VERSION = 1.35.0
+CHART_VERSION = 1.35.6
 
 .PHONY: default
 default: setup-helm build clean-helm

--- a/addons/csi/azure-file/_header.txt
+++ b/addons/csi/azure-file/_header.txt
@@ -27,11 +27,11 @@
 {{ $version = "v1.32.9" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.3" }}
+{{ $version = "v1.34.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.35.0" }}
+{{ $version = "v1.35.6" }}
 {{ end }}

--- a/addons/csi/azure-file/driver.yaml
+++ b/addons/csi/azure-file/driver.yaml
@@ -27,13 +27,13 @@
 {{ $version = "v1.32.9" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.33" }}
-{{ $version = "v1.33.7" }}
+{{ $version = "v1.33.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.34" }}
-{{ $version = "v1.34.3" }}
+{{ $version = "v1.34.7" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.35" }}
-{{ $version = "v1.35.0" }}
+{{ $version = "v1.35.6" }}
 {{ end }}
 apiVersion: v1
 kind: ServiceAccount
@@ -44,8 +44,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller-sa
   namespace: kube-system
 ---
@@ -58,8 +58,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node-sa
   namespace: kube-system
 ---
@@ -72,8 +72,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-attacher-role
 rules:
   - apiGroups:
@@ -143,8 +143,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-provisioner-role
 rules:
   - apiGroups:
@@ -238,8 +238,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-resizer-role
 rules:
   - apiGroups:
@@ -278,6 +278,14 @@ rules:
       - update
       - patch
   - apiGroups:
+      - storage.k8s.io
+    resources:
+      - volumeattributesclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -299,8 +307,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-external-snapshotter-role
 rules:
   - apiGroups:
@@ -368,8 +376,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller-secret-role
 rules:
   - apiGroups:
@@ -389,8 +397,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node-secret-role
 rules:
   - apiGroups:
@@ -409,8 +417,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-attacher-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -430,8 +438,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-provisioner-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -451,8 +459,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-resizer-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -472,8 +480,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: azurefile-csi-snapshotter-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -493,8 +501,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller-secret-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -514,8 +522,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node-secret-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -536,8 +544,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-controller
   namespace: kube-system
 spec:
@@ -560,8 +568,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azurefile-csi-driver
         app.kubernetes.io/part-of: azurefile-csi-driver
-        app.kubernetes.io/version: 1.35.0
-        helm.sh/chart: azurefile-csi-driver-1.35.0
+        app.kubernetes.io/version: 1.35.6
+        helm.sh/chart: azurefile-csi-driver-1.35.6
     spec:
       containers:
         - args:
@@ -630,12 +638,12 @@ spec:
             - --extra-create-metadata=true
             - --kube-api-qps=50
             - --kube-api-burst=100
-            - --feature-gates=HonorPVReclaimPolicy=true
             - --retry-interval-max=30m
+            - --feature-gates=VolumeAttributesClass=true
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.1.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-provisioner:v6.3.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
           resources:
@@ -657,11 +665,13 @@ spec:
             - -leader-election
             - --leader-election-namespace=kube-system
             - -v=2
+            - --kube-api-qps=100
+            - --kube-api-burst=200
             - --retry-interval-max=30m
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.4.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-snapshotter:v8.5.0" }}'
           name: csi-snapshotter
           resources:
             limits:
@@ -684,12 +694,12 @@ spec:
             - --leader-election-namespace=kube-system
             - -handle-volume-inuse-error=false
             - -timeout=120s
-            - -feature-gates=RecoverVolumeExpansionFailure=true
+            - -feature-gates=RecoverVolumeExpansionFailure=true,VolumeAttributesClass=true
             - --retry-interval-max=30m
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.0.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-resizer:v2.2.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-resizer
           resources:
@@ -711,7 +721,7 @@ spec:
             - --probe-timeout=3s
             - --http-endpoint=localhost:29612
             - --v=2
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -771,8 +781,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: csi-azurefile-node
   namespace: kube-system
 spec:
@@ -790,8 +800,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azurefile-csi-driver
         app.kubernetes.io/part-of: azurefile-csi-driver
-        app.kubernetes.io/version: 1.35.0
-        helm.sh/chart: azurefile-csi-driver-1.35.0
+        app.kubernetes.io/version: 1.35.6
+        helm.sh/chart: azurefile-csi-driver-1.35.6
     spec:
       affinity:
         nodeAffinity:
@@ -806,11 +816,8 @@ spec:
         - args:
             - --v=5
             - --endpoint=$(CSI_ENDPOINT)
-            {{- if semverCompare .Cluster.Version ">= 1.33" }}
             - --azurefile-proxy-endpoint=$(AZUREFILE_PROXY_ENDPOINT)
             - --enable-azurefile-proxy=true
-            - --enable-kata-cc-mount=false
-            {{- end }}
             - --nodeid=$(KUBE_NODE_NAME)
             - --kubeconfig=
             - --drivername=file.csi.azure.com
@@ -826,6 +833,7 @@ spec:
             - --mount-permissions=511
             - --allow-inline-volume-key-access-with-identity=false
             - --metrics-address=0.0.0.0:29615
+            - --enable-kata-cc-mount=false
           env:
             - name: AZURE_CREDENTIAL_FILE
               value: /etc/kubernetes/azure.json
@@ -837,10 +845,8 @@ spec:
                   apiVersion: v1
                   fieldPath: spec.nodeName
             - name: AZURE_GO_SDK_LOG_LEVEL
-            {{- if semverCompare .Cluster.Version ">= 1.33" }}
             - name: AZUREFILE_PROXY_ENDPOINT
               value: unix:///csi/azurefile-proxy.sock
-            {{- end }}
           image: '{{ Image (print "mcr.microsoft.com/oss/v2/kubernetes-csi/azurefile-csi:" $version) }}'
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -883,7 +889,7 @@ spec:
             - --probe-timeout=10s
             - --http-endpoint=localhost:29613
             - --v=2
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources:
@@ -899,14 +905,28 @@ spec:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
             - --v=2
+            - --http-endpoint=localhost:29617
           env:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/file.csi.azure.com/csi.sock
-          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.15.0" }}'
+          image: '{{ Image "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.17.0" }}'
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 10
           name: node-driver-registrar
+          ports:
+            - containerPort: 29617
+              name: healthz
+              protocol: TCP
           resources:
             limits:
               memory: 100Mi
@@ -941,7 +961,6 @@ spec:
         {{- end }}
       dnsPolicy: Default
       hostNetwork: true
-      {{- if semverCompare .Cluster.Version ">= 1.33" }}
       hostPID: true
       initContainers:
         - command:
@@ -979,7 +998,6 @@ spec:
             - mountPath: /var/lib/kubelet
               mountPropagation: Bidirectional
               name: mountpoint-dir
-      {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -1035,21 +1053,22 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   annotations:
-    csiDriver: v1.35.0
-    snapshot: v8.4.0
+    csiDriver: v1.35.6
+    snapshot: v8.5.0
   labels:
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/instance: azurefile-csi-driver
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: azurefile-csi-driver
     app.kubernetes.io/part-of: azurefile-csi-driver
-    app.kubernetes.io/version: 1.35.0
-    helm.sh/chart: azurefile-csi-driver-1.35.0
+    app.kubernetes.io/version: 1.35.6
+    helm.sh/chart: azurefile-csi-driver-1.35.6
   name: file.csi.azure.com
 spec:
   attachRequired: false
   fsGroupPolicy: ReadWriteOnceWithFSType
   podInfoOnMount: true
+  requiresRepublish: true
   tokenRequests:
     - audience: api://AzureADTokenExchange
   volumeLifecycleModes:

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -71,7 +71,7 @@ func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDe
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        registry.Must(data.RewriteImage("mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v" + version)),
+					Image:        registry.Must(data.RewriteImage("mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v" + version)),
 					Command:      []string{"cloud-controller-manager"},
 					Args:         getAzureFlags(data),
 					Env:          getEnvVars(),
@@ -111,21 +111,21 @@ func AzureCCMVersion(version semver.Semver) (string, error) {
 	// reminder: do not forget to update addons/azure-cloud-node-manager as well!
 
 	// https://github.com/kubernetes-sigs/cloud-provider-azure/releases
-	// gcrane ls --json mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager | jq -r '.tags[]'
+	// gcrane ls --json mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager | jq -r '.tags[]'
 
 	switch version.MajorMinor() {
 	case v131:
 		return "1.31.5", nil
 	case v132:
-		return "1.32.4", nil
+		return "1.32.20", nil
 	case v133:
-		return "1.33.6", nil
+		return "1.33.16", nil
 	case v134:
-		fallthrough
+		return "1.34.13", nil
 	case v135:
 		fallthrough
 	default:
-		return "1.34.3", nil
+		return "1.35.8", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.32.4
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.32.20
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.33.6
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.33.16
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.34.13
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.34.3
+        image: mcr.microsoft.com/oss/v2/kubernetes/azure-cloud-controller-manager:v1.35.8
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

Manaul cherry pick for #16195 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated the Azure cloud-controller-manager, cloud-node-manager, and the Azure Disk and Azure File CSI drivers to their latest upstream versions per supported Kubernetes minor. The controller-manager and node-manager images now come from the maintained mcr.microsoft.com/oss/v2 registry path (the previous /oss path was frozen at v1.34.3), clearing the base-image CVEs those stale images carried. Kubernetes 1.35 clusters now receive matching 1.35 controller-manager and node-manager images instead of 1.34 ones.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
