### PR TITLE
Lint the sdk module in the golangci-lint workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,9 @@ runs:
   steps:
     - uses: actions/setup-go@v7
       with:
-        go-version: 1.26
+        go-version-file: go.mod
         check-latest: true
         cache: true
+        cache-dependency-path: |
+          go.sum
+          sdk/go.sum

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,3 +20,24 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.12
+
+  golangci-sdk:
+    name: lint sdk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      # sdk is a separate Go module and is linted twice, mirroring
+      # `make -C sdk lint`: once with the SDK's own ruleset and once
+      # with the repository root's configuration.
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12
+          working-directory: sdk
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12
+          working-directory: sdk
+          args: --config ../.golangci.yml


### PR DESCRIPTION
**What this PR does / why we need it**:
golangci-lint does not descend into nested Go modules, so `sdk/` was no longer linted at all and the SDK-specific rules in `sdk/.golangci.yml`  went unenforced. This adds a `lint sdk` job that runs golangci-lint twice inside `sdk/`, once with the SDK config and once with the root config, mirroring `make -C sdk lint`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
