### PR TITLE
Grant cluster-autoscaler read access to resource.k8s.io

### DIFF
--- a/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
+++ b/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
@@ -74,6 +74,20 @@ spec:
         - update
         - watch
         - patch
+      # cluster-autoscaler 1.35 and newer always start DRA informers, since
+      # --enable-dynamic-resource-allocation defaults to true and cannot be turned off. Chart 9.46.6
+      # predates that and grants no resource.k8s.io access; upstream added the same rules in chart
+      # 9.54.0, so these can be dropped once the chart is bumped past it.
+      - apiGroups:
+        - resource.k8s.io
+        resources:
+        - deviceclasses
+        - resourceclaims
+        - resourceslices
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

Grants the Cluster Autoscaler read access to `resource.k8s.io`, which cluster-autoscaler 1.35 and newer need at startup because they always run with `--enable-dynamic-resource-allocation`.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The Cluster Autoscaler application now grants the read access to resource.k8s.io that cluster-autoscaler 1.35 and newer require.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
