### PR TITLE
do not deploy kubernetes-dashboard in CI

### DIFF
--- a/cmd/conformance-tester/pkg/clients/client_kube.go
+++ b/cmd/conformance-tester/pkg/clients/client_kube.go
@@ -187,6 +187,10 @@ func (c *kubeClient) CreateCluster(ctx context.Context, log *zap.SugaredLogger, 
 	cluster.Spec = *scenario.Cluster(c.opts.Secrets)
 	cluster.Spec.HumanReadableName = humanReadableName
 	cluster.Spec.ClusterNetwork.KonnectivityEnabled = ptr.To(c.opts.KonnectivityEnabled) //nolint:staticcheck
+	// kubernetes-dashboard is unmaintained upstream, do not waste CI resources on it
+	cluster.Spec.KubernetesDashboard = &kubermaticv1.KubernetesDashboard{
+		Enabled: false,
+	}
 
 	if c.opts.DualStackEnabled {
 		cluster.Spec.ClusterNetwork.IPFamily = kubermaticv1.IPFamilyDualStack

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -69,10 +69,15 @@ type Addon struct {
 
 func NewClusterJig(client ctrlruntimeclient.Client, log *zap.SugaredLogger) *ClusterJig {
 	jig := &ClusterJig{
-		client:      client,
-		log:         log,
-		versions:    kubermatic.GetFakeVersions(),
-		spec:        &kubermaticv1.ClusterSpec{},
+		client:   client,
+		log:      log,
+		versions: kubermatic.GetFakeVersions(),
+		spec: &kubermaticv1.ClusterSpec{
+			// kubernetes-dashboard is unmaintained upstream, do not waste CI resources on it
+			KubernetesDashboard: &kubermaticv1.KubernetesDashboard{
+				Enabled: false,
+			},
+		},
 		annotations: map[string]string{},
 		labels:      map[string]string{},
 		ownerEmail:  "e2e@test.kubermatic.com",


### PR DESCRIPTION
**What this PR does / why we need it**:
kubernetes-dashboard is not maintained anymore, but CI keeps deploying it to every user cluster it creates. The component is enabled by default when `Cluster.Spec.KubernetesDashboard` is unset (`pkg/defaulting/cluster.go`), and neither the e2e cluster jig nor the conformance-tester set the field. Both now create clusters with `KubernetesDashboard.Enabled = false`.

**Which issue(s) this PR fixes**:
Fixes #16250

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```