### PR TITLE
limit dependabot to one weekly PR per module and branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,8 @@ updates:
     directory: "/"
     target-branch: main
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     labels:
       - dependencies
       - release-note-none
@@ -30,7 +31,8 @@ updates:
     directory: "/"
     target-branch: release/v2.31
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "go"
     labels:
@@ -44,7 +46,8 @@ updates:
     directory: "/"
     target-branch: release/v2.30
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "go"
     labels:
@@ -58,7 +61,8 @@ updates:
     directory: "/"
     target-branch: release/v2.29
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "go"
     labels:
@@ -72,7 +76,8 @@ updates:
     directory: "/sdk"
     target-branch: main
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     labels:
       - dependencies
       - release-note-none
@@ -84,7 +89,8 @@ updates:
     directory: "/sdk"
     target-branch: release/v2.31
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "go"
     labels:
@@ -98,7 +104,8 @@ updates:
     directory: "/sdk"
     target-branch: release/v2.30
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "go"
     labels:
@@ -112,7 +119,8 @@ updates:
     directory: "/sdk"
     target-branch: release/v2.29
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "go"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
The daily schedule added in #16362 produces more open PRs than intended: with 8 update entries (root and sdk module across main and three release branches), the default limit of 5 per entry allows up to 40 open PRs. This sets the schedule back to weekly and caps `open-pull-requests-limit` to 1 per entry, so at most one PR per module per branch is open at a time.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
