### PR TITLE
Handle baremetal provider in machine resource usage validation

### DIFF
--- a/pkg/ee/validation/machine/baremetal.go
+++ b/pkg/ee/validation/machine/baremetal.go
@@ -1,0 +1,233 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package machine
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"k8c.io/machine-controller/sdk/cloudprovider/baremetal"
+	"k8c.io/machine-controller/sdk/cloudprovider/baremetal/plugins/tinkerbell"
+	"k8c.io/machine-controller/sdk/providerconfig"
+	"k8c.io/machine-controller/sdk/providerconfig/configvar"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// agentAttributesAnnotation is the annotation set on the Tinkerbell Hardware object by the
+	// tink-agent after discovery. It holds a JSON document describing CPU/memory/block devices.
+	agentAttributesAnnotation = "tinkerbell.org/agent-attributes"
+
+	// tinkKubeconfigEnvVar is the environment variable KKP injects with the Tinkerbell
+	// kubeconfig (see pkg/resources/data.go).
+	tinkKubeconfigEnvVar = "TINK_KUBECONFIG"
+
+	hardwareGVKGroup   = "tinkerbell.org"
+	hardwareGVKVersion = "v1alpha1"
+	hardwareGVKKind    = "Hardware"
+)
+
+// getBaremetalResourceRequirements computes the CPU/memory/storage usage of a baremetal
+// (Tinkerbell) machine by reading the backing Hardware object. It is best-effort: any failure
+// degrades to zero rather than returning an error, so machine creation is never blocked by a
+// resource-quota side effect.
+func getBaremetalResourceRequirements(ctx context.Context, userClient ctrlruntimeclient.Client, config *providerconfig.Config) (*ResourceDetails, error) {
+	rawConfig, err := baremetal.GetConfig(*config)
+	if err != nil {
+		// Malformed baremetal spec: cannot even identify the hardware. Degrade to zero.
+		return getZeroResourceDetails(), nil
+	}
+
+	var spec tinkerbell.TinkerbellPluginSpec
+	if err := json.Unmarshal(rawConfig.DriverSpec.Raw, &spec); err != nil {
+		return getZeroResourceDetails(), nil
+	}
+
+	kubeconfig, err := resolveTinkerbellKubeconfig(ctx, userClient, spec.Auth.Kubeconfig)
+	if err != nil {
+		// No inline value and no resolvable TINK_KUBECONFIG source.
+		return getZeroResourceDetails(), nil
+	}
+
+	client, err := buildTinkerbellClient(kubeconfig)
+	if err != nil {
+		return getZeroResourceDetails(), nil
+	}
+
+	details, err := getBaremetalResourceDetailsFromCluster(ctx, client, spec.HardwareRef)
+	if err != nil {
+		// Hardware not found / unreachable cluster / unparseable attributes.
+		return getZeroResourceDetails(), nil
+	}
+
+	return details, nil
+}
+
+// resolveTinkerbellKubeconfig replicates machine-controller's GetConfig kubeconfig resolution:
+// an inline value must be base64-decoded; otherwise it resolves via the ConfigVar (secret /
+// configmap) or the TINK_KUBECONFIG env var, again base64-decoding while tolerating unencoded
+// YAML/JSON.
+func resolveTinkerbellKubeconfig(ctx context.Context, userClient ctrlruntimeclient.Client, kubeconfigVar providerconfig.ConfigVarString) (string, error) {
+	if kubeconfigVar.Value != "" {
+		val, err := base64.StdEncoding.DecodeString(kubeconfigVar.Value)
+		if err != nil {
+			return "", fmt.Errorf("failed to decode base64 encoded kubeconfig: %w", err)
+		}
+		return string(val), nil
+	}
+
+	resolver := configvar.NewResolver(ctx, userClient)
+	kubeconfig, err := resolver.GetStringValueOrEnv(kubeconfigVar, tinkKubeconfigEnvVar)
+	if err != nil {
+		return "", fmt.Errorf("failed to get value of \"kubeconfig\" field: %w", err)
+	}
+
+	// We intentionally ignore the decode error with the assumption that an unencoded YAML or
+	// JSON kubeconfig may have been passed in.
+	if val, err := base64.StdEncoding.DecodeString(kubeconfig); err == nil {
+		kubeconfig = string(val)
+	}
+
+	return kubeconfig, nil
+}
+
+// buildTinkerbellClient constructs a controller-runtime client for the Tinkerbell cluster.
+func buildTinkerbellClient(kubeconfig string) (ctrlruntimeclient.Client, error) {
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode kubeconfig: %w", err)
+	}
+
+	client, err := ctrlruntimeclient.New(restConfig, ctrlruntimeclient.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s client: %w", err)
+	}
+
+	return client, nil
+}
+
+// getBaremetalResourceDetailsFromCluster fetches the Hardware object referenced by hardwareRef
+// and parses its resource usage. The client is injectable so tests can pass a fake client.
+func getBaremetalResourceDetailsFromCluster(ctx context.Context, client ctrlruntimeclient.Client, hardwareRef types.NamespacedName) (*ResourceDetails, error) {
+	hardware := &unstructured.Unstructured{}
+	hardware.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   hardwareGVKGroup,
+		Version: hardwareGVKVersion,
+		Kind:    hardwareGVKKind,
+	})
+
+	if err := client.Get(ctx, hardwareRef, hardware); err != nil {
+		return nil, fmt.Errorf("failed to get Tinkerbell Hardware %s: %w", hardwareRef, err)
+	}
+
+	return resourceDetailsFromHardware(hardware)
+}
+
+// resourceDetailsFromHardware extracts CPU/memory/storage from a Tinkerbell Hardware object.
+// It prefers the tinkerbell.org/agent-attributes annotation; otherwise it falls back to
+// spec.resources. Storage prefers spec.resources["disk"], else the sum of blockDevices[].size.
+func resourceDetailsFromHardware(hardware *unstructured.Unstructured) (*ResourceDetails, error) {
+	annotations := hardware.GetAnnotations()
+	if raw, ok := annotations[agentAttributesAnnotation]; ok && raw != "" {
+		return resourceDetailsFromAgentAttributes([]byte(raw))
+	}
+
+	// Fallback: spec.resources (map of quantity strings).
+	resources, found, err := unstructured.NestedStringMap(hardware.Object, "spec", "resources")
+	if err != nil || !found {
+		return nil, fmt.Errorf("hardware has no resource information")
+	}
+
+	return resourceDetailsFromResourceList(resources), nil
+}
+
+// resourceDetailsFromAgentAttributes parses the agent-attributes JSON into quantities.
+func resourceDetailsFromAgentAttributes(raw []byte) (*ResourceDetails, error) {
+	var attrs agentAttributes
+	if err := json.Unmarshal(raw, &attrs); err != nil {
+		return nil, fmt.Errorf("failed to parse agent-attributes: %w", err)
+	}
+
+	cpu := *resource.NewQuantity(int64(attrs.CPU.TotalCores), resource.DecimalSI)
+
+	var mem resource.Quantity
+	if attrs.Memory.Total != "" {
+		var err error
+		mem, err = resource.ParseQuantity(attrs.Memory.Total)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse memory quantity %q: %w", attrs.Memory.Total, err)
+		}
+	}
+
+	storage := resource.Quantity{}
+	for _, blockDevice := range attrs.BlockDevices {
+		if blockDevice.Size == "" {
+			continue
+		}
+		size, err := resource.ParseQuantity(blockDevice.Size)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse block device size %q: %w", blockDevice.Size, err)
+		}
+		storage.Add(size)
+	}
+
+	return NewResourceDetails(cpu, mem, storage), nil
+}
+
+// resourceDetailsFromResourceList builds ResourceDetails from a map of quantity strings with
+// keys cpu/memory/disk.
+func resourceDetailsFromResourceList(resources map[string]string) *ResourceDetails {
+	cpu, _ := resource.ParseQuantity(resources["cpu"])
+	mem, _ := resource.ParseQuantity(resources["memory"])
+	storage, _ := resource.ParseQuantity(resources["disk"])
+	return NewResourceDetails(cpu, mem, storage)
+}
+
+// agentAttributes mirrors the JSON document in the tinkerbell.org/agent-attributes annotation.
+type agentAttributes struct {
+	CPU          agentCPU           `json:"cpu"`
+	Memory       agentMemory        `json:"memory"`
+	BlockDevices []agentBlockDevice `json:"blockDevices"`
+}
+
+type agentCPU struct {
+	TotalCores int `json:"totalCores"`
+}
+
+type agentMemory struct {
+	Total string `json:"total"`
+}
+
+type agentBlockDevice struct {
+	Size string `json:"size"`
+}

--- a/pkg/ee/validation/machine/baremetal.go
+++ b/pkg/ee/validation/machine/baremetal.go
@@ -86,7 +86,7 @@ func getBaremetalResourceRequirements(ctx context.Context, userClient ctrlruntim
 
 	details, err := getBaremetalResourceDetailsFromCluster(ctx, client, spec.HardwareRef)
 	if err != nil {
-		// Hardware not found / unreachable cluster / unparseable attributes.
+		// Hardware not found / unreachable cluster / unparsable attributes.
 		return getZeroResourceDetails(), nil
 	}
 

--- a/pkg/ee/validation/machine/baremetal_test.go
+++ b/pkg/ee/validation/machine/baremetal_test.go
@@ -1,0 +1,251 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package machine
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"k8c.io/machine-controller/sdk/cloudprovider/baremetal"
+	"k8c.io/machine-controller/sdk/cloudprovider/baremetal/plugins/tinkerbell"
+	"k8c.io/machine-controller/sdk/providerconfig"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimefakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var hardwareGVK = schema.GroupVersionKind{
+	Group:   hardwareGVKGroup,
+	Version: hardwareGVKVersion,
+	Kind:    hardwareGVKKind,
+}
+
+func hardwareObject(name, namespace, annotation string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hardwareGVK)
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	obj.SetAnnotations(map[string]string{agentAttributesAnnotation: annotation})
+	return obj
+}
+
+func TestResourceDetailsFromHardware(t *testing.T) {
+	testCases := []struct {
+		name          string
+		hardware      *unstructured.Unstructured
+		expectCpu     string // expected quantity string ("" means expect 0 / not asserted)
+		expectMem     string
+		expectStorage string
+		expectErr     bool
+	}{
+		{
+			name:          "hardware with full agent-attributes",
+			hardware:      hardwareObject("hw1", "default", `{"cpu":{"totalCores":8},"memory":{"total":"96Gi"},"blockDevices":[{"size":"4Ti"},{"size":"512Gi"}]}`),
+			expectCpu:     "8",
+			expectMem:     "96Gi",
+			expectStorage: "4608Gi", // 4Ti + 512Gi, normalized
+			expectErr:     false,
+		},
+		{
+			name:          "hardware with no annotation",
+			hardware:      hardwareObject("hw2", "default", ""),
+			expectCpu:     "0",
+			expectMem:     "0",
+			expectStorage: "0",
+			expectErr:     true,
+		},
+		{
+			name:          "hardware with malformed annotation",
+			hardware:      hardwareObject("hw3", "default", `{not valid json`),
+			expectCpu:     "0",
+			expectMem:     "0",
+			expectStorage: "0",
+			expectErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			details, err := resourceDetailsFromHardware(tc.hardware)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got none: %+v", details)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.expectCpu != "" {
+				if got := details.CPU().String(); got != tc.expectCpu {
+					t.Errorf("CPU: got %q, want %q", got, tc.expectCpu)
+				}
+			}
+			if tc.expectMem != "" {
+				if got := details.Memory().String(); got != tc.expectMem {
+					t.Errorf("Memory: got %q, want %q", got, tc.expectMem)
+				}
+			}
+			if tc.expectStorage != "" {
+				if got := details.Storage().String(); got != tc.expectStorage {
+					t.Errorf("Storage: got %q, want %q", got, tc.expectStorage)
+				}
+			}
+		})
+	}
+}
+
+func TestResourceDetailsFromHardwareSpecResourcesFallback(t *testing.T) {
+	obj := hardwareObject("hw-res", "default", "")
+	// annotate with empty string but provide spec.resources fallback
+	obj.SetAnnotations(nil)
+	obj.Object["spec"] = map[string]interface{}{
+		"resources": map[string]interface{}{
+			"cpu":    "4",
+			"memory": "16Gi",
+			"disk":   "500Gi",
+		},
+	}
+
+	details, err := resourceDetailsFromHardware(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := details.CPU().String(); got != "4" {
+		t.Errorf("CPU: got %q, want %q", got, "4")
+	}
+	if got := details.Memory().String(); got != "16Gi" {
+		t.Errorf("Memory: got %q, want %q", got, "16Gi")
+	}
+	if got := details.Storage().String(); got != "500Gi" {
+		t.Errorf("Storage: got %q, want %q", got, "500Gi")
+	}
+}
+
+func TestGetBaremetalResourceDetailsFromCluster(t *testing.T) {
+	testCases := []struct {
+		name      string
+		objects   []*unstructured.Unstructured
+		ref       types.NamespacedName
+		expectCpu string
+		expectErr bool
+	}{
+		{
+			name: "hardware found with agent-attributes",
+			objects: []*unstructured.Unstructured{
+				hardwareObject("hw1", "default", `{"cpu":{"totalCores":8},"memory":{"total":"96Gi"},"blockDevices":[{"size":"4Ti"}]}`),
+			},
+			ref:       types.NamespacedName{Namespace: "default", Name: "hw1"},
+			expectCpu: "8",
+			expectErr: false,
+		},
+		{
+			name:      "hardware not found",
+			objects:   nil,
+			ref:       types.NamespacedName{Namespace: "default", Name: "missing"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := ctrlruntimefakeclient.NewClientBuilder()
+			for _, obj := range tc.objects {
+				builder = builder.WithObjects(obj)
+			}
+			fakeClient := builder.Build()
+
+			details, err := getBaremetalResourceDetailsFromCluster(context.Background(), fakeClient, tc.ref)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got none: %+v", details)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.expectCpu != "" {
+				if got := details.CPU().String(); got != tc.expectCpu {
+					t.Errorf("CPU: got %q, want %q", got, tc.expectCpu)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBaremetalResourceRequirementsReturnsZeroOnFailure(t *testing.T) {
+	// A nil-embedded mock client (like providers_test.go's MockCtrlRuntimeClient) never
+	// connects anywhere; with no inline kubeconfig and no TINK_KUBECONFIG the resolver
+	// returns zero deterministically.
+	mockClient := &MockCtrlRuntimeClient{}
+	config := &providerconfig.Config{
+		CloudProvider:     providerconfig.CloudProviderBaremetal,
+		CloudProviderSpec: genFakeBaremetalSpec(""),
+	}
+
+	details, err := getBaremetalResourceRequirements(context.Background(), mockClient, config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if details == nil {
+		t.Fatal("expected non-nil ResourceDetails")
+	}
+	zero := resource.Quantity{}
+	if !reflect.DeepEqual(*details.CPU(), zero) ||
+		!reflect.DeepEqual(*details.Memory(), zero) ||
+		!reflect.DeepEqual(*details.Storage(), zero) {
+		t.Fatalf("expected zero resource details, got %+v", details)
+	}
+}
+
+// genFakeBaremetalSpec builds a baremetal provider config. kubeconfig may be empty to force the
+// deterministic zero-fallback path.
+func genFakeBaremetalSpec(kubeconfig string) runtime.RawExtension {
+	driverSpec := tinkerbell.TinkerbellPluginSpec{
+		ClusterName: providerconfig.ConfigVarString{Value: "cluster"},
+		Auth: tinkerbell.Auth{
+			Kubeconfig: providerconfig.ConfigVarString{Value: kubeconfig},
+		},
+		OSImageURL:  providerconfig.ConfigVarString{Value: "http://example.com/os.img"},
+		HardwareRef: types.NamespacedName{Namespace: "default", Name: "hw1"},
+	}
+	driverSpecRaw, _ := json.Marshal(driverSpec)
+
+	rawConfig := &baremetal.RawConfig{
+		Driver:     providerconfig.ConfigVarString{Value: "tinkerbell"},
+		DriverSpec: runtime.RawExtension{Raw: driverSpecRaw},
+	}
+	rawBytes, _ := json.Marshal(rawConfig)
+	return runtime.RawExtension{Raw: rawBytes}
+}

--- a/pkg/ee/validation/machine/baremetal_test.go
+++ b/pkg/ee/validation/machine/baremetal_test.go
@@ -61,7 +61,7 @@ func TestResourceDetailsFromHardware(t *testing.T) {
 	testCases := []struct {
 		name          string
 		hardware      *unstructured.Unstructured
-		expectCpu     string // expected quantity string ("" means expect 0 / not asserted)
+		expectCPU     string // expected quantity string ("" means expect 0 / not asserted)
 		expectMem     string
 		expectStorage string
 		expectErr     bool
@@ -69,7 +69,7 @@ func TestResourceDetailsFromHardware(t *testing.T) {
 		{
 			name:          "hardware with full agent-attributes",
 			hardware:      hardwareObject("hw1", "default", `{"cpu":{"totalCores":8},"memory":{"total":"96Gi"},"blockDevices":[{"size":"4Ti"},{"size":"512Gi"}]}`),
-			expectCpu:     "8",
+			expectCPU:     "8",
 			expectMem:     "96Gi",
 			expectStorage: "4608Gi", // 4Ti + 512Gi, normalized
 			expectErr:     false,
@@ -77,7 +77,7 @@ func TestResourceDetailsFromHardware(t *testing.T) {
 		{
 			name:          "hardware with no annotation",
 			hardware:      hardwareObject("hw2", "default", ""),
-			expectCpu:     "0",
+			expectCPU:     "0",
 			expectMem:     "0",
 			expectStorage: "0",
 			expectErr:     true,
@@ -85,7 +85,7 @@ func TestResourceDetailsFromHardware(t *testing.T) {
 		{
 			name:          "hardware with malformed annotation",
 			hardware:      hardwareObject("hw3", "default", `{not valid json`),
-			expectCpu:     "0",
+			expectCPU:     "0",
 			expectMem:     "0",
 			expectStorage: "0",
 			expectErr:     true,
@@ -105,9 +105,9 @@ func TestResourceDetailsFromHardware(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if tc.expectCpu != "" {
-				if got := details.CPU().String(); got != tc.expectCpu {
-					t.Errorf("CPU: got %q, want %q", got, tc.expectCpu)
+			if tc.expectCPU != "" {
+				if got := details.CPU().String(); got != tc.expectCPU {
+					t.Errorf("CPU: got %q, want %q", got, tc.expectCPU)
 				}
 			}
 			if tc.expectMem != "" {
@@ -157,7 +157,7 @@ func TestGetBaremetalResourceDetailsFromCluster(t *testing.T) {
 		name      string
 		objects   []*unstructured.Unstructured
 		ref       types.NamespacedName
-		expectCpu string
+		expectCPU string
 		expectErr bool
 	}{
 		{
@@ -166,7 +166,7 @@ func TestGetBaremetalResourceDetailsFromCluster(t *testing.T) {
 				hardwareObject("hw1", "default", `{"cpu":{"totalCores":8},"memory":{"total":"96Gi"},"blockDevices":[{"size":"4Ti"}]}`),
 			},
 			ref:       types.NamespacedName{Namespace: "default", Name: "hw1"},
-			expectCpu: "8",
+			expectCPU: "8",
 			expectErr: false,
 		},
 		{
@@ -195,9 +195,9 @@ func TestGetBaremetalResourceDetailsFromCluster(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if tc.expectCpu != "" {
-				if got := details.CPU().String(); got != tc.expectCpu {
-					t.Errorf("CPU: got %q, want %q", got, tc.expectCpu)
+			if tc.expectCPU != "" {
+				if got := details.CPU().String(); got != tc.expectCPU {
+					t.Errorf("CPU: got %q, want %q", got, tc.expectCPU)
 				}
 			}
 		})

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -98,6 +98,12 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 	switch config.CloudProvider {
 	case providerconfig.CloudProviderFake, providerconfig.CloudProviderExternal:
 		quotaUsage, err = getFakeQuotaRequest(config)
+	case providerconfig.CloudProviderBaremetal:
+		// Baremetal machines have no cloud-API resource usage to compute; the fixed
+		// hardware is provisioned out-of-band via Tinkerbell. Read the CPU/memory/storage
+		// from the backing Tinkerbell Hardware object best-effort, degrading to zero when
+		// the hardware is not yet available so machine creation is never blocked.
+		quotaUsage, err = getBaremetalResourceRequirements(ctx, userClient, config)
 	case providerconfig.CloudProviderAWS:
 		quotaUsage, err = getAWSResourceRequirements(ctx, userClient, config)
 	case providerconfig.CloudProviderGoogle:
@@ -127,6 +133,10 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 	}
 
 	return quotaUsage, err
+}
+
+func getZeroResourceDetails() *ResourceDetails {
+	return NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
 }
 
 func getAWSResourceRequirements(ctx context.Context, userClient ctrlruntimeclient.Client, config *providerconfig.Config) (*ResourceDetails, error) {

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -29,10 +29,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
 	"k8c.io/machine-controller/sdk/cloudprovider/kubevirt"
 	vmwareclouddirectortypes "k8c.io/machine-controller/sdk/cloudprovider/vmwareclouddirector"
 	"k8c.io/machine-controller/sdk/providerconfig"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -152,5 +154,61 @@ func genFakeKubeVirtSpec(cpu int, ram, disk string) runtime.RawExtension {
 	rawBytes, _ := json.Marshal(kubevirtConfig)
 	return runtime.RawExtension{
 		Raw: rawBytes,
+	}
+}
+
+func TestGetMachineResourceUsageBaremetalReturnsZero(t *testing.T) {
+	testCases := []struct {
+		name        string
+		config      *providerconfig.Config
+		expectedErr bool
+	}{
+		{
+			name: "baremetal machine without resolvable kubeconfig accounts zero usage",
+			config: &providerconfig.Config{
+				CloudProvider:     providerconfig.CloudProviderBaremetal,
+				CloudProviderSpec: genFakeBaremetalSpec(""),
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &MockCtrlRuntimeClient{}
+
+			// Build a machine whose ProviderSpec decodes to the baremetal config.
+			rawConfig, _ := json.Marshal(tc.config)
+			machine := &clusterv1alpha1.Machine{
+				Spec: clusterv1alpha1.MachineSpec{
+					ProviderSpec: clusterv1alpha1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawConfig},
+					},
+				},
+			}
+
+			details, err := GetMachineResourceUsage(context.Background(), mockClient, "", machine, nil)
+			if err != nil {
+				if !tc.expectedErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if err == nil && tc.expectedErr {
+				t.Fatal("expected error, got none")
+			}
+
+			if err == nil && details == nil {
+				t.Fatal("expected non-nil ResourceDetails")
+			}
+
+			// Baremetal (degraded) should report zero usage and never block creation.
+			if err == nil {
+				zero := resource.Quantity{}
+				if !details.CPU().Equal(zero) || !details.Memory().Equal(zero) || !details.Storage().Equal(zero) {
+					t.Fatalf("expected zero usage, got %+v", details)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`GetMachineResourceUsage` had no case for `CloudProviderBaremetal`, so the switch fell through to the `"Provider baremetal not supported"` error. Once resource quota validation is enabled, this caused every baremetal (Tinkerbell) machine creation to be rejected.

This adds a `CloudProviderBaremetal` case that computes the CPU/memory/storage usage from the backing Tinkerbell `Hardware` object. The lookup is best-effort: if the hardware is not yet available, has no resolvable kubeconfig, or the attributes are malformed, it degrades to zero rather than returning an error, so machine creation is **never** blocked by a resource-quota side effect.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #16314

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

- The resource usage is read from the Tinkerbell `Hardware` object, preferring the `tinkerbell.org/agent-attributes` annotation and falling back to `spec.resources` (storage prefers `spec.resources["disk"]`, else the sum of `blockDevices[].size`).
- The Tinkerbell client is built without importing `github.com/tinkerbell/tink` (not a KKP dependency); the `Hardware` object is fetched as an `unstructured.Unstructured`.
- The kubeconfig resolution replicates machine-controller's `GetConfig` logic (inline base64 value, or `TINK_KUBECONFIG` env var / ConfigVar secret or configmap).
- Any failure in the baremetal path degrades to zero usage and never blocks creation.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix baremetal machine creation being blocked by resource quota validation.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/kubermatic/issues/16317
```

