### PR TITLE
Add KubeVirt accelerator quota feature gate

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -169,6 +169,7 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 			KubernetesOIDCAuthentication: ctrlCtx.runOptions.featureGates.Enabled(features.OpenIDAuthPlugin),
 			EtcdLauncher:                 ctrlCtx.runOptions.featureGates.Enabled(features.EtcdLauncher),
 			DynamicResourceAllocation:    ctrlCtx.runOptions.featureGates.Enabled(features.DynamicResourceAllocation),
+			KubeVirtAcceleratorQuota:     ctrlCtx.runOptions.featureGates.Enabled(features.KubeVirtAcceleratorQuota),
 		},
 		ctrlCtx.versions,
 	)

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -112,6 +112,7 @@ type controllerRunOptions struct {
 	kubeVirtVMIEvictionController     bool
 	kubeVirtInfraKubeconfig           string
 	kubeVirtInfraNamespace            string
+	kubeVirtAcceleratorQuota          bool
 
 	clusterBackup clusterBackupOptions
 
@@ -172,6 +173,7 @@ func main() {
 	flag.BoolVar(&runOp.kubeVirtVMIEvictionController, "kv-vmi-eviction-controller", false, "Start the KubeVirt VMI eviction controller")
 	flag.StringVar(&runOp.kubeVirtInfraKubeconfig, "kv-infra-kubeconfig", "", "Path to the KubeVirt infra kubeconfig.")
 	flag.StringVar(&runOp.kubeVirtInfraNamespace, "kv-infra-namespace", "", "Kubevirt infra namespace where workload will be deployed")
+	flag.BoolVar(&runOp.kubeVirtAcceleratorQuota, "kubevirt-accelerator-quota", false, "Enable KubeVirt accelerator quota accounting")
 	flag.BoolVar(&runOp.kyvernoEnabled, "kyverno-enabled", false, "Enable Kyverno in user cluster.")
 	flag.Parse()
 

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -29,14 +29,15 @@ import (
 )
 
 type appOptions struct {
-	seedWebhook            webhook.Options
-	userWebhook            webhook.Options
-	pprof                  flagopts.PProf
-	log                    kubermaticlog.Options
-	caBundle               *certificates.CABundle
-	projectID              string
-	clusterName            string
-	kubeVirtInfraNamespace string
+	seedWebhook              webhook.Options
+	userWebhook              webhook.Options
+	pprof                    flagopts.PProf
+	log                      kubermaticlog.Options
+	caBundle                 *certificates.CABundle
+	projectID                string
+	clusterName              string
+	kubeVirtInfraNamespace   string
+	kubeVirtAcceleratorQuota bool
 }
 
 func initApplicationOptions() (appOptions, error) {
@@ -60,6 +61,7 @@ func initApplicationOptions() (appOptions, error) {
 	flag.StringVar(&projectID, "project-id", "", "Project ID in which cluster the webhook is running in")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster name in which the webhook is running in")
 	flag.StringVar(&kubeVirtInfraNamespace, "kubevirt-infra-namespace", "", "KubeVirt infra-cluster namespace that holds the cluster's namespaced VirtualMachineInstancetypes; empty falls back to an unscoped lookup")
+	flag.BoolVar(&c.kubeVirtAcceleratorQuota, "kubevirt-accelerator-quota", false, "Enable KubeVirt accelerator quota accounting")
 	flag.Parse()
 
 	caBundle, err := certificates.NewCABundleFromFile(caBundleFile)

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -76,6 +76,7 @@ type Features struct {
 	KubernetesOIDCAuthentication bool
 	EtcdLauncher                 bool
 	DynamicResourceAllocation    bool
+	KubeVirtAcceleratorQuota     bool
 }
 
 // Reconciler is a controller which is responsible for managing clusters.

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -325,6 +325,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithClusterBackupStorageLocation(cbsl).
 		WithVersions(r.versions).
 		WithDRA(r.features.DynamicResourceAllocation).
+		WithKubeVirtAcceleratorQuota(r.features.KubeVirtAcceleratorQuota).
 		Build(), nil
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -80,6 +80,10 @@ const (
 	// for cert-manager integration. This controller watches HTTPRoutes and ensures
 	// Gateway listeners have explicit hostnames so cert-manager can create certificates.
 	HTTPRouteGatewaySync = "HTTPRouteGatewaySync"
+
+	// KubeVirtAcceleratorQuota enables accelerator quota accounting for KubeVirt Machines.
+	// This feature is alpha and disabled by default.
+	KubeVirtAcceleratorQuota = "KubeVirtAcceleratorQuota"
 )
 
 // FeatureGate is map of key=value pairs that enables/disables various features.

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -51,3 +51,37 @@ func TestFeatureGates(t *testing.T) {
 		})
 	}
 }
+
+func TestKubeVirtAcceleratorQuotaFeatureGate(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		enabled bool
+	}{
+		{
+			name: "disabled when omitted",
+		},
+		{
+			name:  "explicitly disabled",
+			input: KubeVirtAcceleratorQuota + "=false",
+		},
+		{
+			name:    "explicitly enabled",
+			input:   KubeVirtAcceleratorQuota + "=true",
+			enabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			featureGates, err := NewFeatures(tc.input)
+			if err != nil {
+				t.Fatalf("failed to parse feature gates: %v", err)
+			}
+
+			if enabled := featureGates.Enabled(KubeVirtAcceleratorQuota); enabled != tc.enabled {
+				t.Fatalf("expected %s enabled=%t, got %t", KubeVirtAcceleratorQuota, tc.enabled, enabled)
+			}
+		})
+	}
+}

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -106,6 +106,7 @@ type TemplateData struct {
 	userClusterMLAEnabled                 bool
 	isKonnectivityEnabled                 bool
 	dra                                   bool
+	kubeVirtAcceleratorQuota              bool
 
 	tunnelingAgentIP string
 
@@ -322,6 +323,11 @@ func (td TemplateDataBuilder) Build() *TemplateData {
 
 func (td *TemplateDataBuilder) WithDRA(draEnabled bool) *TemplateDataBuilder {
 	td.data.dra = draEnabled
+	return td
+}
+
+func (td *TemplateDataBuilder) WithKubeVirtAcceleratorQuota(enabled bool) *TemplateDataBuilder {
+	td.data.kubeVirtAcceleratorQuota = enabled
 	return td
 }
 
@@ -1114,6 +1120,11 @@ func (d *TemplateData) ParseFluentBitRecords() (*kubermaticv1.AuditSidecarConfig
 
 func (d *TemplateData) DRAEnabled() bool {
 	return d.dra
+}
+
+// KubeVirtAcceleratorQuotaEnabled returns whether KubeVirt accelerator quota accounting is enabled.
+func (d *TemplateData) KubeVirtAcceleratorQuotaEnabled() bool {
+	return d.kubeVirtAcceleratorQuota
 }
 
 func expandVariables(input string, vars map[string]string) string {

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -136,6 +136,33 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 	}
 }
 
+func TestKubeVirtAcceleratorQuotaEnabled(t *testing.T) {
+	testCases := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			name: "disabled by default",
+		},
+		{
+			name:    "enabled",
+			enabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			templateData := NewTemplateDataBuilder().
+				WithKubeVirtAcceleratorQuota(tc.enabled).
+				Build()
+
+			if enabled := templateData.KubeVirtAcceleratorQuotaEnabled(); enabled != tc.enabled {
+				t.Fatalf("expected KubeVirt accelerator quota enabled=%t, got %t", tc.enabled, enabled)
+			}
+		})
+	}
+}
+
 func TestKubermaticAPIImage(t *testing.T) {
 	testCases := []struct {
 		name         string

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -59,6 +59,7 @@ type webhookData interface {
 	DC() *kubermaticv1.Datacenter
 	KubermaticAPIImage() string
 	KubermaticDockerTag() string
+	KubeVirtAcceleratorQuotaEnabled() bool
 	GetGlobalSecretKeySelectorValue(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error)
 	GetEnvVars() ([]corev1.EnvVar, error)
 }
@@ -115,6 +116,9 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 					kubeVirtInfraNamespace = data.DC().Spec.Kubevirt.NamespacedMode.Namespace
 				}
 				args = append(args, fmt.Sprintf("-kubevirt-infra-namespace=%s", kubeVirtInfraNamespace))
+				if data.KubeVirtAcceleratorQuotaEnabled() {
+					args = append(args, "-kubevirt-accelerator-quota")
+				}
 			}
 
 			if data.Cluster().Spec.DebugLog {

--- a/pkg/resources/usercluster-webhook/deployment_test.go
+++ b/pkg/resources/usercluster-webhook/deployment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package usercluster
+package webhook
 
 import (
 	"encoding/json"
@@ -23,7 +23,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kkpresources "k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -56,12 +55,12 @@ func TestKubeVirtAcceleratorQuotaArgument(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			data := newDeploymentTestData(tc.kubeVirt, tc.enabled)
+			data := newWebhookDeploymentTestData(tc.kubeVirt, tc.enabled)
 			_, reconcile := DeploymentReconciler(data)()
 
 			deployment, err := reconcile(&appsv1.Deployment{})
 			if err != nil {
-				t.Fatalf("failed to reconcile user-cluster-controller deployment: %v", err)
+				t.Fatalf("failed to reconcile user-cluster-webhook deployment: %v", err)
 			}
 
 			hasArgument := deploymentContainsArgument(deployment, "-kubevirt-accelerator-quota")
@@ -72,7 +71,7 @@ func TestKubeVirtAcceleratorQuotaArgument(t *testing.T) {
 	}
 }
 
-func newDeploymentTestData(kubeVirt, acceleratorQuotaEnabled bool) *kkpresources.TemplateData {
+func newWebhookDeploymentTestData(kubeVirt, acceleratorQuotaEnabled bool) *kkpresources.TemplateData {
 	cloud := kubermaticv1.CloudSpec{Fake: &kubermaticv1.FakeCloudSpec{}}
 	datacenter := kubermaticv1.DatacenterSpec{Fake: &kubermaticv1.DatacenterSpecFake{}}
 	if kubeVirt {
@@ -88,17 +87,11 @@ func newDeploymentTestData(kubeVirt, acceleratorQuotaEnabled bool) *kkpresources
 			},
 		},
 		Spec: kubermaticv1.ClusterSpec{
-			Cloud:          cloud,
-			ExposeStrategy: kubermaticv1.ExposeStrategyTunneling,
-			ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
-				Services: kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.16.0/20"}},
-			},
+			Cloud: cloud,
 		},
 		Status: kubermaticv1.ClusterStatus{
 			NamespaceName: "cluster-test",
 			Address: kubermaticv1.ClusterAddress{
-				Port:         6443,
-				ExternalName: "test.example.com",
 				InternalName: "apiserver.cluster-test.svc.cluster.local",
 			},
 		},
@@ -110,7 +103,6 @@ func newDeploymentTestData(kubeVirt, acceleratorQuotaEnabled bool) *kkpresources
 		WithSeed(&kubermaticv1.Seed{}).
 		WithKubermaticImage("quay.io/kubermatic/kubermatic").
 		WithVersions(kubermatic.GetFakeVersions()).
-		WithKonnectivityEnabled(true).
 		WithKubeVirtAcceleratorQuota(acceleratorQuotaEnabled).
 		Build()
 }
@@ -141,49 +133,4 @@ func deploymentContainsArgument(deployment *appsv1.Deployment, argument string) 
 	}
 
 	return false
-}
-
-func TestGetLabelArgsValue(t *testing.T) {
-	testCases := []struct {
-		name           string
-		initialLabels  map[string]string
-		expectedLabels map[string]string
-	}{
-		{
-			name:           "Labels get applied",
-			initialLabels:  map[string]string{"foo": "bar"},
-			expectedLabels: map[string]string{"foo": "bar"},
-		},
-		{
-			name:           "Protected labels do not get applied",
-			initialLabels:  map[string]string{"foo": "bar", "project-id": "my-project", "worker-name": "w"},
-			expectedLabels: map[string]string{"foo": "bar"},
-		},
-	}
-
-	for idx := range testCases {
-		tc := testCases[idx]
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			cluster := &kubermaticv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: tc.initialLabels,
-				},
-			}
-			result, err := getLabelsArgValue(cluster)
-			if err != nil {
-				t.Fatalf("error when calling getLabelsArgValue: %v", err)
-			}
-
-			actualLabels := map[string]string{}
-			if err := json.Unmarshal([]byte(result), &actualLabels); err != nil {
-				t.Fatalf("failed to unmarshal result: %v", err)
-			}
-
-			if !diff.SemanticallyEqual(tc.expectedLabels, actualLabels) {
-				t.Fatalf("actual labels do not match expected labels:\n%v", diff.ObjectDiff(tc.expectedLabels, actualLabels))
-			}
-		})
-	}
 }

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -77,6 +77,7 @@ type userclusterControllerData interface {
 	GetEnvVars() ([]corev1.EnvVar, error)
 	GetClusterBackupStorageLocation() *kubermaticv1.ClusterBackupStorageLocation
 	SupportsFailureDomainZoneAntiAffinity() bool
+	KubeVirtAcceleratorQuotaEnabled() bool
 }
 
 // DeploymentReconciler returns the function to create and update the user cluster controller deployment
@@ -237,6 +238,9 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 				args = append(args, "-kv-infra-kubeconfig", "/etc/kubernetes/kubevirt/infra-kubeconfig")
 				if data.DC().Spec.Kubevirt != nil && data.DC().Spec.Kubevirt.NamespacedMode != nil && data.DC().Spec.Kubevirt.NamespacedMode.Enabled {
 					args = append(args, "-kv-infra-namespace", data.DC().Spec.Kubevirt.NamespacedMode.Namespace)
+				}
+				if data.KubeVirtAcceleratorQuotaEnabled() {
+					args = append(args, "-kubevirt-accelerator-quota")
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the disabled by default `KubeVirtAcceleratorQuota` feature gate and passes it to the KubeVirt UC webhook and controller manager. This prepares the components for the upcoming accounting implementation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Related to: https://github.com/kubermatic/kubermatic/issues/15646, https://github.com/kubermatic/kubermatic/issues/15820

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
