### PR TITLE
Deprecate no-op spec.ingress.className and spec.ingress.disable fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -179,6 +179,9 @@ linters:
         text: "SA1019: .*VMNetName is deprecated"
       - linters:
           - staticcheck
+        text: "SA1019: .*Ingress\\.ClassName is deprecated"
+      - linters:
+          - staticcheck
         text: "SA1019: registry.GetOverwriteFunc is deprecated"
       - linters:
           - staticcheck

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -257,12 +257,13 @@ spec:
       kind: ClusterIssuer
       # Name is the name of resource being referenced
       name: ""
-    # ClassName is the Ingress resource's class name, used for selecting the appropriate
-    # ingress controller.
+    # Deprecated: ClassName is the Ingress resource's class name, used for selecting the appropriate
+    # ingress controller. Gateway API is enforced as of KKP 2.31 and the operator no longer
+    # creates Ingress resources. This field is ignored.
     className: nginx
-    # Disable will prevent an Ingress from being created at all. This is mostly useful
-    # during testing. If the Ingress is disabled, the CertificateIssuer setting can also
-    # be left empty, as no Certificate resource will be created.
+    # Deprecated: Disable will prevent an Ingress from being created at all. This was mostly
+    # useful during testing. Gateway API is enforced as of KKP 2.31 and the operator no longer
+    # creates Ingress resources. This field is ignored.
     disable: false
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -257,12 +257,13 @@ spec:
       kind: ClusterIssuer
       # Name is the name of resource being referenced
       name: ""
-    # ClassName is the Ingress resource's class name, used for selecting the appropriate
-    # ingress controller.
+    # Deprecated: ClassName is the Ingress resource's class name, used for selecting the appropriate
+    # ingress controller. Gateway API is enforced as of KKP 2.31 and the operator no longer
+    # creates Ingress resources. This field is ignored.
     className: nginx
-    # Disable will prevent an Ingress from being created at all. This is mostly useful
-    # during testing. If the Ingress is disabled, the CertificateIssuer setting can also
-    # be left empty, as no Certificate resource will be created.
+    # Deprecated: Disable will prevent an Ingress from being created at all. This was mostly
+    # useful during testing. Gateway API is enforced as of KKP 2.31 and the operator no longer
+    # creates Ingress resources. This field is ignored.
     disable: false
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -1757,14 +1757,15 @@ spec:
                       x-kubernetes-map-type: atomic
                     className:
                       description: |-
-                        ClassName is the Ingress resource's class name, used for selecting the appropriate
-                        ingress controller.
+                        Deprecated: ClassName is the Ingress resource's class name, used for selecting the appropriate
+                        ingress controller. Gateway API is enforced as of KKP 2.31 and the operator no longer
+                        creates Ingress resources. This field is ignored.
                       type: string
                     disable:
                       description: |-
-                        Disable will prevent an Ingress from being created at all. This is mostly useful
-                        during testing. If the Ingress is disabled, the CertificateIssuer setting can also
-                        be left empty, as no Certificate resource will be created.
+                        Deprecated: Disable will prevent an Ingress from being created at all. This was mostly
+                        useful during testing. Gateway API is enforced as of KKP 2.31 and the operator no longer
+                        creates Ingress resources. This field is ignored.
                       type: boolean
                     domain:
                       description: |-

--- a/sdk/apis/kubermatic/v1/configuration.go
+++ b/sdk/apis/kubermatic/v1/configuration.go
@@ -484,16 +484,17 @@ type KubermaticIngressConfiguration struct {
 	// a disabled Ingress, this must always be a valid hostname.
 	Domain string `json:"domain"`
 
-	// ClassName is the Ingress resource's class name, used for selecting the appropriate
-	// ingress controller.
+	// Deprecated: ClassName is the Ingress resource's class name, used for selecting the appropriate
+	// ingress controller. Gateway API is enforced as of KKP 2.31 and the operator no longer
+	// creates Ingress resources. This field is ignored.
 	ClassName string `json:"className,omitempty"`
 
 	// NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
 	NamespaceOverride string `json:"namespaceOverride,omitempty"`
 
-	// Disable will prevent an Ingress from being created at all. This is mostly useful
-	// during testing. If the Ingress is disabled, the CertificateIssuer setting can also
-	// be left empty, as no Certificate resource will be created.
+	// Deprecated: Disable will prevent an Ingress from being created at all. This was mostly
+	// useful during testing. Gateway API is enforced as of KKP 2.31 and the operator no longer
+	// creates Ingress resources. This field is ignored.
 	Disable bool `json:"disable,omitempty"`
 
 	// CertificateIssuer is the name of a cert-manager Issuer or ClusterIssuer (default)


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP 2.31 enforces Gateway API and the operator no longer creates Ingress resources, which leaves `spec.ingress.className` and `spec.ingress.disable` without functional readers. This PR marks the two fields as `Deprecated:` in `KubermaticIngressConfiguration` (same godoc pattern as `BackupCleanupContainer`) and regenerates the KubermaticConfiguration CRD and the example YAMLs. It is a documentation-only change: the `className` defaulting in `pkg/defaulting` is deliberately kept and covered by a staticcheck exclusion, matching how other deprecated fields referenced for backward compatibility are handled.

`spec.ingress.namespaceOverride` is intentionally not deprecated: the seed-controller-manager still reads it (`pkg/controller/seed-controller-manager/kubernetes/resources.go`) to select the ingress-controller namespace in the user-cluster apiserver OIDC egress NetworkPolicy, so it is not a no-op field.

**Which issue(s) this PR fixes**:
Fixes #16272

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:
No executable behavior changes. Existing KubermaticConfiguration objects are unaffected; deprecated fields can safely be left in existing manifests.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
TBD
```
