### PR TITLE
run dependabot against release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,3 +67,57 @@ updates:
       - docs/none
       - test-issue/none
       - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/sdk"
+    target-branch: main
+    schedule:
+      interval: daily
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/sdk"
+    target-branch: release/v2.31
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "go"
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/sdk"
+    target-branch: release/v2.30
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "go"
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/sdk"
+    target-branch: release/v2.29
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "go"
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,51 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: "/"
+    target-branch: main
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+      interval: daily
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/"
+    target-branch: release/v2.31
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "go"
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/"
+    target-branch: release/v2.30
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "go"
+    labels:
+      - dependencies
+      - release-note-none
+      - docs/none
+      - test-issue/none
+      - ok-to-test
+
+  - package-ecosystem: gomod
+    directory: "/"
+    target-branch: release/v2.29
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "go"
     labels:
       - dependencies
       - release-note-none


### PR DESCRIPTION
**What this PR does / why we need it**:
Dependabot only ran against `main`, so supported release branches got no automated dependency update PRs. This adds daily gomod update entries for `release/v2.31`, `release/v2.30` and `release/v2.29`, and raises the `main` schedule from weekly to daily. Entries for the `/sdk` module are added as well; the `/sdk` PRs seen on `main` so far came from update jobs that predate the explicit dependabot configuration and only target `main`. Release-branch entries ignore the `go` directive because those branches pin an older Go than `main` (1.25.x on v2.30, 1.24.x on v2.29), in both the root and the sdk module.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
