### PR TITLE
bump user-cluster MLA logging agent to Alloy v1.19.2

### DIFF
--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -233,6 +233,9 @@ products:
       - goConstant:
           package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent
           constant: tag
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent
+          constant: imageTag
 
   - name: MinIO
     source: https://github.com/minio/minio
@@ -267,9 +270,6 @@ products:
           directory: charts/monitoring/grafana
       - helmChart:
           directory: charts/mla/grafana
-      - goConstant:
-          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent
-          constant: imageTag
 
   - name: Helm Exporter
     source: https://github.com/sstarcher/helm-exporter

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	imageName     = "grafana/alloy"
-	imageTag      = "v1.9.2"
+	imageTag      = "v1.19.2"
 	appName       = "mla-logging-agent"
 	containerName = "grafana-alloy"
 
@@ -96,7 +96,7 @@ func DaemonSetReconciler(overrides *corev1.ResourceRequirements, imageRewriter r
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            containerName,
-					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s:%s", imageName, imageTag))),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, imageName, imageTag))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"run",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/secret.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/secret.go
@@ -127,7 +127,6 @@ loki.process "logs_default_kubernetes_pods_app_kubernetes_io_name" {
 loki.source.file "logs_default_kubernetes_pods_app_kubernetes_io_name" {
         targets               = local.file_match.logs_default_kubernetes_pods_app_kubernetes_io_name.targets
         forward_to            = [loki.process.logs_default_kubernetes_pods_app_kubernetes_io_name.receiver]
-        legacy_positions_file = "/run/grafana-agent/positions.yaml"
 }
 
 discovery.kubernetes "logs_default_kubernetes_pods_app" {
@@ -206,7 +205,6 @@ loki.process "logs_default_kubernetes_pods_app" {
 loki.source.file "logs_default_kubernetes_pods_app" {
         targets               = local.file_match.logs_default_kubernetes_pods_app.targets
         forward_to            = [loki.process.logs_default_kubernetes_pods_app.receiver]
-        legacy_positions_file = "/run/grafana-agent/positions.yaml"
 }
 
 discovery.kubernetes "logs_default_kubernetes_pods_direct_controllers" {
@@ -281,7 +279,6 @@ loki.process "logs_default_kubernetes_pods_direct_controllers" {
 loki.source.file "logs_default_kubernetes_pods_direct_controllers" {
         targets               = local.file_match.logs_default_kubernetes_pods_direct_controllers.targets
         forward_to            = [loki.process.logs_default_kubernetes_pods_direct_controllers.receiver]
-        legacy_positions_file = "/run/grafana-agent/positions.yaml"
 }
 
 discovery.kubernetes "logs_default_kubernetes_pods_indirect_controller" {
@@ -357,7 +354,6 @@ loki.process "logs_default_kubernetes_pods_indirect_controller" {
 loki.source.file "logs_default_kubernetes_pods_indirect_controller" {
         targets               = local.file_match.logs_default_kubernetes_pods_indirect_controller.targets
         forward_to            = [loki.process.logs_default_kubernetes_pods_indirect_controller.receiver]
-        legacy_positions_file = "/run/grafana-agent/positions.yaml"
 }
 
 discovery.kubernetes "logs_default_kubernetes_other" {
@@ -437,7 +433,6 @@ loki.process "logs_default_kubernetes_other" {
 loki.source.file "logs_default_kubernetes_other" {
         targets               = local.file_match.logs_default_kubernetes_other.targets
         forward_to            = [loki.process.logs_default_kubernetes_other.receiver]
-        legacy_positions_file = "/run/grafana-agent/positions.yaml"
 }
 
 loki.write "logs_default" {

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -54,6 +54,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity"
 	k8sdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
+	mlaloggingagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent"
 	mlamonitoringagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent"
 	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
@@ -514,6 +515,7 @@ func getImagesFromReconcilers(_ logrus.FieldLogger, templateData *resources.Temp
 		kubermaticVersions,
 		templateData.RewriteImage,
 	))
+	daemonsetReconcilers = append(daemonsetReconcilers, mlaloggingagent.DaemonSetReconciler(nil, templateData.RewriteImage))
 	daemonsetReconcilers = append(daemonsetReconcilers, nodelocaldns.DaemonSetReconciler(templateData.RewriteImage))
 	daemonsetReconcilers = append(daemonsetReconcilers, envoyagent.DaemonSetReconciler(templateData.Cluster(), net.IPv4(0, 0, 0, 0), kubermaticVersions, "", templateData.RewriteImage))
 

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -132,6 +132,15 @@ func TestMLAIntegration(t *testing.T) {
 	}
 	defer cleanupMetricsProbe(context.Background(), logger, testJig)
 
+	// deployed early for the same reason as the metrics probe: the logging
+	// agent needs time to discover the pod and ship its first lines before
+	// verifyLogsRoundTrip asserts on them near the end of the run.
+	logger.Info("Deploying the logs probe workload into the user cluster...")
+	if err := deployLogsProbe(ctx, logger, testJig); err != nil {
+		t.Fatalf("failed to deploy logs probe workload: %v", err)
+	}
+	defer cleanupLogsProbe(context.Background(), logger, testJig)
+
 	logger.Info("Waiting for project to get Grafana org annotation...")
 	p := &kubermaticv1.Project{}
 	orgID := ""
@@ -212,6 +221,10 @@ func TestMLAIntegration(t *testing.T) {
 
 	if err := verifyMetricsRoundTrip(ctx, logger, probe, testJig, cluster); err != nil {
 		t.Errorf("failed to verify metrics round trip: %v", err)
+	}
+
+	if err := verifyLogsRoundTrip(ctx, logger, probe, testJig); err != nil {
+		t.Errorf("failed to verify logs round trip: %v", err)
 	}
 
 	logger.Info("Disabling MLA...")
@@ -1278,6 +1291,63 @@ func verifyMetricsRoundTrip(ctx context.Context, log *zap.SugaredLogger, probe *
 	return nil
 }
 
+// verifyLogsRoundTrip proves the user-cluster logging agent works end to end:
+// the logs probe pod's marker line must travel agent -> mla-gateway -> Loki and
+// be readable through the gateway read path. Until this check, the only Loki
+// write the suite exercises is a synthetic curl push that bypasses the agent,
+// so a bump that crashloops ds/mla-logging-agent still passed the suite.
+func verifyLogsRoundTrip(ctx context.Context, log *zap.SugaredLogger, probe *gatewayProbe, testJig *jig.TestJig) error {
+	log.Info("Verifying the logs round trip through Loki...")
+
+	clusterClient, err := testJig.ClusterJig.ClusterClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get user cluster client: %w", err)
+	}
+
+	// without a healthy agent nothing is shipped, so check it first to get a
+	// precise error instead of an opaque query timeout
+	if err := utils.WaitForDaemonSetReady(ctx, clusterClient, log, resources.UserClusterMLANamespace, resources.MLALoggingAgentDaemonSetName, 5*time.Minute); err != nil {
+		return fmt.Errorf("logging agent DaemonSet did not get ready: %w", err)
+	}
+
+	// the probe has been emitting since it was deployed early in the run, so a
+	// one-minute window behind now always contains marker lines
+	readCmd := curlGet(lokiQueryRangeURL(gatewayReadAddr(probe.Namespace), logsProbeJob, time.Now()))
+
+	lastBody := ""
+
+	queryErr := wait.Poll(ctx, 5*time.Second, 6*time.Minute, func(ctx context.Context) (error, error) {
+		stdout, _, execErr := probe.Exec(ctx, gatewayProbeContainer, readCmd...)
+		if execErr != nil {
+			return execErr, nil
+		}
+
+		lastBody = stdout
+
+		response, err := parseLokiQueryResponse(stdout)
+		if err != nil {
+			return err, nil
+		}
+
+		if len(response.Data.Result) == 0 {
+			return errors.New("stream not visible in Loki yet"), nil
+		}
+
+		if !strings.Contains(stdout, logsProbeMarker) {
+			return fmt.Errorf("stream found but marker %q missing (response: %q)", logsProbeMarker, stdout), nil
+		}
+
+		return nil, nil
+	})
+	if queryErr != nil {
+		return fmt.Errorf("job %q not queryable through the gateway read path (last response: %q): %w", logsProbeJob, lastBody, queryErr)
+	}
+
+	log.Info("Logs round trip verified.")
+
+	return nil
+}
+
 // isTLSRejection reports whether an exec error looks like curl refusing at the
 // TLS layer: exit 35 (SSL connect error) when the handshake is rejected
 // outright, exit 56 (recv failure) when nginx completes the TLS 1.3 handshake
@@ -1384,6 +1454,17 @@ const (
 	// metricsProbeMetric is the series the probe pod serves and the test queries
 	// back out of Cortex.
 	metricsProbeMetric = "mla_e2e_probe_total"
+
+	logsProbePodName = "mla-logs-probe"
+	logsProbeImage   = "docker.io/library/busybox:1.36"
+
+	// logsProbeMarker is the fixed line the logs probe emits every few seconds;
+	// its presence in Loki is the logging-agent round trip.
+	logsProbeMarker = "mla-logs-probe-marker"
+
+	// logsProbeJob is the stream label the logging agent's relabel pipeline
+	// derives from the pod's namespace and app.kubernetes.io/name labels.
+	logsProbeJob = metav1.NamespaceDefault + "/" + logsProbePodName
 )
 
 // newMetricsProbePod returns an agnhost "porter" pod, which serves the content of
@@ -1434,6 +1515,69 @@ func newMetricsProbePod(ns, runID string) *corev1.Pod {
 			},
 			TerminationGracePeriodSeconds: ptr.To[int64](0),
 		},
+	}
+}
+
+// newLogsProbePod returns a busybox pod that emits the marker line every few
+// seconds. The app.kubernetes.io/name label is what the logging agent's
+// discovery relabeling keys off; without it the pod is invisible to the agent.
+func newLogsProbePod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      logsProbePodName,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": logsProbePodName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyAlways,
+			Containers: []corev1.Container{
+				{
+					Name:  logsProbePodName,
+					Image: logsProbeImage,
+					Command: []string{
+						"sh", "-c",
+						fmt.Sprintf(`while true; do echo "%s"; sleep 5; done`, logsProbeMarker),
+					},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+}
+
+// deployLogsProbe creates the log source in the user cluster.
+func deployLogsProbe(ctx context.Context, log *zap.SugaredLogger, testJig *jig.TestJig) error {
+	clusterClient, err := testJig.ClusterJig.ClusterClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get user cluster client: %w", err)
+	}
+
+	// best-effort removal of leftovers from a previous aborted run.
+	_ = clusterClient.Delete(ctx, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: logsProbePodName, Namespace: metav1.NamespaceDefault}})
+
+	if err := clusterClient.Create(ctx, newLogsProbePod()); err != nil {
+		return fmt.Errorf("failed to create logs probe pod: %w", err)
+	}
+
+	if !utils.CheckPodsRunningReady(ctx, clusterClient, log, metav1.NamespaceDefault, []string{logsProbePodName}, 5*time.Minute) {
+		return errors.New("timeout occurred while waiting for logs probe pod readiness")
+	}
+
+	return nil
+}
+
+func cleanupLogsProbe(ctx context.Context, log *zap.SugaredLogger, testJig *jig.TestJig) {
+	clusterClient, err := testJig.ClusterJig.ClusterClient(ctx)
+	if err != nil {
+		log.Warnw("Failed to clean up logs probe pod", zap.Error(err))
+		return
+	}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: logsProbePodName, Namespace: metav1.NamespaceDefault}}
+	if err := clusterClient.Delete(ctx, pod); err != nil && !apierrors.IsNotFound(err) {
+		log.Warnw("Failed to clean up logs probe pod", zap.Error(err))
 	}
 }
 

--- a/pkg/test/e2e/utils/kubernetes.go
+++ b/pkg/test/e2e/utils/kubernetes.go
@@ -332,3 +332,25 @@ func WaitForDeploymentReady(ctx context.Context, c ctrlruntimeclient.Client, log
 		return nil, nil
 	})
 }
+
+// WaitForDaemonSetReady waits until every scheduled pod of the DaemonSet is ready.
+func WaitForDaemonSetReady(ctx context.Context, c ctrlruntimeclient.Client, log *zap.SugaredLogger, ns, name string, timeout time.Duration) error {
+	key := ctrlruntimeclient.ObjectKey{Name: name, Namespace: ns}
+
+	// namespace and timeout are already set in the log's context
+	logger := log.With("daemonset", key.String())
+	logger.Info("Waiting for DaemonSet to be ready...")
+
+	return wait.PollImmediateLog(ctx, log, 5*time.Second, timeout, func(ctx context.Context) (error, error) {
+		status, err := resources.HealthyDaemonSet(ctx, c, key, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		if status != kubermaticv1.HealthStatusUp {
+			return fmt.Errorf("DaemonSet is %v", status), nil
+		}
+
+		return nil, nil
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The user-cluster MLA logging agent has been left on Alloy v1.9.2 while the monitoring agent moved to v1.19.2 (#16334) and the seed chart to v1.17.0 (#16027), so one user cluster runs three Alloy versions. This PR bumps the logging agent to v1.19.2 to match the monitoring agent, drops the dead `legacy_positions_file` argument from the config (it points at `/run/grafana-agent/`, a path that has not existed since the grafana-agent rename), moves the logging-agent constant from the Grafana to the Alloy product in `hack/versions.yaml`, and adds the logging agent DaemonSet to the installer image list so airgapped setups cannot miss a future tag divergence between the two agents. The mla e2e suite now also asserts a logs round trip through the logging agent and the gateway read path; until now the Loki write path was only exercised by a synthetic curl push that bypasses the agent, so a bump that crashloops the logging agent still passed.

**Which issue(s) this PR fixes**:
Fixes #16052

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The user-cluster MLA logging agent now runs Grafana Alloy v1.19.2, the same version as the monitoring agent.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```