### PR TITLE
Migrate user cluster MLA monitoring agent to Grafana Alloy

### DIFF
--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -230,6 +230,9 @@ products:
     source: https://github.com/grafana/alloy
     occurrences:
       - helmChart: { directory: charts/logging/alloy }
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent
+          constant: tag
 
   - name: MinIO
     source: https://github.com/minio/minio
@@ -267,9 +270,6 @@ products:
       - goConstant:
           package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent
           constant: imageTag
-      - goConstant:
-          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent
-          constant: tag
 
   - name: Helm Exporter
     source: https://github.com/sstarcher/helm-exporter

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
@@ -34,10 +34,10 @@ import (
 )
 
 const (
-	imageName     = "grafana/agent"
-	tag           = "v0.29.0"
+	imageName     = "grafana/alloy"
+	tag           = "v1.19.2"
 	appName       = "mla-monitoring-agent"
-	containerName = "grafana-agent"
+	containerName = "grafana-alloy"
 
 	reloaderImageName = "prometheus-operator/prometheus-config-reloader"
 	reloaderTag       = "v0.60.1"
@@ -105,10 +105,30 @@ func DeploymentReconciler(overrides *corev1.ResourceRequirements, replicas *int3
 					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, imageName, tag))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
-						fmt.Sprintf("--config.file=%s/%s", configPath, configFileName),
-						"-server.http.address=0.0.0.0:9090",
-						"-disable-reporting",
-						fmt.Sprintf("-metrics.wal-directory=%s/agent", storagePath),
+						"run",
+						fmt.Sprintf("%s/%s", configPath, configFileName),
+						// the configuration is still in the Grafana Agent static mode format, which
+						// Alloy converts on startup; -config.expand-env keeps the ${HOSTNAME}
+						// expansion that makes the __replica__ external label unique per pod.
+						"--config.format=static",
+						"--config.extra-args=-config.expand-env",
+						// tolerate conversion warnings so that an unsupported directive in a
+						// user-provided custom scrape configuration cannot prevent Alloy from starting.
+						"--config.bypass-conversion-errors",
+						fmt.Sprintf("--server.http.listen-addr=0.0.0.0:%d", containerPort),
+						fmt.Sprintf("--storage.path=%s/alloy", storagePath),
+						"--disable-reporting",
+						"--stability.level=generally-available",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "HOSTNAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
 					},
 					Ports: []corev1.ContainerPort{
 						{
@@ -139,7 +159,10 @@ func DeploymentReconciler(overrides *corev1.ResourceRequirements, replicas *int3
 						SuccessThreshold:    1,
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/-/healthy",
+								// Alloy's /-/healthy reports the health of every single component and is
+								// explicitly documented as unsuitable for a liveness probe: one component
+								// failing to scrape would restart the pod and stop all healthy pipelines.
+								Path:   "/-/ready",
 								Port:   intstr.FromInt(containerPort),
 								Scheme: corev1.URISchemeHTTP,
 							},

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -54,6 +54,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity"
 	k8sdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
+	mlamonitoringagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent"
 	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
@@ -484,6 +485,7 @@ func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.Temp
 	deploymentReconcilers = append(deploymentReconcilers, vpa.RecommenderDeploymentReconciler(config, kubermaticVersions))
 	deploymentReconcilers = append(deploymentReconcilers, vpa.UpdaterDeploymentReconciler(config, kubermaticVersions))
 	deploymentReconcilers = append(deploymentReconcilers, mla.GatewayDeploymentReconciler(templateData, nil))
+	deploymentReconcilers = append(deploymentReconcilers, mlamonitoringagent.DeploymentReconciler(nil, nil, templateData.RewriteImage))
 	deploymentReconcilers = append(deploymentReconcilers, k8sdashboard.DeploymentReconciler(templateData.RewriteImage))
 	deploymentReconcilers = append(deploymentReconcilers, gatekeeper.ControllerDeploymentReconciler(false, templateData.RewriteImage, nil))
 	deploymentReconcilers = append(deploymentReconcilers, vmwareclouddirector.ControllerDeploymentReconciler(templateData))

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -955,12 +955,15 @@ const (
 	MLAGatewayKeySecretKey           = "gateway.key"
 	MLAGatewayCertSecretKey          = "gateway.crt"
 
-	// MLAMonitoringAgentCertificatesSecretName is the name for the secret containing the Monitoring Agent (grafana-agent) client certificates.
+	// MLAMonitoringAgentCertificatesSecretName is the name for the secret containing the Monitoring Agent (Grafana Alloy) client certificates.
 	MLAMonitoringAgentCertificatesSecretName = "monitoring-agent-certificates"
-	MLAMonitoringAgentCertificateCommonName  = "grafana-agent"
-	MLAMonitoringAgentClientKeySecretKey     = "client.key"
-	MLAMonitoringAgentClientCertSecretKey    = "client.crt"
-	MLAMonitoringAgentClientCertMountPath    = "/etc/ssl/mla"
+	// MLAMonitoringAgentCertificateCommonName is kept as "grafana-agent" on purpose: the MLA gateway
+	// only verifies the client certificate against the CA and derives the tenant from the injected
+	// X-Scope-OrgID header, so renaming the CN would only churn certificates on existing clusters.
+	MLAMonitoringAgentCertificateCommonName = "grafana-agent"
+	MLAMonitoringAgentClientKeySecretKey    = "client.key"
+	MLAMonitoringAgentClientCertSecretKey   = "client.crt"
+	MLAMonitoringAgentClientCertMountPath   = "/etc/ssl/mla"
 
 	// MLALoggingAgentCertificatesSecretName is the name for the secret containing the Logging Agent client certificates.
 	MLALoggingAgentCertificatesSecretName = "logging-agent-certificates"


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the end-of-life `grafana/agent:v0.29.0` image in the User Cluster MLA monitoring agent with `grafana/alloy:v1.19.2`. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #16143

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Migrated the User Cluster MLA monitoring agent from the end-of-life grafana/agent v0.29.0 image to grafana/alloy v1.19.2.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
