### PR TITLE
Update the Kubermatic util image to 2.10.0

### DIFF
--- a/charts/minio/test/enable-ingress.yaml.out
+++ b/charts/minio/test/enable-ingress.yaml.out
@@ -190,7 +190,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/existing-secret.yaml.out
+++ b/charts/minio/test/existing-secret.yaml.out
@@ -137,7 +137,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -192,7 +192,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -191,7 +191,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -191,7 +191,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -91,7 +91,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.9.0
+      tag: 2.10.0
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -31,7 +31,7 @@ grafana:
     tag: 10.4.1
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 2.9.0
+    tag: 2.10.0
 
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/karma/test/default.yaml.out
+++ b/charts/monitoring/karma/test/default.yaml.out
@@ -233,7 +233,7 @@ spec:
       serviceAccountName: 'release-name'
       initContainers:
       - name: init-seeds
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/charts/monitoring/karma/test/values.example.ce.yaml.out
+++ b/charts/monitoring/karma/test/values.example.ce.yaml.out
@@ -233,7 +233,7 @@ spec:
       serviceAccountName: 'release-name'
       initContainers:
       - name: init-seeds
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/charts/monitoring/karma/test/values.example.ee.yaml.out
+++ b/charts/monitoring/karma/test/values.example.ee.yaml.out
@@ -233,7 +233,7 @@ spec:
       serviceAccountName: 'release-name'
       initContainers:
       - name: init-seeds
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -55,7 +55,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 2.9.0
+      tag: 2.10.0
       pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -3500,7 +3500,7 @@ spec:
           mountPath: /etc/prometheus/rules/
           readOnly: false
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -3500,7 +3500,7 @@ spec:
           mountPath: /etc/prometheus/rules/
           readOnly: false
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -3500,7 +3500,7 @@ spec:
           mountPath: /etc/prometheus/rules/
           readOnly: false
       - name: backup
-        image: 'quay.io/kubermatic/util:2.9.0'
+        image: 'quay.io/kubermatic/util:2.10.0'
         args:
         - /bin/sh
         - -c

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -46,7 +46,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.9.0
+      tag: 2.10.0
     timeout: 60m
 
   # Specify additional external labels which will be added to all

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -93,7 +93,7 @@ func TestStorage(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Optio
 					Containers: []corev1.Container{
 						{
 							Name:  "busybox",
-							Image: "quay.io/kubermatic/util:2.9.0",
+							Image: "quay.io/kubermatic/util:2.10.0",
 							Args: []string{
 								"/bin/sh",
 								"-c",

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.9.0
+          image: quay.io/kubermatic/util:2.10.0
           args:
             - /bin/sh
             - -c

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -120,7 +120,7 @@ is_containerized() {
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.9.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.10.0}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
   local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
   local skip="${NO_CONTAINERIZE:-}"

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -1056,7 +1056,7 @@ func (r *reconciler) generateKubeOneActionJob(ctx context.Context, log *zap.Suga
 					InitContainers: []corev1.Container{
 						{
 							Name:    "copy-ro-manifest",
-							Image:   registry.Must(data.RewriteImage("quay.io/kubermatic/util:2.9.0")),
+							Image:   registry.Must(data.RewriteImage("quay.io/kubermatic/util:2.10.0")),
 							Command: []string{"/bin/sh"},
 							Args: []string{
 								"-c",

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -260,7 +260,7 @@ func masterDeploymentReconciler(seed *kubermaticv1.Seed, secret *corev1.Secret, 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.9.0")),
+					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.10.0")),
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/pkg/resources/cloudcontroller/gcp.go
+++ b/pkg/resources/cloudcontroller/gcp.go
@@ -186,7 +186,7 @@ func gcpDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 func getGCPInitContainer(data *resources.TemplateData) corev1.Container {
 	return corev1.Container{
 		Name:    "decode-sa",
-		Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.9.0")),
+		Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.10.0")),
 		Command: []string{"/bin/sh"},
 		Args: []string{
 			"-c",

--- a/pkg/resources/encryption/job.go
+++ b/pkg/resources/encryption/job.go
@@ -75,7 +75,7 @@ func EncryptionJobCreator(data encryptionData, cluster *kubermaticv1.Cluster, se
 					Containers: []corev1.Container{
 						{
 							Name:    "encryption-runner",
-							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.9.0")),
+							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.10.0")),
 							Command: []string{"/bin/bash", "-c"},
 							Args: []string{
 								fmt.Sprintf(encryptionJobScript, resourceList),

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -95,7 +95,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.9.0
+        image: quay.io/kubermatic/util:2.10.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -95,7 +95,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.9.0
+        image: quay.io/kubermatic/util:2.10.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -95,7 +95,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.9.0
+        image: quay.io/kubermatic/util:2.10.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.36.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.36.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -95,7 +95,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.9.0
+        image: quay.io/kubermatic/util:2.10.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -340,7 +340,7 @@ func egressValidatorPod(ipVersion int) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  fmt.Sprintf("egress-validator-%d-container", ipVersion),
-					Image: "quay.io/kubermatic/util:2.9.0",
+					Image: "quay.io/kubermatic/util:2.10.0",
 					Command: []string{
 						"/bin/sh",
 						"-c",

--- a/pkg/test/dualstack/egress-validator-4.yaml
+++ b/pkg/test/dualstack/egress-validator-4.yaml
@@ -17,7 +17,7 @@ spec:
   containers:
     - name: egress-validator-4-container
       ports: []
-      image: quay.io/kubermatic/util:2.9.0
+      image: quay.io/kubermatic/util:2.10.0
       imagePullPolicy: IfNotPresent
       command:
         - /bin/sh

--- a/pkg/test/dualstack/egress-validator-6.yaml
+++ b/pkg/test/dualstack/egress-validator-6.yaml
@@ -17,7 +17,7 @@ spec:
   containers:
     - name: egress-validator-6-container
       ports: []
-      image: quay.io/kubermatic/util:2.9.0
+      image: quay.io/kubermatic/util:2.10.0
       imagePullPolicy: IfNotPresent
       command:
         - /bin/sh

--- a/pkg/test/dualstack/egress-validator-daemonset.yaml
+++ b/pkg/test/dualstack/egress-validator-daemonset.yaml
@@ -30,7 +30,7 @@ spec:
       hostNetwork: false
       containers:
         - name: egress-validator-4-container
-          image: quay.io/kubermatic/util:2.9.0
+          image: quay.io/kubermatic/util:2.10.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -81,7 +81,7 @@ spec:
       hostNetwork: false
       containers:
         - name: egress-validator-6-container
-          image: quay.io/kubermatic/util:2.9.0
+          image: quay.io/kubermatic/util:2.10.0
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
**What this PR does / why we need it**:
The util image (quay.io/kubermatic/util) was pinned at different tags across the codebase: 2.9.0 in the grafana, prometheus, minio and karma charts and in the GCP CCM, encryption job and seed-proxy controllers, while other spots were already moved to 2.10.0. The prometheus chart even disagreed with its own golden files. This PR pins every reference to 2.10.0 and regenerates the affected chart and test fixtures.

**Which issue(s) this PR fixes**:
Fixes #16193

**What type of PR is this?**:
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Updated the utility container image to 2.10.0 across all charts and controllers.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```