### PR TITLE
Update release example files for Gateway API

### DIFF
--- a/charts/kubermatic.example.ce.yaml
+++ b/charts/kubermatic.example.ce.yaml
@@ -21,8 +21,8 @@ spec:
   ingress:
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.
-    # this domain must match what you configured as dex.ingress.hosts[0].host
-    # in the values.yaml
+    # this domain must match the httpRoute.domain configured in the
+    # values.yaml
     domain: kkp.example.com
     certificateIssuer:
       # APIGroup is the group for the resource being referenced.
@@ -35,7 +35,27 @@ spec:
       # For generating a certificate signed by a trusted root authority replace
       # with "letsencrypt-prod".
       name: "letsencrypt-staging"
-    className: nginx
+
+    # Gateway API (Envoy Gateway) is the enforced ingress path as of KKP 2.31.
+    # The operator creates the Gateway and HTTPRoutes; these settings tune it.
+    # gateway:
+    #   # GatewayClass to use, defaults to kubermatic-envoy-gateway.
+    #   className: kubermatic-envoy-gateway
+    #   # Attach KKP HTTPRoutes to a user-managed Gateway instead of the
+    #   # operator-managed one. Mutually exclusive with className,
+    #   # infrastructureAnnotations, tls and certificateIssuer (the default
+    #   # class value kubermatic-envoy-gateway is tolerated alongside it).
+    #   externalGateway:
+    #     name: platform-gateway
+    #     namespace: networking
+    #   # Annotations propagated to the Gateway infrastructure, e.g. for
+    #   # cloud load balancer settings.
+    #   infrastructureAnnotations: {}
+    #   # Reference an existing TLS Secret for the default HTTPS listener
+    #   # instead of issuing via cert-manager.
+    #   tls:
+    #     secretRef:
+    #       name: my-tls-secret
 
   # These secret keys configure the way components communicate with Dex.
   auth:

--- a/charts/kubermatic.example.ee.yaml
+++ b/charts/kubermatic.example.ee.yaml
@@ -32,8 +32,8 @@ spec:
   ingress:
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.
-    # this domain must match what you configured as dex.ingress.hosts[0].host
-    # in the values.yaml
+    # this domain must match the httpRoute.domain configured in the
+    # values.yaml
     domain: kkp.example.com
     certificateIssuer:
       # APIGroup is the group for the resource being referenced.
@@ -46,7 +46,27 @@ spec:
       # For generating a certificate signed by a trusted root authority replace
       # with "letsencrypt-prod".
       name: "letsencrypt-staging"
-    className: nginx
+
+    # Gateway API (Envoy Gateway) is the enforced ingress path as of KKP 2.31.
+    # The operator creates the Gateway and HTTPRoutes; these settings tune it.
+    # gateway:
+    #   # GatewayClass to use, defaults to kubermatic-envoy-gateway.
+    #   className: kubermatic-envoy-gateway
+    #   # Attach KKP HTTPRoutes to a user-managed Gateway instead of the
+    #   # operator-managed one. Mutually exclusive with className,
+    #   # infrastructureAnnotations, tls and certificateIssuer (the default
+    #   # class value kubermatic-envoy-gateway is tolerated alongside it).
+    #   externalGateway:
+    #     name: platform-gateway
+    #     namespace: networking
+    #   # Annotations propagated to the Gateway infrastructure, e.g. for
+    #   # cloud load balancer settings.
+    #   infrastructureAnnotations: {}
+    #   # Reference an existing TLS Secret for the default HTTPS listener
+    #   # instead of issuing via cert-manager.
+    #   tls:
+    #     secretRef:
+    #       name: my-tls-secret
 
   # These secret keys configure the way components communicate with Dex.
   auth:

--- a/charts/values.example.ce.yaml
+++ b/charts/values.example.ce.yaml
@@ -23,33 +23,15 @@ httpRoute:
   gatewayNamespace: kubermatic
   # configure your base domain, under which the Kubermatic dashboard shall be available
   domain: "kkp.example.com"
+  # request timeout for the Dex HTTPRoute; 3600s supports long-running
+  # dashboard sessions such as the web terminal. Matches the chart default.
+  timeout: 3600s
 
 dex:
   ingress:
-    # Gateway API (HTTPRoute) handles routing as of KKP 2.31, so the upstream Dex Ingress
-    # is disabled. The settings below are retained for reference / non-Gateway setups.
+    # Gateway API (HTTPRoute) handles routing as of KKP 2.31; the upstream
+    # Dex Ingress stays disabled.
     enabled: false
-    # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
-    # If you want to deploy your own certificate without relying on cert-manager
-    # uncomment the next line and remove subsequent certIssuer configuration.
-    annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-staging
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
-    # configure your base domain, under which the Kubermatic dashboard shall be available
-    hosts:
-      # Required: host must be set; usually this is the same
-      # host as is used for the KKP Dashboard, but it can be
-      # any other domain.
-      - host: "kkp.example.com"
-        paths:
-          - path: /dex
-            pathType: ImplementationSpecific
-    tls:
-      - secretName: dex-tls
-        hosts:
-          # Required: must include at least the host chosen above.
-          - "kkp.example.com"
   config:
     issuer: "https://kkp.example.com/dex"
     expiry:
@@ -113,7 +95,7 @@ dex:
         # `cat /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c32`
         secret: <a-random-key>
         RedirectURIs:
-          # ensure the URLs below use the dex.ingress.hosts[0].host configured above
+          # ensure the URLs below use the httpRoute.domain configured above
           - https://kkp.example.com/api/v1/kubeconfig
           - https://kkp.example.com/api/v2/kubeconfig/secret
           - https://kkp.example.com/api/v2/dashboard/login

--- a/charts/values.example.ee.yaml
+++ b/charts/values.example.ee.yaml
@@ -23,33 +23,15 @@ httpRoute:
   gatewayNamespace: kubermatic
   # configure your base domain, under which the Kubermatic dashboard shall be available
   domain: "kkp.example.com"
+  # request timeout for the Dex HTTPRoute; 3600s supports long-running
+  # dashboard sessions such as the web terminal. Matches the chart default.
+  timeout: 3600s
 
 dex:
   ingress:
-    # Gateway API (HTTPRoute) handles routing as of KKP 2.31, so the upstream Dex Ingress
-    # is disabled. The settings below are retained for reference / non-Gateway setups.
+    # Gateway API (HTTPRoute) handles routing as of KKP 2.31; the upstream
+    # Dex Ingress stays disabled.
     enabled: false
-    # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
-    # If you want to deploy your own certificate without relying on cert-manager
-    # uncomment the next line and remove subsequent certIssuer configuration.
-    annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-staging
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
-    # configure your base domain, under which the Kubermatic dashboard shall be available
-    hosts:
-      # Required: host must be set; usually this is the same
-      # host as is used for the KKP Dashboard, but it can be
-      # any other domain.
-      - host: "kkp.example.com"
-        paths:
-          - path: /dex
-            pathType: ImplementationSpecific
-    tls:
-      - secretName: dex-tls
-        hosts:
-          # Required: must include at least the host chosen above.
-          - "kkp.example.com"
   config:
     issuer: "https://kkp.example.com/dex"
     expiry:
@@ -113,7 +95,7 @@ dex:
         # `cat /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c32`
         secret: <a-random-key>
         RedirectURIs:
-          # ensure the URLs below use the dex.ingress.hosts[0].host configured above
+          # ensure the URLs below use the httpRoute.domain configured above
           - https://kkp.example.com/api/v1/kubeconfig
           - https://kkp.example.com/api/v2/kubeconfig/secret
           - https://kkp.example.com/api/v2/dashboard/login


### PR DESCRIPTION
**What this PR does / why we need it**:
The v2.31 release archives still ship example files from the nginx ingress era: the matching-domain comments point at the disabled `dex.ingress.hosts[0].host` key, `className: nginx` is still listed, and the `spec.ingress.gateway` options are undiscoverable. This PR updates the four example files (ce and ee) to reference `httpRoute.domain`, drop the nginx class, and document the gateway block (`className`, `externalGateway`, `infrastructureAnnotations`, `tls.secretRef`) as comments. The dead `dex.ingress` annotations block is pruned and `httpRoute.timeout: 3600s` is surfaced, matching the dex chart default and the operator's HTTPRoute timeout.

**Which issue(s) this PR fixes**:
Fixes #16271

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/2271
```

**Test issue**:
```test-issue
NONE
```
