### PR TITLE
Add kubevirt accelerator resolver

### DIFF
--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -50,8 +50,7 @@ type InstanceTypeSource struct {
 
 // ResolvedInstanceType contains the resources and source identity of a KubeVirt instancetype.
 // DeviceResources preserves the exact device-plugin resource names requested by the
-// instancetype. It intentionally remains separate from NodeCapacity.GPUs, which is a flat,
-// provider-independent quantity and cannot represent different device resource names.
+// instancetype.
 type ResolvedInstanceType struct {
 	Capacity        *provider.NodeCapacity
 	DeviceResources corev1.ResourceList
@@ -102,6 +101,27 @@ func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter 
 	return instancetypes
 }
 
+// DescribeInstanceType returns the NodeCapacity from the VirtualMachine instancetype.
+// namespace is the KubeVirt infra-cluster namespace that holds the cluster's namespaced
+// instancetypes. Resolving a custom (non-standard) namespaced instancetype without it fails,
+// to avoid an unscoped cross-tenant lookup. The embedded Kubermatic standard instancetypes are
+// namespace-independent and still resolve when it is empty.
+func DescribeInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+	client, err := NewClient(kubeconfig, ClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return describeInstanceType(ctx, client, namespace, it)
+}
+
+func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+	instanceType, err := findInstanceType(ctx, client, namespace, it)
+	if err != nil {
+		return nil, err
+	}
+	return instanceTypeToNodeCapacity(instanceType.Spec)
+}
+
 // ResolveInstanceType returns the capacity, exact device resource requests, and source
 // identity from the selected VirtualMachine instancetype.
 //
@@ -116,17 +136,11 @@ func ResolveInstanceType(ctx context.Context, kubeconfig string, namespace strin
 	return resolveInstanceType(ctx, client, namespace, it)
 }
 
-// DescribeInstanceType returns only the NodeCapacity from the selected VirtualMachine
-// instancetype.
-func DescribeInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
-	client, err := NewClient(kubeconfig, ClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return describeInstanceType(ctx, client, namespace, it)
-}
-
 func resolveInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*ResolvedInstanceType, error) {
+	if it == nil {
+		return nil, fmt.Errorf("VMI instancetype matcher must not be nil")
+	}
+
 	instanceType, err := findInstanceType(ctx, client, namespace, it)
 	if err != nil {
 		return nil, err
@@ -134,19 +148,7 @@ func resolveInstanceType(ctx context.Context, client ctrlruntimeclient.Client, n
 	return resolveInstanceTypeSpec(instanceType.Spec, instanceType.Source)
 }
 
-func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
-	instanceType, err := findInstanceType(ctx, client, namespace, it)
-	if err != nil {
-		return nil, err
-	}
-	return instanceTypeToNodeCapacity(instanceType.Spec)
-}
-
 func findInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*instanceTypeSpec, error) {
-	if it == nil {
-		return nil, fmt.Errorf("VMI instancetype matcher must not be nil")
-	}
-
 	switch it.Kind {
 	case VirtualMachineInstancetypeKind: // namespaced: kubermatic standard or user-deployed custom
 		if instanceType, err := findNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -141,11 +141,39 @@ func resolveInstanceType(ctx context.Context, client ctrlruntimeclient.Client, n
 		return nil, fmt.Errorf("VMI instancetype matcher must not be nil")
 	}
 
-	instanceType, err := findInstanceType(ctx, client, namespace, it)
+	instanceType, err := findInstanceTypeForResolution(ctx, client, namespace, it)
 	if err != nil {
 		return nil, err
 	}
 	return resolveInstanceTypeSpec(instanceType.Spec, instanceType.Source)
+}
+
+func findInstanceTypeForResolution(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*instanceTypeSpec, error) {
+	switch it.Kind {
+	case VirtualMachineInstancetypeKind:
+		if instanceType, err := findLiveNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
+		}
+
+	case VirtualMachineClusterInstancetypeKind:
+		if instanceType, err := findClusterInstanceType(ctx, client, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
+		}
+
+	case "":
+		// machine-controller resolves legacy matchers without a kind in namespace scope first.
+		// Keep the accelerator footprint aligned with the instancetype used to provision the VM.
+		if namespace != "" {
+			if instanceType, err := findLiveNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
+				return instanceType, err
+			}
+		}
+		if instanceType, err := findClusterInstanceType(ctx, client, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
+		}
+	}
+
+	return nil, fmt.Errorf("VMI instancetype %s of Kind %s not found", it.Name, it.Kind)
 }
 
 func findInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*instanceTypeSpec, error) {
@@ -204,11 +232,13 @@ func findNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Cl
 			}, nil
 		}
 	}
-	// Fall back to listing user-deployed namespaced VirtualMachineInstancetype objects
-	// from the infra cluster — these are custom instancetypes (e.g. GPU variants)
-	// that aren't part of the embedded Kubermatic standards.
+	return findLiveNamespacedInstanceType(ctx, client, namespace, name)
+}
+
+func findLiveNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*instanceTypeSpec, error) {
+	// List namespaced VirtualMachineInstancetype objects from the infrastructure cluster.
 	//
-	// This requires the cluster's infra namespace: a custom instancetype must be resolved
+	// This requires the cluster's infra namespace: a namespaced instancetype must be resolved
 	// against the tenant that owns it, because two tenants may define instancetypes with the
 	// same name but different specs. Without a namespace we cannot do that safely, so we fail
 	// rather than risk feeding another tenant's spec into resource-quota validation.

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -29,9 +29,33 @@ import (
 	kvmanifests "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt/manifests"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	VirtualMachineInstancetypeKind        = "VirtualMachineInstancetype"
+	VirtualMachineClusterInstancetypeKind = "VirtualMachineClusterInstancetype"
+)
+
+// InstanceTypeSource identifies the KubeVirt instancetype used to resolve a VM's resources.
+type InstanceTypeSource struct {
+	Kind      string
+	Namespace string
+	Name      string
+}
+
+// ResolvedInstanceType contains the resources and source identity of a KubeVirt instancetype.
+// DeviceResources preserves the exact device-plugin resource names requested by the
+// instancetype. It intentionally remains separate from NodeCapacity.GPUs, which is a flat,
+// provider-independent quantity and cannot represent different device resource names.
+type ResolvedInstanceType struct {
+	Capacity        *provider.NodeCapacity
+	DeviceResources corev1.ResourceList
+	Source          InstanceTypeSource
+}
 
 func instancetypeReconciler(instancetype *kvinstancetypev1beta1.VirtualMachineInstancetype) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {
 	return func() (string, reconciling.VirtualMachineInstancetypeReconciler) {
@@ -72,60 +96,90 @@ func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter 
 	return instancetypes
 }
 
-// DescribeInstanceType returns the NodeCapacity from the VirtualMachine instancetype.
+// ResolveInstanceType returns the capacity, exact device resource requests, and source
+// identity from the selected VirtualMachine instancetype.
 // namespace is the KubeVirt infra-cluster namespace that holds the cluster's namespaced
 // instancetypes. Resolving a custom (non-standard) namespaced instancetype without it fails,
 // to avoid an unscoped cross-tenant lookup. The embedded Kubermatic standard instancetypes are
 // namespace-independent and still resolve when it is empty.
-func DescribeInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+func ResolveInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*ResolvedInstanceType, error) {
 	client, err := NewClient(kubeconfig, ClientOptions{})
 	if err != nil {
 		return nil, err
 	}
-	return describeInstanceType(ctx, client, namespace, it)
+	return resolveInstanceType(ctx, client, namespace, it)
 }
 
-func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+// DescribeInstanceType returns only the NodeCapacity from the selected VirtualMachine
+// instancetype. It is kept as a compatibility wrapper for existing callers.
+func DescribeInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+	resolved, err := ResolveInstanceType(ctx, kubeconfig, namespace, it)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.Capacity, nil
+}
+
+func resolveInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*ResolvedInstanceType, error) {
+	if it == nil {
+		return nil, fmt.Errorf("VMI instancetype matcher must not be nil")
+	}
+
 	switch it.Kind {
-	case "VirtualMachineInstancetype": // namespaced: kubermatic standard or user-deployed custom
-		if nodeCap, err := describeNamespacedInstanceType(ctx, client, namespace, it.Name); nodeCap != nil || err != nil {
-			return nodeCap, err
+	case VirtualMachineInstancetypeKind: // namespaced: kubermatic standard or user-deployed custom
+		if resolved, err := resolveNamespacedInstanceType(ctx, client, namespace, it.Name); resolved != nil || err != nil {
+			return resolved, err
 		}
 
-	case "VirtualMachineClusterInstancetype": // cluster-wide
-		if nodeCap, err := describeClusterInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
-			return nodeCap, err
+	case VirtualMachineClusterInstancetypeKind: // cluster-wide
+		if resolved, err := resolveClusterInstanceType(ctx, client, it.Name); resolved != nil || err != nil {
+			return resolved, err
 		}
 
 	case "": // kind absent — saved before kind was added to the API; search both types
-		if nodeCap, err := describeClusterInstanceType(ctx, client, it.Name); nodeCap != nil || err != nil {
-			return nodeCap, err
+		if resolved, err := resolveClusterInstanceType(ctx, client, it.Name); resolved != nil || err != nil {
+			return resolved, err
 		}
-		if nodeCap, err := describeNamespacedInstanceType(ctx, client, namespace, it.Name); nodeCap != nil || err != nil {
-			return nodeCap, err
+		if resolved, err := resolveNamespacedInstanceType(ctx, client, namespace, it.Name); resolved != nil || err != nil {
+			return resolved, err
 		}
 	}
 	return nil, fmt.Errorf("VMI instancetype %s of Kind %s not found", it.Name, it.Kind)
 }
 
-func describeClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*provider.NodeCapacity, error) {
+func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+	resolved, err := resolveInstanceType(ctx, client, namespace, it)
+	if err != nil {
+		return nil, err
+	}
+	return resolved.Capacity, nil
+}
+
+func resolveClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*ResolvedInstanceType, error) {
 	clusterInstancetypes := kvinstancetypev1beta1.VirtualMachineClusterInstancetypeList{}
 	if err := client.List(ctx, &clusterInstancetypes); err != nil {
 		return nil, err
 	}
 	for _, instancetype := range clusterInstancetypes.Items {
 		if strings.EqualFold(instancetype.Name, name) {
-			return instanceTypeToNodeCapacity(instancetype.Spec)
+			return resolveInstanceTypeSpec(instancetype.Spec, InstanceTypeSource{
+				Kind: VirtualMachineClusterInstancetypeKind,
+				Name: instancetype.Name,
+			})
 		}
 	}
 	return nil, nil
 }
 
-func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*provider.NodeCapacity, error) {
+func resolveNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*ResolvedInstanceType, error) {
 	standardInstancetypes := GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
 	for _, instancetype := range standardInstancetypes {
 		if strings.EqualFold(instancetype.Name, name) {
-			return instanceTypeToNodeCapacity(instancetype.Spec)
+			return resolveInstanceTypeSpec(instancetype.Spec, InstanceTypeSource{
+				Kind:      VirtualMachineInstancetypeKind,
+				Namespace: namespace,
+				Name:      instancetype.Name,
+			})
 		}
 	}
 	// Fall back to listing user-deployed namespaced VirtualMachineInstancetype objects
@@ -145,13 +199,18 @@ func describeNamespacedInstanceType(ctx context.Context, client ctrlruntimeclien
 	}
 	for i := range namespacedInstancetypes.Items {
 		if strings.EqualFold(namespacedInstancetypes.Items[i].Name, name) {
-			return instanceTypeToNodeCapacity(namespacedInstancetypes.Items[i].Spec)
+			instancetype := &namespacedInstancetypes.Items[i]
+			return resolveInstanceTypeSpec(instancetype.Spec, InstanceTypeSource{
+				Kind:      VirtualMachineInstancetypeKind,
+				Namespace: instancetype.Namespace,
+				Name:      instancetype.Name,
+			})
 		}
 	}
 	return nil, nil
 }
 
-// instanceTypeToNodeCapacity extracts cpu, mem and gpu resource requests from the kubevirt instancetype.
+// instanceTypeToNodeCapacity extracts CPU and memory requests from the KubeVirt instancetype.
 func instanceTypeToNodeCapacity(it kvinstancetypev1beta1.VirtualMachineInstancetypeSpec) (*provider.NodeCapacity, error) {
 	capacity := provider.NewNodeCapacity()
 
@@ -168,4 +227,55 @@ func instanceTypeToNodeCapacity(it kvinstancetypev1beta1.VirtualMachineInstancet
 		capacity.WithCPUCount(int(cpu.Value()))
 	}
 	return capacity, nil
+}
+
+func resolveInstanceTypeSpec(it kvinstancetypev1beta1.VirtualMachineInstancetypeSpec, source InstanceTypeSource) (*ResolvedInstanceType, error) {
+	capacity, err := instanceTypeToNodeCapacity(it)
+	if err != nil {
+		return nil, err
+	}
+
+	var deviceResources corev1.ResourceList
+	for i, gpu := range it.GPUs {
+		deviceResources, err = addDeviceResource(deviceResources, fmt.Sprintf("spec.gpus[%d].deviceName", i), gpu.DeviceName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for i, hostDevice := range it.HostDevices {
+		deviceResources, err = addDeviceResource(deviceResources, fmt.Sprintf("spec.hostDevices[%d].deviceName", i), hostDevice.DeviceName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ResolvedInstanceType{
+		Capacity:        capacity,
+		DeviceResources: deviceResources,
+		Source:          source,
+	}, nil
+}
+
+func addDeviceResource(resources corev1.ResourceList, fieldPath, deviceName string) (corev1.ResourceList, error) {
+	// The KubeVirt API version currently used by KKP requires deviceName for both GPUs and
+	// host devices. Future DRA-backed entries need an explicit resolver rather than being
+	// silently omitted from the quota footprint.
+	if deviceName == "" {
+		return nil, fmt.Errorf("%s must not be empty", fieldPath)
+	}
+	if strings.Count(deviceName, "/") != 1 {
+		return nil, fmt.Errorf("%s %q must be a qualified resource name with exactly one '/'", fieldPath, deviceName)
+	}
+	if validationErrors := k8svalidation.IsQualifiedName(deviceName); len(validationErrors) > 0 {
+		return nil, fmt.Errorf("%s %q is not a valid qualified resource name: %s", fieldPath, deviceName, strings.Join(validationErrors, "; "))
+	}
+	if resources == nil {
+		resources = corev1.ResourceList{}
+	}
+
+	resourceName := corev1.ResourceName(deviceName)
+	quantity := resources[resourceName]
+	quantity.Add(*resource.NewQuantity(1, resource.DecimalSI))
+	resources[resourceName] = quantity
+	return resources, nil
 }

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -41,6 +41,7 @@ const (
 )
 
 // InstanceTypeSource identifies the KubeVirt instancetype used to resolve a VM's resources.
+// It is diagnostic resolution metadata, not an immutable version or infrastructure reservation.
 type InstanceTypeSource struct {
 	Kind      string
 	Namespace string
@@ -55,6 +56,11 @@ type ResolvedInstanceType struct {
 	Capacity        *provider.NodeCapacity
 	DeviceResources corev1.ResourceList
 	Source          InstanceTypeSource
+}
+
+type instanceTypeSpec struct {
+	Spec   kvinstancetypev1beta1.VirtualMachineInstancetypeSpec
+	Source InstanceTypeSource
 }
 
 func instancetypeReconciler(instancetype *kvinstancetypev1beta1.VirtualMachineInstancetype) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {
@@ -98,10 +104,10 @@ func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter 
 
 // ResolveInstanceType returns the capacity, exact device resource requests, and source
 // identity from the selected VirtualMachine instancetype.
-// namespace is the KubeVirt infra-cluster namespace that holds the cluster's namespaced
-// instancetypes. Resolving a custom (non-standard) namespaced instancetype without it fails,
-// to avoid an unscoped cross-tenant lookup. The embedded Kubermatic standard instancetypes are
-// namespace-independent and still resolve when it is empty.
+//
+// [Alpha]: this function is part of the alpha KubeVirt accelerator quota integration.
+//
+// namespace scopes custom VirtualMachineInstancetype lookup to an infrastructure tenant.
 func ResolveInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*ResolvedInstanceType, error) {
 	client, err := NewClient(kubeconfig, ClientOptions{})
 	if err != nil {
@@ -111,75 +117,89 @@ func ResolveInstanceType(ctx context.Context, kubeconfig string, namespace strin
 }
 
 // DescribeInstanceType returns only the NodeCapacity from the selected VirtualMachine
-// instancetype. It is kept as a compatibility wrapper for existing callers.
+// instancetype.
 func DescribeInstanceType(ctx context.Context, kubeconfig string, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
-	resolved, err := ResolveInstanceType(ctx, kubeconfig, namespace, it)
+	client, err := NewClient(kubeconfig, ClientOptions{})
 	if err != nil {
 		return nil, err
 	}
-	return resolved.Capacity, nil
+	return describeInstanceType(ctx, client, namespace, it)
 }
 
 func resolveInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*ResolvedInstanceType, error) {
+	instanceType, err := findInstanceType(ctx, client, namespace, it)
+	if err != nil {
+		return nil, err
+	}
+	return resolveInstanceTypeSpec(instanceType.Spec, instanceType.Source)
+}
+
+func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
+	instanceType, err := findInstanceType(ctx, client, namespace, it)
+	if err != nil {
+		return nil, err
+	}
+	return instanceTypeToNodeCapacity(instanceType.Spec)
+}
+
+func findInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*instanceTypeSpec, error) {
 	if it == nil {
 		return nil, fmt.Errorf("VMI instancetype matcher must not be nil")
 	}
 
 	switch it.Kind {
 	case VirtualMachineInstancetypeKind: // namespaced: kubermatic standard or user-deployed custom
-		if resolved, err := resolveNamespacedInstanceType(ctx, client, namespace, it.Name); resolved != nil || err != nil {
-			return resolved, err
+		if instanceType, err := findNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
 		}
 
 	case VirtualMachineClusterInstancetypeKind: // cluster-wide
-		if resolved, err := resolveClusterInstanceType(ctx, client, it.Name); resolved != nil || err != nil {
-			return resolved, err
+		if instanceType, err := findClusterInstanceType(ctx, client, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
 		}
 
 	case "": // kind absent — saved before kind was added to the API; search both types
-		if resolved, err := resolveClusterInstanceType(ctx, client, it.Name); resolved != nil || err != nil {
-			return resolved, err
+		if instanceType, err := findClusterInstanceType(ctx, client, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
 		}
-		if resolved, err := resolveNamespacedInstanceType(ctx, client, namespace, it.Name); resolved != nil || err != nil {
-			return resolved, err
+		if instanceType, err := findNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
+			return instanceType, err
 		}
 	}
 	return nil, fmt.Errorf("VMI instancetype %s of Kind %s not found", it.Name, it.Kind)
 }
 
-func describeInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*provider.NodeCapacity, error) {
-	resolved, err := resolveInstanceType(ctx, client, namespace, it)
-	if err != nil {
-		return nil, err
-	}
-	return resolved.Capacity, nil
-}
-
-func resolveClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*ResolvedInstanceType, error) {
+func findClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*instanceTypeSpec, error) {
 	clusterInstancetypes := kvinstancetypev1beta1.VirtualMachineClusterInstancetypeList{}
 	if err := client.List(ctx, &clusterInstancetypes); err != nil {
 		return nil, err
 	}
 	for _, instancetype := range clusterInstancetypes.Items {
 		if strings.EqualFold(instancetype.Name, name) {
-			return resolveInstanceTypeSpec(instancetype.Spec, InstanceTypeSource{
-				Kind: VirtualMachineClusterInstancetypeKind,
-				Name: instancetype.Name,
-			})
+			return &instanceTypeSpec{
+				Spec: instancetype.Spec,
+				Source: InstanceTypeSource{
+					Kind: VirtualMachineClusterInstancetypeKind,
+					Name: instancetype.Name,
+				},
+			}, nil
 		}
 	}
 	return nil, nil
 }
 
-func resolveNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*ResolvedInstanceType, error) {
+func findNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*instanceTypeSpec, error) {
 	standardInstancetypes := GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
 	for _, instancetype := range standardInstancetypes {
 		if strings.EqualFold(instancetype.Name, name) {
-			return resolveInstanceTypeSpec(instancetype.Spec, InstanceTypeSource{
-				Kind:      VirtualMachineInstancetypeKind,
-				Namespace: namespace,
-				Name:      instancetype.Name,
-			})
+			return &instanceTypeSpec{
+				Spec: instancetype.Spec,
+				Source: InstanceTypeSource{
+					Kind:      VirtualMachineInstancetypeKind,
+					Namespace: namespace,
+					Name:      instancetype.Name,
+				},
+			}, nil
 		}
 	}
 	// Fall back to listing user-deployed namespaced VirtualMachineInstancetype objects
@@ -200,11 +220,14 @@ func resolveNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient
 	for i := range namespacedInstancetypes.Items {
 		if strings.EqualFold(namespacedInstancetypes.Items[i].Name, name) {
 			instancetype := &namespacedInstancetypes.Items[i]
-			return resolveInstanceTypeSpec(instancetype.Spec, InstanceTypeSource{
-				Kind:      VirtualMachineInstancetypeKind,
-				Namespace: instancetype.Namespace,
-				Name:      instancetype.Name,
-			})
+			return &instanceTypeSpec{
+				Spec: instancetype.Spec,
+				Source: InstanceTypeSource{
+					Kind:      VirtualMachineInstancetypeKind,
+					Namespace: instancetype.Namespace,
+					Name:      instancetype.Name,
+				},
+			}, nil
 		}
 	}
 	return nil, nil

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -23,6 +23,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +48,7 @@ func TestDescribeInstanceType(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "namespaced user-deployed instancetype with GPU is found (GPUs not counted in capacity)",
+			name:      "namespaced user-deployed instancetype with GPU is found",
 			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
 				&kvinstancetypev1beta1.VirtualMachineInstancetype{
@@ -55,7 +56,7 @@ func TestDescribeInstanceType(t *testing.T) {
 					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
 						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
 						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
-						GPUs:   []kubevirtv1.GPU{{Name: "A100", DeviceName: "nv-a100-standard"}},
+						GPUs:   []kubevirtv1.GPU{{Name: "A100", DeviceName: "nvidia.com/A100"}},
 					},
 				},
 			},
@@ -178,6 +179,7 @@ func TestDescribeInstanceType(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatal("expected non-nil NodeCapacity, got nil")
+				return
 			}
 			if got.CPUCores == nil || got.CPUCores.Value() != tc.wantCPU {
 				t.Errorf("CPU: got %v, want %d", got.CPUCores, tc.wantCPU)
@@ -189,5 +191,249 @@ func TestDescribeInstanceType(t *testing.T) {
 				t.Errorf("GPUs: got %v, want nil (GPUs are not counted in capacity)", got.GPUs)
 			}
 		})
+	}
+}
+
+func TestResolveInstanceTypeDeviceResourcesAndSource(t *testing.T) {
+	testCases := []struct {
+		name            string
+		namespace       string
+		objects         []ctrlruntimeclient.Object
+		matcher         *kubevirtv1.InstancetypeMatcher
+		wantResources   corev1.ResourceList
+		wantSource      InstanceTypeSource
+		wantCapacityCPU int64
+		wantMemory      resource.Quantity
+	}{
+		{
+			name: "cluster-scoped host devices are counted and the explicit kind wins a same-name collision",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "h200-two-gpu"},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 32},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("128Gi")},
+						HostDevices: []kubevirtv1.HostDevice{
+							{Name: "gpu-1", DeviceName: "nvidia.com/GH100_H200_NVL"},
+							{Name: "gpu-2", DeviceName: "nvidia.com/GH100_H200_NVL"},
+						},
+					},
+				},
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "h200-two-gpu", Namespace: "tenant-a"},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
+					},
+				},
+			},
+			namespace: "tenant-a",
+			matcher: &kubevirtv1.InstancetypeMatcher{
+				Name: "h200-two-gpu",
+				Kind: VirtualMachineClusterInstancetypeKind,
+			},
+			wantResources: corev1.ResourceList{
+				"nvidia.com/GH100_H200_NVL": resource.MustParse("2"),
+			},
+			wantSource: InstanceTypeSource{
+				Kind: VirtualMachineClusterInstancetypeKind,
+				Name: "h200-two-gpu",
+			},
+			wantCapacityCPU: 32,
+			wantMemory:      resource.MustParse("128Gi"),
+		},
+		{
+			name:      "namespaced GPU and host devices are combined by exact resource name",
+			namespace: "tenant-a",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mixed-devices",
+						Namespace: "tenant-a",
+					},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 8},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("32Gi")},
+						GPUs: []kubevirtv1.GPU{
+							{Name: "gpu-1", DeviceName: "nvidia.com/A100"},
+							{Name: "gpu-2", DeviceName: "nvidia.com/A100"},
+						},
+						HostDevices: []kubevirtv1.HostDevice{
+							{Name: "gpu-3", DeviceName: "nvidia.com/A100"},
+							{Name: "fpga-1", DeviceName: "example.com/fpga"},
+						},
+					},
+				},
+			},
+			matcher: &kubevirtv1.InstancetypeMatcher{
+				Name: "mixed-devices",
+				Kind: VirtualMachineInstancetypeKind,
+			},
+			wantResources: corev1.ResourceList{
+				"nvidia.com/A100":  resource.MustParse("3"),
+				"example.com/fpga": resource.MustParse("1"),
+			},
+			wantSource: InstanceTypeSource{
+				Kind:      VirtualMachineInstancetypeKind,
+				Namespace: "tenant-a",
+				Name:      "mixed-devices",
+			},
+			wantCapacityCPU: 8,
+			wantMemory:      resource.MustParse("32Gi"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newTestClient(t, tc.objects...)
+			got, err := resolveInstanceType(context.Background(), client, tc.namespace, tc.matcher)
+			if err != nil {
+				t.Fatalf("resolveInstanceType() error = %v", err)
+			}
+
+			if got.Capacity == nil || got.Capacity.CPUCores == nil || got.Capacity.CPUCores.Value() != tc.wantCapacityCPU {
+				t.Fatalf("CPU: got %v, want %d", got.Capacity, tc.wantCapacityCPU)
+			}
+			if got.Capacity.GPUs != nil {
+				t.Errorf("NodeCapacity.GPUs: got %v, want nil", got.Capacity.GPUs)
+			}
+			if got.Capacity.Memory == nil || got.Capacity.Memory.Cmp(tc.wantMemory) != 0 {
+				t.Errorf("Memory: got %v, want %s", got.Capacity.Memory, tc.wantMemory.String())
+			}
+			assertResourceListEqual(t, got.DeviceResources, tc.wantResources)
+			if got.Source != tc.wantSource {
+				t.Errorf("Source: got %#v, want %#v", got.Source, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestResolveInstanceTypeWithNilMatcher(t *testing.T) {
+	_, err := resolveInstanceType(context.Background(), newTestClient(t), "tenant-a", nil)
+	if err == nil {
+		t.Fatal("resolveInstanceType() expected an error for a nil matcher")
+	}
+}
+
+func TestResolveInstanceTypeRecordsActualSourceForLegacyMatcher(t *testing.T) {
+	testCases := []struct {
+		name       string
+		namespace  string
+		objects    []ctrlruntimeclient.Object
+		wantSource InstanceTypeSource
+	}{
+		{
+			name: "cluster-scoped match",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "legacy"},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					},
+				},
+			},
+			wantSource: InstanceTypeSource{
+				Kind: VirtualMachineClusterInstancetypeKind,
+				Name: "legacy",
+			},
+		},
+		{
+			name:      "namespaced fallback",
+			namespace: "tenant-a",
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "legacy", Namespace: "tenant-a"},
+					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					},
+				},
+			},
+			wantSource: InstanceTypeSource{
+				Kind:      VirtualMachineInstancetypeKind,
+				Namespace: "tenant-a",
+				Name:      "legacy",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveInstanceType(
+				context.Background(),
+				newTestClient(t, tc.objects...),
+				tc.namespace,
+				&kubevirtv1.InstancetypeMatcher{Name: "legacy"},
+			)
+			if err != nil {
+				t.Fatalf("resolveInstanceType() error = %v", err)
+			}
+			if got.Source != tc.wantSource {
+				t.Errorf("Source: got %#v, want %#v", got.Source, tc.wantSource)
+			}
+			if got.DeviceResources != nil {
+				t.Errorf("DeviceResources: got %v, want nil", got.DeviceResources)
+			}
+		})
+	}
+}
+
+func TestResolveInstanceTypeRejectsInvalidDeviceName(t *testing.T) {
+	testCases := []struct {
+		name string
+		spec kvinstancetypev1beta1.VirtualMachineInstancetypeSpec
+	}{
+		{
+			name: "GPU",
+			spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				GPUs: []kubevirtv1.GPU{{Name: "gpu-1"}},
+			},
+		},
+		{
+			name: "host device",
+			spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				HostDevices: []kubevirtv1.HostDevice{{Name: "host-device-1"}},
+			},
+		},
+		{
+			name: "unqualified resource name",
+			spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				GPUs: []kubevirtv1.GPU{{Name: "gpu-1", DeviceName: "nvidia-a100"}},
+			},
+		},
+		{
+			name: "resource name with multiple separators",
+			spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				GPUs: []kubevirtv1.GPU{{Name: "gpu-1", DeviceName: "nvidia.com/gpu/a100"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveInstanceTypeSpec(tc.spec, InstanceTypeSource{})
+			if err == nil {
+				t.Fatal("resolveInstanceTypeSpec() expected an error for an invalid deviceName")
+			}
+		})
+	}
+}
+
+func assertResourceListEqual(t *testing.T, got, want corev1.ResourceList) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("DeviceResources length: got %d (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for name, wantQuantity := range want {
+		gotQuantity, exists := got[name]
+		if !exists {
+			t.Errorf("DeviceResources[%q]: missing, want %s", name, wantQuantity.String())
+			continue
+		}
+		if gotQuantity.Cmp(wantQuantity) != 0 {
+			t.Errorf("DeviceResources[%q]: got %s, want %s", name, gotQuantity.String(), wantQuantity.String())
+		}
 	}
 }

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -369,6 +369,107 @@ func TestResolveInstanceTypeWithNilMatcher(t *testing.T) {
 	}
 }
 
+func TestResolveInstanceTypeLegacyMatcherUsesMachineControllerOrder(t *testing.T) {
+	const (
+		name      = "legacy-collision"
+		namespace = "tenant-a"
+	)
+
+	client := newTestClient(t,
+		&kvinstancetypev1beta1.VirtualMachineInstancetype{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 8},
+				Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("32Gi")},
+				GPUs: []kubevirtv1.GPU{
+					{Name: "gpu-1", DeviceName: "nvidia.com/A100"},
+				},
+			},
+		},
+		&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
+				Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
+			},
+		},
+	)
+	matcher := &kubevirtv1.InstancetypeMatcher{Name: name}
+
+	resolved, err := resolveInstanceType(context.Background(), client, namespace, matcher)
+	if err != nil {
+		t.Fatalf("resolveInstanceType() error = %v", err)
+	}
+	if resolved.Source != (InstanceTypeSource{Kind: VirtualMachineInstancetypeKind, Namespace: namespace, Name: name}) {
+		t.Errorf("Source: got %#v, want namespaced instancetype", resolved.Source)
+	}
+	if resolved.Capacity.CPUCores == nil || resolved.Capacity.CPUCores.Value() != 8 {
+		t.Errorf("Resolve CPU: got %v, want namespaced value 8", resolved.Capacity.CPUCores)
+	}
+	assertResourceListEqual(t, resolved.DeviceResources, corev1.ResourceList{
+		"nvidia.com/A100": resource.MustParse("1"),
+	})
+
+	capacity, err := describeInstanceType(context.Background(), client, namespace, matcher)
+	if err != nil {
+		t.Fatalf("describeInstanceType() error = %v", err)
+	}
+	if capacity.CPUCores == nil || capacity.CPUCores.Value() != 2 {
+		t.Errorf("Describe CPU: got %v, want legacy cluster-scoped value 2", capacity.CPUCores)
+	}
+}
+
+func TestResolveInstanceTypeLegacyMatcherUsesOnlyLiveNamespacedObjects(t *testing.T) {
+	const (
+		name      = "standard-2"
+		namespace = "tenant-a"
+	)
+
+	client := newTestClient(t, &kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+			CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 16},
+			Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("64Gi")},
+			GPUs: []kubevirtv1.GPU{
+				{Name: "gpu-1", DeviceName: "nvidia.com/A100"},
+			},
+		},
+	})
+
+	resolved, err := resolveInstanceType(
+		context.Background(),
+		client,
+		namespace,
+		&kubevirtv1.InstancetypeMatcher{Name: name},
+	)
+	if err != nil {
+		t.Fatalf("resolveInstanceType() error = %v", err)
+	}
+	if resolved.Source != (InstanceTypeSource{Kind: VirtualMachineClusterInstancetypeKind, Name: name}) {
+		t.Errorf("Source: got %#v, want live cluster-scoped instancetype", resolved.Source)
+	}
+	assertResourceListEqual(t, resolved.DeviceResources, corev1.ResourceList{
+		"nvidia.com/A100": resource.MustParse("1"),
+	})
+}
+
+func TestResolveInstanceTypeExplicitNamespacedMatcherRequiresLiveObject(t *testing.T) {
+	const (
+		name      = "standard-2"
+		namespace = "tenant-a"
+	)
+
+	client := newTestClient(t)
+	matcher := &kubevirtv1.InstancetypeMatcher{Name: name, Kind: VirtualMachineInstancetypeKind}
+
+	if _, err := resolveInstanceType(context.Background(), client, namespace, matcher); err == nil {
+		t.Fatal("resolveInstanceType() expected an error when the namespaced instancetype is not live")
+	}
+	if _, err := describeInstanceType(context.Background(), client, namespace, matcher); err != nil {
+		t.Fatalf("describeInstanceType() did not preserve embedded-standard lookup: %v", err)
+	}
+}
+
 func TestResolveInstanceTypeRecordsActualSourceForLegacyMatcher(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -48,7 +48,7 @@ func TestDescribeInstanceType(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "namespaced user-deployed instancetype with GPU is found",
+			name:      "namespaced user-deployed instancetype with GPU is found without validating the device",
 			namespace: "kkp-dev",
 			objects: []ctrlruntimeclient.Object{
 				&kvinstancetypev1beta1.VirtualMachineInstancetype{
@@ -56,7 +56,7 @@ func TestDescribeInstanceType(t *testing.T) {
 					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
 						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 2},
 						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("8Gi")},
-						GPUs:   []kubevirtv1.GPU{{Name: "A100", DeviceName: "nvidia.com/A100"}},
+						GPUs:   []kubevirtv1.GPU{{Name: "A100", DeviceName: "nv-a100-standard"}},
 					},
 				},
 			},
@@ -189,6 +189,60 @@ func TestDescribeInstanceType(t *testing.T) {
 			// KubeVirt provider, so they must never be set.
 			if got.GPUs != nil {
 				t.Errorf("GPUs: got %v, want nil (GPUs are not counted in capacity)", got.GPUs)
+			}
+		})
+	}
+}
+
+func TestDescribeInstanceTypeDoesNotValidateDeviceResources(t *testing.T) {
+	testCases := []struct {
+		name        string
+		gpus        []kubevirtv1.GPU
+		hostDevices []kubevirtv1.HostDevice
+	}{
+		{
+			name: "GPU",
+			gpus: []kubevirtv1.GPU{{Name: "gpu-1", DeviceName: "unqualified-gpu"}},
+		},
+		{
+			name:        "host device",
+			hostDevices: []kubevirtv1.HostDevice{{Name: "host-device-1"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			const (
+				namespace = "tenant-a"
+				name      = "legacy-device-metadata"
+			)
+			client := newTestClient(t, &kvinstancetypev1beta1.VirtualMachineInstancetype{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+					CPU:         kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+					Memory:      kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
+					GPUs:        tc.gpus,
+					HostDevices: tc.hostDevices,
+				},
+			})
+			matcher := &kubevirtv1.InstancetypeMatcher{Name: name, Kind: VirtualMachineInstancetypeKind}
+
+			capacity, err := describeInstanceType(context.Background(), client, namespace, matcher)
+			if err != nil {
+				t.Fatalf("describeInstanceType() unexpectedly validated device resources: %v", err)
+			}
+			if capacity.CPUCores == nil || capacity.CPUCores.Value() != 4 {
+				t.Errorf("CPU: got %v, want 4", capacity.CPUCores)
+			}
+			if capacity.Memory == nil || capacity.Memory.Cmp(resource.MustParse("16Gi")) != 0 {
+				t.Errorf("Memory: got %v, want 16Gi", capacity.Memory)
+			}
+			if capacity.GPUs != nil {
+				t.Errorf("GPUs: got %v, want nil", capacity.GPUs)
+			}
+
+			if _, err := resolveInstanceType(context.Background(), client, namespace, matcher); err == nil {
+				t.Fatal("resolveInstanceType() expected an error for invalid device metadata")
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the KubeVirt instancetype resolver for GPU Machine accounting in KKP. The new `ResolveInstanceType` function resolves the selected live `VirtualMachineInstancetype` or `VirtualMachineClusterInstancetype`, it then returns its CPU, memory, and device resources declared in `spec.gpus` and `spec.hostDevices`. Matchers without a `Kind` use namespaced resolution to match machine controller provisioning, while existing `DescribeInstanceType` behavior remains unchanged.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/16240

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
