### PR TITLE
Add trusted KubeVirt Machine accelerator footprints

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -29,6 +29,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	addonmutation "k8c.io/kubermatic/v2/pkg/webhook/addon/mutation"
@@ -198,9 +199,16 @@ func main() {
 	// /////////////////////////////////////////
 	// setup Resource Quota webhooks
 
-	quotaValidator := resourcequotavalidation.NewValidator(mgr.GetClient())
+	quotaValidator := resourcequotavalidation.NewValidator(mgr.GetClient(), options.featureGates)
 	if err := builder.WebhookManagedBy(mgr, &kubermaticv1.ResourceQuota{}).WithValidator(quotaValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup resource quota validation webhook", zap.Error(err))
+	}
+	accountingValidator := resourcequotavalidation.NewAcceleratorAccountingValidator(mgr.GetClient(), options.featureGates)
+	if err := builder.WebhookManagedBy(mgr, &kubermaticv1.ResourceQuota{}).
+		WithValidator(accountingValidator).
+		WithValidatorCustomPath(resources.AcceleratorAccountingWebhookPath).
+		Complete(); err != nil {
+		log.Fatalw("Failed to setup ResourceQuota accelerator accounting validation webhook", zap.Error(err))
 	}
 
 	// /////////////////////////////////////////

--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -164,12 +164,12 @@ func createKubernetesController(ctrlCtx *controllerContext) error {
 		ctrlCtx.runOptions.tunnelingAgentIP.String(),
 		ctrlCtx.runOptions.caBundle,
 		kubernetescontroller.Features{
-			VPA:                          ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),
-			EtcdDataCorruptionChecks:     ctrlCtx.runOptions.featureGates.Enabled(features.EtcdDataCorruptionChecks),
-			KubernetesOIDCAuthentication: ctrlCtx.runOptions.featureGates.Enabled(features.OpenIDAuthPlugin),
-			EtcdLauncher:                 ctrlCtx.runOptions.featureGates.Enabled(features.EtcdLauncher),
-			DynamicResourceAllocation:    ctrlCtx.runOptions.featureGates.Enabled(features.DynamicResourceAllocation),
-			KubeVirtAcceleratorQuota:     ctrlCtx.runOptions.featureGates.Enabled(features.KubeVirtAcceleratorQuota),
+			VPA:                           ctrlCtx.runOptions.featureGates.Enabled(features.VerticalPodAutoscaler),
+			EtcdDataCorruptionChecks:      ctrlCtx.runOptions.featureGates.Enabled(features.EtcdDataCorruptionChecks),
+			KubernetesOIDCAuthentication:  ctrlCtx.runOptions.featureGates.Enabled(features.OpenIDAuthPlugin),
+			EtcdLauncher:                  ctrlCtx.runOptions.featureGates.Enabled(features.EtcdLauncher),
+			DynamicResourceAllocation:     ctrlCtx.runOptions.featureGates.Enabled(features.DynamicResourceAllocation),
+			KubeVirtAcceleratorAccounting: acceleratorAccountingSupported(),
 		},
 		ctrlCtx.versions,
 	)

--- a/cmd/seed-controller-manager/wrappers_ce.go
+++ b/cmd/seed-controller-manager/wrappers_ce.go
@@ -32,6 +32,10 @@ func addFlags(fs *flag.FlagSet) {
 	// NOP
 }
 
+func acceleratorAccountingSupported() bool {
+	return false
+}
+
 func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Reader, options controllerRunOptions) (provider.SeedGetter, error) {
 	return kubernetes.SeedGetterFactory(ctx, client, options.seedName, options.namespace)
 }

--- a/cmd/seed-controller-manager/wrappers_ee.go
+++ b/cmd/seed-controller-manager/wrappers_ee.go
@@ -40,6 +40,10 @@ func addFlags(fs *flag.FlagSet) {
 	// NOP
 }
 
+func acceleratorAccountingSupported() bool {
+	return true
+}
+
 func seedGetterFactory(ctx context.Context, client ctrlruntimeclient.Reader, options controllerRunOptions) (provider.SeedGetter, error) {
 	return eeseedctrlmgr.SeedGetterFactory(ctx, client, options.seedName, options.namespace)
 }

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -344,6 +344,7 @@ func main() {
 		runOp.konnectivityKeepaliveTime,
 		runOp.ccmMigration,
 		runOp.ccmMigrationCompleted,
+		runOp.kubeVirtAcceleratorQuota,
 		runOp.kyvernoEnabled,
 		log,
 	); err != nil {

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -27,10 +27,13 @@ import (
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	applicationinstallationmutation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationinstallation/mutation"
 	applicationinstallationvalidation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationinstallation/validation"
+	machineacceleratorvalidation "k8c.io/kubermatic/v2/pkg/webhook/machine/acceleratorvalidation"
+	machinemutation "k8c.io/kubermatic/v2/pkg/webhook/machine/mutation"
 	machinevalidation "k8c.io/kubermatic/v2/pkg/webhook/machine/validation"
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
 
@@ -130,12 +133,26 @@ func main() {
 	applicationinstallationvalidation.NewAdmissionHandler(log, seedMgr.GetScheme(), seedMgr.GetClient(), options.clusterName).SetupWebhookWithManager(seedMgr)
 
 	// Setup Machine Webhook in user manager.
+	// The user-cluster controller installs the dedicated accelerator webhook configurations
+	// when the feature is activated. Handlers stay authoritative whenever those configurations
+	// call them, including during rolling updates and after sticky activation.
 	machineValidator, err := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle, options.projectID, options.kubeVirtInfraNamespace)
 	if err != nil {
 		log.Fatalw("Failed to setup Machine validator", zap.Error(err))
 	}
-	if err := builder.WebhookManagedBy(userMgr, &clusterv1alpha1.Machine{}).WithValidator(machineValidator).Complete(); err != nil {
+	if err := builder.WebhookManagedBy(userMgr, &clusterv1alpha1.Machine{}).
+		WithValidator(machineValidator).
+		Complete(); err != nil {
 		log.Fatalw("Failed to setup Machine validation webhook", zap.Error(err))
+	}
+
+	if err := builder.WebhookManagedBy(userMgr, &clusterv1alpha1.Machine{}).
+		WithDefaulter(machinemutation.NewMutator(userMgr.GetClient(), options.kubeVirtInfraNamespace)).
+		WithValidator(machineacceleratorvalidation.NewValidator()).
+		WithDefaulterCustomPath(accelerator.MutatingWebhookPath).
+		WithValidatorCustomPath(accelerator.ValidatingWebhookPath).
+		Complete(); err != nil {
+		log.Fatalw("Failed to setup Machine accelerator footprint webhooks", zap.Error(err))
 	}
 
 	// /////////////////////////////////////////

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -27,12 +27,11 @@ import (
 	appskubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
-	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	applicationinstallationmutation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationinstallation/mutation"
 	applicationinstallationvalidation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationinstallation/validation"
-	machineacceleratorvalidation "k8c.io/kubermatic/v2/pkg/webhook/machine/acceleratorvalidation"
 	machinemutation "k8c.io/kubermatic/v2/pkg/webhook/machine/mutation"
 	machinevalidation "k8c.io/kubermatic/v2/pkg/webhook/machine/validation"
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
@@ -133,24 +132,22 @@ func main() {
 	applicationinstallationvalidation.NewAdmissionHandler(log, seedMgr.GetScheme(), seedMgr.GetClient(), options.clusterName).SetupWebhookWithManager(seedMgr)
 
 	// Setup Machine Webhook in user manager.
-	// The user-cluster controller installs the dedicated accelerator webhook configurations
-	// when the feature is activated. Handlers stay authoritative whenever those configurations
-	// call them, including during rolling updates and after sticky activation.
 	machineValidator, err := machinevalidation.NewValidator(seedMgr.GetClient(), userMgr.GetClient(), log, options.caBundle, options.projectID, options.kubeVirtInfraNamespace)
 	if err != nil {
 		log.Fatalw("Failed to setup Machine validator", zap.Error(err))
 	}
-	if err := builder.WebhookManagedBy(userMgr, &clusterv1alpha1.Machine{}).
-		WithValidator(machineValidator).
-		Complete(); err != nil {
+	if err := builder.WebhookManagedBy(userMgr, &clusterv1alpha1.Machine{}).WithValidator(machineValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup Machine validation webhook", zap.Error(err))
 	}
 
+	// The user-cluster controller installs the dedicated accelerator webhook configurations
+	// when the feature is activated. Handlers stay authoritative whenever those configurations
+	// call them, including during rolling updates and after sticky activation.
 	if err := builder.WebhookManagedBy(userMgr, &clusterv1alpha1.Machine{}).
 		WithDefaulter(machinemutation.NewMutator(userMgr.GetClient(), options.kubeVirtInfraNamespace)).
-		WithValidator(machineacceleratorvalidation.NewValidator()).
-		WithDefaulterCustomPath(accelerator.MutatingWebhookPath).
-		WithValidatorCustomPath(accelerator.ValidatingWebhookPath).
+		WithValidator(machinevalidation.NewAcceleratorValidator()).
+		WithDefaulterCustomPath(resources.MachineAcceleratorFootprintMutatingWebhookPath).
+		WithValidatorCustomPath(resources.MachineAcceleratorFootprintValidatingWebhookPath).
 		Complete(); err != nil {
 		log.Fatalw("Failed to setup Machine accelerator footprint webhooks", zap.Error(err))
 	}

--- a/cmd/user-cluster-webhook/options.go
+++ b/cmd/user-cluster-webhook/options.go
@@ -29,15 +29,14 @@ import (
 )
 
 type appOptions struct {
-	seedWebhook              webhook.Options
-	userWebhook              webhook.Options
-	pprof                    flagopts.PProf
-	log                      kubermaticlog.Options
-	caBundle                 *certificates.CABundle
-	projectID                string
-	clusterName              string
-	kubeVirtInfraNamespace   string
-	kubeVirtAcceleratorQuota bool
+	seedWebhook            webhook.Options
+	userWebhook            webhook.Options
+	pprof                  flagopts.PProf
+	log                    kubermaticlog.Options
+	caBundle               *certificates.CABundle
+	projectID              string
+	clusterName            string
+	kubeVirtInfraNamespace string
 }
 
 func initApplicationOptions() (appOptions, error) {
@@ -60,8 +59,7 @@ func initApplicationOptions() (appOptions, error) {
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all userclusters")
 	flag.StringVar(&projectID, "project-id", "", "Project ID in which cluster the webhook is running in")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster name in which the webhook is running in")
-	flag.StringVar(&kubeVirtInfraNamespace, "kubevirt-infra-namespace", "", "KubeVirt infra-cluster namespace that holds the cluster's namespaced VirtualMachineInstancetypes; empty falls back to an unscoped lookup")
-	flag.BoolVar(&c.kubeVirtAcceleratorQuota, "kubevirt-accelerator-quota", false, "Enable KubeVirt accelerator quota accounting")
+	flag.StringVar(&kubeVirtInfraNamespace, "kubevirt-infra-namespace", "", "KubeVirt infra-cluster namespace that holds the cluster's namespaced VirtualMachineInstancetypes")
 	flag.Parse()
 
 	caBundle, err := certificates.NewCABundleFromFile(caBundleFile)

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	kubevirt.io/containerized-data-importer-api v1.60.3
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
+	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -506,7 +507,6 @@ require (
 	k8s.io/streaming v0.36.2 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.2.4 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
-	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -82,6 +82,9 @@ const (
 
 	// ResourceQuotaAdmissionWebhookName is the name of the validating and mutating webhook for ResourceQuotas.
 	ResourceQuotaAdmissionWebhookName = "kubermatic-resourcequotas"
+	// ResourceQuotaAcceleratorAccountingAdmissionWebhookName is the dedicated validating webhook
+	// that protects project accelerator-accounting activation across rolling upgrades.
+	ResourceQuotaAcceleratorAccountingAdmissionWebhookName = "kubermatic-resourcequotas-accelerator-accounting"
 
 	// ExternalClusterAdmissionWebhookName is the name of the mutating webhook for ExternalClusters.
 	ExternalClusterAdmissionWebhookName = "kubermatic-externalclusters"

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -238,6 +238,7 @@ func (r *Reconciler) cleanupDeletedConfiguration(ctx context.Context, config *ku
 		common.KubermaticConfigurationAdmissionWebhookName(config),
 		common.GroupProjectBindingAdmissionWebhookName,
 		common.ResourceQuotaAdmissionWebhookName,
+		common.ResourceQuotaAcceleratorAccountingAdmissionWebhookName,
 		common.PolicyTemplateAdmissionWebhookName,
 	}
 
@@ -699,6 +700,7 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 		kubermatic.UserValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		common.ApplicationDefinitionValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		kubermatic.ResourceQuotaValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
+		kubermatic.ResourceQuotaAcceleratorAccountingValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		kubermatic.GroupProjectBindingValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		common.PoliciesWebhookConfigurationReconciler(ctx, config, r.Client),
 		common.PolicyTemplateValidatingWebhookConfigurationReconciler(ctx, config, r.Client),

--- a/pkg/controller/operator/master/resources/kubermatic/webhooks.go
+++ b/pkg/controller/operator/master/resources/kubermatic/webhooks.go
@@ -22,6 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -247,6 +248,66 @@ func ResourceQuotaValidatingWebhookConfigurationReconciler(ctx context.Context,
 					},
 				},
 			}
+
+			return hook, nil
+		}
+	}
+}
+
+func ResourceQuotaAcceleratorAccountingValidatingWebhookConfigurationReconciler(ctx context.Context,
+	cfg *kubermaticv1.KubermaticConfiguration,
+	client ctrlruntimeclient.Client,
+) reconciling.NamedValidatingWebhookConfigurationReconcilerFactory {
+	return func() (string, reconciling.ValidatingWebhookConfigurationReconciler) {
+		return common.ResourceQuotaAcceleratorAccountingAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+			matchPolicy := admissionregistrationv1.Exact
+			failurePolicy := admissionregistrationv1.Fail
+			sideEffects := admissionregistrationv1.SideEffectClassNone
+			scope := admissionregistrationv1.ClusterScope
+
+			ca, err := common.WebhookCABundle(ctx, cfg, client)
+			if err != nil {
+				return nil, fmt.Errorf("cannot find webhook CA bundle: %w", err)
+			}
+
+			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{{
+				Name:                    "accelerator-accounting.resourcequotas.kubermatic.k8c.io",
+				AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
+				MatchPolicy:             &matchPolicy,
+				FailurePolicy:           &failurePolicy,
+				SideEffects:             &sideEffects,
+				TimeoutSeconds:          ptr.To[int32](30),
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					CABundle: ca,
+					Service: &admissionregistrationv1.ServiceReference{
+						Name:      common.WebhookServiceName,
+						Namespace: cfg.Namespace,
+						Path:      ptr.To(resources.AcceleratorAccountingWebhookPath),
+						Port:      ptr.To[int32](443),
+					},
+				},
+				ObjectSelector:    &metav1.LabelSelector{},
+				NamespaceSelector: &metav1.LabelSelector{},
+				MatchConditions: []admissionregistrationv1.MatchCondition{{
+					Name: "accounting-annotation-present",
+					Expression: fmt.Sprintf("(object != null && has(object.metadata.annotations) && %q in object.metadata.annotations) || "+
+						"(oldObject != null && has(oldObject.metadata.annotations) && %q in oldObject.metadata.annotations)",
+						resources.AcceleratorAccountingEnabledAnnotation, resources.AcceleratorAccountingEnabledAnnotation),
+				}},
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{kubermaticv1.GroupName},
+						APIVersions: []string{"*"},
+						Resources:   []string{"resourcequotas"},
+						Scope:       &scope,
+					},
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+						admissionregistrationv1.Update,
+						admissionregistrationv1.Delete,
+					},
+				}},
+			}}
 
 			return hook, nil
 		}

--- a/pkg/controller/operator/master/resources/kubermatic/webhooks_test.go
+++ b/pkg/controller/operator/master/resources/kubermatic/webhooks_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubermatic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestResourceQuotaValidatingWebhookOperations(t *testing.T) {
+	const namespace = "kubermatic"
+	client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      common.WebhookServingCASecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			resources.CACertSecretKey: []byte("test-ca"),
+		},
+	}).Build()
+	cfg := &kubermaticv1.KubermaticConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+	}
+
+	_, reconciler := ResourceQuotaValidatingWebhookConfigurationReconciler(context.Background(), cfg, client)()
+	configuration, err := reconciler(&admissionregistrationv1.ValidatingWebhookConfiguration{})
+	if err != nil {
+		t.Fatalf("failed to reconcile ResourceQuota validating webhook: %v", err)
+	}
+	if len(configuration.Webhooks) != 1 || len(configuration.Webhooks[0].Rules) != 1 {
+		t.Fatalf("expected one ResourceQuota webhook with one rule, got %#v", configuration.Webhooks)
+	}
+
+	operations := sets.New(configuration.Webhooks[0].Rules[0].Operations...)
+	for _, expected := range []admissionregistrationv1.OperationType{
+		admissionregistrationv1.Create,
+		admissionregistrationv1.Update,
+	} {
+		if !operations.Has(expected) {
+			t.Errorf("expected ResourceQuota webhook to handle %s", expected)
+		}
+	}
+	if operations.Len() != 2 {
+		t.Errorf("expected exactly CREATE and UPDATE operations, got %v", sets.List(operations))
+	}
+}
+
+func TestResourceQuotaAcceleratorAccountingWebhook(t *testing.T) {
+	const namespace = "kubermatic"
+	client := fake.NewClientBuilder().WithObjects(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: common.WebhookServingCASecretName, Namespace: namespace},
+		Data:       map[string][]byte{resources.CACertSecretKey: []byte("test-ca")},
+	}).Build()
+	cfg := &kubermaticv1.KubermaticConfiguration{ObjectMeta: metav1.ObjectMeta{Namespace: namespace}}
+
+	name, reconciler := ResourceQuotaAcceleratorAccountingValidatingWebhookConfigurationReconciler(context.Background(), cfg, client)()
+	if name != common.ResourceQuotaAcceleratorAccountingAdmissionWebhookName {
+		t.Fatalf("name = %q, want %q", name, common.ResourceQuotaAcceleratorAccountingAdmissionWebhookName)
+	}
+	configuration, err := reconciler(&admissionregistrationv1.ValidatingWebhookConfiguration{})
+	if err != nil {
+		t.Fatalf("failed to reconcile accelerator-accounting webhook: %v", err)
+	}
+	if len(configuration.Webhooks) != 1 || len(configuration.Webhooks[0].MatchConditions) != 1 {
+		t.Fatalf("expected one webhook with one match condition, got %#v", configuration.Webhooks)
+	}
+	hook := configuration.Webhooks[0]
+	if hook.ClientConfig.Service == nil || hook.ClientConfig.Service.Path == nil || *hook.ClientConfig.Service.Path != resources.AcceleratorAccountingWebhookPath {
+		t.Fatalf("service = %#v, want dedicated accelerator-accounting path", hook.ClientConfig.Service)
+	}
+	if hook.FailurePolicy == nil || *hook.FailurePolicy != admissionregistrationv1.Fail {
+		t.Fatalf("failurePolicy = %v, want Fail", hook.FailurePolicy)
+	}
+	if len(hook.Rules) != 1 {
+		t.Fatalf("expected one accelerator-accounting webhook rule, got %#v", hook.Rules)
+	}
+	operations := sets.New(hook.Rules[0].Operations...)
+	for _, expected := range []admissionregistrationv1.OperationType{
+		admissionregistrationv1.Create,
+		admissionregistrationv1.Update,
+		admissionregistrationv1.Delete,
+	} {
+		if !operations.Has(expected) {
+			t.Errorf("expected accelerator-accounting webhook to handle %s", expected)
+		}
+	}
+	if operations.Len() != 3 {
+		t.Errorf("expected exactly CREATE, UPDATE, and DELETE operations, got %v", sets.List(operations))
+	}
+	expression := hook.MatchConditions[0].Expression
+	for _, operand := range []string{"object.metadata.annotations", "oldObject.metadata.annotations", resources.AcceleratorAccountingEnabledAnnotation} {
+		if !strings.Contains(expression, operand) {
+			t.Errorf("match condition %q does not contain %q", expression, operand)
+		}
+	}
+}

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller.go
@@ -71,12 +71,12 @@ type userClusterConnectionProvider interface {
 }
 
 type Features struct {
-	VPA                          bool
-	EtcdDataCorruptionChecks     bool
-	KubernetesOIDCAuthentication bool
-	EtcdLauncher                 bool
-	DynamicResourceAllocation    bool
-	KubeVirtAcceleratorQuota     bool
+	VPA                           bool
+	EtcdDataCorruptionChecks      bool
+	KubernetesOIDCAuthentication  bool
+	EtcdLauncher                  bool
+	DynamicResourceAllocation     bool
+	KubeVirtAcceleratorAccounting bool
 }
 
 // Reconciler is a controller which is responsible for managing clusters.
@@ -239,6 +239,13 @@ func Add(
 		handler.EnqueueRequestsFromMapFunc(reconciler.enqueueClustersForOIDCIssuerLoadBalancerService),
 		builder.WithPredicates(oidcIssuerLoadBalancerServicePredicate()),
 	)
+	if reconciler.features.KubeVirtAcceleratorAccounting {
+		bldr.Watches(
+			&kubermaticv1.ResourceQuota{},
+			handler.EnqueueRequestsFromMapFunc(reconciler.enqueueKubeVirtClustersForAcceleratorQuotaResourceQuota),
+			builder.WithPredicates(resourceQuotaAcceleratorAccountingActivationPredicate()),
+		)
+	}
 
 	_, err := bldr.Build(reconciler)
 
@@ -274,6 +281,59 @@ func oidcIssuerLoadBalancerServicePredicate() predicate.Predicate {
 			return false
 		},
 	}
+}
+
+func resourceQuotaAcceleratorAccountingActivationPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return resourceQuotaAcceleratorAccountingActive(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !resourceQuotaAcceleratorAccountingActive(e.ObjectOld) && resourceQuotaAcceleratorAccountingActive(e.ObjectNew)
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+func resourceQuotaAcceleratorAccountingActive(obj ctrlruntimeclient.Object) bool {
+	resourceQuota, ok := obj.(*kubermaticv1.ResourceQuota)
+	return ok && acceleratorAccountingActiveForProject(resourceQuota, resourceQuota.Spec.Subject.Name)
+}
+
+// enqueueKubeVirtClustersForAcceleratorQuotaResourceQuota makes activation changes
+// roll out promptly to every KubeVirt cluster belonging to the changed project.
+func (r *Reconciler) enqueueKubeVirtClustersForAcceleratorQuotaResourceQuota(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+	resourceQuota, ok := obj.(*kubermaticv1.ResourceQuota)
+	if !ok || resourceQuota.Spec.Subject.Kind != kubermaticv1.ProjectSubjectKind || resourceQuota.Spec.Subject.Name == "" {
+		return nil
+	}
+	projectID := resourceQuota.Spec.Subject.Name
+
+	clusters := &kubermaticv1.ClusterList{}
+	if err := r.List(ctx, clusters, ctrlruntimeclient.MatchingLabels{
+		kubermaticv1.ProjectIDLabelKey: projectID,
+	}); err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list Clusters for accelerator quota Project %q: %w", projectID, err))
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(clusters.Items))
+	for i := range clusters.Items {
+		cluster := &clusters.Items[i]
+		if cluster.DeletionTimestamp != nil ||
+			cluster.Spec.Cloud.Kubevirt == nil ||
+			cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: cluster.Name}})
+	}
+
+	sort.Slice(requests, func(i, j int) bool {
+		return requests[i].Name < requests[j].Name
+	})
+
+	return requests
 }
 
 // isOIDCIssuerLoadBalancerServiceCandidate only checks cheap Service fields.

--- a/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/cluster_controller_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +35,78 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+func TestEnqueueKubeVirtClustersForAcceleratorQuotaResourceQuota(t *testing.T) {
+	deletingCluster := kubeVirtCluster("deleting", "project-a")
+	deletionTimestamp := metav1.NewTime(time.Now())
+	deletingCluster.DeletionTimestamp = &deletionTimestamp
+	deletingCluster.Finalizers = []string{"test-finalizer"}
+	otherWorkerCluster := kubeVirtCluster("other-worker", "project-a")
+	otherWorkerCluster.Labels[kubermaticv1.WorkerNameLabelKey] = "other-worker"
+
+	r := &Reconciler{Client: fake.NewClientBuilder().WithObjects(
+		kubeVirtCluster("cluster-b", "project-a"),
+		kubeVirtCluster("cluster-a", "project-a"),
+		kubeVirtCluster("other-project", "project-b"),
+		awsCluster("aws", "project-a"),
+		deletingCluster,
+		otherWorkerCluster,
+	).Build()}
+
+	got := r.enqueueKubeVirtClustersForAcceleratorQuotaResourceQuota(
+		context.Background(),
+		projectResourceQuota("quota-a", "project-a", resources.AcceleratorAccountingEnabledAnnotationValue),
+	)
+
+	require.Equal(t, []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: "cluster-a"}},
+		{NamespacedName: types.NamespacedName{Name: "cluster-b"}},
+	}, got)
+}
+
+func TestResourceQuotaAcceleratorAccountingActivationPredicate(t *testing.T) {
+	pred := resourceQuotaAcceleratorAccountingActivationPredicate()
+	inactive := projectResourceQuota("quota-a", "project-a", "")
+	active := inactive.DeepCopy()
+	active.Annotations = map[string]string{
+		resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+	}
+	deletingActive := active.DeepCopy()
+	now := metav1.Now()
+	deletingActive.DeletionTimestamp = &now
+	deletingActive.Finalizers = []string{"test.kubermatic.io/cleanup"}
+
+	require.False(t, pred.Create(event.CreateEvent{Object: inactive}))
+	require.True(t, pred.Create(event.CreateEvent{Object: active}))
+	require.False(t, pred.Create(event.CreateEvent{Object: deletingActive}))
+	require.True(t, pred.Update(event.UpdateEvent{ObjectOld: inactive, ObjectNew: active}))
+	require.False(t, pred.Update(event.UpdateEvent{ObjectOld: active, ObjectNew: active.DeepCopy()}))
+
+	changedSubjectNameLabel := active.DeepCopy()
+	changedSubjectNameLabel.Labels[kubermaticv1.ResourceQuotaSubjectNameLabelKey] = "project-b"
+	require.True(t, pred.Update(event.UpdateEvent{ObjectOld: changedSubjectNameLabel, ObjectNew: active}))
+
+	changedSubjectKindLabel := active.DeepCopy()
+	changedSubjectKindLabel.Labels[kubermaticv1.ResourceQuotaSubjectKindLabelKey] = "other"
+	require.True(t, pred.Update(event.UpdateEvent{ObjectOld: changedSubjectKindLabel, ObjectNew: active}))
+
+	changedSubjectName := active.DeepCopy()
+	changedSubjectName.Spec.Subject.Name = "project-b"
+	require.True(t, pred.Update(event.UpdateEvent{ObjectOld: changedSubjectName, ObjectNew: active}))
+
+	changedSubjectKind := active.DeepCopy()
+	changedSubjectKind.Spec.Subject.Kind = "other"
+	require.True(t, pred.Update(event.UpdateEvent{ObjectOld: changedSubjectKind, ObjectNew: active}))
+	require.False(t, pred.Update(event.UpdateEvent{ObjectOld: active, ObjectNew: deletingActive}))
+
+	unrelatedMetadataChange := active.DeepCopy()
+	unrelatedMetadataChange.Annotations["example.com/unrelated"] = "value"
+	require.False(t, pred.Update(event.UpdateEvent{ObjectOld: active, ObjectNew: unrelatedMetadataChange}))
+
+	require.False(t, pred.Delete(event.DeleteEvent{Object: active}))
+	require.False(t, pred.Delete(event.DeleteEvent{Object: deletingActive}))
+	require.False(t, pred.Delete(event.DeleteEvent{Object: inactive}))
+}
 
 func TestOIDCIssuerLoadBalancerServicePredicate(t *testing.T) {
 	predicate := oidcIssuerLoadBalancerServicePredicate()

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -290,6 +290,11 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		return nil, err
 	}
 
+	kubeVirtAcceleratorQuotaEnabled, err := r.kubeVirtAcceleratorQuotaEnabledForCluster(ctx, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine KubeVirt accelerator quota activation: %w", err)
+	}
+
 	return resources.NewTemplateDataBuilder().
 		WithContext(ctx).
 		WithClient(r).
@@ -325,8 +330,54 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithClusterBackupStorageLocation(cbsl).
 		WithVersions(r.versions).
 		WithDRA(r.features.DynamicResourceAllocation).
-		WithKubeVirtAcceleratorQuota(r.features.KubeVirtAcceleratorQuota).
+		WithKubeVirtAcceleratorQuota(kubeVirtAcceleratorQuotaEnabled).
 		Build(), nil
+}
+
+// kubeVirtAcceleratorQuotaEnabledForCluster reads the synchronized, admin-owned
+// project ResourceQuota. The central ResourceQuota webhook uses the global gate
+// to authorize first activation; later gate changes do not deactivate an
+// already accepted project.
+func (r *Reconciler) kubeVirtAcceleratorQuotaEnabledForCluster(ctx context.Context, cluster *kubermaticv1.Cluster) (bool, error) {
+	if !r.features.KubeVirtAcceleratorAccounting || cluster.Spec.Cloud.Kubevirt == nil {
+		return false, nil
+	}
+
+	projectID := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
+	if projectID == "" {
+		return false, nil
+	}
+
+	resourceQuotas := &kubermaticv1.ResourceQuotaList{}
+	if err := r.List(ctx, resourceQuotas, ctrlruntimeclient.MatchingLabels{
+		kubermaticv1.ResourceQuotaSubjectNameLabelKey: projectID,
+		kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
+	}); err != nil {
+		return false, fmt.Errorf("failed to list ResourceQuotas for Project %q: %w", projectID, err)
+	}
+
+	// Labels make the cache lookup efficient, but the subject is authoritative.
+	// Ignore forged, stale, duplicate, or malformed candidates so optional
+	// accelerator activation cannot block general cluster reconciliation.
+	for i := range resourceQuotas.Items {
+		resourceQuota := &resourceQuotas.Items[i]
+		if acceleratorAccountingActiveForProject(resourceQuota, projectID) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func acceleratorAccountingActiveForProject(resourceQuota *kubermaticv1.ResourceQuota, projectID string) bool {
+	return resourceQuota != nil &&
+		projectID != "" &&
+		resourceQuota.Spec.Subject.Kind == kubermaticv1.ProjectSubjectKind &&
+		resourceQuota.Spec.Subject.Name == projectID &&
+		resourceQuota.Labels[kubermaticv1.ResourceQuotaSubjectNameLabelKey] == projectID &&
+		resourceQuota.Labels[kubermaticv1.ResourceQuotaSubjectKindLabelKey] == kubermaticv1.ProjectSubjectKind &&
+		resourceQuota.DeletionTimestamp.IsZero() &&
+		resourceQuota.Annotations[resources.AcceleratorAccountingEnabledAnnotation] == resources.AcceleratorAccountingEnabledAnnotationValue
 }
 
 // reconcileClusterNamespace will ensure that the cluster namespace is

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -39,6 +39,197 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func TestKubeVirtAcceleratorQuotaEnabledForCluster(t *testing.T) {
+	const projectID = "project-a"
+
+	activeQuota := projectResourceQuota("quota-a", projectID, resources.AcceleratorAccountingEnabledAnnotationValue)
+
+	t.Run("community edition remains inactive", func(t *testing.T) {
+		r := &Reconciler{
+			Client: fake.NewClientBuilder().WithObjects(activeQuota.DeepCopy()).Build(),
+		}
+
+		active, err := r.kubeVirtAcceleratorQuotaEnabledForCluster(context.Background(), kubeVirtCluster("cluster-a", projectID))
+		require.NoError(t, err)
+		require.False(t, active)
+	})
+
+	testCases := []struct {
+		name           string
+		cluster        *kubermaticv1.Cluster
+		resourceQuotas []*kubermaticv1.ResourceQuota
+		wantActive     bool
+	}{
+		{
+			name:           "annotation absent does not activate project",
+			cluster:        kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{projectResourceQuota("quota-a", projectID, "")},
+		},
+		{
+			name:           "exact activation enables KubeVirt cluster",
+			cluster:        kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{activeQuota},
+			wantActive:     true,
+		},
+		{
+			name:           "annotation value is exact",
+			cluster:        kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{projectResourceQuota("quota-a", projectID, "True")},
+		},
+		{
+			name:           "non KubeVirt cluster remains inactive",
+			cluster:        awsCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{activeQuota},
+		},
+		{
+			name:           "missing project label remains inactive",
+			cluster:        kubeVirtCluster("cluster-a", ""),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{activeQuota},
+		},
+		{
+			name:    "missing synchronized quota remains inactive",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+		},
+		{
+			name:    "duplicate active project quotas do not block activation",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{
+				activeQuota,
+				projectResourceQuota("quota-b", projectID, resources.AcceleratorAccountingEnabledAnnotationValue),
+			},
+			wantActive: true,
+		},
+		{
+			name:    "malformed duplicate does not block valid activation",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{
+				activeQuota,
+				projectResourceQuota("quota-b", projectID, "True"),
+			},
+			wantActive: true,
+		},
+		{
+			name:    "terminating quota is inactive",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{func() *kubermaticv1.ResourceQuota {
+				quota := projectResourceQuota("quota-a", projectID, resources.AcceleratorAccountingEnabledAnnotationValue)
+				now := metav1.Now()
+				quota.DeletionTimestamp = &now
+				quota.Finalizers = []string{"test.kubermatic.io/cleanup"}
+				return quota
+			}()},
+		},
+		{
+			name:    "terminating duplicate does not block valid activation",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{
+				activeQuota,
+				func() *kubermaticv1.ResourceQuota {
+					quota := projectResourceQuota("quota-b", projectID, resources.AcceleratorAccountingEnabledAnnotationValue)
+					now := metav1.Now()
+					quota.DeletionTimestamp = &now
+					quota.Finalizers = []string{"test.kubermatic.io/cleanup"}
+					return quota
+				}(),
+			},
+			wantActive: true,
+		},
+		{
+			name:    "label-spoofed subject mismatch is ignored",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{func() *kubermaticv1.ResourceQuota {
+				quota := projectResourceQuota("quota-a", projectID, resources.AcceleratorAccountingEnabledAnnotationValue)
+				quota.Spec.Subject.Name = "project-b"
+				return quota
+			}()},
+		},
+		{
+			name:    "label-spoofed candidate does not block valid activation",
+			cluster: kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{
+				activeQuota,
+				func() *kubermaticv1.ResourceQuota {
+					quota := projectResourceQuota("quota-b", projectID, resources.AcceleratorAccountingEnabledAnnotationValue)
+					quota.Spec.Subject.Name = "project-b"
+					return quota
+				}(),
+			},
+			wantActive: true,
+		},
+		{
+			name:           "other project activation remains isolated",
+			cluster:        kubeVirtCluster("cluster-a", projectID),
+			resourceQuotas: []*kubermaticv1.ResourceQuota{projectResourceQuota("quota-b", "project-b", resources.AcceleratorAccountingEnabledAnnotationValue)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder()
+			for _, quota := range tc.resourceQuotas {
+				builder.WithObjects(quota.DeepCopy())
+			}
+			r := &Reconciler{
+				Client: builder.Build(),
+				features: Features{
+					KubeVirtAcceleratorAccounting: true,
+				},
+			}
+
+			got, err := r.kubeVirtAcceleratorQuotaEnabledForCluster(context.Background(), tc.cluster)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantActive, got)
+		})
+	}
+}
+
+func projectResourceQuota(name, projectID, activationValue string) *kubermaticv1.ResourceQuota {
+	annotations := map[string]string(nil)
+	if activationValue != "" {
+		annotations = map[string]string{resources.AcceleratorAccountingEnabledAnnotation: activationValue}
+	}
+
+	return &kubermaticv1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				kubermaticv1.ResourceQuotaSubjectNameLabelKey: projectID,
+				kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
+			},
+			Annotations: annotations,
+		},
+		Spec: kubermaticv1.ResourceQuotaSpec{Subject: kubermaticv1.Subject{
+			Name: projectID,
+			Kind: kubermaticv1.ProjectSubjectKind,
+		}},
+	}
+}
+
+func kubeVirtCluster(name, projectID string) *kubermaticv1.Cluster {
+	labels := map[string]string{}
+	if projectID != "" {
+		labels[kubermaticv1.ProjectIDLabelKey] = projectID
+	}
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Spec: kubermaticv1.ClusterSpec{Cloud: kubermaticv1.CloudSpec{
+			Kubevirt: &kubermaticv1.KubevirtCloudSpec{},
+		}},
+	}
+}
+
+func awsCluster(name, projectID string) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: projectID},
+		},
+		Spec: kubermaticv1.ClusterSpec{Cloud: kubermaticv1.CloudSpec{
+			AWS: &kubermaticv1.AWSCloudSpec{},
+		}},
+	}
+}
+
 func TestCloudControllerManagerDeployment(t *testing.T) {
 	// these tests use openstack as an example for a provider that has
 	// a CCM; the logic tested here is independent of the provider itself

--- a/pkg/controller/user-cluster-controller-manager/resources/accelerator_footprint_test.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/accelerator_footprint_test.go
@@ -18,14 +18,18 @@ package resources
 
 import (
 	"context"
+	"crypto/x509"
+	"slices"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -34,7 +38,7 @@ func TestAcceleratorFootprintAdmissionActive(t *testing.T) {
 	testCases := []struct {
 		name     string
 		provider string
-		gate     bool
+		enabled  bool
 		objects  []ctrlruntimeclient.Object
 		want     bool
 	}{
@@ -43,16 +47,16 @@ func TestAcceleratorFootprintAdmissionActive(t *testing.T) {
 			provider: string(kubermaticv1.KubevirtCloudProvider),
 		},
 		{
-			name:     "enabled by feature gate",
+			name:     "enabled for this cluster",
 			provider: string(kubermaticv1.KubevirtCloudProvider),
-			gate:     true,
+			enabled:  true,
 			want:     true,
 		},
 		{
 			name:     "mutating configuration keeps activation sticky",
 			provider: string(kubermaticv1.KubevirtCloudProvider),
 			objects: []ctrlruntimeclient.Object{&admissionregistrationv1.MutatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorMutatingWebhookConfigurationName},
+				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorAdmissionWebhookName},
 			}},
 			want: true,
 		},
@@ -60,16 +64,16 @@ func TestAcceleratorFootprintAdmissionActive(t *testing.T) {
 			name:     "validating configuration keeps activation sticky",
 			provider: string(kubermaticv1.KubevirtCloudProvider),
 			objects: []ctrlruntimeclient.Object{&admissionregistrationv1.ValidatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorValidatingWebhookConfigurationName},
+				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorAdmissionWebhookName},
 			}},
 			want: true,
 		},
 		{
 			name:     "non KubeVirt clusters remain inactive",
 			provider: string(kubermaticv1.AWSCloudProvider),
-			gate:     true,
+			enabled:  true,
 			objects: []ctrlruntimeclient.Object{&admissionregistrationv1.ValidatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorValidatingWebhookConfigurationName},
+				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorAdmissionWebhookName},
 			}},
 		},
 	}
@@ -81,7 +85,7 @@ func TestAcceleratorFootprintAdmissionActive(t *testing.T) {
 				t.Fatalf("add admissionregistration API to scheme: %v", err)
 			}
 			client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
-			r := &reconciler{Client: client, kubeVirtAcceleratorQuota: tc.gate}
+			r := &reconciler{Client: client, kubeVirtAcceleratorQuota: tc.enabled}
 
 			got, err := r.acceleratorFootprintAdmissionActive(context.Background(), reconcileData{cloudProviderName: tc.provider})
 			if err != nil {
@@ -91,5 +95,69 @@ func TestAcceleratorFootprintAdmissionActive(t *testing.T) {
 				t.Fatalf("acceleratorFootprintAdmissionActive() = %t, want %t", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestReconcileAcceleratorFootprintAdmission(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := admissionregistrationv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add admissionregistration API to scheme: %v", err)
+	}
+	client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	r := &reconciler{
+		Client:                   client,
+		namespace:                "cluster-abcd",
+		kubeVirtAcceleratorQuota: true,
+	}
+	data := reconcileData{
+		caCert:            &triple.KeyPair{Cert: &x509.Certificate{Raw: []byte("test-ca")}},
+		cloudProviderName: string(kubermaticv1.KubevirtCloudProvider),
+	}
+
+	if err := r.reconcileAcceleratorFootprintAdmission(context.Background(), data); err != nil {
+		t.Fatalf("reconcileAcceleratorFootprintAdmission() error = %v", err)
+	}
+	assertAcceleratorAdmissionConfigurations(t, client)
+
+	if err := client.Delete(context.Background(), &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorAdmissionWebhookName},
+	}); err != nil {
+		t.Fatalf("delete mutating configuration: %v", err)
+	}
+	validation := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: machine.AcceleratorAdmissionWebhookName}, validation); err != nil {
+		t.Fatalf("get validating configuration: %v", err)
+	}
+	validation.Webhooks[0].FailurePolicy = ptr.To(admissionregistrationv1.Ignore)
+	if err := client.Update(context.Background(), validation); err != nil {
+		t.Fatalf("drift validating configuration: %v", err)
+	}
+	if err := r.reconcileAcceleratorFootprintAdmission(context.Background(), data); err != nil {
+		t.Fatalf("repair reconcileAcceleratorFootprintAdmission() error = %v", err)
+	}
+	assertAcceleratorAdmissionConfigurations(t, client)
+}
+
+func assertAcceleratorAdmissionConfigurations(t *testing.T, client ctrlruntimeclient.Client) {
+	t.Helper()
+
+	mutation := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: machine.AcceleratorAdmissionWebhookName}, mutation); err != nil {
+		t.Fatalf("get mutating configuration: %v", err)
+	}
+	if len(mutation.Webhooks) != 1 || len(mutation.Webhooks[0].Rules) != 1 ||
+		!slices.Equal(mutation.Webhooks[0].Rules[0].Operations, []admissionregistrationv1.OperationType{admissionregistrationv1.Create}) {
+		t.Fatalf("unexpected mutating configuration: %#v", mutation.Webhooks)
+	}
+
+	validation := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	if err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: machine.AcceleratorAdmissionWebhookName}, validation); err != nil {
+		t.Fatalf("get validating configuration: %v", err)
+	}
+	wantOperations := []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+	if len(validation.Webhooks) != 1 || len(validation.Webhooks[0].Rules) != 1 ||
+		!slices.Equal(validation.Webhooks[0].Rules[0].Operations, wantOperations) ||
+		validation.Webhooks[0].FailurePolicy == nil || *validation.Webhooks[0].FailurePolicy != admissionregistrationv1.Fail {
+		t.Fatalf("unexpected validating configuration: %#v", validation.Webhooks)
 	}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/accelerator_footprint_test.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/accelerator_footprint_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestAcceleratorFootprintAdmissionActive(t *testing.T) {
+	testCases := []struct {
+		name     string
+		provider string
+		gate     bool
+		objects  []ctrlruntimeclient.Object
+		want     bool
+	}{
+		{
+			name:     "never enabled",
+			provider: string(kubermaticv1.KubevirtCloudProvider),
+		},
+		{
+			name:     "enabled by feature gate",
+			provider: string(kubermaticv1.KubevirtCloudProvider),
+			gate:     true,
+			want:     true,
+		},
+		{
+			name:     "mutating configuration keeps activation sticky",
+			provider: string(kubermaticv1.KubevirtCloudProvider),
+			objects: []ctrlruntimeclient.Object{&admissionregistrationv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorMutatingWebhookConfigurationName},
+			}},
+			want: true,
+		},
+		{
+			name:     "validating configuration keeps activation sticky",
+			provider: string(kubermaticv1.KubevirtCloudProvider),
+			objects: []ctrlruntimeclient.Object{&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorValidatingWebhookConfigurationName},
+			}},
+			want: true,
+		},
+		{
+			name:     "non KubeVirt clusters remain inactive",
+			provider: string(kubermaticv1.AWSCloudProvider),
+			gate:     true,
+			objects: []ctrlruntimeclient.Object{&admissionregistrationv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorValidatingWebhookConfigurationName},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := admissionregistrationv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add admissionregistration API to scheme: %v", err)
+			}
+			client := ctrlruntimefakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objects...).Build()
+			r := &reconciler{Client: client, kubeVirtAcceleratorQuota: tc.gate}
+
+			got, err := r.acceleratorFootprintAdmissionActive(context.Background(), reconcileData{cloudProviderName: tc.provider})
+			if err != nil {
+				t.Fatalf("acceleratorFootprintAdmissionActive() error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("acceleratorFootprintAdmissionActive() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -102,6 +102,7 @@ func Add(
 	konnectivityKeepaliveTime string,
 	ccmMigration bool,
 	ccmMigrationCompleted bool,
+	kubeVirtAcceleratorQuota bool,
 	kyvernoEnabled bool,
 	log *zap.SugaredLogger) error {
 	r := &reconciler{
@@ -134,6 +135,7 @@ func Add(
 		konnectivityKeepaliveTime: konnectivityKeepaliveTime,
 		ccmMigration:              ccmMigration,
 		ccmMigrationCompleted:     ccmMigrationCompleted,
+		kubeVirtAcceleratorQuota:  kubeVirtAcceleratorQuota,
 		kyvernoEnabled:            kyvernoEnabled,
 	}
 
@@ -268,6 +270,7 @@ type reconciler struct {
 	konnectivityKeepaliveTime string
 	ccmMigration              bool
 	ccmMigrationCompleted     bool
+	kubeVirtAcceleratorQuota  bool
 	kyvernoEnabled            bool
 
 	rLock                      *sync.Mutex

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -657,6 +657,13 @@ func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context,
 	if data.cloudProviderName != string(kubermaticv1.EdgeCloudProvider) {
 		creators = append(creators, machinecontroller.MutatingwebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
 	}
+	acceleratorAdmissionActive, err := r.acceleratorFootprintAdmissionActive(ctx, data)
+	if err != nil {
+		return err
+	}
+	if acceleratorAdmissionActive {
+		creators = append(creators, machine.AcceleratorMutatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
+	}
 
 	if r.opaIntegration && r.opaEnableMutation {
 		creators = append(creators, gatekeeper.MutatingWebhookConfigurationReconciler(r.opaWebhookTimeout))
@@ -678,6 +685,14 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 		creators = append(creators, machine.ValidatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
 	}
 
+	acceleratorAdmissionActive, err := r.acceleratorFootprintAdmissionActive(ctx, data)
+	if err != nil {
+		return err
+	}
+	if acceleratorAdmissionActive {
+		creators = append(creators, machine.AcceleratorValidatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
+	}
+
 	if r.opaIntegration {
 		creators = append(creators, gatekeeper.ValidatingWebhookConfigurationReconciler(r.opaWebhookTimeout))
 	}
@@ -697,6 +712,31 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 		return fmt.Errorf("failed to reconcile ValidatingWebhookConfigurations: %w", err)
 	}
 	return nil
+}
+
+// acceleratorFootprintAdmissionActive makes activation sticky. Once either footprint webhook
+// exists, both remain reconciled so disabling the gate cannot make persisted footprints mutable.
+func (r *reconciler) acceleratorFootprintAdmissionActive(ctx context.Context, data reconcileData) (bool, error) {
+	if data.cloudProviderName != string(kubermaticv1.KubevirtCloudProvider) {
+		return false, nil
+	}
+	if r.kubeVirtAcceleratorQuota {
+		return true, nil
+	}
+
+	objects := []ctrlruntimeclient.Object{
+		&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorMutatingWebhookConfigurationName}},
+		&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorValidatingWebhookConfigurationName}},
+	}
+	for _, object := range objects {
+		if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(object), object); err == nil {
+			return true, nil
+		} else if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to determine KubeVirt accelerator footprint admission state: %w", err)
+		}
+	}
+
+	return false, nil
 }
 
 func (r *reconciler) reconcileServices(ctx context.Context, data reconcileData) error {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -225,6 +225,10 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return err
 	}
 
+	if err := r.reconcileAcceleratorFootprintAdmission(ctx, data); err != nil {
+		return err
+	}
+
 	if r.networkPolices {
 		if err := r.reconcileNetworkPolicies(ctx, data); err != nil {
 			return err
@@ -657,13 +661,6 @@ func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context,
 	if data.cloudProviderName != string(kubermaticv1.EdgeCloudProvider) {
 		creators = append(creators, machinecontroller.MutatingwebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
 	}
-	acceleratorAdmissionActive, err := r.acceleratorFootprintAdmissionActive(ctx, data)
-	if err != nil {
-		return err
-	}
-	if acceleratorAdmissionActive {
-		creators = append(creators, machine.AcceleratorMutatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
-	}
 
 	if r.opaIntegration && r.opaEnableMutation {
 		creators = append(creators, gatekeeper.MutatingWebhookConfigurationReconciler(r.opaWebhookTimeout))
@@ -683,14 +680,6 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 
 	if data.cloudProviderName != string(kubermaticv1.EdgeCloudProvider) {
 		creators = append(creators, machine.ValidatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
-	}
-
-	acceleratorAdmissionActive, err := r.acceleratorFootprintAdmissionActive(ctx, data)
-	if err != nil {
-		return err
-	}
-	if acceleratorAdmissionActive {
-		creators = append(creators, machine.AcceleratorValidatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace))
 	}
 
 	if r.opaIntegration {
@@ -714,6 +703,41 @@ func (r *reconciler) reconcileValidatingWebhookConfigurations(ctx context.Contex
 	return nil
 }
 
+// reconcileAcceleratorFootprintAdmission reconciles the mutating configuration before the
+// validating configuration. Kubernetes observes the two configuration kinds independently,
+// so project activation requires the documented operational rollout procedure.
+func (r *reconciler) reconcileAcceleratorFootprintAdmission(ctx context.Context, data reconcileData) error {
+	active, err := r.acceleratorFootprintAdmissionActive(ctx, data)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return nil
+	}
+
+	if err := r.reconcileAcceleratorMutatingWebhookConfiguration(ctx, data); err != nil {
+		return fmt.Errorf("failed to reconcile Machine accelerator footprint mutation: %w", err)
+	}
+	if err := r.reconcileAcceleratorValidatingWebhookConfiguration(ctx, data); err != nil {
+		return fmt.Errorf("failed to install Machine accelerator footprint CREATE and UPDATE validation: %w", err)
+	}
+	return nil
+}
+
+func (r *reconciler) reconcileAcceleratorValidatingWebhookConfiguration(ctx context.Context, data reconcileData) error {
+	return reconciling.ReconcileValidatingWebhookConfigurations(ctx,
+		[]reconciling.NamedValidatingWebhookConfigurationReconcilerFactory{
+			machine.AcceleratorValidatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace),
+		}, "", r)
+}
+
+func (r *reconciler) reconcileAcceleratorMutatingWebhookConfiguration(ctx context.Context, data reconcileData) error {
+	return reconciling.ReconcileMutatingWebhookConfigurations(ctx,
+		[]reconciling.NamedMutatingWebhookConfigurationReconcilerFactory{
+			machine.AcceleratorMutatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace),
+		}, "", r)
+}
+
 // acceleratorFootprintAdmissionActive makes activation sticky. Once either footprint webhook
 // exists, both remain reconciled so disabling the gate cannot make persisted footprints mutable.
 func (r *reconciler) acceleratorFootprintAdmissionActive(ctx context.Context, data reconcileData) (bool, error) {
@@ -725,8 +749,8 @@ func (r *reconciler) acceleratorFootprintAdmissionActive(ctx context.Context, da
 	}
 
 	objects := []ctrlruntimeclient.Object{
-		&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorMutatingWebhookConfigurationName}},
-		&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorValidatingWebhookConfigurationName}},
+		&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorAdmissionWebhookName}},
+		&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: machine.AcceleratorAdmissionWebhookName}},
 	}
 	for _, object := range objects {
 		if err := r.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(object), object); err == nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -20,7 +20,6 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
@@ -34,10 +33,8 @@ import (
 
 const (
 	machineValidatingWebhookConfigurationName = "kubermatic-machine-validation"
-	// AcceleratorMutatingWebhookConfigurationName is the KKP-owned Machine footprint webhook configuration.
-	AcceleratorMutatingWebhookConfigurationName = "kubermatic-machine-accelerator-footprint"
-	// AcceleratorValidatingWebhookConfigurationName protects the KKP-owned Machine footprint contract.
-	AcceleratorValidatingWebhookConfigurationName = "kubermatic-machine-accelerator-footprint-validation"
+	// AcceleratorAdmissionWebhookName is the name of the validating and mutating Machine footprint webhooks.
+	AcceleratorAdmissionWebhookName = "kubermatic-machine-accelerator-footprint"
 )
 
 // ValidatingWebhookConfigurationReconciler returns the ValidatingWebhookConfiguration for the machine CRD.
@@ -54,6 +51,7 @@ func ValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespac
 				namespace,
 				resources.UserClusterWebhookUserListenPort,
 			)
+
 			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
 					Name:                    "machines.cluster.k8c.io", // this should be a FQDN
@@ -76,7 +74,9 @@ func ValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespac
 								Resources:   []string{"machines"},
 								Scope:       &scope,
 							},
-							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+							},
 						},
 					},
 				},
@@ -89,7 +89,7 @@ func ValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespac
 // AcceleratorValidatingWebhookConfigurationReconciler returns the Machine footprint validation webhook configuration.
 func AcceleratorValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationReconcilerFactory {
 	return func() (string, reconciling.ValidatingWebhookConfigurationReconciler) {
-		return AcceleratorValidatingWebhookConfigurationName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+		return AcceleratorAdmissionWebhookName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
 			sideEffects := admissionregistrationv1.SideEffectClassNone
@@ -99,7 +99,7 @@ func AcceleratorValidatingWebhookConfigurationReconciler(caCert *x509.Certificat
 				resources.UserClusterWebhookServiceName,
 				namespace,
 				resources.UserClusterWebhookUserListenPort,
-				accelerator.ValidatingWebhookPath,
+				resources.MachineAcceleratorFootprintValidatingWebhookPath,
 			)
 
 			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{{
@@ -134,9 +134,10 @@ func AcceleratorValidatingWebhookConfigurationReconciler(caCert *x509.Certificat
 // AcceleratorMutatingWebhookConfigurationReconciler returns the feature-gated Machine footprint webhook configuration.
 func AcceleratorMutatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespace string) reconciling.NamedMutatingWebhookConfigurationReconcilerFactory {
 	return func() (string, reconciling.MutatingWebhookConfigurationReconciler) {
-		return AcceleratorMutatingWebhookConfigurationName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
+		return AcceleratorAdmissionWebhookName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
 			matchPolicy := admissionregistrationv1.Exact
 			failurePolicy := admissionregistrationv1.Fail
+			// Re-run after later Machine mutators so the footprint describes the final provider spec.
 			reinvocationPolicy := admissionregistrationv1.IfNeededReinvocationPolicy
 			sideEffects := admissionregistrationv1.SideEffectClassNone
 			scope := admissionregistrationv1.NamespacedScope
@@ -145,7 +146,7 @@ func AcceleratorMutatingWebhookConfigurationReconciler(caCert *x509.Certificate,
 				resources.UserClusterWebhookServiceName,
 				namespace,
 				resources.UserClusterWebhookUserListenPort,
-				accelerator.MutatingWebhookPath,
+				resources.MachineAcceleratorFootprintMutatingWebhookPath,
 			)
 
 			hook.Webhooks = []admissionregistrationv1.MutatingWebhook{{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
@@ -33,6 +34,10 @@ import (
 
 const (
 	machineValidatingWebhookConfigurationName = "kubermatic-machine-validation"
+	// AcceleratorMutatingWebhookConfigurationName is the KKP-owned Machine footprint webhook configuration.
+	AcceleratorMutatingWebhookConfigurationName = "kubermatic-machine-accelerator-footprint"
+	// AcceleratorValidatingWebhookConfigurationName protects the KKP-owned Machine footprint contract.
+	AcceleratorValidatingWebhookConfigurationName = "kubermatic-machine-accelerator-footprint-validation"
 )
 
 // ValidatingWebhookConfigurationReconciler returns the ValidatingWebhookConfiguration for the machine CRD.
@@ -49,7 +54,6 @@ func ValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespac
 				namespace,
 				resources.UserClusterWebhookUserListenPort,
 			)
-
 			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{
 				{
 					Name:                    "machines.cluster.k8c.io", // this should be a FQDN
@@ -72,13 +76,103 @@ func ValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespac
 								Resources:   []string{"machines"},
 								Scope:       &scope,
 							},
-							Operations: []admissionregistrationv1.OperationType{
-								admissionregistrationv1.Create,
-							},
+							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 						},
 					},
 				},
 			}
+			return hook, nil
+		}
+	}
+}
+
+// AcceleratorValidatingWebhookConfigurationReconciler returns the Machine footprint validation webhook configuration.
+func AcceleratorValidatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespace string) reconciling.NamedValidatingWebhookConfigurationReconcilerFactory {
+	return func() (string, reconciling.ValidatingWebhookConfigurationReconciler) {
+		return AcceleratorValidatingWebhookConfigurationName, func(hook *admissionregistrationv1.ValidatingWebhookConfiguration) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+			matchPolicy := admissionregistrationv1.Exact
+			failurePolicy := admissionregistrationv1.Fail
+			sideEffects := admissionregistrationv1.SideEffectClassNone
+			scope := admissionregistrationv1.NamespacedScope
+
+			url := fmt.Sprintf("https://%s.%s.svc.cluster.local.:%d%s",
+				resources.UserClusterWebhookServiceName,
+				namespace,
+				resources.UserClusterWebhookUserListenPort,
+				accelerator.ValidatingWebhookPath,
+			)
+
+			hook.Webhooks = []admissionregistrationv1.ValidatingWebhook{{
+				Name:                    "accelerator-footprints.machines.cluster.k8c.io",
+				AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
+				MatchPolicy:             &matchPolicy,
+				FailurePolicy:           &failurePolicy,
+				SideEffects:             &sideEffects,
+				TimeoutSeconds:          ptr.To[int32](3),
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					CABundle: triple.EncodeCertPEM(caCert),
+					URL:      &url,
+				},
+				ObjectSelector:    &metav1.LabelSelector{},
+				NamespaceSelector: &metav1.LabelSelector{},
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{clusterv1alpha1.SchemeGroupVersion.Group},
+						APIVersions: []string{clusterv1alpha1.SchemeGroupVersion.Version},
+						Resources:   []string{"machines"},
+						Scope:       &scope,
+					},
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
+				}},
+			}}
+
+			return hook, nil
+		}
+	}
+}
+
+// AcceleratorMutatingWebhookConfigurationReconciler returns the feature-gated Machine footprint webhook configuration.
+func AcceleratorMutatingWebhookConfigurationReconciler(caCert *x509.Certificate, namespace string) reconciling.NamedMutatingWebhookConfigurationReconcilerFactory {
+	return func() (string, reconciling.MutatingWebhookConfigurationReconciler) {
+		return AcceleratorMutatingWebhookConfigurationName, func(hook *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
+			matchPolicy := admissionregistrationv1.Exact
+			failurePolicy := admissionregistrationv1.Fail
+			reinvocationPolicy := admissionregistrationv1.IfNeededReinvocationPolicy
+			sideEffects := admissionregistrationv1.SideEffectClassNone
+			scope := admissionregistrationv1.NamespacedScope
+
+			url := fmt.Sprintf("https://%s.%s.svc.cluster.local.:%d%s",
+				resources.UserClusterWebhookServiceName,
+				namespace,
+				resources.UserClusterWebhookUserListenPort,
+				accelerator.MutatingWebhookPath,
+			)
+
+			hook.Webhooks = []admissionregistrationv1.MutatingWebhook{{
+				Name:                    "accelerator-footprints.machines.cluster.k8c.io",
+				AdmissionReviewVersions: []string{admissionregistrationv1.SchemeGroupVersion.Version, admissionregistrationv1beta1.SchemeGroupVersion.Version},
+				MatchPolicy:             &matchPolicy,
+				FailurePolicy:           &failurePolicy,
+				ReinvocationPolicy:      &reinvocationPolicy,
+				SideEffects:             &sideEffects,
+				TimeoutSeconds:          ptr.To[int32](3),
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					CABundle: triple.EncodeCertPEM(caCert),
+					URL:      &url,
+				},
+				ObjectSelector:    &metav1.LabelSelector{},
+				NamespaceSelector: &metav1.LabelSelector{},
+				Rules: []admissionregistrationv1.RuleWithOperations{{
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{clusterv1alpha1.SchemeGroupVersion.Group},
+						APIVersions: []string{clusterv1alpha1.SchemeGroupVersion.Version},
+						Resources:   []string{"machines"},
+						Scope:       &scope,
+					},
+					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
+				}},
+			}}
+
 			return hook, nil
 		}
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook_test.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook_test.go
@@ -40,8 +40,8 @@ func TestValidatingWebhookConfigurationOperations(t *testing.T) {
 
 func TestAcceleratorMutatingWebhookConfiguration(t *testing.T) {
 	name, reconciler := AcceleratorMutatingWebhookConfigurationReconciler(testCertificate(), "cluster-abcd")()
-	if name != AcceleratorMutatingWebhookConfigurationName {
-		t.Fatalf("name = %q, want %q", name, AcceleratorMutatingWebhookConfigurationName)
+	if name != AcceleratorAdmissionWebhookName {
+		t.Fatalf("name = %q, want %q", name, AcceleratorAdmissionWebhookName)
 	}
 	configuration, err := reconciler(&admissionregistrationv1.MutatingWebhookConfiguration{})
 	if err != nil {
@@ -71,8 +71,8 @@ func TestAcceleratorMutatingWebhookConfiguration(t *testing.T) {
 
 func TestAcceleratorValidatingWebhookConfiguration(t *testing.T) {
 	name, reconciler := AcceleratorValidatingWebhookConfigurationReconciler(testCertificate(), "cluster-abcd")()
-	if name != AcceleratorValidatingWebhookConfigurationName {
-		t.Fatalf("name = %q, want %q", name, AcceleratorValidatingWebhookConfigurationName)
+	if name != AcceleratorAdmissionWebhookName {
+		t.Fatalf("name = %q, want %q", name, AcceleratorAdmissionWebhookName)
 	}
 	configuration, err := reconciler(&admissionregistrationv1.ValidatingWebhookConfiguration{})
 	if err != nil {
@@ -92,8 +92,9 @@ func TestAcceleratorValidatingWebhookConfiguration(t *testing.T) {
 	if hook.FailurePolicy == nil || *hook.FailurePolicy != admissionregistrationv1.Fail {
 		t.Fatalf("failurePolicy = %v, want Fail", hook.FailurePolicy)
 	}
-	if len(hook.Rules) != 1 || !slices.Equal(hook.Rules[0].Operations, []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}) {
-		t.Fatalf("rules = %#v, want Machine CREATE and UPDATE", hook.Rules)
+	wantOperations := []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}
+	if len(hook.Rules) != 1 || !slices.Equal(hook.Rules[0].Operations, wantOperations) {
+		t.Fatalf("rules = %#v, want operations %v", hook.Rules, wantOperations)
 	}
 }
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook_test.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/machine/webhook_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"crypto/x509"
+	"slices"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+)
+
+func TestValidatingWebhookConfigurationOperations(t *testing.T) {
+	_, reconciler := ValidatingWebhookConfigurationReconciler(testCertificate(), "cluster-abcd")()
+	configuration, err := reconciler(&admissionregistrationv1.ValidatingWebhookConfiguration{})
+	if err != nil {
+		t.Fatalf("reconcile validating webhook: %v", err)
+	}
+	if len(configuration.Webhooks) != 1 || len(configuration.Webhooks[0].Rules) != 1 {
+		t.Fatalf("unexpected webhook configuration: %#v", configuration.Webhooks)
+	}
+	if got := configuration.Webhooks[0].Rules[0].Operations; !slices.Equal(got, []admissionregistrationv1.OperationType{admissionregistrationv1.Create}) {
+		t.Fatalf("operations = %v, want [CREATE]", got)
+	}
+}
+
+func TestAcceleratorMutatingWebhookConfiguration(t *testing.T) {
+	name, reconciler := AcceleratorMutatingWebhookConfigurationReconciler(testCertificate(), "cluster-abcd")()
+	if name != AcceleratorMutatingWebhookConfigurationName {
+		t.Fatalf("name = %q, want %q", name, AcceleratorMutatingWebhookConfigurationName)
+	}
+	configuration, err := reconciler(&admissionregistrationv1.MutatingWebhookConfiguration{})
+	if err != nil {
+		t.Fatalf("reconcile mutating webhook: %v", err)
+	}
+	if len(configuration.Webhooks) != 1 {
+		t.Fatalf("webhook count = %d, want 1", len(configuration.Webhooks))
+	}
+	hook := configuration.Webhooks[0]
+	const expectedURL = "https://usercluster-webhook.cluster-abcd.svc.cluster.local.:6443/mutate-machine-accelerator-footprint"
+	if hook.ClientConfig.URL == nil || *hook.ClientConfig.URL != expectedURL {
+		if hook.ClientConfig.URL == nil {
+			t.Fatal("URL is nil")
+		}
+		t.Fatalf("URL = %q, want %q", *hook.ClientConfig.URL, expectedURL)
+	}
+	if hook.FailurePolicy == nil || *hook.FailurePolicy != admissionregistrationv1.Fail {
+		t.Fatalf("failurePolicy = %v, want Fail", hook.FailurePolicy)
+	}
+	if hook.ReinvocationPolicy == nil || *hook.ReinvocationPolicy != admissionregistrationv1.IfNeededReinvocationPolicy {
+		t.Fatalf("reinvocationPolicy = %v, want IfNeeded", hook.ReinvocationPolicy)
+	}
+	if len(hook.Rules) != 1 || !slices.Equal(hook.Rules[0].Operations, []admissionregistrationv1.OperationType{admissionregistrationv1.Create}) {
+		t.Fatalf("rules = %#v, want Machine CREATE", hook.Rules)
+	}
+}
+
+func TestAcceleratorValidatingWebhookConfiguration(t *testing.T) {
+	name, reconciler := AcceleratorValidatingWebhookConfigurationReconciler(testCertificate(), "cluster-abcd")()
+	if name != AcceleratorValidatingWebhookConfigurationName {
+		t.Fatalf("name = %q, want %q", name, AcceleratorValidatingWebhookConfigurationName)
+	}
+	configuration, err := reconciler(&admissionregistrationv1.ValidatingWebhookConfiguration{})
+	if err != nil {
+		t.Fatalf("reconcile validating webhook: %v", err)
+	}
+	if len(configuration.Webhooks) != 1 {
+		t.Fatalf("webhook count = %d, want 1", len(configuration.Webhooks))
+	}
+	hook := configuration.Webhooks[0]
+	const expectedURL = "https://usercluster-webhook.cluster-abcd.svc.cluster.local.:6443/validate-machine-accelerator-footprint"
+	if hook.ClientConfig.URL == nil || *hook.ClientConfig.URL != expectedURL {
+		if hook.ClientConfig.URL == nil {
+			t.Fatal("URL is nil")
+		}
+		t.Fatalf("URL = %q, want %q", *hook.ClientConfig.URL, expectedURL)
+	}
+	if hook.FailurePolicy == nil || *hook.FailurePolicy != admissionregistrationv1.Fail {
+		t.Fatalf("failurePolicy = %v, want Fail", hook.FailurePolicy)
+	}
+	if len(hook.Rules) != 1 || !slices.Equal(hook.Rules[0].Operations, []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update}) {
+		t.Fatalf("rules = %#v, want Machine CREATE and UPDATE", hook.Rules)
+	}
+}
+
+func testCertificate() *x509.Certificate {
+	return &x509.Certificate{Raw: []byte("test-ca")}
+}

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
@@ -33,6 +33,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/util"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +48,7 @@ const (
 	// This controller syncs the ResourceQuotas from the master cluster to the seed clusters.
 	ControllerName = "kkp-resource-quota-synchronizer"
 
-	// cleanupFinalizer indicates that synced resource quota on seed clusters needs cleanup.
+	// cleanupFinalizer indicates that synced ResourceQuotas on Seed clusters need cleanup.
 	cleanupFinalizer = "kubermatic.k8c.io/cleanup-seed-resource-quota"
 )
 
@@ -88,9 +89,36 @@ func resourceQuotaReconcilerFactory(rq *kubermaticv1.ResourceQuota) reconciling.
 			c.Name = rq.Name
 			c.Labels = rq.Labels
 			c.Spec = rq.Spec
+			reconcileManagedAnnotation(c, rq, resources.AcceleratorAccountingEnabledAnnotation)
 			return c, nil
 		}
 	}
+}
+
+// reconcileManagedAnnotation mirrors one controller-owned annotation without replacing
+// seed-local annotations. Removing the annotation from the source removes only that key.
+func reconcileManagedAnnotation(target, source metav1.Object, key string) {
+	value, enabled := source.GetAnnotations()[key]
+	annotations := target.GetAnnotations()
+
+	if enabled {
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[key] = value
+		target.SetAnnotations(annotations)
+		return
+	}
+
+	if _, exists := annotations[key]; !exists {
+		return
+	}
+
+	delete(annotations, key)
+	if len(annotations) == 0 {
+		annotations = nil
+	}
+	target.SetAnnotations(annotations)
 }
 
 // Reconcile reconciles the resource quotas in the master cluster and syncs them to all seeds.

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer_test.go
@@ -31,6 +31,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 	"k8c.io/kubermatic/v2/pkg/test/generator"
@@ -130,6 +131,98 @@ func TestReconcile(t *testing.T) {
 				t.Fatalf("Objects differ:\n%v", diff.ObjectDiff(tc.expectedRQ, rq))
 			}
 		})
+	}
+}
+
+func TestResourceQuotaReconcilerFactoryOnlyMirrorsManagedAnnotations(t *testing.T) {
+	testCases := []struct {
+		name     string
+		master   map[string]string
+		seed     map[string]string
+		expected map[string]string
+	}{
+		{
+			name: "activation is copied without copying unrelated master annotations",
+			master: map[string]string{
+				resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+				"master.example/ignore":                          "value",
+			},
+			seed: map[string]string{
+				resources.AcceleratorAccountingEnabledAnnotation: "stale",
+				"seed.example/keep": "value",
+			},
+			expected: map[string]string{
+				resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+				"seed.example/keep": "value",
+			},
+		},
+		{
+			name:   "activation is removed without removing unrelated seed annotations",
+			master: map[string]string{"master.example/ignore": "value"},
+			seed: map[string]string{
+				resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+				"seed.example/keep": "value",
+			},
+			expected: map[string]string{"seed.example/keep": "value"},
+		},
+		{
+			name: "absent annotations remain absent",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			master := genResourceQuota(rqName, false)
+			master.Annotations = tc.master
+			seed := genResourceQuota(rqName, false)
+			seed.Annotations = tc.seed
+
+			_, reconcileResourceQuota := resourceQuotaReconcilerFactory(master)()
+			result, err := reconcileResourceQuota(seed)
+			if err != nil {
+				t.Fatalf("reconciling ResourceQuota: %v", err)
+			}
+			if !diff.SemanticallyEqual(tc.expected, result.Annotations) {
+				t.Fatalf("annotations differ:\n%v", diff.ObjectDiff(tc.expected, result.Annotations))
+			}
+		})
+	}
+}
+
+func TestReconcilePropagatesActivation(t *testing.T) {
+	ctx := context.Background()
+	masterResourceQuota := genResourceQuota(rqName, false)
+	masterResourceQuota.Annotations = map[string]string{
+		resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+		"master.example/ignore":                          "value",
+	}
+	seedResourceQuota := genResourceQuota(rqName, false)
+	seedResourceQuota.Annotations = map[string]string{"seed.example/keep": "value"}
+
+	masterClient := fake.NewClientBuilder().WithObjects(masterResourceQuota).Build()
+	seedClient := fake.NewClientBuilder().WithObjects(seedResourceQuota).Build()
+	r := &reconciler{
+		log:          kubermaticlog.Logger,
+		recorder:     &events.FakeRecorder{},
+		masterClient: masterClient,
+		seedClients:  map[string]ctrlruntimeclient.Client{"first": seedClient},
+	}
+
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: rqName}}
+	if _, err := r.Reconcile(ctx, request); err != nil {
+		t.Fatalf("reconciling failed: %v", err)
+	}
+
+	gotResourceQuota := &kubermaticv1.ResourceQuota{}
+	if err := seedClient.Get(ctx, request.NamespacedName, gotResourceQuota); err != nil {
+		t.Fatalf("getting seed ResourceQuota: %v", err)
+	}
+	expectedResourceQuotaAnnotations := map[string]string{
+		resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+		"seed.example/keep": "value",
+	}
+	if !diff.SemanticallyEqual(expectedResourceQuotaAnnotations, gotResourceQuota.Annotations) {
+		t.Fatalf("ResourceQuota annotations differ:\n%v", diff.ObjectDiff(expectedResourceQuotaAnnotations, gotResourceQuota.Annotations))
 	}
 }
 

--- a/pkg/machine/accelerator/footprint.go
+++ b/pkg/machine/accelerator/footprint.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package accelerator defines the trusted per-Machine accelerator accounting footprint.
+package accelerator
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
+	kjson "sigs.k8s.io/json"
+)
+
+const (
+	// AnnotationPrefix is reserved for KKP-owned Machine accelerator accounting metadata.
+	AnnotationPrefix = "accelerators.kubermatic.io/"
+	// FootprintAnnotationKey stores the trusted accelerator accounting footprint on a Machine.
+	FootprintAnnotationKey = AnnotationPrefix + "footprint"
+	// MutatingWebhookPath is the dedicated Machine footprint mutation endpoint.
+	MutatingWebhookPath = "/mutate-machine-accelerator-footprint"
+	// ValidatingWebhookPath is the dedicated Machine footprint validation endpoint.
+	ValidatingWebhookPath = "/validate-machine-accelerator-footprint"
+
+	// SchemaVersionV1Alpha1 is the first version of the footprint annotation payload schema.
+	SchemaVersionV1Alpha1 = "v1alpha1"
+	// ProviderKubeVirt identifies a footprint derived from KubeVirt Machine intent.
+	ProviderKubeVirt = "kubevirt"
+)
+
+// Footprint is the versioned accelerator consumption captured for one Machine.
+// An empty Resources map records that the Machine was processed and consumes no accelerators.
+type Footprint struct {
+	SchemaVersion string              `json:"schemaVersion"`
+	Provider      string              `json:"provider"`
+	Resources     corev1.ResourceList `json:"resources"`
+}
+
+// NewKubeVirtFootprint returns an isolated KubeVirt footprint for the given resources.
+func NewKubeVirtFootprint(resources corev1.ResourceList) Footprint {
+	if resources == nil {
+		resources = corev1.ResourceList{}
+	} else {
+		resources = resources.DeepCopy()
+	}
+
+	return Footprint{
+		SchemaVersion: SchemaVersionV1Alpha1,
+		Provider:      ProviderKubeVirt,
+		Resources:     resources,
+	}
+}
+
+// Encode validates and serializes a footprint into its canonical annotation value.
+func Encode(footprint Footprint) (string, error) {
+	if err := validate(footprint); err != nil {
+		return "", err
+	}
+
+	encoded, err := json.Marshal(footprint)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode accelerator footprint: %w", err)
+	}
+	return string(encoded), nil
+}
+
+// Decode strictly parses and validates an accelerator footprint annotation value.
+func Decode(value string) (Footprint, error) {
+	footprint := Footprint{}
+	strictErrors, err := kjson.UnmarshalStrict([]byte(value), &footprint)
+	if err != nil {
+		return Footprint{}, fmt.Errorf("failed to decode accelerator footprint: %w", err)
+	}
+	if len(strictErrors) > 0 {
+		messages := make([]string, len(strictErrors))
+		for i, strictErr := range strictErrors {
+			messages[i] = strictErr.Error()
+		}
+		sort.Strings(messages)
+		return Footprint{}, fmt.Errorf("failed to decode accelerator footprint: %s", strings.Join(messages, "; "))
+	}
+	if err := validate(footprint); err != nil {
+		return Footprint{}, err
+	}
+
+	footprint.Resources = footprint.Resources.DeepCopy()
+	return footprint, nil
+}
+
+// IsReservedAnnotationKey reports whether a key belongs to KKP's accelerator annotation namespace.
+func IsReservedAnnotationKey(key string) bool {
+	return strings.HasPrefix(key, AnnotationPrefix)
+}
+
+func validate(footprint Footprint) error {
+	if footprint.SchemaVersion != SchemaVersionV1Alpha1 {
+		return fmt.Errorf("unsupported accelerator footprint schemaVersion %q", footprint.SchemaVersion)
+	}
+	if footprint.Provider != ProviderKubeVirt {
+		return fmt.Errorf("unsupported accelerator footprint provider %q", footprint.Provider)
+	}
+	if footprint.Resources == nil {
+		return fmt.Errorf("accelerator footprint resources must not be null")
+	}
+
+	resourceNames := make([]string, 0, len(footprint.Resources))
+	for resourceName := range footprint.Resources {
+		resourceNames = append(resourceNames, string(resourceName))
+	}
+	sort.Strings(resourceNames)
+
+	for _, resourceName := range resourceNames {
+		quantity := footprint.Resources[corev1.ResourceName(resourceName)]
+		if strings.Count(resourceName, "/") != 1 {
+			return fmt.Errorf("accelerator resource %q must be a qualified name with exactly one '/'", resourceName)
+		}
+		if validationErrors := k8svalidation.IsQualifiedName(resourceName); len(validationErrors) > 0 {
+			return fmt.Errorf("accelerator resource %q is not a valid qualified name: %s", resourceName, strings.Join(validationErrors, "; "))
+		}
+		if quantity.Sign() <= 0 {
+			return fmt.Errorf("accelerator resource %q must have a positive quantity", resourceName)
+		}
+		if _, exact := quantity.AsScale(0); !exact {
+			return fmt.Errorf("accelerator resource %q must have a whole-number quantity", resourceName)
+		}
+	}
+
+	return nil
+}

--- a/pkg/machine/accelerator/footprint.go
+++ b/pkg/machine/accelerator/footprint.go
@@ -33,10 +33,6 @@ const (
 	AnnotationPrefix = "accelerators.kubermatic.io/"
 	// FootprintAnnotationKey stores the trusted accelerator accounting footprint on a Machine.
 	FootprintAnnotationKey = AnnotationPrefix + "footprint"
-	// MutatingWebhookPath is the dedicated Machine footprint mutation endpoint.
-	MutatingWebhookPath = "/mutate-machine-accelerator-footprint"
-	// ValidatingWebhookPath is the dedicated Machine footprint validation endpoint.
-	ValidatingWebhookPath = "/validate-machine-accelerator-footprint"
 
 	// SchemaVersionV1Alpha1 is the first version of the footprint annotation payload schema.
 	SchemaVersionV1Alpha1 = "v1alpha1"

--- a/pkg/machine/accelerator/footprint_test.go
+++ b/pkg/machine/accelerator/footprint_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accelerator
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestEncodeCanonicalFootprint(t *testing.T) {
+	resources := corev1.ResourceList{
+		"nvidia.com/H200":  resource.MustParse("2"),
+		"example.com/fpga": resource.MustParse("1"),
+	}
+	footprint := NewKubeVirtFootprint(resources)
+
+	// The constructor must isolate the trusted value from caller mutations.
+	resources["nvidia.com/H200"] = resource.MustParse("9")
+	resources["example.com/new"] = resource.MustParse("1")
+
+	encoded, err := Encode(footprint)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	const expected = `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"example.com/fpga":"1","nvidia.com/H200":"2"}}`
+	if encoded != expected {
+		t.Fatalf("Encode() = %s, want %s", encoded, expected)
+	}
+
+	decoded, err := Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	h200 := decoded.Resources["nvidia.com/H200"]
+	if h200.Cmp(resource.MustParse("2")) != 0 {
+		t.Fatalf("decoded H200 quantity = %s, want 2", h200.String())
+	}
+}
+
+func TestEmptyFootprint(t *testing.T) {
+	encoded, err := Encode(NewKubeVirtFootprint(nil))
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	const expected = `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{}}`
+	if encoded != expected {
+		t.Fatalf("Encode() = %s, want %s", encoded, expected)
+	}
+
+	decoded, err := Decode(encoded)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	if decoded.Resources == nil || len(decoded.Resources) != 0 {
+		t.Fatalf("decoded resources = %#v, want non-nil empty map", decoded.Resources)
+	}
+}
+
+func TestNewKubeVirtFootprintDeepCopiesLargeQuantity(t *testing.T) {
+	const resourceName = "nvidia.com/H200"
+	resources := corev1.ResourceList{resourceName: resource.MustParse("9223372036854775808")}
+	footprint := NewKubeVirtFootprint(resources)
+
+	quantity := resources[resourceName]
+	quantity.Add(resource.MustParse("1"))
+
+	got := footprint.Resources[resourceName]
+	if got.Cmp(resource.MustParse("9223372036854775808")) != 0 {
+		t.Fatalf("copied quantity = %s, want original large value", got.String())
+	}
+}
+
+func TestDecodeNormalizesResourceQuantities(t *testing.T) {
+	decoded, err := Decode(`{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"nvidia.com/H200":"1000m"}}`)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	encoded, err := Encode(decoded)
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if !strings.Contains(encoded, `"nvidia.com/H200":"1"`) {
+		t.Fatalf("Encode() = %s, want canonical whole-number quantity", encoded)
+	}
+}
+
+func TestDecodeRejectsInvalidFootprints(t *testing.T) {
+	testCases := []struct {
+		name        string
+		value       string
+		errorString string
+	}{
+		{name: "malformed JSON", value: `{`, errorString: "failed to decode"},
+		{name: "trailing JSON", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{}} {}`, errorString: "failed to decode"},
+		{name: "unknown field", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{},"unknown":true}`, errorString: "unknown field"},
+		{name: "duplicate top-level field", value: `{"schemaVersion":"v1alpha1","schemaVersion":"v1alpha1","provider":"kubevirt","resources":{}}`, errorString: "duplicate field"},
+		{name: "duplicate resource", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"nvidia.com/H200":"1","nvidia.com/H200":"2"}}`, errorString: "duplicate field"},
+		{name: "missing schema", value: `{"provider":"kubevirt","resources":{}}`, errorString: "schemaVersion"},
+		{name: "unsupported schema", value: `{"schemaVersion":"v2","provider":"kubevirt","resources":{}}`, errorString: "unsupported accelerator footprint schemaVersion"},
+		{name: "missing provider", value: `{"schemaVersion":"v1alpha1","resources":{}}`, errorString: "provider"},
+		{name: "unsupported provider", value: `{"schemaVersion":"v1alpha1","provider":"aws","resources":{}}`, errorString: "unsupported accelerator footprint provider"},
+		{name: "missing resources", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt"}`, errorString: "resources must not be null"},
+		{name: "null resources", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":null}`, errorString: "resources must not be null"},
+		{name: "unqualified resource", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"H200":"1"}}`, errorString: "qualified name"},
+		{name: "multiple slashes", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"nvidia.com/gpu/H200":"1"}}`, errorString: "qualified name"},
+		{name: "malformed resource", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"NVIDIA!.com/H200":"1"}}`, errorString: "not a valid qualified name"},
+		{name: "zero quantity", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"nvidia.com/H200":"0"}}`, errorString: "positive quantity"},
+		{name: "negative quantity", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"nvidia.com/H200":"-1"}}`, errorString: "positive quantity"},
+		{name: "fractional quantity", value: `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{"nvidia.com/H200":"500m"}}`, errorString: "whole-number quantity"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Decode(tc.value)
+			if err == nil {
+				t.Fatal("Decode() expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("Decode() error = %q, want substring %q", err, tc.errorString)
+			}
+		})
+	}
+}
+
+func TestEncodeAcceptsLargeWholeQuantity(t *testing.T) {
+	_, err := Encode(Footprint{
+		SchemaVersion: SchemaVersionV1Alpha1,
+		Provider:      ProviderKubeVirt,
+		Resources: corev1.ResourceList{
+			"nvidia.com/H200": resource.MustParse("9223372036854775808"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Encode() rejected a large whole-number quantity: %v", err)
+	}
+}
+
+func TestIsReservedAnnotationKey(t *testing.T) {
+	for _, key := range []string{FootprintAnnotationKey, AnnotationPrefix + "future-field"} {
+		if !IsReservedAnnotationKey(key) {
+			t.Errorf("IsReservedAnnotationKey(%q) = false, want true", key)
+		}
+	}
+	for _, key := range []string{"", "accelerators.kubermatic.io", "example.com/accelerators.kubermatic.io/footprint"} {
+		if IsReservedAnnotationKey(key) {
+			t.Errorf("IsReservedAnnotationKey(%q) = true, want false", key)
+		}
+	}
+}

--- a/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -151,29 +151,51 @@ func resolveInstanceType(ctx context.Context, client ctrlruntimeclient.Client, n
 func findInstanceTypeForResolution(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*instanceTypeSpec, error) {
 	switch it.Kind {
 	case VirtualMachineInstancetypeKind:
-		if instanceType, err := findLiveNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
+		if instanceType, err := findLiveNamespacedInstanceTypeExact(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
 			return instanceType, err
 		}
 
 	case VirtualMachineClusterInstancetypeKind:
-		if instanceType, err := findClusterInstanceType(ctx, client, it.Name); instanceType != nil || err != nil {
-			return instanceType, err
+		instanceType, err := findClusterInstanceTypeExact(ctx, client, it.Name)
+		if err != nil {
+			return nil, err
 		}
+		if instanceType == nil {
+			break
+		}
+
+		// machine-controller versions without exact-kind matching resolve namespaced
+		// instancetypes first. Reject a cross-scope name collision so the footprint
+		// cannot describe a different object from the one used to provision the VM.
+		if namespace != "" {
+			collidingInstanceType, err := findLiveNamespacedInstanceTypeExact(ctx, client, namespace, it.Name)
+			if err != nil {
+				return nil, err
+			}
+			if collidingInstanceType != nil && (hasDeviceEntries(instanceType.Spec) || hasDeviceEntries(collidingInstanceType.Spec)) {
+				return nil, fmt.Errorf("VMI instancetype %q exists as both %s and %s; accelerator accounting requires a unique name across scopes", it.Name, VirtualMachineInstancetypeKind, VirtualMachineClusterInstancetypeKind)
+			}
+		}
+		return instanceType, nil
 
 	case "":
 		// machine-controller resolves legacy matchers without a kind in namespace scope first.
 		// Keep the accelerator footprint aligned with the instancetype used to provision the VM.
 		if namespace != "" {
-			if instanceType, err := findLiveNamespacedInstanceType(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
+			if instanceType, err := findLiveNamespacedInstanceTypeExact(ctx, client, namespace, it.Name); instanceType != nil || err != nil {
 				return instanceType, err
 			}
 		}
-		if instanceType, err := findClusterInstanceType(ctx, client, it.Name); instanceType != nil || err != nil {
+		if instanceType, err := findClusterInstanceTypeExact(ctx, client, it.Name); instanceType != nil || err != nil {
 			return instanceType, err
 		}
 	}
 
 	return nil, fmt.Errorf("VMI instancetype %s of Kind %s not found", it.Name, it.Kind)
+}
+
+func hasDeviceEntries(spec kvinstancetypev1beta1.VirtualMachineInstancetypeSpec) bool {
+	return len(spec.GPUs) > 0 || len(spec.HostDevices) > 0
 }
 
 func findInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace string, it *kubevirtv1.InstancetypeMatcher) (*instanceTypeSpec, error) {
@@ -200,12 +222,22 @@ func findInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name
 }
 
 func findClusterInstanceType(ctx context.Context, client ctrlruntimeclient.Client, name string) (*instanceTypeSpec, error) {
+	return findClusterInstanceTypeWithMatcher(ctx, client, name, strings.EqualFold)
+}
+
+func findClusterInstanceTypeExact(ctx context.Context, client ctrlruntimeclient.Client, name string) (*instanceTypeSpec, error) {
+	return findClusterInstanceTypeWithMatcher(ctx, client, name, func(actual, requested string) bool {
+		return actual == requested
+	})
+}
+
+func findClusterInstanceTypeWithMatcher(ctx context.Context, client ctrlruntimeclient.Client, name string, matches func(string, string) bool) (*instanceTypeSpec, error) {
 	clusterInstancetypes := kvinstancetypev1beta1.VirtualMachineClusterInstancetypeList{}
 	if err := client.List(ctx, &clusterInstancetypes); err != nil {
 		return nil, err
 	}
 	for _, instancetype := range clusterInstancetypes.Items {
-		if strings.EqualFold(instancetype.Name, name) {
+		if matches(instancetype.Name, name) {
 			return &instanceTypeSpec{
 				Spec: instancetype.Spec,
 				Source: InstanceTypeSource{
@@ -236,6 +268,16 @@ func findNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Cl
 }
 
 func findLiveNamespacedInstanceType(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*instanceTypeSpec, error) {
+	return findLiveNamespacedInstanceTypeWithMatcher(ctx, client, namespace, name, strings.EqualFold)
+}
+
+func findLiveNamespacedInstanceTypeExact(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string) (*instanceTypeSpec, error) {
+	return findLiveNamespacedInstanceTypeWithMatcher(ctx, client, namespace, name, func(actual, requested string) bool {
+		return actual == requested
+	})
+}
+
+func findLiveNamespacedInstanceTypeWithMatcher(ctx context.Context, client ctrlruntimeclient.Client, namespace, name string, matches func(string, string) bool) (*instanceTypeSpec, error) {
 	// List namespaced VirtualMachineInstancetype objects from the infrastructure cluster.
 	//
 	// This requires the cluster's infra namespace: a namespaced instancetype must be resolved
@@ -250,7 +292,7 @@ func findLiveNamespacedInstanceType(ctx context.Context, client ctrlruntimeclien
 		return nil, err
 	}
 	for i := range namespacedInstancetypes.Items {
-		if strings.EqualFold(namespacedInstancetypes.Items[i].Name, name) {
+		if matches(namespacedInstancetypes.Items[i].Name, name) {
 			instancetype := &namespacedInstancetypes.Items[i]
 			return &instanceTypeSpec{
 				Spec: instancetype.Spec,

--- a/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
+++ b/pkg/provider/cloud/kubevirt/vm_instancetype_test.go
@@ -18,6 +18,7 @@ package kubevirt
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -260,7 +261,7 @@ func TestResolveInstanceTypeDeviceResourcesAndSource(t *testing.T) {
 		wantMemory      resource.Quantity
 	}{
 		{
-			name: "cluster-scoped host devices are counted and the explicit kind wins a same-name collision",
+			name: "cluster-scoped host devices are counted",
 			objects: []ctrlruntimeclient.Object{
 				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "h200-two-gpu"},
@@ -271,13 +272,6 @@ func TestResolveInstanceTypeDeviceResourcesAndSource(t *testing.T) {
 							{Name: "gpu-1", DeviceName: "nvidia.com/GH100_H200_NVL"},
 							{Name: "gpu-2", DeviceName: "nvidia.com/GH100_H200_NVL"},
 						},
-					},
-				},
-				&kvinstancetypev1beta1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "h200-two-gpu", Namespace: "tenant-a"},
-					Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
-						CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
-						Memory: kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
 					},
 				},
 			},
@@ -360,6 +354,103 @@ func TestResolveInstanceTypeDeviceResourcesAndSource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveInstanceTypeRejectsExplicitClusterScopeCollision(t *testing.T) {
+	const (
+		name      = "h200-two-gpu"
+		namespace = "tenant-a"
+	)
+	client := newTestClient(t,
+		&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 32},
+				Memory: resourceMemory("128Gi"),
+				HostDevices: []kubevirtv1.HostDevice{{
+					Name:       "gpu-1",
+					DeviceName: "nvidia.com/H200",
+				}},
+			},
+		},
+		&kvinstancetypev1beta1.VirtualMachineInstancetype{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+				Memory: resourceMemory("16Gi"),
+			},
+		},
+	)
+
+	_, err := resolveInstanceType(context.Background(), client, namespace, &kubevirtv1.InstancetypeMatcher{
+		Name: name,
+		Kind: VirtualMachineClusterInstancetypeKind,
+	})
+	if err == nil {
+		t.Fatal("resolveInstanceType() expected a cross-scope collision error")
+	}
+	if !strings.Contains(err.Error(), "requires a unique name across scopes") {
+		t.Fatalf("resolveInstanceType() error = %q, want collision explanation", err)
+	}
+}
+
+func TestResolveInstanceTypeAllowsCPUOnlyCrossScopeCollision(t *testing.T) {
+	const (
+		name      = "standard-4"
+		namespace = "tenant-a"
+	)
+	client := newTestClient(t,
+		&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+				Memory: resourceMemory("16Gi"),
+			},
+		},
+		&kvinstancetypev1beta1.VirtualMachineInstancetype{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+				CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+				Memory: resourceMemory("16Gi"),
+			},
+		},
+	)
+
+	resolved, err := resolveInstanceType(context.Background(), client, namespace, &kubevirtv1.InstancetypeMatcher{
+		Name: name,
+		Kind: VirtualMachineClusterInstancetypeKind,
+	})
+	if err != nil {
+		t.Fatalf("resolveInstanceType() error = %v", err)
+	}
+	if resolved.Source.Kind != VirtualMachineClusterInstancetypeKind {
+		t.Fatalf("source kind = %q, want %q", resolved.Source.Kind, VirtualMachineClusterInstancetypeKind)
+	}
+	if len(resolved.DeviceResources) != 0 {
+		t.Fatalf("device resources = %#v, want empty", resolved.DeviceResources)
+	}
+}
+
+func TestResolveInstanceTypeRequiresExactName(t *testing.T) {
+	client := newTestClient(t, &kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+		ObjectMeta: metav1.ObjectMeta{Name: "h200-worker"},
+		Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+			CPU:    kvinstancetypev1beta1.CPUInstancetype{Guest: 4},
+			Memory: resourceMemory("16Gi"),
+		},
+	})
+
+	_, err := resolveInstanceType(context.Background(), client, "tenant-a", &kubevirtv1.InstancetypeMatcher{
+		Name: "H200-worker",
+		Kind: VirtualMachineClusterInstancetypeKind,
+	})
+	if err == nil {
+		t.Fatal("resolveInstanceType() expected an error for a case-mismatched name")
+	}
+}
+
+func resourceMemory(value string) kvinstancetypev1beta1.MemoryInstancetype {
+	return kvinstancetypev1beta1.MemoryInstancetype{Guest: resource.MustParse(value)}
 }
 
 func TestResolveInstanceTypeWithNilMatcher(t *testing.T) {

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1084,6 +1084,21 @@ const (
 	ClusterBackupNamespaceName      = "velero"
 )
 
+// KubeVirt accelerator accounting is an alpha feature. These constants are part
+// of its provisional contract and may change before the feature graduates.
+const (
+	// AcceleratorAccountingEnabledAnnotation enables accelerator accounting for a project ResourceQuota.
+	AcceleratorAccountingEnabledAnnotation = "accelerators.kubermatic.io/accounting-enabled"
+	// AcceleratorAccountingEnabledAnnotationValue is the only value that enables accelerator accounting.
+	AcceleratorAccountingEnabledAnnotationValue = "true"
+	// AcceleratorAccountingWebhookPath is the dedicated fail-closed ResourceQuota activation path.
+	AcceleratorAccountingWebhookPath = "/validate-resourcequota-accelerator-accounting"
+	// MachineAcceleratorFootprintMutatingWebhookPath is the dedicated Machine footprint mutation endpoint.
+	MachineAcceleratorFootprintMutatingWebhookPath = "/mutate-machine-accelerator-footprint"
+	// MachineAcceleratorFootprintValidatingWebhookPath is the dedicated Machine footprint validation endpoint.
+	MachineAcceleratorFootprintValidatingWebhookPath = "/validate-machine-accelerator-footprint"
+)
+
 var DefaultApplicationCacheSize = resource.MustParse("300Mi")
 
 // GetApplicationCacheSize return the application cache size if defined, otherwise fallback to the default size.

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -105,10 +105,11 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 				fmt.Sprintf("-project-id=%s", projectID),
 				fmt.Sprintf("-cluster-name=%s", data.Cluster().Name),
 			}
+			readinessPort := intstr.FromString("metrics")
 
 			// For KubeVirt clusters, tell the webhook which infra-cluster namespace holds the
-			// cluster's namespaced VirtualMachineInstancetypes so the resource-quota validation
-			// resolves them in the right namespace. Defaults to the cluster's dedicated namespace,
+			// cluster's namespaced VirtualMachineInstancetypes so Machine admission resolves them
+			// in the right namespace. Defaults to the cluster's dedicated namespace,
 			// or the datacenter's single-namespace ("namespaced mode") namespace when enabled.
 			if data.Cluster().Spec.Cloud.Kubevirt != nil {
 				kubeVirtInfraNamespace := data.Cluster().Status.NamespaceName
@@ -117,7 +118,7 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 				}
 				args = append(args, fmt.Sprintf("-kubevirt-infra-namespace=%s", kubeVirtInfraNamespace))
 				if data.KubeVirtAcceleratorQuotaEnabled() {
-					args = append(args, "-kubevirt-accelerator-quota")
+					readinessPort = intstr.FromInt(userWebhookListenPort)
 				}
 			}
 
@@ -219,7 +220,7 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 						FailureThreshold:    3,
 						ProbeHandler: corev1.ProbeHandler{
 							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.Parse("metrics"),
+								Port: readinessPort,
 							},
 						},
 					},

--- a/pkg/resources/usercluster-webhook/deployment_test.go
+++ b/pkg/resources/usercluster-webhook/deployment_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"encoding/json"
-	"slices"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
@@ -26,46 +24,54 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestKubeVirtAcceleratorQuotaArgument(t *testing.T) {
-	testCases := []struct {
-		name         string
-		kubeVirt     bool
-		enabled      bool
-		wantArgument bool
+func TestUserAdmissionReadinessProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		kubeVirt bool
+		active   bool
+		wantPort intstr.IntOrString
 	}{
 		{
-			name:     "disabled",
+			name:     "inactive KubeVirt project keeps existing metrics readiness",
 			kubeVirt: true,
+			wantPort: intstr.FromString("metrics"),
 		},
 		{
-			name:         "enabled",
-			kubeVirt:     true,
-			enabled:      true,
-			wantArgument: true,
+			name:     "active KubeVirt project waits for user admission",
+			kubeVirt: true,
+			active:   true,
+			wantPort: intstr.FromInt(userWebhookListenPort),
 		},
 		{
-			name:    "not rendered for another provider",
-			enabled: true,
+			name:     "non-KubeVirt cluster remains unchanged",
+			active:   true,
+			wantPort: intstr.FromString("metrics"),
 		},
-	}
-
-	for _, tc := range testCases {
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			data := newWebhookDeploymentTestData(tc.kubeVirt, tc.enabled)
-			_, reconcile := DeploymentReconciler(data)()
-
-			deployment, err := reconcile(&appsv1.Deployment{})
+			data := newWebhookDeploymentTestData(tc.kubeVirt, tc.active)
+			_, reconciler := DeploymentReconciler(data)()
+			deployment, err := reconciler(&appsv1.Deployment{})
 			if err != nil {
-				t.Fatalf("failed to reconcile user-cluster-webhook deployment: %v", err)
+				t.Fatalf("failed to reconcile Deployment: %v", err)
 			}
 
-			hasArgument := deploymentContainsArgument(deployment, "-kubevirt-accelerator-quota")
-			if hasArgument != tc.wantArgument {
-				t.Fatalf("expected accelerator quota argument present=%t, got %t", tc.wantArgument, hasArgument)
+			container := deployment.Spec.Template.Spec.Containers[0]
+			if container.ReadinessProbe == nil || container.ReadinessProbe.TCPSocket == nil {
+				t.Fatalf("readiness probe = %#v, want TCP probe", container.ReadinessProbe)
+			}
+			if got := container.ReadinessProbe.TCPSocket.Port; got != tc.wantPort {
+				t.Fatalf("readiness probe port = %#v, want %#v", got, tc.wantPort)
+			}
+			if len(container.Ports) != 2 {
+				t.Fatalf("container ports = %#v, want existing admission and metrics ports only", container.Ports)
+			}
+			if container.Ports[0].Name != "admission" || container.Ports[1].Name != "metrics" {
+				t.Fatalf("container ports = %#v, want existing admission and metrics ports only", container.Ports)
 			}
 		})
 	}
@@ -105,32 +111,4 @@ func newWebhookDeploymentTestData(kubeVirt, acceleratorQuotaEnabled bool) *kkpre
 		WithVersions(kubermatic.GetFakeVersions()).
 		WithKubeVirtAcceleratorQuota(acceleratorQuotaEnabled).
 		Build()
-}
-
-func deploymentContainsArgument(deployment *appsv1.Deployment, argument string) bool {
-	for _, containers := range [][]corev1.Container{
-		deployment.Spec.Template.Spec.InitContainers,
-		deployment.Spec.Template.Spec.Containers,
-	} {
-		for _, container := range containers {
-			if slices.Contains(container.Args, argument) {
-				return true
-			}
-
-			for i := 1; i < len(container.Args); i++ {
-				if container.Args[i-1] != "-command" {
-					continue
-				}
-
-				wrappedCommand := struct {
-					Args []string `json:"args"`
-				}{}
-				if err := json.Unmarshal([]byte(container.Args[i]), &wrappedCommand); err == nil && slices.Contains(wrappedCommand.Args, argument) {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
 }

--- a/pkg/webhook/machine/acceleratorvalidation/validation.go
+++ b/pkg/webhook/machine/acceleratorvalidation/validation.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package acceleratorvalidation protects KKP-owned Machine accelerator accounting metadata.
+package acceleratorvalidation
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"sort"
+
+	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	"k8c.io/machine-controller/sdk/providerconfig"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validator validates the trusted accelerator accounting contract on Machines.
+type Validator struct{}
+
+// NewValidator returns a Machine accelerator accounting validator.
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+var _ admission.Validator[*clusterv1alpha1.Machine] = &Validator{}
+
+// ValidateCreate ensures that only the KKP-generated KubeVirt footprint is stored under the
+// reserved accelerator annotation prefix.
+func (v *Validator) ValidateCreate(_ context.Context, machine *clusterv1alpha1.Machine) (admission.Warnings, error) {
+	config, err := providerconfig.GetConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read machine.spec.providerSpec while validating accelerator footprint: %w", err)
+	}
+
+	reserved := reservedAnnotations(machine.Annotations)
+	reservedKeys := make([]string, 0, len(reserved))
+	for key := range reserved {
+		reservedKeys = append(reservedKeys, key)
+	}
+	sort.Strings(reservedKeys)
+	for _, key := range reservedKeys {
+		if key != accelerator.FootprintAnnotationKey {
+			return nil, fmt.Errorf("Machine annotation %q uses KKP's reserved accelerator prefix", key)
+		}
+	}
+
+	footprintValue, hasFootprint := reserved[accelerator.FootprintAnnotationKey]
+	if config.CloudProvider != providerconfig.CloudProviderKubeVirt {
+		if hasFootprint {
+			return nil, fmt.Errorf("Machine annotation %q is only valid for KubeVirt Machines", accelerator.FootprintAnnotationKey)
+		}
+		return nil, nil
+	}
+
+	if !hasFootprint {
+		return nil, fmt.Errorf("KubeVirt Machine is missing KKP-managed annotation %q", accelerator.FootprintAnnotationKey)
+	}
+	if _, err := accelerator.Decode(footprintValue); err != nil {
+		return nil, fmt.Errorf("Machine annotation %q is invalid: %w", accelerator.FootprintAnnotationKey, err)
+	}
+
+	return nil, nil
+}
+
+// ValidateUpdate keeps the footprint and its source Machine intent immutable. This check remains
+// authoritative even when machine-controller's one-shot spec-mutation bypass annotation is used.
+func (v *Validator) ValidateUpdate(_ context.Context, oldMachine, newMachine *clusterv1alpha1.Machine) (admission.Warnings, error) {
+	oldReserved := reservedAnnotations(oldMachine.Annotations)
+	newReserved := reservedAnnotations(newMachine.Annotations)
+	if !maps.Equal(oldReserved, newReserved) {
+		return nil, fmt.Errorf("Machine annotations under %q are managed by KKP and are immutable", accelerator.AnnotationPrefix)
+	}
+
+	if apiequality.Semantic.DeepEqual(oldMachine.Spec.ProviderSpec, newMachine.Spec.ProviderSpec) {
+		return nil, nil
+	}
+
+	oldConfig, oldErr := providerconfig.GetConfig(oldMachine.Spec.ProviderSpec)
+	newConfig, newErr := providerconfig.GetConfig(newMachine.Spec.ProviderSpec)
+	if len(oldReserved) > 0 || len(newReserved) > 0 || oldErr != nil || newErr != nil ||
+		oldConfig.CloudProvider == providerconfig.CloudProviderKubeVirt ||
+		newConfig.CloudProvider == providerconfig.CloudProviderKubeVirt {
+		return nil, fmt.Errorf("Machine spec.providerSpec is immutable for accelerator accounting")
+	}
+
+	return nil, nil
+}
+
+func (v *Validator) ValidateDelete(_ context.Context, _ *clusterv1alpha1.Machine) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func reservedAnnotations(annotations map[string]string) map[string]string {
+	reserved := map[string]string{}
+	for key, value := range annotations {
+		if accelerator.IsReservedAnnotationKey(key) {
+			reserved[key] = value
+		}
+	}
+	return reserved
+}

--- a/pkg/webhook/machine/acceleratorvalidation/validation_test.go
+++ b/pkg/webhook/machine/acceleratorvalidation/validation_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acceleratorvalidation
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	kubevirttypes "k8c.io/machine-controller/sdk/cloudprovider/kubevirt"
+	"k8c.io/machine-controller/sdk/providerconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestValidateCreate(t *testing.T) {
+	validFootprint, err := accelerator.Encode(accelerator.NewKubeVirtFootprint(corev1.ResourceList{
+		"nvidia.com/H200": resource.MustParse("2"),
+	}))
+	if err != nil {
+		t.Fatalf("failed to encode test footprint: %v", err)
+	}
+
+	testCases := []struct {
+		name        string
+		machine     func(*testing.T) *clusterv1alpha1.Machine
+		annotations map[string]string
+		errorString string
+	}{
+		{
+			name:        "valid KubeVirt footprint",
+			machine:     func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, "h200-v1") },
+			annotations: map[string]string{accelerator.FootprintAnnotationKey: validFootprint},
+		},
+		{
+			name: "valid non-KubeVirt Machine",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return providerMachine(t, providerconfig.CloudProviderAWS, map[string]any{})
+			},
+		},
+		{
+			name:        "missing KubeVirt footprint",
+			machine:     func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, "h200-v1") },
+			errorString: "is missing",
+		},
+		{
+			name:        "invalid footprint",
+			machine:     func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, "h200-v1") },
+			annotations: map[string]string{accelerator.FootprintAnnotationKey: "invalid"},
+			errorString: "is invalid",
+		},
+		{
+			name:    "unknown reserved annotation",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, "h200-v1") },
+			annotations: map[string]string{
+				accelerator.FootprintAnnotationKey:      validFootprint,
+				accelerator.AnnotationPrefix + "future": "value",
+			},
+			errorString: "reserved accelerator prefix",
+		},
+		{
+			name: "footprint on non-KubeVirt Machine",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return providerMachine(t, providerconfig.CloudProviderAWS, map[string]any{})
+			},
+			annotations: map[string]string{accelerator.FootprintAnnotationKey: validFootprint},
+			errorString: "only valid for KubeVirt",
+		},
+		{
+			name: "malformed provider config",
+			machine: func(*testing.T) *clusterv1alpha1.Machine {
+				return &clusterv1alpha1.Machine{Spec: clusterv1alpha1.MachineSpec{ProviderSpec: clusterv1alpha1.ProviderSpec{
+					Value: &runtime.RawExtension{Raw: []byte(`not-json`)},
+				}}}
+			},
+			errorString: "failed to read machine.spec.providerSpec",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			machine := tc.machine(t)
+			machine.Annotations = tc.annotations
+			_, err := NewValidator().ValidateCreate(context.Background(), machine)
+			assertErrorContains(t, err, tc.errorString)
+		})
+	}
+}
+
+func TestValidateUpdateProtectsFootprintAndProviderSpec(t *testing.T) {
+	validFootprint, err := accelerator.Encode(accelerator.NewKubeVirtFootprint(corev1.ResourceList{
+		"nvidia.com/H200": resource.MustParse("1"),
+	}))
+	if err != nil {
+		t.Fatalf("failed to encode test footprint: %v", err)
+	}
+
+	base := kubeVirtMachine(t, "h200-v1")
+	base.Annotations = map[string]string{
+		accelerator.FootprintAnnotationKey: validFootprint,
+		"example.com/value":                "old",
+	}
+
+	testCases := []struct {
+		name        string
+		oldMachine  func(*testing.T) *clusterv1alpha1.Machine
+		mutate      func(*testing.T, *clusterv1alpha1.Machine)
+		errorString string
+	}{
+		{
+			name:       "unchanged accounting intent",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine { return base.DeepCopy() },
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Annotations["example.com/value"] = "new"
+			},
+		},
+		{
+			name:       "footprint cannot change",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine { return base.DeepCopy() },
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Annotations[accelerator.FootprintAnnotationKey] = "changed"
+			},
+			errorString: "are managed by KKP and are immutable",
+		},
+		{
+			name:       "footprint cannot be removed",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine { return base.DeepCopy() },
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				delete(machine.Annotations, accelerator.FootprintAnnotationKey)
+			},
+			errorString: "are managed by KKP and are immutable",
+		},
+		{
+			name:       "reserved annotation cannot be added",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine { return base.DeepCopy() },
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Annotations[accelerator.AnnotationPrefix+"future"] = "value"
+			},
+			errorString: "are managed by KKP and are immutable",
+		},
+		{
+			name: "unchanged malformed legacy footprint does not wedge metadata updates",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine {
+				machine := base.DeepCopy()
+				machine.Annotations[accelerator.FootprintAnnotationKey] = "legacy-invalid-value"
+				return machine
+			},
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Labels = map[string]string{"example.com/key": "value"}
+			},
+		},
+		{
+			name:       "providerSpec cannot change through machine-controller bypass",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine { return base.DeepCopy() },
+			mutate: func(t *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Spec.ProviderSpec = kubeVirtMachine(t, "h200-v2").Spec.ProviderSpec
+				machine.Annotations["kubermatic.io/bypass-no-spec-mutation-requirement"] = "true"
+			},
+			errorString: "spec.providerSpec is immutable for accelerator accounting",
+		},
+		{
+			name: "legacy KubeVirt Machine cannot change providerSpec through bypass",
+			oldMachine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return kubeVirtMachine(t, "h200-v1")
+			},
+			mutate: func(t *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Spec.ProviderSpec = kubeVirtMachine(t, "h200-v2").Spec.ProviderSpec
+				if machine.Annotations == nil {
+					machine.Annotations = map[string]string{}
+				}
+				machine.Annotations["kubermatic.io/bypass-no-spec-mutation-requirement"] = "true"
+			},
+			errorString: "spec.providerSpec is immutable for accelerator accounting",
+		},
+		{
+			name: "legacy KubeVirt Machine allows unrelated update",
+			oldMachine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return kubeVirtMachine(t, "h200-v1")
+			},
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Labels = map[string]string{"example.com/key": "value"}
+			},
+		},
+		{
+			name: "transition into KubeVirt cannot bypass footprint creation",
+			oldMachine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return providerMachine(t, providerconfig.CloudProviderAWS, map[string]any{"instanceType": "m5.large"})
+			},
+			mutate: func(t *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Spec.ProviderSpec = kubeVirtMachine(t, "h200-v1").Spec.ProviderSpec
+			},
+			errorString: "spec.providerSpec is immutable for accelerator accounting",
+		},
+		{
+			name: "unprotected non-KubeVirt providerSpec change remains untouched",
+			oldMachine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return providerMachine(t, providerconfig.CloudProviderAWS, map[string]any{"instanceType": "m5.large"})
+			},
+			mutate: func(t *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Spec.ProviderSpec = providerMachine(t, providerconfig.CloudProviderAWS, map[string]any{"instanceType": "m5.xlarge"}).Spec.ProviderSpec
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldMachine := tc.oldMachine(t)
+			newMachine := oldMachine.DeepCopy()
+			tc.mutate(t, newMachine)
+
+			_, err := NewValidator().ValidateUpdate(context.Background(), oldMachine, newMachine)
+			assertErrorContains(t, err, tc.errorString)
+		})
+	}
+}
+
+func providerMachine(t *testing.T, provider providerconfig.CloudProvider, cloudProviderSpec any) *clusterv1alpha1.Machine {
+	t.Helper()
+	rawCloudProviderSpec, err := json.Marshal(cloudProviderSpec)
+	if err != nil {
+		t.Fatalf("failed to marshal cloud provider config: %v", err)
+	}
+	rawProviderSpec, err := json.Marshal(providerconfig.Config{
+		CloudProvider:     provider,
+		CloudProviderSpec: runtime.RawExtension{Raw: rawCloudProviderSpec},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal provider config: %v", err)
+	}
+	return &clusterv1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: metav1.NamespaceSystem},
+		Spec: clusterv1alpha1.MachineSpec{ProviderSpec: clusterv1alpha1.ProviderSpec{
+			Value: &runtime.RawExtension{Raw: rawProviderSpec},
+		}},
+	}
+}
+
+func kubeVirtMachine(t *testing.T, instancetypeName string) *clusterv1alpha1.Machine {
+	t.Helper()
+	return providerMachine(t, providerconfig.CloudProviderKubeVirt, kubevirttypes.RawConfig{
+		VirtualMachine: kubevirttypes.VirtualMachine{Instancetype: &kubevirtv1.InstancetypeMatcher{
+			Name: instancetypeName,
+			Kind: "VirtualMachineClusterInstancetype",
+		}},
+	})
+}
+
+func assertErrorContains(t *testing.T, err error, expected string) {
+	t.Helper()
+	if expected == "" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", expected)
+	}
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("error = %q, want substring %q", err, expected)
+	}
+}

--- a/pkg/webhook/machine/mutation/mutation.go
+++ b/pkg/webhook/machine/mutation/mutation.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mutation captures the trusted accelerator footprint of KubeVirt Machines.
+package mutation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
+	kubevirtprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	kubevirttypes "k8c.io/machine-controller/sdk/cloudprovider/kubevirt"
+	"k8c.io/machine-controller/sdk/providerconfig"
+	"k8c.io/machine-controller/sdk/providerconfig/configvar"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const envKubeVirtKubeconfig = "KUBEVIRT_KUBECONFIG"
+
+type instanceTypeResolver func(context.Context, string, string, *kubevirtv1.InstancetypeMatcher) (*kubevirtprovider.ResolvedInstanceType, error)
+
+// Mutator stamps KKP-owned accelerator accounting metadata on KubeVirt Machines.
+type Mutator struct {
+	userClient             ctrlruntimeclient.Client
+	kubeVirtInfraNamespace string
+	resolveInstanceType    instanceTypeResolver
+}
+
+// NewMutator returns a Machine accelerator footprint mutator.
+func NewMutator(userClient ctrlruntimeclient.Client, kubeVirtInfraNamespace string) *Mutator {
+	return &Mutator{
+		userClient:             userClient,
+		kubeVirtInfraNamespace: kubeVirtInfraNamespace,
+		resolveInstanceType:    kubevirtprovider.ResolveInstanceType,
+	}
+}
+
+var _ admission.Defaulter[*clusterv1alpha1.Machine] = &Mutator{}
+
+// Default recomputes the trusted footprint from Machine intent. User-supplied values under
+// the reserved annotation prefix are removed before the server-owned value is written.
+func (m *Mutator) Default(ctx context.Context, machine *clusterv1alpha1.Machine) error {
+	removeReservedAnnotations(machine)
+
+	config, err := providerconfig.GetConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return fmt.Errorf("failed to read machine.spec.providerSpec: %w", err)
+	}
+	if config.CloudProvider != providerconfig.CloudProviderKubeVirt {
+		return nil
+	}
+
+	rawConfig, err := kubevirttypes.GetConfig(*config)
+	if err != nil {
+		return fmt.Errorf("failed to get KubeVirt provider configuration: %w", err)
+	}
+
+	footprint := accelerator.NewKubeVirtFootprint(nil)
+	matcher := rawConfig.VirtualMachine.Instancetype
+	if matcher != nil {
+		if err := validateInstanceTypeMatcher(matcher); err != nil {
+			return err
+		}
+		if m.kubeVirtInfraNamespace == "" {
+			return fmt.Errorf("cannot resolve KubeVirt instancetype %q: no infrastructure namespace configured", matcher.Name)
+		}
+
+		kubeconfig, err := configvar.NewResolver(ctx, m.userClient).GetStringValueOrEnv(rawConfig.Auth.Kubeconfig, envKubeVirtKubeconfig)
+		if err != nil {
+			return fmt.Errorf("failed to resolve KubeVirt kubeconfig: %w", err)
+		}
+		if kubeconfig == "" {
+			return fmt.Errorf("failed to resolve KubeVirt kubeconfig: value is empty")
+		}
+
+		resolved, err := m.resolveInstanceType(ctx, kubeconfig, m.kubeVirtInfraNamespace, matcher)
+		if err != nil {
+			return fmt.Errorf("failed to resolve KubeVirt instancetype %q: %w", matcher.Name, err)
+		}
+		if resolved == nil {
+			return fmt.Errorf("failed to resolve KubeVirt instancetype %q: resolver returned no result", matcher.Name)
+		}
+		footprint = accelerator.NewKubeVirtFootprint(resolved.DeviceResources)
+	}
+
+	encodedFootprint, err := accelerator.Encode(footprint)
+	if err != nil {
+		return fmt.Errorf("failed to encode Machine accelerator footprint: %w", err)
+	}
+	if machine.Annotations == nil {
+		machine.Annotations = map[string]string{}
+	}
+	machine.Annotations[accelerator.FootprintAnnotationKey] = encodedFootprint
+
+	return nil
+}
+
+func validateInstanceTypeMatcher(matcher *kubevirtv1.InstancetypeMatcher) error {
+	if matcher.RevisionName != "" {
+		return errors.New("KubeVirt instancetype revisionName is not supported by accelerator accounting")
+	}
+	if matcher.InferFromVolume != "" {
+		return errors.New("KubeVirt instancetype inference from volume is not supported by accelerator accounting")
+	}
+	if matcher.InferFromVolumeFailurePolicy != nil {
+		return errors.New("KubeVirt instancetype inference failure policy is not supported by accelerator accounting")
+	}
+	if matcher.Name == "" {
+		return errors.New("KubeVirt instancetype matcher name must not be empty")
+	}
+	return nil
+}
+
+func removeReservedAnnotations(machine *clusterv1alpha1.Machine) {
+	for key := range machine.Annotations {
+		if accelerator.IsReservedAnnotationKey(key) {
+			delete(machine.Annotations, key)
+		}
+	}
+	if len(machine.Annotations) == 0 {
+		machine.Annotations = nil
+	}
+}

--- a/pkg/webhook/machine/mutation/mutation_test.go
+++ b/pkg/webhook/machine/mutation/mutation_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	"k8c.io/kubermatic/v2/pkg/machine/accelerator"
+	kubevirtprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	kubevirttypes "k8c.io/machine-controller/sdk/cloudprovider/kubevirt"
+	"k8c.io/machine-controller/sdk/providerconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestMutatorIgnoresNonKubeVirtMachineAndReservesAnnotations(t *testing.T) {
+	machine := machineWithProviderConfig(t, providerconfig.CloudProviderAWS, map[string]any{})
+	machine.Annotations = map[string]string{
+		accelerator.FootprintAnnotationKey:      "forged",
+		accelerator.AnnotationPrefix + "future": "forged",
+		"example.com/keep":                      "value",
+	}
+
+	if err := NewMutator(nil, "tenant-a").Default(context.Background(), machine); err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	if _, exists := machine.Annotations[accelerator.FootprintAnnotationKey]; exists {
+		t.Fatal("reserved footprint annotation was not removed")
+	}
+	if _, exists := machine.Annotations[accelerator.AnnotationPrefix+"future"]; exists {
+		t.Fatal("unknown reserved annotation was not removed")
+	}
+	if machine.Annotations["example.com/keep"] != "value" {
+		t.Fatal("unrelated annotation was changed")
+	}
+}
+
+func TestMutatorStampsExplicitEmptyKubeVirtFootprintWithoutMatcher(t *testing.T) {
+	machine := kubeVirtMachine(t, nil, "unused-kubeconfig")
+	machine.Annotations = map[string]string{
+		accelerator.FootprintAnnotationKey: "forged",
+		"example.com/keep":                 "value",
+	}
+	mutator := NewMutator(nil, "tenant-a")
+	mutator.resolveInstanceType = func(context.Context, string, string, *kubevirtv1.InstancetypeMatcher) (*kubevirtprovider.ResolvedInstanceType, error) {
+		t.Fatal("resolver must not be called without an instancetype matcher")
+		return nil, nil
+	}
+
+	if err := mutator.Default(context.Background(), machine); err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	footprint := decodeMachineFootprint(t, machine)
+	if footprint.Resources == nil || len(footprint.Resources) != 0 {
+		t.Fatalf("resources = %#v, want non-nil empty map", footprint.Resources)
+	}
+	if machine.Annotations["example.com/keep"] != "value" {
+		t.Fatal("unrelated annotation was changed")
+	}
+}
+
+func TestMutatorResolvesAndStampsKubeVirtFootprint(t *testing.T) {
+	matcher := &kubevirtv1.InstancetypeMatcher{
+		Name: "gpu-2d-8c-32gb-h200nvl",
+		Kind: kubevirtprovider.VirtualMachineClusterInstancetypeKind,
+	}
+	machine := kubeVirtMachine(t, matcher, "infra-kubeconfig")
+	machine.Annotations = map[string]string{
+		accelerator.FootprintAnnotationKey:       `{"schemaVersion":"v1alpha1","provider":"kubevirt","resources":{}}`,
+		accelerator.AnnotationPrefix + "unknown": "forged",
+		"example.com/keep":                       "value",
+	}
+
+	mutator := NewMutator(ctrlruntimefakeclient.NewClientBuilder().Build(), "tenant-general")
+	callCount := 0
+	mutator.resolveInstanceType = func(_ context.Context, kubeconfig, namespace string, gotMatcher *kubevirtv1.InstancetypeMatcher) (*kubevirtprovider.ResolvedInstanceType, error) {
+		callCount++
+		if kubeconfig != "infra-kubeconfig" {
+			t.Errorf("kubeconfig = %q, want infra-kubeconfig", kubeconfig)
+		}
+		if namespace != "tenant-general" {
+			t.Errorf("namespace = %q, want tenant-general", namespace)
+		}
+		if gotMatcher.Name != matcher.Name || gotMatcher.Kind != matcher.Kind {
+			t.Errorf("matcher = %#v, want %#v", gotMatcher, matcher)
+		}
+		return &kubevirtprovider.ResolvedInstanceType{DeviceResources: corev1.ResourceList{
+			"nvidia.com/GH100_H200_NVL": resource.MustParse("2"),
+			"example.com/fpga":          resource.MustParse("1"),
+		}}, nil
+	}
+
+	ctx := context.Background()
+	if err := mutator.Default(ctx, machine); err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+	firstValue := machine.Annotations[accelerator.FootprintAnnotationKey]
+	if err := mutator.Default(ctx, machine); err != nil {
+		t.Fatalf("second Default() error = %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("resolver call count = %d, want 2", callCount)
+	}
+	if got := machine.Annotations[accelerator.FootprintAnnotationKey]; got != firstValue {
+		t.Fatalf("second mutation changed canonical footprint: first=%s second=%s", firstValue, got)
+	}
+	if _, exists := machine.Annotations[accelerator.AnnotationPrefix+"unknown"]; exists {
+		t.Fatal("unknown reserved annotation was not removed")
+	}
+	if machine.Annotations["example.com/keep"] != "value" {
+		t.Fatal("unrelated annotation was changed")
+	}
+
+	footprint := decodeMachineFootprint(t, machine)
+	assertQuantity(t, footprint.Resources, "nvidia.com/GH100_H200_NVL", "2")
+	assertQuantity(t, footprint.Resources, "example.com/fpga", "1")
+}
+
+func TestMutatorFailsClosed(t *testing.T) {
+	matcher := &kubevirtv1.InstancetypeMatcher{Name: "h200-worker", Kind: kubevirtprovider.VirtualMachineClusterInstancetypeKind}
+	inferFailurePolicy := kubevirtv1.RejectInferFromVolumeFailure
+	testCases := []struct {
+		name           string
+		machine        func(*testing.T) *clusterv1alpha1.Machine
+		namespace      string
+		resolverResult *kubevirtprovider.ResolvedInstanceType
+		resolverErr    error
+		errorString    string
+	}{
+		{
+			name:        "malformed provider config",
+			machine:     func(*testing.T) *clusterv1alpha1.Machine { return malformedMachine() },
+			namespace:   "tenant-a",
+			errorString: "failed to read machine.spec.providerSpec",
+		},
+		{
+			name: "empty instancetype matcher name",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return kubeVirtMachine(t, &kubevirtv1.InstancetypeMatcher{}, "kubeconfig")
+			},
+			namespace:   "tenant-a",
+			errorString: "matcher name must not be empty",
+		},
+		{
+			name: "instancetype revision",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return kubeVirtMachine(t, &kubevirtv1.InstancetypeMatcher{Name: "h200-worker", RevisionName: "h200-worker-v1"}, "kubeconfig")
+			},
+			namespace:   "tenant-a",
+			errorString: "revisionName is not supported",
+		},
+		{
+			name: "instancetype inferred from volume",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return kubeVirtMachine(t, &kubevirtv1.InstancetypeMatcher{InferFromVolume: "rootdisk"}, "kubeconfig")
+			},
+			namespace:   "tenant-a",
+			errorString: "inference from volume is not supported",
+		},
+		{
+			name: "instancetype inference failure policy",
+			machine: func(t *testing.T) *clusterv1alpha1.Machine {
+				return kubeVirtMachine(t, &kubevirtv1.InstancetypeMatcher{
+					Name:                         "h200-worker",
+					InferFromVolumeFailurePolicy: &inferFailurePolicy,
+				}, "kubeconfig")
+			},
+			namespace:   "tenant-a",
+			errorString: "inference failure policy is not supported",
+		},
+		{
+			name:        "missing infrastructure namespace",
+			machine:     func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, matcher, "kubeconfig") },
+			errorString: "no infrastructure namespace configured",
+		},
+		{
+			name:        "missing kubeconfig",
+			machine:     func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, matcher, "") },
+			namespace:   "tenant-a",
+			errorString: "value is empty",
+		},
+		{
+			name:        "resolver error",
+			machine:     func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, matcher, "kubeconfig") },
+			namespace:   "tenant-a",
+			resolverErr: errors.New("collision"),
+			errorString: "collision",
+		},
+		{
+			name:           "nil resolver result",
+			machine:        func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, matcher, "kubeconfig") },
+			namespace:      "tenant-a",
+			resolverResult: nil,
+			errorString:    "resolver returned no result",
+		},
+		{
+			name:      "invalid resolved resource quantity",
+			machine:   func(t *testing.T) *clusterv1alpha1.Machine { return kubeVirtMachine(t, matcher, "kubeconfig") },
+			namespace: "tenant-a",
+			resolverResult: &kubevirtprovider.ResolvedInstanceType{DeviceResources: corev1.ResourceList{
+				"nvidia.com/H200": resource.MustParse("500m"),
+			}},
+			errorString: "whole-number quantity",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			machine := tc.machine(t)
+			mutator := NewMutator(ctrlruntimefakeclient.NewClientBuilder().Build(), tc.namespace)
+			mutator.resolveInstanceType = func(context.Context, string, string, *kubevirtv1.InstancetypeMatcher) (*kubevirtprovider.ResolvedInstanceType, error) {
+				if tc.resolverErr != nil {
+					return nil, tc.resolverErr
+				}
+				return tc.resolverResult, nil
+			}
+
+			err := mutator.Default(context.Background(), machine)
+			if err == nil {
+				t.Fatal("Default() expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.errorString) {
+				t.Fatalf("Default() error = %q, want substring %q", err, tc.errorString)
+			}
+			if machine.Annotations != nil {
+				if _, exists := machine.Annotations[accelerator.FootprintAnnotationKey]; exists {
+					t.Fatal("failed mutation left a footprint annotation")
+				}
+			}
+		})
+	}
+}
+
+func machineWithProviderConfig(t *testing.T, provider providerconfig.CloudProvider, cloudProviderSpec any) *clusterv1alpha1.Machine {
+	t.Helper()
+	rawCloudProviderSpec, err := json.Marshal(cloudProviderSpec)
+	if err != nil {
+		t.Fatalf("failed to marshal cloud provider config: %v", err)
+	}
+	rawProviderSpec, err := json.Marshal(providerconfig.Config{
+		CloudProvider:     provider,
+		CloudProviderSpec: runtime.RawExtension{Raw: rawCloudProviderSpec},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal provider config: %v", err)
+	}
+
+	return &clusterv1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: metav1.NamespaceSystem},
+		Spec: clusterv1alpha1.MachineSpec{ProviderSpec: clusterv1alpha1.ProviderSpec{
+			Value: &runtime.RawExtension{Raw: rawProviderSpec},
+		}},
+	}
+}
+
+func kubeVirtMachine(t *testing.T, matcher *kubevirtv1.InstancetypeMatcher, kubeconfig string) *clusterv1alpha1.Machine {
+	t.Helper()
+	return machineWithProviderConfig(t, providerconfig.CloudProviderKubeVirt, kubevirttypes.RawConfig{
+		Auth: kubevirttypes.Auth{Kubeconfig: providerconfig.ConfigVarString{Value: kubeconfig}},
+		VirtualMachine: kubevirttypes.VirtualMachine{
+			Instancetype: matcher,
+		},
+	})
+}
+
+func malformedMachine() *clusterv1alpha1.Machine {
+	return &clusterv1alpha1.Machine{Spec: clusterv1alpha1.MachineSpec{
+		ProviderSpec: clusterv1alpha1.ProviderSpec{Value: &runtime.RawExtension{Raw: []byte(`not-json`)}},
+	}}
+}
+
+func decodeMachineFootprint(t *testing.T, machine *clusterv1alpha1.Machine) accelerator.Footprint {
+	t.Helper()
+	value, exists := machine.Annotations[accelerator.FootprintAnnotationKey]
+	if !exists {
+		t.Fatal("Machine has no accelerator footprint annotation")
+	}
+	footprint, err := accelerator.Decode(value)
+	if err != nil {
+		t.Fatalf("failed to decode Machine footprint: %v", err)
+	}
+	return footprint
+}
+
+func assertQuantity(t *testing.T, resources corev1.ResourceList, name corev1.ResourceName, expected string) {
+	t.Helper()
+	quantity, exists := resources[name]
+	if !exists {
+		t.Fatalf("resource %q is missing", name)
+	}
+	if quantity.Cmp(resource.MustParse(expected)) != 0 {
+		t.Fatalf("resource %q quantity = %s, want %s", name, quantity.String(), expected)
+	}
+}

--- a/pkg/webhook/machine/validation/accelerator.go
+++ b/pkg/webhook/machine/validation/accelerator.go
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package acceleratorvalidation protects KKP-owned Machine accelerator accounting metadata.
-package acceleratorvalidation
+package validation
 
 import (
 	"context"
@@ -31,19 +30,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// Validator validates the trusted accelerator accounting contract on Machines.
-type Validator struct{}
+// acceleratorValidator validates the trusted accelerator accounting contract on Machines.
+type acceleratorValidator struct{}
 
-// NewValidator returns a Machine accelerator accounting validator.
-func NewValidator() *Validator {
-	return &Validator{}
+// NewAcceleratorValidator returns a Machine accelerator accounting validator.
+func NewAcceleratorValidator() *acceleratorValidator {
+	return &acceleratorValidator{}
 }
 
-var _ admission.Validator[*clusterv1alpha1.Machine] = &Validator{}
+var _ admission.Validator[*clusterv1alpha1.Machine] = &acceleratorValidator{}
 
 // ValidateCreate ensures that only the KKP-generated KubeVirt footprint is stored under the
 // reserved accelerator annotation prefix.
-func (v *Validator) ValidateCreate(_ context.Context, machine *clusterv1alpha1.Machine) (admission.Warnings, error) {
+func (v *acceleratorValidator) ValidateCreate(_ context.Context, machine *clusterv1alpha1.Machine) (admission.Warnings, error) {
 	config, err := providerconfig.GetConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read machine.spec.providerSpec while validating accelerator footprint: %w", err)
@@ -79,9 +78,9 @@ func (v *Validator) ValidateCreate(_ context.Context, machine *clusterv1alpha1.M
 	return nil, nil
 }
 
-// ValidateUpdate keeps the footprint and its source Machine intent immutable. This check remains
-// authoritative even when machine-controller's one-shot spec-mutation bypass annotation is used.
-func (v *Validator) ValidateUpdate(_ context.Context, oldMachine, newMachine *clusterv1alpha1.Machine) (admission.Warnings, error) {
+// ValidateUpdate keeps the footprint and its source Machine intent immutable, except for
+// machine-controller's one-time migration from the removed providerConfig field.
+func (v *acceleratorValidator) ValidateUpdate(_ context.Context, oldMachine, newMachine *clusterv1alpha1.Machine) (admission.Warnings, error) {
 	oldReserved := reservedAnnotations(oldMachine.Annotations)
 	newReserved := reservedAnnotations(newMachine.Annotations)
 	if !maps.Equal(oldReserved, newReserved) {
@@ -89,6 +88,9 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldMachine, newMachine *cl
 	}
 
 	if apiequality.Semantic.DeepEqual(oldMachine.Spec.ProviderSpec, newMachine.Spec.ProviderSpec) {
+		return nil, nil
+	}
+	if isLegacyProviderConfigMigration(oldMachine, newMachine, oldReserved, newReserved) {
 		return nil, nil
 	}
 
@@ -103,7 +105,31 @@ func (v *Validator) ValidateUpdate(_ context.Context, oldMachine, newMachine *cl
 	return nil, nil
 }
 
-func (v *Validator) ValidateDelete(_ context.Context, _ *clusterv1alpha1.Machine) (admission.Warnings, error) {
+func isLegacyProviderConfigMigration(oldMachine, newMachine *clusterv1alpha1.Machine, oldReserved, newReserved map[string]string) bool {
+	if len(oldReserved) != 0 || len(newReserved) != 0 {
+		return false
+	}
+
+	oldProviderSpec := oldMachine.Spec.ProviderSpec
+	if oldProviderSpec.Value != nil || oldProviderSpec.ValueFrom != nil {
+		return false
+	}
+
+	newProviderSpec := newMachine.Spec.ProviderSpec
+	if newProviderSpec.Value == nil || len(newProviderSpec.Value.Raw) == 0 || newProviderSpec.ValueFrom != nil {
+		return false
+	}
+
+	// machine-controller validates its one-shot providerConfig migration bypass in a
+	// mutating webhook and removes the annotation before validating webhooks run. The
+	// empty-to-valid ProviderSpec transition is therefore the remaining migration shape.
+	// It does not add a footprint; accounting readiness continues to classify the Machine
+	// as legacy until it is recreated through CREATE admission.
+	_, err := providerconfig.GetConfig(newProviderSpec)
+	return err == nil
+}
+
+func (v *acceleratorValidator) ValidateDelete(_ context.Context, _ *clusterv1alpha1.Machine) (admission.Warnings, error) {
 	return nil, nil
 }
 

--- a/pkg/webhook/machine/validation/accelerator_test.go
+++ b/pkg/webhook/machine/validation/accelerator_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package acceleratorvalidation
+package validation
 
 import (
 	"context"
@@ -103,7 +103,7 @@ func TestValidateCreate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			machine := tc.machine(t)
 			machine.Annotations = tc.annotations
-			_, err := NewValidator().ValidateCreate(context.Background(), machine)
+			_, err := NewAcceleratorValidator().ValidateCreate(context.Background(), machine)
 			assertErrorContains(t, err, tc.errorString)
 		})
 	}
@@ -181,16 +181,25 @@ func TestValidateUpdateProtectsFootprintAndProviderSpec(t *testing.T) {
 			errorString: "spec.providerSpec is immutable for accelerator accounting",
 		},
 		{
-			name: "legacy KubeVirt Machine cannot change providerSpec through bypass",
-			oldMachine: func(t *testing.T) *clusterv1alpha1.Machine {
-				return kubeVirtMachine(t, "h200-v1")
+			name: "legacy providerConfig migration to KubeVirt ProviderSpec is allowed after bypass consumption",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine {
+				return &clusterv1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: metav1.NamespaceSystem},
+				}
 			},
 			mutate: func(t *testing.T, machine *clusterv1alpha1.Machine) {
-				machine.Spec.ProviderSpec = kubeVirtMachine(t, "h200-v2").Spec.ProviderSpec
-				if machine.Annotations == nil {
-					machine.Annotations = map[string]string{}
+				machine.Spec.ProviderSpec = kubeVirtMachine(t, "h200-v1").Spec.ProviderSpec
+			},
+		},
+		{
+			name: "legacy providerConfig migration to malformed ProviderSpec is rejected",
+			oldMachine: func(*testing.T) *clusterv1alpha1.Machine {
+				return &clusterv1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: metav1.NamespaceSystem},
 				}
-				machine.Annotations["kubermatic.io/bypass-no-spec-mutation-requirement"] = "true"
+			},
+			mutate: func(_ *testing.T, machine *clusterv1alpha1.Machine) {
+				machine.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: []byte(`not-json`)}
 			},
 			errorString: "spec.providerSpec is immutable for accelerator accounting",
 		},
@@ -230,7 +239,7 @@ func TestValidateUpdateProtectsFootprintAndProviderSpec(t *testing.T) {
 			newMachine := oldMachine.DeepCopy()
 			tc.mutate(t, newMachine)
 
-			_, err := NewValidator().ValidateUpdate(context.Background(), oldMachine, newMachine)
+			_, err := NewAcceleratorValidator().ValidateUpdate(context.Background(), oldMachine, newMachine)
 			assertErrorContains(t, err, tc.errorString)
 		})
 	}

--- a/pkg/webhook/resourcequota/validation/validation.go
+++ b/pkg/webhook/resourcequota/validation/validation.go
@@ -18,35 +18,224 @@ package validation
 
 import (
 	"context"
+	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/resources"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // validator for validating Resource Quota CRD.
 type validator struct {
-	client ctrlruntimeclient.Client
+	client   ctrlruntimeclient.Client
+	features features.FeatureGate
 }
 
 // NewValidator returns a new Resource Quota validator.
-func NewValidator(client ctrlruntimeclient.Client) *validator {
+func NewValidator(client ctrlruntimeclient.Client, enabledFeatures features.FeatureGate) *validator {
 	return &validator{
-		client: client,
+		client:   client,
+		features: enabledFeatures,
 	}
 }
 
+type acceleratorAccountingValidator struct {
+	*validator
+}
+
+// NewAcceleratorAccountingValidator returns a validator for the dedicated,
+// fail-closed accelerator-accounting admission path.
+func NewAcceleratorAccountingValidator(client ctrlruntimeclient.Client, enabledFeatures features.FeatureGate) *acceleratorAccountingValidator {
+	return &acceleratorAccountingValidator{validator: NewValidator(client, enabledFeatures)}
+}
+
 var _ admission.Validator[*kubermaticv1.ResourceQuota] = &validator{}
+var _ admission.Validator[*kubermaticv1.ResourceQuota] = &acceleratorAccountingValidator{}
 
 func (v *validator) ValidateCreate(ctx context.Context, obj *kubermaticv1.ResourceQuota) (admission.Warnings, error) {
+	if err := validateAccountingCreate(obj); err != nil {
+		return nil, err
+	}
+
 	return nil, validateCreate(ctx, obj, v.client)
 }
 
+func (v *acceleratorAccountingValidator) ValidateCreate(_ context.Context, obj *kubermaticv1.ResourceQuota) (admission.Warnings, error) {
+	return nil, validateAccountingCreate(obj)
+}
+
+func validateAccountingCreate(obj *kubermaticv1.ResourceQuota) error {
+	if obj != nil {
+		if _, exists := obj.Annotations[resources.AcceleratorAccountingEnabledAnnotation]; exists {
+			return fmt.Errorf("ResourceQuota annotation %q cannot be set during creation; wait for the ResourceQuota controllers to prepare the object before enabling accelerator accounting", resources.AcceleratorAccountingEnabledAnnotation)
+		}
+	}
+	return nil
+}
+
 func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj *kubermaticv1.ResourceQuota) (admission.Warnings, error) {
+	if oldObj != nil && newObj != nil {
+		if err := v.validateAccountingUpdate(ctx, oldObj, newObj); err != nil {
+			return nil, err
+		}
+	}
+
 	return nil, validateUpdate(ctx, oldObj, newObj)
 }
 
+func (v *acceleratorAccountingValidator) ValidateUpdate(ctx context.Context, oldObj, newObj *kubermaticv1.ResourceQuota) (admission.Warnings, error) {
+	if oldObj != nil && newObj != nil {
+		return nil, v.validateAccountingUpdate(ctx, oldObj, newObj)
+	}
+	return nil, nil
+}
+
 func (v *validator) ValidateDelete(ctx context.Context, obj *kubermaticv1.ResourceQuota) (admission.Warnings, error) {
+	if err := v.validateAccountingDelete(ctx, obj); err != nil {
+		return nil, err
+	}
+
 	return nil, validateDelete(ctx, obj, v.client)
+}
+
+func (v *acceleratorAccountingValidator) ValidateDelete(ctx context.Context, obj *kubermaticv1.ResourceQuota) (admission.Warnings, error) {
+	return nil, v.validateAccountingDelete(ctx, obj)
+}
+
+func (v *validator) validateAccountingDelete(ctx context.Context, obj *kubermaticv1.ResourceQuota) error {
+	if obj != nil && obj.Annotations[resources.AcceleratorAccountingEnabledAnnotation] == resources.AcceleratorAccountingEnabledAnnotationValue {
+		project := &kubermaticv1.Project{}
+		if err := v.client.Get(ctx, types.NamespacedName{Name: obj.Spec.Subject.Name}, project); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to get ResourceQuota project %q: %w", obj.Spec.Subject.Name, err)
+			}
+		} else if project.DeletionTimestamp.IsZero() && project.Status.Phase != kubermaticv1.ProjectTerminating {
+			return fmt.Errorf("activated ResourceQuota %q cannot be deleted while project %q is active", obj.Name, project.Name)
+		}
+	}
+	return nil
+}
+
+func (v *validator) validateAccountingUpdate(ctx context.Context, oldQuota, newQuota *kubermaticv1.ResourceQuota) error {
+	oldValue, oldHasAnnotation := oldQuota.Annotations[resources.AcceleratorAccountingEnabledAnnotation]
+	newValue, newHasAnnotation := newQuota.Annotations[resources.AcceleratorAccountingEnabledAnnotation]
+	// Once deletion has started, leave the existing lifecycle controllers free
+	// to finish their normal cleanup updates.
+	if !newQuota.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	if oldHasAnnotation {
+		if oldValue == resources.AcceleratorAccountingEnabledAnnotationValue {
+			if !newHasAnnotation || newValue != resources.AcceleratorAccountingEnabledAnnotationValue {
+				return fmt.Errorf("ResourceQuota annotation %q is immutable once accelerator accounting is enabled", resources.AcceleratorAccountingEnabledAnnotation)
+			}
+			if err := validateAcceleratorAccountingResourceQuota(newQuota); err != nil {
+				return err
+			}
+			oldOwner := metav1.GetControllerOf(oldQuota)
+			newOwner := metav1.GetControllerOf(newQuota)
+			if !sameOwnerReference(oldOwner, newOwner) {
+				return fmt.Errorf("ResourceQuota must retain its project controller owner reference while accelerator accounting is enabled")
+			}
+			if oldQuota.Spec.Subject != newQuota.Spec.Subject {
+				return fmt.Errorf("ResourceQuota project subject is immutable while accelerator accounting is enabled")
+			}
+			if newOwner == nil || newOwner.Name != newQuota.Spec.Subject.Name || newOwner.Kind != kubermaticv1.ProjectKindName {
+				return fmt.Errorf("ResourceQuota must retain a controller owner reference matching its project subject while accelerator accounting is enabled")
+			}
+			if !hasMatchingSubjectLabels(newQuota) {
+				return fmt.Errorf("ResourceQuota must retain subject labels matching its project while accelerator accounting is enabled")
+			}
+			if len(newQuota.Spec.Quota.Accelerators) != 0 {
+				return fmt.Errorf("ResourceQuota accelerator limits cannot be configured until accelerator accounting readiness and enforcement are implemented")
+			}
+			return nil
+		}
+
+		// The webhook never permits creating a non-canonical value. Still allow such a
+		// value, if it was written while the webhook was unavailable, to be removed.
+		if newHasAnnotation {
+			return fmt.Errorf("ResourceQuota annotation %q has invalid value %q; remove it before enabling accelerator accounting", resources.AcceleratorAccountingEnabledAnnotation, oldValue)
+		}
+		return nil
+	}
+
+	if !newHasAnnotation {
+		return nil
+	}
+	if newValue != resources.AcceleratorAccountingEnabledAnnotationValue {
+		return fmt.Errorf("ResourceQuota annotation %q must have the exact value %q", resources.AcceleratorAccountingEnabledAnnotation, resources.AcceleratorAccountingEnabledAnnotationValue)
+	}
+	if !acceleratorAccountingSupported() {
+		return fmt.Errorf("ResourceQuota accelerator accounting activation is only supported in Kubermatic Enterprise Edition")
+	}
+	if !v.features.Enabled(features.KubeVirtAcceleratorQuota) {
+		return fmt.Errorf("ResourceQuota annotation %q requires the %q feature gate", resources.AcceleratorAccountingEnabledAnnotation, features.KubeVirtAcceleratorQuota)
+	}
+	if newQuota.Spec.Subject.Kind != kubermaticv1.ProjectSubjectKind {
+		return fmt.Errorf("ResourceQuota annotation %q is only supported for project quotas", resources.AcceleratorAccountingEnabledAnnotation)
+	}
+	if err := validateAcceleratorAccountingResourceQuota(oldQuota); err != nil {
+		return err
+	}
+	if err := validateAcceleratorAccountingResourceQuota(newQuota); err != nil {
+		return err
+	}
+	if len(newQuota.Spec.Quota.Accelerators) != 0 {
+		return fmt.Errorf("ResourceQuota accelerator limits must be empty when enabling accelerator accounting; enable accounting first, then configure accelerator limits")
+	}
+	if !hasMatchingSubjectLabels(oldQuota) {
+		return fmt.Errorf("ResourceQuota must already have subject labels matching its project before accelerator accounting can be enabled")
+	}
+	if !hasMatchingSubjectLabels(newQuota) {
+		return fmt.Errorf("ResourceQuota must retain subject labels matching its project when accelerator accounting is enabled")
+	}
+
+	project := &kubermaticv1.Project{}
+	if err := v.client.Get(ctx, types.NamespacedName{Name: newQuota.Spec.Subject.Name}, project); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("cannot enable accelerator accounting: project %q does not exist", newQuota.Spec.Subject.Name)
+		}
+		return fmt.Errorf("failed to get ResourceQuota project %q: %w", newQuota.Spec.Subject.Name, err)
+	}
+	if !project.DeletionTimestamp.IsZero() || project.Status.Phase == kubermaticv1.ProjectTerminating {
+		return fmt.Errorf("cannot enable accelerator accounting while project %q is terminating", project.Name)
+	}
+	if !hasMatchingProjectControllerReference(oldQuota, project) {
+		return fmt.Errorf("ResourceQuota must already have a controller owner reference matching project %q before accelerator accounting can be enabled", project.Name)
+	}
+	if !hasMatchingProjectControllerReference(newQuota, project) {
+		return fmt.Errorf("ResourceQuota must retain its controller owner reference to project %q when accelerator accounting is enabled", project.Name)
+	}
+
+	return nil
+}
+
+func hasMatchingProjectControllerReference(quota *kubermaticv1.ResourceQuota, project *kubermaticv1.Project) bool {
+	owner := metav1.GetControllerOf(quota)
+	return owner != nil &&
+		owner.APIVersion == kubermaticv1.SchemeGroupVersion.String() &&
+		owner.Kind == kubermaticv1.ProjectKindName &&
+		owner.Name == project.Name &&
+		owner.UID == project.UID
+}
+
+func sameOwnerReference(oldOwner, newOwner *metav1.OwnerReference) bool {
+	return oldOwner != nil && newOwner != nil &&
+		oldOwner.APIVersion == newOwner.APIVersion &&
+		oldOwner.Kind == newOwner.Kind &&
+		oldOwner.Name == newOwner.Name &&
+		oldOwner.UID == newOwner.UID
+}
+
+func hasMatchingSubjectLabels(quota *kubermaticv1.ResourceQuota) bool {
+	return quota.Labels[kubermaticv1.ResourceQuotaSubjectNameLabelKey] == quota.Spec.Subject.Name &&
+		quota.Labels[kubermaticv1.ResourceQuotaSubjectKindLabelKey] == quota.Spec.Subject.Kind
 }

--- a/pkg/webhook/resourcequota/validation/validation.go
+++ b/pkg/webhook/resourcequota/validation/validation.go
@@ -133,30 +133,7 @@ func (v *validator) validateAccountingUpdate(ctx context.Context, oldQuota, newQ
 
 	if oldHasAnnotation {
 		if oldValue == resources.AcceleratorAccountingEnabledAnnotationValue {
-			if !newHasAnnotation || newValue != resources.AcceleratorAccountingEnabledAnnotationValue {
-				return fmt.Errorf("ResourceQuota annotation %q is immutable once accelerator accounting is enabled", resources.AcceleratorAccountingEnabledAnnotation)
-			}
-			if err := validateAcceleratorAccountingResourceQuota(newQuota); err != nil {
-				return err
-			}
-			oldOwner := metav1.GetControllerOf(oldQuota)
-			newOwner := metav1.GetControllerOf(newQuota)
-			if !sameOwnerReference(oldOwner, newOwner) {
-				return fmt.Errorf("ResourceQuota must retain its project controller owner reference while accelerator accounting is enabled")
-			}
-			if oldQuota.Spec.Subject != newQuota.Spec.Subject {
-				return fmt.Errorf("ResourceQuota project subject is immutable while accelerator accounting is enabled")
-			}
-			if newOwner == nil || newOwner.Name != newQuota.Spec.Subject.Name || newOwner.Kind != kubermaticv1.ProjectKindName {
-				return fmt.Errorf("ResourceQuota must retain a controller owner reference matching its project subject while accelerator accounting is enabled")
-			}
-			if !hasMatchingSubjectLabels(newQuota) {
-				return fmt.Errorf("ResourceQuota must retain subject labels matching its project while accelerator accounting is enabled")
-			}
-			if len(newQuota.Spec.Quota.Accelerators) != 0 {
-				return fmt.Errorf("ResourceQuota accelerator limits cannot be configured until accelerator accounting readiness and enforcement are implemented")
-			}
-			return nil
+			return validateEnabledAcceleratorAccountingUpdate(oldQuota, newQuota, newValue, newHasAnnotation)
 		}
 
 		// The webhook never permits creating a non-canonical value. Still allow such a
@@ -170,6 +147,37 @@ func (v *validator) validateAccountingUpdate(ctx context.Context, oldQuota, newQ
 	if !newHasAnnotation {
 		return nil
 	}
+	return v.validateAcceleratorAccountingActivation(ctx, oldQuota, newQuota, newValue)
+}
+
+func validateEnabledAcceleratorAccountingUpdate(oldQuota, newQuota *kubermaticv1.ResourceQuota, newValue string, newHasAnnotation bool) error {
+	if !newHasAnnotation || newValue != resources.AcceleratorAccountingEnabledAnnotationValue {
+		return fmt.Errorf("ResourceQuota annotation %q is immutable once accelerator accounting is enabled", resources.AcceleratorAccountingEnabledAnnotation)
+	}
+	if err := validateAcceleratorAccountingResourceQuota(newQuota); err != nil {
+		return err
+	}
+	oldOwner := metav1.GetControllerOf(oldQuota)
+	newOwner := metav1.GetControllerOf(newQuota)
+	if !sameOwnerReference(oldOwner, newOwner) {
+		return fmt.Errorf("ResourceQuota must retain its project controller owner reference while accelerator accounting is enabled")
+	}
+	if oldQuota.Spec.Subject != newQuota.Spec.Subject {
+		return fmt.Errorf("ResourceQuota project subject is immutable while accelerator accounting is enabled")
+	}
+	if newOwner == nil || newOwner.Name != newQuota.Spec.Subject.Name || newOwner.Kind != kubermaticv1.ProjectKindName {
+		return fmt.Errorf("ResourceQuota must retain a controller owner reference matching its project subject while accelerator accounting is enabled")
+	}
+	if !hasMatchingSubjectLabels(newQuota) {
+		return fmt.Errorf("ResourceQuota must retain subject labels matching its project while accelerator accounting is enabled")
+	}
+	if len(newQuota.Spec.Quota.Accelerators) != 0 {
+		return fmt.Errorf("ResourceQuota accelerator limits cannot be configured until accelerator accounting readiness and enforcement are implemented")
+	}
+	return nil
+}
+
+func (v *validator) validateAcceleratorAccountingActivation(ctx context.Context, oldQuota, newQuota *kubermaticv1.ResourceQuota, newValue string) error {
 	if newValue != resources.AcceleratorAccountingEnabledAnnotationValue {
 		return fmt.Errorf("ResourceQuota annotation %q must have the exact value %q", resources.AcceleratorAccountingEnabledAnnotation, resources.AcceleratorAccountingEnabledAnnotationValue)
 	}

--- a/pkg/webhook/resourcequota/validation/validation_test.go
+++ b/pkg/webhook/resourcequota/validation/validation_test.go
@@ -1,0 +1,500 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	testProjectName = "project-id"
+	testProjectUID  = types.UID("project-uid")
+)
+
+type accountingValidatorRoute struct {
+	name      string
+	validator admission.Validator[*kubermaticv1.ResourceQuota]
+}
+
+func accountingValidatorRoutes(client ctrlruntimeclient.Client, enabledFeatures features.FeatureGate) []accountingValidatorRoute {
+	return []accountingValidatorRoute{
+		{name: "general route", validator: NewValidator(client, enabledFeatures)},
+		{name: "dedicated route", validator: NewAcceleratorAccountingValidator(client, enabledFeatures)},
+	}
+}
+
+func TestAccountingAnnotationRejectedOnCreate(t *testing.T) {
+	validator := NewValidator(fake.NewClientBuilder().Build(), features.FeatureGate{
+		features.KubeVirtAcceleratorQuota: true,
+	})
+
+	for _, value := range []string{resources.AcceleratorAccountingEnabledAnnotationValue, "false", ""} {
+		t.Run("value="+value, func(t *testing.T) {
+			quota := testResourceQuota(testProject())
+			quota.Annotations = map[string]string{resources.AcceleratorAccountingEnabledAnnotation: value}
+
+			_, err := validator.ValidateCreate(context.Background(), quota)
+			assertErrorContains(t, err, "cannot be set during creation")
+		})
+	}
+}
+
+func TestDedicatedAccountingValidatorRejectsAnnotatedCreate(t *testing.T) {
+	validator := NewAcceleratorAccountingValidator(fake.NewClientBuilder().Build(), features.FeatureGate{
+		features.KubeVirtAcceleratorQuota: true,
+	})
+	quota := testResourceQuota(testProject())
+	quota.Annotations = map[string]string{resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue}
+
+	_, err := validator.ValidateCreate(context.Background(), quota)
+	assertErrorContains(t, err, "cannot be set during creation")
+}
+
+func TestAccountingActivationUpdate(t *testing.T) {
+	if !acceleratorAccountingSupported() {
+		project := testProject()
+		oldQuota := testResourceQuota(project)
+		newQuota := oldQuota.DeepCopy()
+		newQuota.Annotations = map[string]string{
+			resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+		}
+
+		client := fake.NewClientBuilder().WithObjects(project).Build()
+		enabledFeatures := features.FeatureGate{
+			features.KubeVirtAcceleratorQuota: true,
+		}
+		for _, route := range accountingValidatorRoutes(client, enabledFeatures) {
+			t.Run(route.name, func(t *testing.T) {
+				_, err := route.validator.ValidateUpdate(context.Background(), oldQuota, newQuota)
+				assertErrorContains(t, err, "only supported in Kubermatic Enterprise Edition")
+			})
+		}
+		return
+	}
+
+	testCases := []struct {
+		name           string
+		featureEnabled bool
+		missingProject bool
+		mutateProject  func(*kubermaticv1.Project)
+		mutateOld      func(*kubermaticv1.ResourceQuota)
+		mutateNew      func(*kubermaticv1.ResourceQuota)
+		errorContains  string
+	}{
+		{
+			name:           "prepared project quota is activated",
+			featureEnabled: true,
+		},
+		{
+			name:           "annotation value must be exact",
+			featureEnabled: true,
+			mutateNew: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Annotations[resources.AcceleratorAccountingEnabledAnnotation] = "True"
+			},
+			errorContains: "must have the exact value",
+		},
+		{
+			name:          "feature gate is required",
+			errorContains: "feature gate",
+		},
+		{
+			name:           "only project quota is supported",
+			featureEnabled: true,
+			mutateOld: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Spec.Subject.Kind = "seed"
+			},
+			mutateNew: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Spec.Subject.Kind = "seed"
+			},
+			errorContains: "only supported for project quotas",
+		},
+		{
+			name:           "default-managed project quota must be detached before activation",
+			featureEnabled: true,
+			mutateOld: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Labels["kkp-default-resource-quota"] = "true"
+			},
+			mutateNew: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Labels["kkp-default-resource-quota"] = "true"
+			},
+			errorContains: "default-managed ResourceQuota",
+		},
+		{
+			name:           "default-management label removal and activation must be separate updates",
+			featureEnabled: true,
+			mutateOld: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Labels["kkp-default-resource-quota"] = "true"
+			},
+			errorContains: "default-managed ResourceQuota",
+		},
+		{
+			name:           "accelerator limits must initially be empty",
+			featureEnabled: true,
+			mutateNew: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Spec.Quota.Accelerators = testAcceleratorQuota()
+			},
+			errorContains: "accelerator limits must be empty",
+		},
+		{
+			name:           "project must exist",
+			featureEnabled: true,
+			missingProject: true,
+			errorContains:  "does not exist",
+		},
+		{
+			name:           "project phase must not be terminating",
+			featureEnabled: true,
+			mutateProject: func(project *kubermaticv1.Project) {
+				project.Status.Phase = kubermaticv1.ProjectTerminating
+			},
+			errorContains: "project \"project-id\" is terminating",
+		},
+		{
+			name:           "deleting project is terminating even before phase update",
+			featureEnabled: true,
+			mutateProject: func(project *kubermaticv1.Project) {
+				now := metav1.Now()
+				project.DeletionTimestamp = &now
+				project.Finalizers = []string{"test.kubermatic.io/project-cleanup"}
+			},
+			errorContains: "project \"project-id\" is terminating",
+		},
+		{
+			name:           "subject labels must already match",
+			featureEnabled: true,
+			mutateOld: func(quota *kubermaticv1.ResourceQuota) {
+				delete(quota.Labels, kubermaticv1.ResourceQuotaSubjectNameLabelKey)
+			},
+			errorContains: "must already have subject labels",
+		},
+		{
+			name:           "subject labels must be retained",
+			featureEnabled: true,
+			mutateNew: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Labels[kubermaticv1.ResourceQuotaSubjectKindLabelKey] = "other"
+			},
+			errorContains: "must retain subject labels",
+		},
+		{
+			name:           "project controller owner must already exist",
+			featureEnabled: true,
+			mutateOld: func(quota *kubermaticv1.ResourceQuota) {
+				quota.OwnerReferences = nil
+			},
+			errorContains: "must already have a controller owner reference",
+		},
+		{
+			name:           "project controller owner must be retained",
+			featureEnabled: true,
+			mutateNew: func(quota *kubermaticv1.ResourceQuota) {
+				quota.OwnerReferences = nil
+			},
+			errorContains: "must retain its controller owner reference",
+		},
+		{
+			name:           "owner UID must match live project",
+			featureEnabled: true,
+			mutateOld: func(quota *kubermaticv1.ResourceQuota) {
+				quota.OwnerReferences[0].UID = "different-project-uid"
+			},
+			errorContains: "must already have a controller owner reference",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			project := testProject()
+			if tc.mutateProject != nil {
+				tc.mutateProject(project)
+			}
+
+			oldQuota := testResourceQuota(project)
+			newQuota := oldQuota.DeepCopy()
+			newQuota.Annotations = map[string]string{
+				resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+			}
+			if tc.mutateOld != nil {
+				tc.mutateOld(oldQuota)
+			}
+			if tc.mutateNew != nil {
+				tc.mutateNew(newQuota)
+			}
+
+			objects := []ctrlruntimeclient.Object{}
+			if !tc.missingProject {
+				objects = append(objects, project)
+			}
+			client := fake.NewClientBuilder().WithObjects(objects...).Build()
+			enabledFeatures := features.FeatureGate{
+				features.KubeVirtAcceleratorQuota: tc.featureEnabled,
+			}
+
+			for _, route := range accountingValidatorRoutes(client, enabledFeatures) {
+				t.Run(route.name, func(t *testing.T) {
+					_, err := route.validator.ValidateUpdate(context.Background(), oldQuota, newQuota)
+					if tc.errorContains == "" {
+						if err != nil {
+							t.Fatalf("expected activation to succeed, got %v", err)
+						}
+						return
+					}
+					assertErrorContains(t, err, tc.errorContains)
+				})
+			}
+		})
+	}
+}
+
+func TestEnabledAccountingAnnotationIsImmutable(t *testing.T) {
+	oldQuota := testResourceQuota(testProject())
+	oldQuota.Annotations = map[string]string{
+		resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+	}
+
+	type testCase struct {
+		name          string
+		mutate        func(*kubermaticv1.ResourceQuota)
+		errorContains string
+	}
+	testCases := []testCase{
+		{
+			name:   "unchanged annotation remains valid without gate or project lookup",
+			mutate: func(*kubermaticv1.ResourceQuota) {},
+		},
+		{
+			name: "project controller owner cannot be removed",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				quota.OwnerReferences = nil
+			},
+			errorContains: "must retain its project controller owner reference",
+		},
+		{
+			name: "project subject labels cannot be removed",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				delete(quota.Labels, kubermaticv1.ResourceQuotaSubjectNameLabelKey)
+			},
+			errorContains: "must retain subject labels",
+		},
+		{
+			name: "project subject cannot be changed with matching labels",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Spec.Subject.Name = "another-project"
+				quota.Labels[kubermaticv1.ResourceQuotaSubjectNameLabelKey] = "another-project"
+			},
+			errorContains: "project subject is immutable",
+		},
+		{
+			name: "accelerator limits remain unavailable in the capture-only release",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Spec.Quota.Accelerators = testAcceleratorQuota()
+			},
+			errorContains: "readiness and enforcement are implemented",
+		},
+		{
+			name: "annotation cannot be removed",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				delete(quota.Annotations, resources.AcceleratorAccountingEnabledAnnotation)
+			},
+			errorContains: "is immutable once accelerator accounting is enabled",
+		},
+		{
+			name: "annotation cannot be changed",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Annotations[resources.AcceleratorAccountingEnabledAnnotation] = "false"
+			},
+			errorContains: "is immutable once accelerator accounting is enabled",
+		},
+	}
+	if acceleratorAccountingSupported() {
+		testCases = append(testCases, testCase{
+			name: "default-management label cannot be added after activation",
+			mutate: func(quota *kubermaticv1.ResourceQuota) {
+				quota.Labels["kkp-default-resource-quota"] = "true"
+			},
+			errorContains: "default-managed ResourceQuota",
+		})
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, route := range accountingValidatorRoutes(fake.NewClientBuilder().Build(), nil) {
+				t.Run(route.name, func(t *testing.T) {
+					newQuota := oldQuota.DeepCopy()
+					tc.mutate(newQuota)
+
+					_, err := route.validator.ValidateUpdate(context.Background(), oldQuota, newQuota)
+					if tc.errorContains == "" {
+						if err != nil {
+							t.Fatalf("expected update to succeed, got %v", err)
+						}
+						return
+					}
+					assertErrorContains(t, err, tc.errorContains)
+				})
+			}
+		})
+	}
+}
+
+func TestMalformedAccountingAnnotationCanOnlyBeRemoved(t *testing.T) {
+	for _, route := range accountingValidatorRoutes(fake.NewClientBuilder().Build(), nil) {
+		t.Run(route.name, func(t *testing.T) {
+			oldQuota := testResourceQuota(testProject())
+			oldQuota.Annotations = map[string]string{resources.AcceleratorAccountingEnabledAnnotation: "false"}
+
+			unchanged := oldQuota.DeepCopy()
+			_, err := route.validator.ValidateUpdate(context.Background(), oldQuota, unchanged)
+			assertErrorContains(t, err, "has invalid value")
+
+			removed := oldQuota.DeepCopy()
+			delete(removed.Annotations, resources.AcceleratorAccountingEnabledAnnotation)
+			if _, err := route.validator.ValidateUpdate(context.Background(), oldQuota, removed); err != nil {
+				t.Fatalf("expected invalid annotation removal to succeed, got %v", err)
+			}
+
+			deleting := oldQuota.DeepCopy()
+			now := metav1.Now()
+			deleting.DeletionTimestamp = &now
+			if _, err := route.validator.ValidateUpdate(context.Background(), oldQuota, deleting); err != nil {
+				t.Fatalf("expected deleting malformed quota cleanup to succeed, got %v", err)
+			}
+		})
+	}
+}
+
+func TestActiveAccountingResourceQuotaDelete(t *testing.T) {
+	activeProject := testProject()
+	terminatingProject := testProject()
+	now := metav1.Now()
+	terminatingProject.DeletionTimestamp = &now
+	terminatingProject.Finalizers = []string{"test.kubermatic.io/project-cleanup"}
+
+	testCases := []struct {
+		name          string
+		project       *kubermaticv1.Project
+		errorContains string
+	}{
+		{
+			name:          "active project keeps activation anchor",
+			project:       activeProject,
+			errorContains: "cannot be deleted while project",
+		},
+		{
+			name:    "terminating project may delete activation anchor",
+			project: terminatingProject,
+		},
+		{
+			name: "missing project may finish garbage collection",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			quota := testResourceQuota(testProject())
+			quota.Annotations = map[string]string{
+				resources.AcceleratorAccountingEnabledAnnotation: resources.AcceleratorAccountingEnabledAnnotationValue,
+			}
+			objects := []ctrlruntimeclient.Object{}
+			if tc.project != nil {
+				objects = append(objects, tc.project)
+			}
+			client := fake.NewClientBuilder().WithObjects(objects...).Build()
+			for _, route := range accountingValidatorRoutes(client, nil) {
+				t.Run(route.name, func(t *testing.T) {
+					_, err := route.validator.ValidateDelete(context.Background(), quota)
+					if tc.errorContains == "" {
+						if err != nil {
+							t.Fatalf("expected delete to succeed, got %v", err)
+						}
+						return
+					}
+					assertErrorContains(t, err, tc.errorContains)
+				})
+			}
+		})
+	}
+}
+
+func testProject() *kubermaticv1.Project {
+	return &kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testProjectName,
+			UID:  testProjectUID,
+		},
+		Status: kubermaticv1.ProjectStatus{Phase: kubermaticv1.ProjectActive},
+	}
+}
+
+func testResourceQuota(project *kubermaticv1.Project) *kubermaticv1.ResourceQuota {
+	return &kubermaticv1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "project-quota",
+			Labels: map[string]string{
+				kubermaticv1.ResourceQuotaSubjectNameLabelKey: project.Name,
+				kubermaticv1.ResourceQuotaSubjectKindLabelKey: kubermaticv1.ProjectSubjectKind,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(project, schema.GroupVersionKind{
+					Group:   kubermaticv1.SchemeGroupVersion.Group,
+					Version: kubermaticv1.SchemeGroupVersion.Version,
+					Kind:    kubermaticv1.ProjectKindName,
+				}),
+			},
+		},
+		Spec: kubermaticv1.ResourceQuotaSpec{
+			Subject: kubermaticv1.Subject{
+				Name: project.Name,
+				Kind: kubermaticv1.ProjectSubjectKind,
+			},
+			Quota: kubermaticv1.ResourceDetails{},
+		},
+	}
+}
+
+func testAcceleratorQuota() []kubermaticv1.AcceleratorQuota {
+	return []kubermaticv1.AcceleratorQuota{{
+		Provider: string(kubermaticv1.KubevirtCloudProvider),
+		Resources: corev1.ResourceList{
+			"nvidia.com/GPU": resource.MustParse("1"),
+		},
+	}}
+}
+
+func assertErrorContains(t *testing.T, err error, expected string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", expected)
+	}
+	if !strings.Contains(err.Error(), expected) {
+		t.Fatalf("expected error %q to contain %q", err, expected)
+	}
+}

--- a/pkg/webhook/resourcequota/validation/wrappers_ce.go
+++ b/pkg/webhook/resourcequota/validation/wrappers_ce.go
@@ -26,6 +26,10 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func acceleratorAccountingSupported() bool { return false }
+
+func validateAcceleratorAccountingResourceQuota(_ *kubermaticv1.ResourceQuota) error { return nil }
+
 func validateCreate(_ context.Context,
 	_ *kubermaticv1.ResourceQuota,
 	_ ctrlruntimeclient.Client,

--- a/pkg/webhook/resourcequota/validation/wrappers_ee.go
+++ b/pkg/webhook/resourcequota/validation/wrappers_ee.go
@@ -20,12 +20,23 @@ package validation
 
 import (
 	"context"
+	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	resourcequotadefaultcontroller "k8c.io/kubermatic/v2/pkg/ee/resource-quota/default-quota-controller"
 	eeresourcequotavalidation "k8c.io/kubermatic/v2/pkg/ee/validation/resourcequota"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func acceleratorAccountingSupported() bool { return true }
+
+func validateAcceleratorAccountingResourceQuota(quota *kubermaticv1.ResourceQuota) error {
+	if quota.Labels[resourcequotadefaultcontroller.DefaultProjectResourceQuotaKey] == resourcequotadefaultcontroller.DefaultProjectResourceQuotaValue {
+		return fmt.Errorf("default-managed ResourceQuota %q cannot activate accelerator accounting; remove label %q before activation", quota.Name, resourcequotadefaultcontroller.DefaultProjectResourceQuotaKey)
+	}
+	return nil
+}
 
 func validateCreate(ctx context.Context,
 	obj *kubermaticv1.ResourceQuota,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR capture feature-gated, immutable accelerator footprints from selected KubeVirt instancetypes and validate their accounting intent for future quota enforcement. Considering the feature is in alpha this integration will be scoped to activation to explicitly enabled project ResourceQuotas.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
