### PR TITLE
Add cluster-autoscaler chart 9.59.0

### DIFF
--- a/hack/mirror-application-charts.sh
+++ b/hack/mirror-application-charts.sh
@@ -58,7 +58,7 @@ declare -A CHART_URLS=(
 declare -A CHART_VERSIONS=(
   ["agentgateway"]="1.3.1"
   ["agentgateway-crds"]="1.3.1"
-  ["cluster-autoscaler"]="9.46.6"
+  ["cluster-autoscaler"]="9.59.0"
   ["cilium"]="1.19.5"
   # Add more default versions here as needed
   ["aikit"]="0.18.0"
@@ -87,6 +87,9 @@ declare -A CHART_VERSIONS=(
 # postsubmit wrapper; direct script callers can still pass explicit versions.
 declare -A CHART_ADDITIONAL_VERSIONS=(
   ["cilium"]="1.17.17,1.18.11"
+  # 9.46.6 stays listed in the cluster-autoscaler ApplicationDefinition for
+  # installations created before 9.59.0 was offered.
+  ["cluster-autoscaler"]="9.46.6"
 )
 
 # Re-enable unset variable checking after array declarations

--- a/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
+++ b/pkg/applicationdefinitions/system-applications/cluster-autoscaler.yaml
@@ -33,6 +33,13 @@ spec:
             chartVersion: 9.46.6
             url: oci://quay.io/kubermatic-mirror/helm-charts
       version: 1.32.0
+    - template:
+        source:
+          helm:
+            chartName: cluster-autoscaler
+            chartVersion: 9.59.0
+            url: oci://quay.io/kubermatic-mirror/helm-charts
+      version: 1.35.0
   defaultValuesBlock: |
     cloudProvider: clusterapi
     clusterAPIMode: incluster-incluster


### PR DESCRIPTION
**What this PR does / why we need it**:

Offers cluster-autoscaler chart `9.59.0` (appVersion 1.35.0) alongside the existing `9.46.6`, which was published in March 2025 and is 13 chart minors behind the autoscaler images KKP injects.

**Which issue(s) this PR fixes**:
Fixes #16252

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Bump the Cluster Autoscaler Helm chart to 9.59.0
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
https://github.com/kubermatic/kubermatic/issues/16233
```
