### PR TITLE
Sync changelogs for KKP patch releases v2.31.1/v2.30.7/v2.29.11

### DIFF
--- a/docs/changelogs/CHANGELOG-2.29.md
+++ b/docs/changelogs/CHANGELOG-2.29.md
@@ -11,6 +11,37 @@
 - [v2.29.8](#v2298)
 - [v2.29.9](#v2299)
 - [v2.29.10](#v22910)
+- [v2.29.11](#v22911)
+
+## v2.29.11
+
+**GitHub release: [v2.29.11](https://github.com/kubermatic/kubermatic/releases/tag/v2.29.11)**
+
+### Supported Kubernetes Versions
+
+- Add support for k8s patch release v1.34.11 ([#16301](https://github.com/kubermatic/kubermatic/pull/16301))
+
+#### Supported Versions
+
+- v1.34.11
+
+### Cloud Providers
+
+#### OpenStack
+
+- Update OpenStack Cinder CSI sidecar images (csi-attacher v4.12.0, csi-snapshotter v8.6.0, livenessprobe v2.19.0, csi-node-driver-registrar v2.17.0) to address known CVEs ([#16333](https://github.com/kubermatic/kubermatic/pull/16333))
+
+### Updates
+
+- Update machine-controller to [v1.64.5](https://github.com/kubermatic/machine-controller/releases/tag/v1.64.5) ([#16349](https://github.com/kubermatic/kubermatic/pull/16349))
+- Update machine-controller to [v1.64.4](https://github.com/kubermatic/machine-controller/releases/tag/v1.64.4) ([#16278](https://github.com/kubermatic/kubermatic/pull/16278))
+- Update the utility container image to 2.10.0 across all charts and controllers ([#16341](https://github.com/kubermatic/kubermatic/pull/16341))
+
+### Dashboard and API
+
+#### Bugfixes
+
+- Hide cluster backup options in Community Edition, where the feature is not supported ([#8255](https://github.com/kubermatic/dashboard/pull/8255))
 
 ## v2.29.10
 

--- a/docs/changelogs/CHANGELOG-2.30.md
+++ b/docs/changelogs/CHANGELOG-2.30.md
@@ -7,6 +7,60 @@
 - [v2.30.4](#v2304)
 - [v2.30.5](#v2305)
 - [v2.30.6](#v2306)
+- [v2.30.7](#v2307)
+
+## v2.30.7
+
+**GitHub release: [v2.30.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.30.7)**
+
+### Supported Kubernetes Versions
+
+- Add support for k8s patch releases v1.35.8/v1.34.11 and set the default Kubernetes version to v1.34.11 ([#16300](https://github.com/kubermatic/kubermatic/pull/16300))
+
+#### Supported Versions
+
+- v1.35.8
+- v1.34.11
+
+### Cloud Providers
+
+#### Azure
+
+- Update the Azure cloud-controller-manager, cloud-node-manager, and the Azure Disk and Azure File CSI drivers to their latest upstream versions per supported Kubernetes minor. The controller-manager and node-manager images now come from the maintained mcr.microsoft.com/oss/v2 registry path (the previous /oss path was frozen at v1.34.3), clearing the base-image CVEs those stale images carried. Kubernetes 1.35 clusters now receive matching 1.35 controller-manager and node-manager images instead of 1.34 ones ([#16216](https://github.com/kubermatic/kubermatic/pull/16216))
+
+#### OpenStack
+
+- Update OpenStack Cinder CSI sidecar images (csi-attacher v4.12.0, csi-snapshotter v8.6.0, livenessprobe v2.19.0, csi-node-driver-registrar v2.17.0) to address known CVEs ([#16328](https://github.com/kubermatic/kubermatic/pull/16328))
+
+### Bugfixes
+
+- Migrate the user cluster MLA monitoring agent from the end-of-life grafana/agent v0.29.0 image to grafana/alloy v1.19.2 ([#16334](https://github.com/kubermatic/kubermatic/pull/16334))
+- Fix hardcoded datasource references in the mla-components Grafana dashboard by using a `$datasource` variable, and drop the unused Loki datasource ([#16313](https://github.com/kubermatic/kubermatic/pull/16313))
+- The Cluster Autoscaler application now grants the read access to resource.k8s.io that cluster-autoscaler 1.35 and newer require ([#16251](https://github.com/kubermatic/kubermatic/pull/16251))
+- Kubermatic-installer now passes --force-conflicts to Helm 4 only for releases that Helm applies server-side, fixing deploy failures on releases that were originally installed with Helm 3 ([#16210](https://github.com/kubermatic/kubermatic/pull/16210))
+
+### Updates
+
+- Update machine-controller to [v1.65.7](https://github.com/kubermatic/machine-controller/releases/tag/v1.65.7) and operating-system-manager to [v1.10.9](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.10.9) ([#16348](https://github.com/kubermatic/kubermatic/pull/16348))
+- Update machine-controller to [v1.65.6](https://github.com/kubermatic/machine-controller/releases/tag/v1.65.6) ([#16277](https://github.com/kubermatic/kubermatic/pull/16277))
+- Update operating-system-manager to [v1.10.8](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.10.8) ([#16283](https://github.com/kubermatic/kubermatic/pull/16283))
+- Add KubeLB CCM v1.5.0 support with updated permissions, CRDs and tenant proxy configuration ([#16336](https://github.com/kubermatic/kubermatic/pull/16336))
+- Update the metering version to v1.4.1, adding persistent storage usage to the JSON cluster report ([#16270](https://github.com/kubermatic/kubermatic/pull/16270))
+- Update the utility container image to 2.10.0 across all charts and controllers ([#16340](https://github.com/kubermatic/kubermatic/pull/16340))
+- Update util image version to 2.8.1 ([#16259](https://github.com/kubermatic/kubermatic/pull/16259))
+- Update the d3fk/s3cmd image to a current digest built on Alpine 3.24, resolving 62 CVEs inherited from the previously used end-of-life Alpine 3.17 base ([#16194](https://github.com/kubermatic/kubermatic/pull/16194))
+- Update Go version to v1.25.14 ([#16285](https://github.com/kubermatic/kubermatic/pull/16285))
+
+### Dashboard and API
+
+#### Bugfixes
+
+- Hide cluster backup options in Community Edition, where the feature is not supported ([#8240](https://github.com/kubermatic/dashboard/pull/8240))
+
+#### Updates
+
+- Update web-terminal image version to v1.12.1 ([#8275](https://github.com/kubermatic/dashboard/pull/8275))
+- Update chrome-headless to v1.9.4 and Go to v1.25.14 ([#8271](https://github.com/kubermatic/dashboard/pull/8271))
 
 ## v2.30.6
 

--- a/docs/changelogs/CHANGELOG-2.31.md
+++ b/docs/changelogs/CHANGELOG-2.31.md
@@ -1,6 +1,48 @@
 # Kubermatic 2.31
 
+- [v2.31.1](#v2311)
 - [v2.31.0](#v2310)
+
+## v2.31.1
+
+**GitHub release: [v2.31.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.31.1)**
+
+### Supported Kubernetes Versions
+
+- Add support for k8s patch releases v1.36.4/v1.35.8/v1.34.11 and set the default Kubernetes version to v1.35.8 ([#16293](https://github.com/kubermatic/kubermatic/pull/16293))
+
+#### Supported Versions
+
+- v1.36.4
+- v1.35.8
+- v1.34.11
+
+### Cloud Providers
+
+#### OpenStack
+
+- Update OpenStack Cinder CSI sidecar images (csi-attacher v4.12.0, csi-snapshotter v8.6.0, livenessprobe v2.19.0, csi-node-driver-registrar v2.17.0) to address known CVEs ([#16328](https://github.com/kubermatic/kubermatic/pull/16328))
+
+### Bugfixes
+
+- Migrate the user cluster MLA monitoring agent from the end-of-life grafana/agent v0.29.0 image to grafana/alloy v1.19.2 ([#16334](https://github.com/kubermatic/kubermatic/pull/16334))
+- Fix hardcoded datasource references in the mla-components Grafana dashboard by using a `$datasource` variable, and drop the unused Loki datasource ([#16313](https://github.com/kubermatic/kubermatic/pull/16313))
+
+### Updates
+
+- Update machine-controller to [v1.66.3](https://github.com/kubermatic/machine-controller/releases/tag/v1.66.3) and operating-system-manager to [v1.11.4](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.11.4) ([#16350](https://github.com/kubermatic/kubermatic/pull/16350))
+- Add KubeLB CCM v1.5.0 support with updated permissions, CRDs and tenant proxy configuration ([#16336](https://github.com/kubermatic/kubermatic/pull/16336))
+- Add Cilium versions v1.18.13/v1.19.7 and set the default Cilium version to v1.19.7 ([#16311](https://github.com/kubermatic/kubermatic/pull/16311))
+- Update the utility container image to 2.10.0 across all charts and controllers ([#16337](https://github.com/kubermatic/kubermatic/pull/16337))
+- Update web-terminal image version to v1.13.1 ([#16294](https://github.com/kubermatic/kubermatic/pull/16294))
+- Update Go version to v1.26.7 ([#16284](https://github.com/kubermatic/kubermatic/pull/16284))
+
+### Dashboard and API
+
+#### Updates
+
+- Update web-terminal image to v1.13.1 ([#8272](https://github.com/kubermatic/dashboard/pull/8272))
+- Update chrome-headless image to v1.10.0 and Go to v1.26.7 ([#8270](https://github.com/kubermatic/dashboard/pull/8270))
 
 ## v2.31.0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Syncs the v2.31.1, v2.30.7 and v2.29.11 changelog sections to main, verbatim from the merged release-branch changelog PRs #16353, #16354 and #16355. Follows the pattern of #16184.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**test-issue**:
```test-issue
NONE
```