### PR TITLE
Add '--secure-port' to the OpenStack Cloud Controller Manager

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -28,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -75,6 +76,20 @@ func openStackDeploymentReconciler(data *resources.TemplateData) reconciling.Nam
 					Args:         getOSFlags(data),
 					Env:          getEnvVars(),
 					VolumeMounts: getVolumeMounts(true),
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(10258),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						SuccessThreshold:    1,
+						FailureThreshold:    3,
+						InitialDelaySeconds: 20,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      5,
+					},
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: ptr.To[int64](1001),
 					},
@@ -101,6 +116,8 @@ func getOSFlags(data *resources.TemplateData) []string {
 		"--v=1",
 		"--cloud-config=/etc/kubernetes/cloud/config",
 		"--cloud-provider=openstack",
+		// Expose secure port for metrics/health like Azure/GCP CCM
+		"--secure-port=10258",
 	}
 	if data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] {
 		flags = append(flags, "--cluster-name", data.Cluster().Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add '`--secure-port`' to the UC's openstack-cloud-controller-manager, as it happens with Azure:

https://github.com/kubermatic/kubermatic/blob/787808991bfa9d140b89b78b1184bb7c44a9ce6e/pkg/resources/cloudcontroller/azure.go#L144

...and GCP: 

https://github.com/kubermatic/kubermatic/blob/787808991bfa9d140b89b78b1184bb7c44a9ce6e/pkg/resources/cloudcontroller/gcp.go#L128

This allows running a `LivenessProbe` against it.

For the time being, this is not possible [on the kubeone/addon/ccm-openstack](https://github.com/kubermatic/kubeone/blob/8773b2b577b12c834ce00b5ffbdf9ab6216ee869/addons/ccm-openstack/ccm-openstack.yaml#L171) as the `--bind-address` is set in that case.

**What type of PR is this?**
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind feature

**Special notes for your reviewer**:
This could open the door to collecting the OSCCM metrics 

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
openstack-cloud-controller-manager: enable LivenessProbe through '--secure-port'.
```

```documentation
NONE
```

```test-issue
NONE
```
