### PR TITLE
[release/v2.30] Add support for k8s patch releases v1.35.8/v1.34.11 and set default to v1.34.11

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -664,7 +664,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.34.10
+    default: v1.34.11
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -761,6 +761,7 @@ spec:
       - v1.34.8
       - v1.34.9
       - v1.34.10
+      - v1.34.11
       - v1.35.0
       - v1.35.1
       - v1.35.2
@@ -769,6 +770,7 @@ spec:
       - v1.35.5
       - v1.35.6
       - v1.35.7
+      - v1.35.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -664,7 +664,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.34.10
+    default: v1.34.11
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -761,6 +761,7 @@ spec:
       - v1.34.8
       - v1.34.9
       - v1.34.10
+      - v1.34.11
       - v1.35.0
       - v1.35.1
       - v1.35.2
@@ -769,6 +770,7 @@ spec:
       - v1.35.5
       - v1.35.6
       - v1.35.7
+      - v1.35.8
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -223,7 +223,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.34.10"),
+		Default: semver.NewSemverOrDie("v1.34.11"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -266,6 +266,7 @@ var (
 			newSemver("v1.34.8"),
 			newSemver("v1.34.9"),
 			newSemver("v1.34.10"),
+			newSemver("v1.34.11"),
 			// Kubernetes 1.35
 			newSemver("v1.35.0"),
 			newSemver("v1.35.1"),
@@ -275,6 +276,7 @@ var (
 			newSemver("v1.35.5"),
 			newSemver("v1.35.6"),
 			newSemver("v1.35.7"),
+			newSemver("v1.35.8"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.32 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for k8s patch releases v1.35.8/v1.34.11 and set default to v1.34.11

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for k8s patch releases v1.35.8/v1.34.11 and set default to v1.34.11
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
