### PR TITLE
[release/v2.29] Bump machine-controller to v1.64.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	helm.sh/helm/v3 v3.17.4
 	k8c.io/kubeone v1.10.0
 	k8c.io/kubermatic/sdk/v2 v2.0.0-00010101000000-000000000000
-	k8c.io/machine-controller/sdk v1.64.3
+	k8c.io/machine-controller/sdk v1.64.4
 	k8c.io/operating-system-manager v1.7.6
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.33.4

--- a/go.sum
+++ b/go.sum
@@ -1620,8 +1620,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.10.0 h1:bS2h4Fi8Hjv+vikHORcHadioTel5EQzz5vX1Cojwr1g=
 k8c.io/kubeone v1.10.0/go.mod h1:wKdzhFcZf8sBKN3MxtueXGXTsMk1LDpZ/mSSJFUhLaE=
-k8c.io/machine-controller/sdk v1.64.3 h1:/sjQ5cW09jCT/98q3nxAZOGben+XRdRscyIdRvfZzTI=
-k8c.io/machine-controller/sdk v1.64.3/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
+k8c.io/machine-controller/sdk v1.64.4 h1:aV5YSei+hIk3fowkz4hxrVFf3gNDxzIf/5nGow9VnGc=
+k8c.io/machine-controller/sdk v1.64.4/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
 k8c.io/operating-system-manager v1.7.6 h1:CO7H0U3Ia/Wt6xAT3+fHFb4AXl6aeH6ZAFc8Em7/ALo=
 k8c.io/operating-system-manager v1.7.6/go.mod h1:FpkUHaKko9ZPBIxPY0CD1eOP37VuVAzme0MXLxhWVhI=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -52,7 +52,7 @@ var controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
 
 const (
 	Name = "machine-controller"
-	Tag  = "v1.64.3"
+	Tag  = "v1.64.4"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller-webhook.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.31.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.31.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller.yaml
@@ -84,7 +84,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.31.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.31.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.31.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.31.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller-webhook.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.31.0-machine-controller.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller.yaml
@@ -105,7 +105,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.31.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller-webhook.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller.yaml
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.31.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.64.3
+        image: quay.io/kubermatic/machine-controller:v1.64.4
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps machine-controller to v1.64.4 on release/v2.29.

- image tag: `pkg/resources/machinecontroller/deployment.go` `Tag` -> v1.64.4
- Go module: `k8c.io/machine-controller/sdk` v1.64.3 -> v1.64.4

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:
v1.64.4 is a patch release; see https://github.com/kubermatic/machine-controller/releases/tag/v1.64.4

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update machine-controller to v1.64.4
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```