### PR TITLE
Bump OpenStack Cinder CSI sidecar images to patch CVEs

### DIFF
--- a/addons/csi/openstack/driver.yaml
+++ b/addons/csi/openstack/driver.yaml
@@ -442,7 +442,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v4.10.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v4.12.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-attacher
           resources: {}
@@ -477,7 +477,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v8.4.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-snapshotter
           resources: {}
@@ -508,7 +508,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources: {}
@@ -619,7 +619,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0" }}'
           imagePullPolicy: IfNotPresent
           name: node-driver-registrar
           resources: {}
@@ -634,7 +634,7 @@ spec:
         - args:
             - -v=2
             - --csi-address=/csi/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources: {}

--- a/addons/csi/openstack/helm-values
+++ b/addons/csi/openstack/helm-values
@@ -16,13 +16,8 @@ storageClass:
   enabled: false
 
 csi:
-  # Override sidecar image tags pinned by the chart; they lag upstream releases
-  # and accumulate known CVEs (see https://github.com/kubermatic/kubermatic/issues/16192).
-  # The chart's csi-snapshotter default is not just stale but a regression: v8.4.0 ships
-  # more CRITICAL/HIGH findings than the v8.3.0 it replaced, while v8.6.0 rebased onto
-  # Debian 13 and drops most of them (measurements in kubermatic/kubeone#4193).
-  # csi-provisioner and csi-resizer are intentionally not overridden: the chart already
-  # ships the latest release of their respective majors (v5.x / v1.x).
+  # Override sidecar image tags pinned by the chart to pick up CVE fixes
+  # (https://github.com/kubermatic/kubermatic/issues/16192).
   attacher:
     image:
       tag: v4.12.0

--- a/addons/csi/openstack/helm-values
+++ b/addons/csi/openstack/helm-values
@@ -16,6 +16,25 @@ storageClass:
   enabled: false
 
 csi:
+  # Override sidecar image tags pinned by the chart; they lag upstream releases
+  # and accumulate known CVEs (see https://github.com/kubermatic/kubermatic/issues/16192).
+  # The chart's csi-snapshotter default is not just stale but a regression: v8.4.0 ships
+  # more CRITICAL/HIGH findings than the v8.3.0 it replaced, while v8.6.0 rebased onto
+  # Debian 13 and drops most of them (measurements in kubermatic/kubeone#4193).
+  # csi-provisioner and csi-resizer are intentionally not overridden: the chart already
+  # ships the latest release of their respective majors (v5.x / v1.x).
+  attacher:
+    image:
+      tag: v4.12.0
+  snapshotter:
+    image:
+      tag: v8.6.0
+  livenessprobe:
+    image:
+      tag: v2.19.0
+  nodeDriverRegistrar:
+    image:
+      tag: v2.17.0
   plugin:
     volumes:
       - name: ca-bundle


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes known CVEs reported for the OpenStack Cinder CSI addon by updating four sidecar images to the latest releases within their current majors.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #16192

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

Trivy scan results (unique CVE IDs, CRITICAL/HIGH only, point-in-time):

| image | old → new | old CRIT/HIGH | new CRIT/HIGH | resolved | residual | introduced |
|---|---|---|---|---|---|---|
| csi-attacher | v4.10.0 → v4.12.0 | 3/39 | 1/25 | 16 | 26 | 0 |
| csi-snapshotter | v8.4.0 → v8.6.0 | 3/39 | 1/16 | 25 | 17 | 0 |
| livenessprobe | v2.17.0 → v2.19.0 | 2/27 | 0/16 | 13 | 16 | 0 |
| csi-node-driver-registrar | v2.15.0 → v2.17.0 | 2/28 | 0/16 | 14 | 16 | 0 |


#### Important

The reported CVEs (CVE-2025-68121, CVE-2026-33186) are present in csi-attacher v4.10.0 and fixed in v4.12.0. Remaining findings are from base-image dependencies, not the sidecar itself.

> All bumps stay within their existing majors, so there is no behavioural change and the supported Kubernetes range is unchanged.

#### Testing Check
```bash
docker run --rm aquasec/trivy image \
  --scanners vuln --severity CRITICAL,HIGH --quiet \
  registry.k8s.io/sig-storage/csi-attacher:v4.12.0

# After

docker run --rm aquasec/trivy image \
  --scanners vuln --severity CRITICAL,HIGH --quiet \
  registry.k8s.io/sig-storage/csi-attacher:v4.12.0 | grep -E 'CVE-2025-68121|CVE-2026-33186'
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump OpenStack Cinder CSI sidecar images (csi-attacher v4.12.0, csi-snapshotter v8.6.0, livenessprobe v2.19.0, csi-node-driver-registrar v2.17.0) to address known CVEs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
