### PR TITLE
Wait for KKP version status in Gateway API migration E2E

### DIFF
--- a/hack/ci/lib-gateway-api-migration.sh
+++ b/hack/ci/lib-gateway-api-migration.sh
@@ -317,6 +317,23 @@ setup_kkp_migration_environment() {
   write_migration_helm_values "${HELM_VALUES_FILE_UNDER_TEST_HYBRID}" "hybrid" "${KUBERMATIC_VERSION}"
 }
 
+check_kubermatic_version() {
+  local expected_version="$1"
+  local actual_version
+
+  if ! actual_version="$(kubectl --namespace kubermatic get kubermaticconfiguration e2e --output jsonpath='{.status.kubermaticVersion}' 2> /dev/null)"; then
+    echodate "Unable to read the current KubermaticConfiguration version."
+    return 1
+  fi
+
+  if [ "${actual_version}" != "${expected_version}" ]; then
+    echodate "KubermaticConfiguration reports ${actual_version:-<empty>}; waiting for ${expected_version}."
+    return 1
+  fi
+
+  return 0
+}
+
 deploy_kkp_v229() {
   echodate "Step 1: deploying KKP ${KKP_V229_VERSION} (nginx-ingress era)..."
   TEST_NAME="Install KKP ${KKP_V229_VERSION}"
@@ -345,6 +362,8 @@ deploy_kkp_v230_with_gateway_api_flag() {
 
   retry 10 check_all_deployments_ready kubermatic
   retry 10 check_all_deployments_ready envoy-gateway-controller
+  TEST_NAME="Wait for KKP ${KKP_V230_VERSION} status"
+  retry 10 check_kubermatic_version "${KKP_V230_VERSION}"
   echodate "KKP ${KKP_V230_VERSION} installed; Gateway API and nginx-ingress coexist."
 }
 
@@ -360,6 +379,8 @@ deploy_kkp_v230_without_gateway_api_flag() {
 
   retry 10 check_all_deployments_ready kubermatic
   retry 10 check_all_deployments_ready nginx-ingress-controller
+  TEST_NAME="Wait for KKP ${KKP_V230_VERSION} status"
+  retry 10 check_kubermatic_version "${KKP_V230_VERSION}"
   echodate "KKP ${KKP_V230_VERSION} installed; remains on nginx-ingress."
 }
 

--- a/hack/ci/testdata/kubermatic_gatewayapi.yaml
+++ b/hack/ci/testdata/kubermatic_gatewayapi.yaml
@@ -26,6 +26,8 @@ spec:
     domain: '__KUBERMATIC_DOMAIN__'
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   auth:
+    issuerClientSecret: 'kubermatic-static-client-secret'
+    issuerCookieKey: 'kubermatic-static-cookie-key-1234'
     serviceAccountKey: '__SERVICE_ACCOUNT_KEY__'
   userCluster:
     apiserverReplicas: 1

--- a/hack/ci/testdata/kubermatic_nginx.yaml
+++ b/hack/ci/testdata/kubermatic_nginx.yaml
@@ -24,6 +24,8 @@ spec:
     disable: false
   imagePullSecret: '__IMAGE_PULL_SECRET__'
   auth:
+    issuerClientSecret: 'kubermatic-static-client-secret'
+    issuerCookieKey: 'kubermatic-static-cookie-key-1234'
     serviceAccountKey: '__SERVICE_ACCOUNT_KEY__'
   userCluster:
     apiserverReplicas: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Waits for `KubermaticConfiguration.status.kubermaticVersion` to report the expected v2.30 release before the Gateway API migration E2E starts the installer under test.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/pull/15946, https://github.com/kubermatic/kubermatic/issues/15951, https://github.com/kubermatic/kubermatic/pull/16242, https://github.com/kubermatic/kubermatic/pull/16215

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
