### PR TITLE
[release/v2.29] - Bump OpenStack Cinder CSI sidecar images to patch CVEs (#16328)

### DIFF
--- a/addons/csi/openstack/driver.yaml
+++ b/addons/csi/openstack/driver.yaml
@@ -442,7 +442,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v4.10.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v4.12.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-attacher
           resources: {}
@@ -477,7 +477,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0" }}'
           imagePullPolicy: IfNotPresent
           name: csi-snapshotter
           resources: {}
@@ -508,7 +508,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources: {}
@@ -619,7 +619,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0" }}'
           imagePullPolicy: IfNotPresent
           name: node-driver-registrar
           resources: {}
@@ -634,7 +634,7 @@ spec:
         - args:
             - -v=2
             - --csi-address=/csi/csi.sock
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.17.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.19.0" }}'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
           resources: {}

--- a/addons/csi/openstack/helm-values
+++ b/addons/csi/openstack/helm-values
@@ -16,6 +16,20 @@ storageClass:
   enabled: false
 
 csi:
+  # Override sidecar image tags pinned by the chart to pick up CVE fixes
+  # (https://github.com/kubermatic/kubermatic/issues/16192).
+  attacher:
+    image:
+      tag: v4.12.0
+  snapshotter:
+    image:
+      tag: v8.6.0
+  livenessprobe:
+    image:
+      tag: v2.19.0
+  nodeDriverRegistrar:
+    image:
+      tag: v2.17.0
   plugin:
     volumes:
       - name: ca-bundle


### PR DESCRIPTION
This is a manual cherry-pick of #16328, since the automated cherry-pick failed to apply.

This PR fixes known CVEs reported for the OpenStack Cinder CSI addon on the release/v2.29 branch by updating the sidecar images to the latest releases within their current majors.


```release-note
Bump OpenStack Cinder CSI sidecar images (csi-attacher v4.12.0, csi-snapshotter v8.6.0, livenessprobe v2.19.0, csi-node-driver-registrar v2.17.0) to address known CVEs
```