### PR TITLE
[release/v2.30] Update metering to v1.4.1

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.3.1"
+	meteringVersion = "v1.4.1"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of #16268 to `release/v2.30`, where the cherrypick bot failed on a conflict in `pkg/ee/metering/reconcile.go`. Updates the metering image from v1.3.1 to v1.4.1, which also picks up the v1.4.0 toolchain and dependency updates. v1.4.1 adds persistent storage usage to the JSON cluster report; no CLI flag or integration changes affect KKP.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The metering version is upgraded to v1.4.1, adding persistent storage usage to the JSON cluster report.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
