### PR TITLE
Check for syft and oras before building release images

### DIFF
--- a/hack/release-images.sh
+++ b/hack/release-images.sh
@@ -46,6 +46,14 @@ fi
 cd $(dirname "$0")/..
 source hack/lib.sh
 
+# both are provided by the CI build image; checking upfront means a missing
+# binary fails here instead of after an hour of building, with images already pushed
+for tool in syft oras; do
+  if ! command -v "$tool" > /dev/null; then
+    fatal "$tool is required to generate and attach image SBOMs, but was not found in \$PATH."
+  fi
+done
+
 mkdir -p _dist/images
 
 export ALL_TAGS=$@


### PR DESCRIPTION
**What this PR does / why we need it**:

`hack/release-images.sh` builds and pushes images for about an hour before it first calls `syft` or `oras`. When `oras` was missing from the CI build image, `post-kubermatic-push-ee-images-main` failed at line 78 only after `kubermatic-ee` had already been pushed to quay, leaving a partially published tag set. This adds a `command -v` check for both binaries right after `source hack/lib.sh`, so a missing tool fails in seconds instead.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
