### PR TITLE
[release/v2.30] Bump machine-controller to v1.65.7 and operating-system-manager to v1.10.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,8 +98,8 @@ require (
 	helm.sh/helm/v3 v3.19.0
 	k8c.io/kubeone v1.12.3
 	k8c.io/kubermatic/sdk/v2 v2.28.1
-	k8c.io/machine-controller/sdk v1.65.6
-	k8c.io/operating-system-manager v1.10.8
+	k8c.io/machine-controller/sdk v1.65.7
+	k8c.io/operating-system-manager v1.10.9
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.35.0
 	k8s.io/apiextensions-apiserver v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -1669,10 +1669,10 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.12.3 h1:b+dmLJDsofUiDHzyUmR512wXnF5LDDI1KpHsS/BTbrY=
 k8c.io/kubeone v1.12.3/go.mod h1:saB47KgCNP2028b/ZHZlNal1p7xHqmVfc3LSj+WOW/A=
-k8c.io/machine-controller/sdk v1.65.6 h1:mdNbdtRKGDwx7ojHkyN9CqGcW1ex4QbAlEN665r9QYI=
-k8c.io/machine-controller/sdk v1.65.6/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
-k8c.io/operating-system-manager v1.10.8 h1:8SxZe/UkTTAXcarXxuFALElws2L+0FX77MQTl+nFyoI=
-k8c.io/operating-system-manager v1.10.8/go.mod h1:zb4iLxfuEpwObHf8vhGpdoP3MQfn+2WHgr3gKGdRE6E=
+k8c.io/machine-controller/sdk v1.65.7 h1:XQh+wieW1nC2mheicj/K42acdgGF7MvHgU6em2Aia+M=
+k8c.io/machine-controller/sdk v1.65.7/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
+k8c.io/operating-system-manager v1.10.9 h1:JSy6KzJktF3O3obQ0/rku8XydBCqLKvekvex6iohkDs=
+k8c.io/operating-system-manager v1.10.9/go.mod h1:qD6tOKHgL5r8ckyI2rnwFU98Db/8BWYMsKhMnjVvoy0=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=
 k8c.io/reconciler v0.5.0/go.mod h1:pT1+SVcVXJQeBJhpJBXQ5XW64QnKKeYTnVlQf0dGE0k=
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -53,7 +53,7 @@ var controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
 const (
 	// Name is the alias for `resources.MachineControllerContainerName` for backward compatibility.
 	Name = resources.MachineControllerContainerName
-	Tag  = "v1.65.6"
+	Tag  = "v1.65.7"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -55,7 +55,7 @@ var controllerResourceRequirements = map[string]*corev1.ResourceRequirements{
 }
 
 const (
-	Tag = "v1.10.8"
+	Tag = "v1.10.9"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller-webhook.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-machine-controller.yaml
@@ -76,7 +76,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller-webhook.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-machine-controller.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.32.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller-webhook.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-machine-controller.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.33.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller-webhook.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-machine-controller.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.34.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller-webhook.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-machine-controller.yaml
@@ -82,7 +82,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.35.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.32.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.33.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.34.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller-externalCloudProvider.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller-webhook.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-machine-controller.yaml
@@ -67,7 +67,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.35.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller-webhook.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-machine-controller.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.32.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller-webhook.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-machine-controller.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.33.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller-webhook.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-machine-controller.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.34.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller-webhook.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-machine-controller.yaml
@@ -103,7 +103,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.35.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-machine-controller.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.32.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-machine-controller.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.33.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-machine-controller.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.34.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.35.0-machine-controller-webhook.yaml
@@ -88,7 +88,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.35.0-machine-controller.yaml
@@ -90,7 +90,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.35.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-cluster-dns","169.254.20.10"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.32.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.33.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.34.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.65.6
+        image: quay.io/kubermatic/machine-controller:v1.65.7
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager-webhook.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.35.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.10.8
+        image: quay.io/kubermatic/operating-system-manager:v1.10.9
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the machine-controller module pin and image tag to v1.65.7 and operating-system-manager to v1.10.9. Both upstream releases are Go toolchain security bumps. The MC tag carries its `sdk/v1.65.7` twin, and OSM v1.10.9 has no API changes, so no codegen or CRD sync is needed. Resource fixtures are regenerated to match the new image tags.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update machine-controller to v1.65.7 and operating-system-manager to v1.10.9.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```