### PR TITLE
Update metering to v1.4.1

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.4.0"
+	meteringVersion = "v1.4.1"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the metering image from v1.4.0 to v1.4.1. The v1.4.1 release adds persistent storage usage to the JSON cluster report; no CLI flag or integration changes that affect KKP.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The metering version is upgraded to v1.4.1, adding persistent storage usage to the JSON cluster report.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
