### PR TITLE
Reconcile KubeLB tenant defaults when project settings change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730
+	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -510,5 +511,4 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/release-utils v0.12.4 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -106,6 +106,10 @@ echodate "Running integration tests..."
 # * Extracting the dirname as the `go test` command doesn't play well with individual files as args
 # * Prefixing them with `./` as that's needed by `go test` as well
 for file in $(grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ | xargs dirname | sort -u); do
+  if [[ "${KUBERMATIC_EDITION:-ce}" == "ce" && "$file" == pkg/ee/* ]]; then
+    continue
+  fi
+
   echodate "Testing package ${file}..."
 
   if [[ "$file" =~ .*vsphere.* ]] && provider_disabled vsphere; then

--- a/pkg/ee/kubelb/README.md
+++ b/pkg/ee/kubelb/README.md
@@ -5,6 +5,18 @@ SyncSecret CRD and TenantWAFPolicy CRD in the user cluster. The CRDs are sourced
 from the KubeLB EE v1.5.0 CCM chart. In mTLS mode, the tenant proxy runs in the
 user cluster's `kube-system` namespace.
 
+## Project defaults
+
+Changes to `Project.spec.defaultTenantSpec` are applied to existing KubeLB
+Tenants as well as new ones. KKP manages these defaults with Server-Side Apply;
+removing a default removes fields owned only by KKP. Management-side settings
+owned by other field managers are preserved. Conflicting edits to the same
+field are reported as reconciliation errors and must be resolved by the
+administrator; KKP does not force ownership.
+
+Existing ownership from `seed-controller-manager` is migrated for the Tenant
+spec and KKP labels. Tenants created by other tools retain their field ownership.
+
 ## Images
 
 The xDS writer uses the configured CCM image. Envoy and shutdown-manager image

--- a/pkg/ee/kubelb/README.md
+++ b/pkg/ee/kubelb/README.md
@@ -7,15 +7,19 @@ user cluster's `kube-system` namespace.
 
 ## Project defaults
 
-Changes to `Project.spec.defaultTenantSpec` are applied to existing KubeLB
-Tenants as well as new ones. KKP manages these defaults with Server-Side Apply;
-removing a default removes fields owned only by KKP. Management-side settings
-owned by other field managers are preserved. Conflicting edits to the same
-field are reported as reconciliation errors and must be resolved by the
-administrator; KKP does not force ownership.
+Changes to `Project.spec.defaultTenantSpec` are applied to new and existing
+KubeLB Tenants with Server-Side Apply. Removing a previously adopted default
+removes fields owned only by KKP. Other managers' settings are preserved;
+conflicts are reported as reconciliation errors without forcing ownership.
+Conflicts on active Tenants do not stop CCM maintenance.
 
-Existing ownership from `seed-controller-manager` is migrated for the Tenant
-spec and KKP labels. Tenants created by other tools retain their field ownership.
+Legacy ownership from `seed-controller-manager` is adopted only for KKP labels
+and fields explicitly set in the current project defaults. Omitted legacy fields
+are retained because their original configuration is unknown. Once a field is
+adopted, subsequent removal from the project defaults works normally.
+
+Custom management-cluster credentials must allow `patch` on
+`tenants.kubelb.k8c.io`.
 
 ## Images
 

--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -26,7 +26,6 @@ package kubelbcontroller
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -50,17 +49,23 @@ import (
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kubernetesjson "k8s.io/apimachinery/pkg/util/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -117,6 +122,7 @@ func Add(mgr manager.Manager, numWorkers int, workerName string, overwriteRegist
 			MaxConcurrentReconciles: numWorkers,
 		}).
 		For(&kubermaticv1.Cluster{}, builder.WithPredicates(workerlabel.Predicate(workerName), clusterIsAlive)).
+		Watches(&kubermaticv1.Project{}, reconciler.enqueueClustersForProject(), builder.WithPredicates(projectDefaultsChangedPredicate())).
 		Build(reconciler)
 
 	return err
@@ -249,32 +255,43 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 }
 
 func (r *reconciler) createOrUpdateKubeLBManagementClusterResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, defaultTenantSpec *runtime.RawExtension) error {
-	tenant := &unstructured.Unstructured{}
-	tenant.SetGroupVersionKind(kubelbclusterresources.KubelbTenantGVK)
-	tenant.SetName(cluster.Name)
-	tenant.SetLabels(map[string]string{
-		"kubermatic.k8c.io/cluster-name":          cluster.Name,
-		"kubermatic.k8c.io/cluster-external-name": cluster.Status.Address.ExternalName,
-		"kubermatic.k8c.io/cluster-project-id":    cluster.Labels[kubermaticv1.ProjectIDLabelKey],
-	})
-
-	if defaultTenantSpec != nil && len(defaultTenantSpec.Raw) > 0 {
-		spec := map[string]any{}
-		if err := json.Unmarshal(defaultTenantSpec.Raw, &spec); err != nil {
-			return fmt.Errorf("failed to decode project default tenant spec: %w", err)
-		}
-		tenant.Object["spec"] = spec
+	tenant, err := kubelbclusterresources.Tenant(cluster, defaultTenantSpec)
+	if err != nil {
+		return err
 	}
 
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(kubelbclusterresources.KubelbTenantGVK)
 	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(tenant), existing); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get tenant: %w", err)
+			return fmt.Errorf("failed to get tenant %q: %w", tenant.GetName(), err)
 		}
-		if err := client.Create(ctx, tenant); err != nil {
-			return fmt.Errorf("failed to create tenant: %w", err)
+	} else {
+		if !existing.GetDeletionTimestamp().IsZero() {
+			return fmt.Errorf("tenant %q is still terminating", tenant.GetName())
 		}
+
+		// Older KKP versions created Tenants with Update field ownership. Move
+		// only KKP's fields to the apply manager so updates and removals work
+		// without taking ownership from management-cluster administrators.
+		patch, err := kubelbclusterresources.TenantManagedFieldsMigrationPatch(existing, ControllerName)
+		if err != nil {
+			return fmt.Errorf("failed to migrate tenant %q field ownership: %w", tenant.GetName(), err)
+		}
+		if patch != nil {
+			if err := client.Patch(ctx, existing, ctrlruntimeclient.RawPatch(types.JSONPatchType, patch)); err != nil {
+				return fmt.Errorf("failed to migrate tenant %q field ownership: %w", tenant.GetName(), err)
+			}
+		}
+	}
+
+	// Standard Create/Update reconcilers do not detect field ownership conflicts.
+	// Apply only project defaults and KKP labels. Omitted fields previously
+	// owned by KKP are removed; other managers' fields remain untouched. A
+	// conflicting administrator edit is reported through the reconciliation
+	// condition instead of being overwritten with ForceOwnership.
+	if err := client.Apply(ctx, ctrlruntimeclient.ApplyConfigurationFromUnstructured(tenant), ctrlruntimeclient.FieldOwner(ControllerName)); err != nil {
+		return fmt.Errorf("failed to apply project defaults to tenant %q: %w", tenant.GetName(), err)
 	}
 	return nil
 }
@@ -472,4 +489,72 @@ func normalizeTenantKubeconfig(tenantKubeconfig, managementKubeconfig []byte) ([
 	}
 
 	return clientcmd.Write(*tenantCfg)
+}
+
+func (r *reconciler) enqueueClustersForProject() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj ctrlruntimeclient.Object) []reconcile.Request {
+		project, ok := obj.(*kubermaticv1.Project)
+		if !ok || project == nil || !project.DeletionTimestamp.IsZero() {
+			return nil
+		}
+
+		clusters := &kubermaticv1.ClusterList{}
+		if err := r.List(ctx, clusters, ctrlruntimeclient.MatchingLabels{kubermaticv1.ProjectIDLabelKey: project.Name}); err != nil {
+			// Mapping handlers cannot retry failed reads. A later Project or Cluster
+			// event must enqueue the affected clusters again.
+			utilruntime.HandleError(fmt.Errorf("failed to list clusters for KubeLB project %q: %w", project.Name, err))
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, cluster := range clusters.Items {
+			// Mapped requests bypass the predicates on the Cluster watch.
+			if cluster.Labels[kubermaticv1.WorkerNameLabelKey] != r.workerName ||
+				cluster.Spec.Pause || cluster.Status.NamespaceName == "" ||
+				!cluster.DeletionTimestamp.IsZero() || !cluster.Spec.IsKubeLBEnabled() {
+				continue
+			}
+			requests = append(requests, reconcile.Request{NamespacedName: ctrlruntimeclient.ObjectKeyFromObject(&cluster)})
+		}
+		return requests
+	})
+}
+
+func projectDefaultsChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		// Include initial informer events even when defaults are empty: defaults
+		// may have been removed while this controller was stopped.
+		CreateFunc: func(e event.CreateEvent) bool {
+			project, ok := e.Object.(*kubermaticv1.Project)
+			return ok && project != nil && project.DeletionTimestamp.IsZero()
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldProject, oldOK := e.ObjectOld.(*kubermaticv1.Project)
+			newProject, newOK := e.ObjectNew.(*kubermaticv1.Project)
+			return oldOK && newOK && oldProject != nil && newProject != nil && newProject.DeletionTimestamp.IsZero() &&
+				!projectDefaultTenantSpecsEqual(oldProject.Spec.DefaultTenantSpec, newProject.Spec.DefaultTenantSpec)
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+func projectDefaultTenantSpecsEqual(oldSpec, newSpec *runtime.RawExtension) bool {
+	if apiequality.Semantic.DeepEqual(oldSpec, newSpec) {
+		return true
+	}
+	if oldSpec == nil || newSpec == nil {
+		return false
+	}
+
+	// Formatting and object-key order do not change the desired Tenant spec.
+	// Preserve integer values when decoding so large numbers compare correctly.
+	var oldValue, newValue any
+	if err := kubernetesjson.Unmarshal(oldSpec.Raw, &oldValue); err != nil {
+		return false
+	}
+	if err := kubernetesjson.Unmarshal(newSpec.Raw, &newValue); err != nil {
+		return false
+	}
+	return apiequality.Semantic.DeepEqual(oldValue, newValue)
 }

--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	kubernetesjson "k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
@@ -240,60 +241,72 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 		}
 	}
 
-	// Create/update required resources in kubeLB management cluster.
-	if err := r.createOrUpdateKubeLBManagementClusterResources(ctx, kubeLBManagementClient, cluster, project.Spec.DefaultTenantSpec); err != nil {
-		return nil, err
+	return r.reconcileKubeLBResources(ctx, kubeLBManagementClient, kubeLBManagementKubeConfig, cluster, datacenter, project.Spec.DefaultTenantSpec)
+}
+
+func (r *reconciler) reconcileKubeLBResources(ctx context.Context, kubeLBManagementClient ctrlruntimeclient.Client, kubeLBManagementKubeConfig []byte, cluster *kubermaticv1.Cluster, datacenter kubermaticv1.Datacenter, defaultTenantSpec *runtime.RawExtension) (*reconcile.Result, error) {
+	// Register new Tenants before waiting for their credentials. For an existing
+	// live Tenant, a defaults error must not block CCM maintenance.
+	existingUsable, tenantErr := r.createOrUpdateKubeLBManagementClusterResources(ctx, kubeLBManagementClient, cluster, defaultTenantSpec)
+	if tenantErr != nil && !existingUsable {
+		return nil, tenantErr
 	}
 
 	// Create/update required resources in user cluster.
 	if err := r.createOrUpdateKubeLBUserClusterResources(ctx, cluster, datacenter); err != nil {
-		return nil, err
+		return nil, kerrors.NewAggregate([]error{tenantErr, err})
 	}
 
 	// Create/update required resources in user cluster namespace in seed.
-	return r.createOrUpdateKubeLBSeedClusterResources(ctx, cluster, kubeLBManagementClient, kubeLBManagementKubeConfig, datacenter)
+	result, err := r.createOrUpdateKubeLBSeedClusterResources(ctx, cluster, kubeLBManagementClient, kubeLBManagementKubeConfig, datacenter)
+	return result, kerrors.NewAggregate([]error{tenantErr, err})
 }
 
-func (r *reconciler) createOrUpdateKubeLBManagementClusterResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, defaultTenantSpec *runtime.RawExtension) error {
-	tenant, err := kubelbclusterresources.Tenant(cluster, defaultTenantSpec)
-	if err != nil {
-		return err
-	}
-
+// createOrUpdateKubeLBManagementClusterResources reports whether an existing,
+// nonterminating Tenant permits CCM maintenance when updating its defaults fails.
+func (r *reconciler) createOrUpdateKubeLBManagementClusterResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, defaultTenantSpec *runtime.RawExtension) (bool, error) {
 	existing := &unstructured.Unstructured{}
 	existing.SetGroupVersionKind(kubelbclusterresources.KubelbTenantGVK)
-	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(tenant), existing); err != nil {
+	existing.SetName(cluster.Name)
+	existingUsable := false
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(existing), existing); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to get tenant %q: %w", tenant.GetName(), err)
+			return false, fmt.Errorf("failed to get tenant %q: %w", cluster.Name, err)
 		}
 	} else {
 		if !existing.GetDeletionTimestamp().IsZero() {
-			return fmt.Errorf("tenant %q is still terminating", tenant.GetName())
+			return false, fmt.Errorf("tenant %q is still terminating", cluster.Name)
 		}
+		existingUsable = true
+	}
 
-		// Older KKP versions created Tenants with Update field ownership. Move
-		// only KKP's fields to the apply manager so updates and removals work
-		// without taking ownership from management-cluster administrators.
-		patch, err := kubelbclusterresources.TenantManagedFieldsMigrationPatch(existing, ControllerName)
+	tenant, err := kubelbclusterresources.Tenant(cluster, defaultTenantSpec)
+	if err != nil {
+		return existingUsable, err
+	}
+	if existingUsable {
+		// Adopt legacy ownership only for fields explicitly desired now.
+		// Omitted legacy fields may be API defaults and must be preserved.
+		patch, err := kubelbclusterresources.TenantManagedFieldsMigrationPatch(existing, tenant, ControllerName)
 		if err != nil {
-			return fmt.Errorf("failed to migrate tenant %q field ownership: %w", tenant.GetName(), err)
+			return true, fmt.Errorf("failed to migrate tenant %q field ownership: %w", tenant.GetName(), err)
 		}
 		if patch != nil {
 			if err := client.Patch(ctx, existing, ctrlruntimeclient.RawPatch(types.JSONPatchType, patch)); err != nil {
-				return fmt.Errorf("failed to migrate tenant %q field ownership: %w", tenant.GetName(), err)
+				return true, fmt.Errorf("failed to migrate tenant %q field ownership: %w", tenant.GetName(), err)
 			}
 		}
 	}
 
 	// Standard Create/Update reconcilers do not detect field ownership conflicts.
-	// Apply only project defaults and KKP labels. Omitted fields previously
-	// owned by KKP are removed; other managers' fields remain untouched. A
+	// Apply only project defaults and KKP labels. Omitted fields owned only
+	// by this apply manager are removed; other managers' fields remain. A
 	// conflicting administrator edit is reported through the reconciliation
 	// condition instead of being overwritten with ForceOwnership.
 	if err := client.Apply(ctx, ctrlruntimeclient.ApplyConfigurationFromUnstructured(tenant), ctrlruntimeclient.FieldOwner(ControllerName)); err != nil {
-		return fmt.Errorf("failed to apply project defaults to tenant %q: %w", tenant.GetName(), err)
+		return existingUsable, fmt.Errorf("failed to apply project defaults to tenant %q: %w", tenant.GetName(), err)
 	}
-	return nil
+	return existingUsable, nil
 }
 
 func (r *reconciler) createOrUpdateKubeLBUserClusterResources(ctx context.Context, cluster *kubermaticv1.Cluster, dc kubermaticv1.Datacenter) error {

--- a/pkg/ee/kubelb/controller_integration_test.go
+++ b/pkg/ee/kubelb/controller_integration_test.go
@@ -26,6 +26,7 @@ package kubelbcontroller
 
 import (
 	"context"
+	encodingjson "encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -101,7 +102,8 @@ func TestProjectWatchPropagatesTenantDefaultsIntegration(t *testing.T) {
 			if err := mgr.GetClient().Get(ctx, ctrlruntimeclient.ObjectKey{Name: cluster.Labels[kubermaticv1.ProjectIDLabelKey]}, project); err != nil {
 				return reconcile.Result{}, err
 			}
-			return reconcile.Result{}, tenantReconciler.createOrUpdateKubeLBManagementClusterResources(ctx, client, cluster, project.Spec.DefaultTenantSpec)
+			_, err := tenantReconciler.createOrUpdateKubeLBManagementClusterResources(ctx, client, cluster, project.Spec.DefaultTenantSpec)
+			return reconcile.Result{}, err
 		}))
 	if err != nil {
 		t.Fatalf("create target controller: %v", err)
@@ -208,12 +210,14 @@ func TestTenantProjectDefaultsIntegration(t *testing.T) {
 	fixture := newTenantIntegrationFixture(t)
 	t.Run("update and remove project fields while preserving administrator settings", fixture.updateAndRemoveDefaults)
 	t.Run("administrator override conflicts without partially applying defaults", fixture.administratorConflict)
-	t.Run("legacy KKP fields migrate and removed defaults are deleted", fixture.legacyMigration)
+	t.Run("legacy fields are preserved until explicitly adopted", fixture.legacyMigration)
+	t.Run("legacy GatewayClass mappings retain omitted entries and fields", fixture.legacyGatewayClassMappings)
 	t.Run("legacy administrator edit survives ownership migration", fixture.legacyAdministratorEdit)
 	t.Run("migration cannot overwrite concurrent field ownership changes", fixture.concurrentMigration)
 	t.Run("unknown previous owner is not migrated", fixture.unknownOwner)
 	t.Run("invalid defaults leave existing Tenant unchanged", fixture.invalidDefaults)
 	t.Run("Tenant pending deletion is not updated", fixture.deletingTenant)
+	t.Run("legacy API defaults survive changed and removed schema defaults", fixture.legacyDefaultProvenance)
 }
 
 type tenantIntegrationFixture struct {
@@ -238,7 +242,11 @@ func newTenantIntegrationFixture(t *testing.T) *tenantIntegrationFixture {
 			t.Errorf("stop API server: %v", err)
 		}
 	})
-	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register CRDs: %v", err)
+	}
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Scheme: scheme})
 	if err != nil {
 		t.Fatalf("create client: %v", err)
 	}
@@ -266,7 +274,7 @@ func (f *tenantIntegrationFixture) get(t *testing.T, cluster *kubermaticv1.Clust
 
 func (f *tenantIntegrationFixture) reconcile(t *testing.T, cluster *kubermaticv1.Cluster, raw string) {
 	t.Helper()
-	if err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(raw)}); err != nil {
+	if _, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(raw)}); err != nil {
 		t.Fatalf("reconcile Tenant: %v", err)
 	}
 }
@@ -345,7 +353,7 @@ func (f *tenantIntegrationFixture) updateAndRemoveDefaults(t *testing.T) {
 	assertIntegrationManagerMetadata(t, tenant)
 
 	for _, defaults := range []*runtime.RawExtension{nil, {}, {Raw: []byte(`{}`)}, {Raw: []byte(`null`)}} {
-		if err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, defaults); err != nil {
+		if _, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, defaults); err != nil {
 			t.Fatalf("clear project defaults: %v", err)
 		}
 		tenant = f.get(t, cluster)
@@ -364,7 +372,10 @@ func (f *tenantIntegrationFixture) administratorConflict(t *testing.T) {
 	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-project"},"loadBalancer":{"limit":5}}`)
 	f.applyAdmin(t, cluster, `{"gatewayAPI":{"class":"eg-admin"}}`, true)
 	before := f.get(t, cluster)
-	err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-new"},"loadBalancer":{"limit":10}}`)})
+	existingUsable, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-new"},"loadBalancer":{"limit":10}}`)})
+	if !existingUsable {
+		t.Error("existing Tenant must remain usable after an apply conflict")
+	}
 	if !apierrors.IsConflict(err) {
 		t.Fatalf("expected field ownership conflict, got %v", err)
 	}
@@ -396,20 +407,197 @@ func (f *tenantIntegrationFixture) legacyMigration(t *testing.T) {
 	assertIntegrationTenantSpec(t, tenant, `{
 		"allowedDomains":["**"],
 		"gatewayAPI":{"class":"eg-new"},
-		"timeouts":{"connect":"10s","idleConnection":"1h"},
-		"defaultAnnotations":{"service":{"admin":"keep"}}
+		"timeouts":{"connect":"10s","request":"30s","idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"project":"old","remove":"old","admin":"keep"}}
 	}`)
 	assertIntegrationManagerMetadata(t, tenant)
 	if tenant.GetLabels()["kubermatic.k8c.io/cluster-external-name"] != "test.example.com" {
 		t.Error("legacy cluster label was not updated")
 	}
-	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-later"}}`)
+
+	// A later Project update can adopt an initially omitted legacy field.
+	// Removing it subsequently then follows normal apply ownership semantics.
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-later"},"timeouts":{"request":"45s"},"defaultAnnotations":{"service":{"project":"new"}}}`)
 	assertIntegrationTenantSpec(t, f.get(t, cluster), `{
 		"allowedDomains":["**"],
 		"gatewayAPI":{"class":"eg-later"},
-		"timeouts":{"idleConnection":"1h"},
-		"defaultAnnotations":{"service":{"admin":"keep"}}
+		"timeouts":{"request":"45s","idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"project":"new","remove":"old","admin":"keep"}}
 	}`)
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-final"}}`)
+	assertIntegrationTenantSpec(t, f.get(t, cluster), `{
+		"allowedDomains":["**"],
+		"gatewayAPI":{"class":"eg-final"},
+		"timeouts":{"idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"remove":"old","admin":"keep"}}
+	}`)
+}
+
+func (f *tenantIntegrationFixture) legacyGatewayClassMappings(t *testing.T) {
+	// Model a future mapping field that KKP does not include in its desired
+	// configuration. The structural schema still tracks that field separately.
+	crd := f.tenantCRD(t)
+	original := crd.Spec.DeepCopy()
+	spec := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"]
+	gateway := spec.Properties["gatewayAPI"]
+	mappings := gateway.Properties["classMappings"]
+	mappings.Items.Schema.Properties["description"] = apiextensionsv1.JSONSchemaProps{Type: "string"}
+	if err := f.client.Update(f.ctx, crd); err != nil {
+		t.Fatalf("extend mapping schema: %v", err)
+	}
+	t.Cleanup(func() {
+		current := f.tenantCRD(t)
+		current.Spec = *original
+		if err := f.client.Update(f.ctx, current); err != nil {
+			t.Errorf("restore mapping schema: %v", err)
+		}
+	})
+	f.waitForTenantSchema(t,
+		`{"gatewayAPI":{"classMappings":[{"source":"probe","target":"eg-probe","description":"keep"}]}}`,
+		`{"allowedDomains":["**"],"gatewayAPI":{"classMappings":[{"source":"probe","target":"eg-probe","description":"keep"}]}}`)
+
+	cluster := f.newCluster()
+	tenant := integrationTenant(cluster.Name, integrationTenantSpec(t, `{
+		"gatewayAPI":{"classMappings":[
+			{"source":"public","target":"eg-old","description":"keep-public"},
+			{"source":"internal","target":"eg-internal","description":"keep-internal"}
+		]}
+	}`))
+	if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("seed-controller-manager")); err != nil {
+		t.Fatalf("create legacy Tenant mappings: %v", err)
+	}
+	f.reconcile(t, cluster, `{"gatewayAPI":{"classMappings":[{"source":"public","target":"eg-new"}]}}`)
+	tenant = f.get(t, cluster)
+	assertIntegrationTenantSpec(t, tenant, `{
+		"allowedDomains":["**"],
+		"gatewayAPI":{"classMappings":[
+			{"source":"public","target":"eg-new","description":"keep-public"},
+			{"source":"internal","target":"eg-internal","description":"keep-internal"}
+		]}
+	}`)
+	assertIntegrationTenantFieldOwner(t, tenant, ControllerName, true, "f:spec", "f:gatewayAPI", "f:classMappings", `k:{"source":"public"}`, "f:target")
+	for _, path := range [][]string{
+		{"f:spec", "f:gatewayAPI", "f:classMappings", `k:{"source":"public"}`, "f:description"},
+		{"f:spec", "f:gatewayAPI", "f:classMappings", `k:{"source":"internal"}`, "f:target"},
+	} {
+		assertIntegrationTenantFieldOwner(t, tenant, "seed-controller-manager", true, path...)
+		assertIntegrationTenantFieldOwner(t, tenant, ControllerName, false, path...)
+	}
+}
+
+func (f *tenantIntegrationFixture) legacyDefaultProvenance(t *testing.T) {
+	original := f.tenantCRD(t).Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"].Properties["allowedDomains"].Default
+	t.Cleanup(func() { f.setTenantDefault(t, original) })
+	cases := []struct {
+		name         string
+		defaultValue *apiextensionsv1.JSON
+		cluster      *kubermaticv1.Cluster
+	}{
+		{name: "changed default", defaultValue: &apiextensionsv1.JSON{Raw: []byte(`["*.current.example"]`)}, cluster: f.newCluster()},
+		{name: "removed default", cluster: f.newCluster()},
+	}
+	// Both Tenants were created under the original schema. Their Update manager
+	// owns API defaults as well as the fields explicitly supplied by old KKP.
+	for _, tc := range cases {
+		tenant := integrationTenant(tc.cluster.Name, integrationTenantSpec(t, `{"gatewayAPI":{"class":"eg-old"}}`))
+		if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("seed-controller-manager")); err != nil {
+			t.Fatalf("create legacy Tenant: %v", err)
+		}
+		assertIntegrationTenantFieldOwner(t, tenant, "seed-controller-manager", true, "f:spec", "f:allowedDomains")
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f.setTenantDefault(t, tc.defaultValue)
+			for _, class := range []string{"eg-new", "eg-later"} {
+				f.reconcile(t, tc.cluster, fmt.Sprintf(`{"gatewayAPI":{"class":%q}}`, class))
+				tenant := f.get(t, tc.cluster)
+				assertIntegrationTenantSpec(t, tenant, fmt.Sprintf(`{"allowedDomains":["**"],"gatewayAPI":{"class":%q}}`, class))
+				assertIntegrationTenantFieldOwner(t, tenant, "seed-controller-manager", true, "f:spec", "f:allowedDomains")
+				assertIntegrationTenantFieldOwner(t, tenant, ControllerName, false, "f:spec", "f:allowedDomains")
+			}
+
+			// Only an explicit Project value adopts the field. Later omission can
+			// then remove it and let the currently installed schema default apply.
+			f.reconcile(t, tc.cluster, `{"gatewayAPI":{"class":"eg-later"},"allowedDomains":["*.project.example"]}`)
+			tenant := f.get(t, tc.cluster)
+			assertIntegrationTenantSpec(t, tenant, `{"allowedDomains":["*.project.example"],"gatewayAPI":{"class":"eg-later"}}`)
+			assertIntegrationTenantFieldOwner(t, tenant, ControllerName, true, "f:spec", "f:allowedDomains")
+			assertIntegrationTenantFieldOwner(t, tenant, "seed-controller-manager", false, "f:spec", "f:allowedDomains")
+			f.reconcile(t, tc.cluster, `{"gatewayAPI":{"class":"eg-final"}}`)
+			expected := `{"gatewayAPI":{"class":"eg-final"}}`
+			if tc.defaultValue != nil {
+				expected = fmt.Sprintf(`{"gatewayAPI":{"class":"eg-final"},"allowedDomains":%s}`, tc.defaultValue.Raw)
+			}
+			assertIntegrationTenantSpec(t, f.get(t, tc.cluster), expected)
+		})
+	}
+}
+
+func (f *tenantIntegrationFixture) tenantCRD(t *testing.T) *apiextensionsv1.CustomResourceDefinition {
+	t.Helper()
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := f.client.Get(f.ctx, ctrlruntimeclient.ObjectKey{Name: "tenants.kubelb.k8c.io"}, crd); err != nil {
+		t.Fatalf("get Tenant CRD: %v", err)
+	}
+	return crd
+}
+
+func (f *tenantIntegrationFixture) setTenantDefault(t *testing.T, value *apiextensionsv1.JSON) {
+	t.Helper()
+	crd := f.tenantCRD(t)
+	spec := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"]
+	allowedDomains := spec.Properties["allowedDomains"]
+	allowedDomains.Default = value
+	spec.Properties["allowedDomains"] = allowedDomains
+	if err := f.client.Update(f.ctx, crd); err != nil {
+		t.Fatalf("update Tenant schema default: %v", err)
+	}
+	expected := `{"gatewayAPI":{"class":"eg-probe"}}`
+	if value != nil {
+		expected = fmt.Sprintf(`{"gatewayAPI":{"class":"eg-probe"},"allowedDomains":%s}`, value.Raw)
+	}
+	f.waitForTenantSchema(t, `{"gatewayAPI":{"class":"eg-probe"}}`, expected)
+}
+
+func (f *tenantIntegrationFixture) waitForTenantSchema(t *testing.T, probeSpec, expectedSpec string) {
+	t.Helper()
+	expected := integrationTenantSpec(t, expectedSpec)
+	err := wait.PollUntilContextTimeout(f.ctx, 100*time.Millisecond, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+		probe := integrationTenant(f.newCluster().Name, integrationTenantSpec(t, probeSpec))
+		if err := f.client.Create(ctx, probe); err != nil {
+			return false, err
+		}
+		if err := f.client.Delete(ctx, probe); err != nil {
+			return false, err
+		}
+		actual, _, err := unstructured.NestedMap(probe.Object, "spec")
+		return reflect.DeepEqual(actual, expected), err
+	})
+	if err != nil {
+		t.Fatalf("wait for updated Tenant schema: %v", err)
+	}
+}
+
+func assertIntegrationTenantFieldOwner(t *testing.T, tenant *unstructured.Unstructured, manager string, want bool, path ...string) {
+	t.Helper()
+	owned := false
+	for _, entry := range tenant.GetManagedFields() {
+		if entry.Manager != manager || entry.FieldsV1 == nil || entry.Subresource != "" {
+			continue
+		}
+		fields := map[string]interface{}{}
+		if err := encodingjson.NewDecoder(entry.FieldsV1.GetRawReader()).Decode(&fields); err != nil {
+			t.Fatalf("decode field ownership: %v", err)
+		}
+		_, found, err := unstructured.NestedFieldNoCopy(fields, path...)
+		if err != nil {
+			t.Fatalf("read field ownership: %v", err)
+		}
+		owned = owned || found
+	}
+	if owned != want {
+		t.Errorf("manager %q ownership of %v: got %t, want %t", manager, path, owned, want)
+	}
 }
 
 func (f *tenantIntegrationFixture) legacyAdministratorEdit(t *testing.T) {
@@ -421,7 +609,7 @@ func (f *tenantIntegrationFixture) legacyAdministratorEdit(t *testing.T) {
 	if err := f.client.Patch(f.ctx, tenant, ctrlruntimeclient.RawPatch(types.MergePatchType, []byte(`{"spec":{"gatewayAPI":{"class":"eg-admin"}}}`)), ctrlruntimeclient.FieldOwner("tenant-admin")); err != nil {
 		t.Fatalf("edit legacy Tenant: %v", err)
 	}
-	err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-project"},"loadBalancer":{"limit":10}}`)})
+	_, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-project"},"loadBalancer":{"limit":10}}`)})
 	if !apierrors.IsConflict(err) {
 		t.Fatalf("expected conflict with the administrator's legacy edit, got %v", err)
 	}
@@ -434,7 +622,8 @@ func (f *tenantIntegrationFixture) concurrentMigration(t *testing.T) {
 	if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("seed-controller-manager")); err != nil {
 		t.Fatalf("create legacy Tenant: %v", err)
 	}
-	migration, err := kubelbclusterresources.TenantManagedFieldsMigrationPatch(tenant, ControllerName)
+	desired := integrationTenant(cluster.Name, integrationTenantSpec(t, `{"gatewayAPI":{"class":"eg-project"}}`))
+	migration, err := kubelbclusterresources.TenantManagedFieldsMigrationPatch(tenant, desired, ControllerName)
 	if err != nil || migration == nil {
 		t.Fatalf("prepare ownership migration: patch=%s error=%v", migration, err)
 	}
@@ -457,7 +646,7 @@ func (f *tenantIntegrationFixture) unknownOwner(t *testing.T) {
 		t.Fatalf("create externally managed Tenant: %v", err)
 	}
 	before := f.get(t, cluster)
-	err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-project"}}`)})
+	_, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-project"}}`)})
 	if !apierrors.IsConflict(err) {
 		t.Fatalf("expected existing owner conflict, got %v", err)
 	}
@@ -472,7 +661,10 @@ func (f *tenantIntegrationFixture) invalidDefaults(t *testing.T) {
 	for _, raw := range []string{`{`, `[]`, `"text"`, `true`, `42`, `{"unknownSetting":true}`, `{"loadBalancer":{"limit":"invalid"}}`} {
 		t.Run(raw, func(t *testing.T) {
 			before := f.get(t, cluster)
-			err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(raw)})
+			existingUsable, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(raw)})
+			if !existingUsable {
+				t.Error("existing Tenant must remain usable after invalid defaults")
+			}
 			if err == nil {
 				t.Fatal("expected invalid defaults to be rejected")
 			}
@@ -495,8 +687,12 @@ func (f *tenantIntegrationFixture) deletingTenant(t *testing.T) {
 	if before.GetDeletionTimestamp().IsZero() {
 		t.Fatal("Tenant should be pending finalization")
 	}
-	if err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-new"}}`)}); err == nil {
+	existingUsable, err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-new"}}`)})
+	if err == nil {
 		t.Fatal("expected reconciliation of a deleting Tenant to fail")
+	}
+	if existingUsable {
+		t.Error("a terminating Tenant must not be considered usable")
 	}
 	if !reflect.DeepEqual(before.Object, f.get(t, cluster).Object) {
 		t.Error("reconciliation changed a Tenant pending deletion")
@@ -540,7 +736,7 @@ func assertIntegrationTenantSpec(t *testing.T, tenant *unstructured.Unstructured
 			bySource := map[string]interface{}{}
 			for _, entry := range mappings {
 				mapping := entry.(map[string]interface{})
-				bySource[mapping["source"].(string)] = mapping["target"]
+				bySource[mapping["source"].(string)] = mapping
 			}
 			if err := unstructured.SetNestedMap(spec, bySource, "gatewayAPI", "classMappings"); err != nil {
 				t.Fatalf("normalize GatewayClass mappings: %v", err)

--- a/pkg/ee/kubelb/controller_integration_test.go
+++ b/pkg/ee/kubelb/controller_integration_test.go
@@ -1,0 +1,553 @@
+//go:build ee && integration
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2026 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package kubelbcontroller
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	kubelbclusterresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/kubelb-cluster"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestProjectWatchPropagatesTenantDefaultsIntegration(t *testing.T) {
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{"testdata/tenant-crd.yaml"},
+		ErrorIfCRDPathMissing: true,
+		CRDs: []*apiextensionsv1.CustomResourceDefinition{
+			projectWatchIntegrationCRD("Project", "projects"),
+			projectWatchIntegrationCRD("Cluster", "clusters"),
+		},
+	}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("start API server: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := env.Stop(); err != nil {
+			t.Errorf("stop API server: %v", err)
+		}
+	})
+	scheme := runtime.NewScheme()
+	if err := kubermaticv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register KKP resources: %v", err)
+	}
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("create direct client: %v", err)
+	}
+	mgr, err := manager.New(cfg, manager.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+
+	// The target controller has no Cluster watch or periodic requeue. Every
+	// reconciliation must originate from the production Project mapper and predicate.
+	tenantReconciler := &reconciler{Client: mgr.GetClient()}
+	_, err = builder.ControllerManagedBy(mgr).
+		Named("tenant-project-watch-test").
+		Watches(&kubermaticv1.Project{}, tenantReconciler.enqueueClustersForProject(), builder.WithPredicates(projectDefaultsChangedPredicate())).
+		Build(reconcile.Func(func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+			cluster := &kubermaticv1.Cluster{}
+			if err := mgr.GetClient().Get(ctx, request.NamespacedName, cluster); err != nil {
+				return reconcile.Result{}, err
+			}
+			project := &kubermaticv1.Project{}
+			if err := mgr.GetClient().Get(ctx, ctrlruntimeclient.ObjectKey{Name: cluster.Labels[kubermaticv1.ProjectIDLabelKey]}, project); err != nil {
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{}, tenantReconciler.createOrUpdateKubeLBManagementClusterResources(ctx, client, cluster, project.Spec.DefaultTenantSpec)
+		}))
+	if err != nil {
+		t.Fatalf("create target controller: %v", err)
+	}
+
+	ctx := context.Background()
+	project := &kubermaticv1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project"},
+		Spec: kubermaticv1.ProjectSpec{
+			DefaultTenantSpec: &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-initial"}}`)},
+		},
+	}
+	if err := client.Create(ctx, project); err != nil {
+		t.Fatalf("create Project: %v", err)
+	}
+	cluster := projectWatchCluster("project-watch-cluster")
+	if err := client.Create(ctx, cluster); err != nil {
+		t.Fatalf("create Cluster: %v", err)
+	}
+	cluster.Status.NamespaceName = "cluster-" + cluster.Name
+	if err := client.Status().Update(ctx, cluster); err != nil {
+		t.Fatalf("mark Cluster provisioned: %v", err)
+	}
+	clusterResourceVersion := cluster.ResourceVersion
+
+	managerCtx, cancel := context.WithCancel(ctx)
+	managerDone := make(chan error, 1)
+	go func() { managerDone <- mgr.Start(managerCtx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-managerDone:
+			if err != nil {
+				t.Errorf("manager failed: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("manager did not stop")
+		}
+	})
+
+	waitForClass := func(want string) {
+		t.Helper()
+		var lastClass string
+		err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 15*time.Second, true, func(ctx context.Context) (bool, error) {
+			tenant := integrationTenant(cluster.Name, nil)
+			if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(tenant), tenant); err != nil {
+				return false, ctrlruntimeclient.IgnoreNotFound(err)
+			}
+			value, found, err := unstructured.NestedString(tenant.Object, "spec", "gatewayAPI", "class")
+			lastClass = value
+			return value == want && found == (want != ""), err
+		})
+		if err != nil {
+			t.Fatalf("wait for Project watch to set Tenant class %q: %v (last class %q)", want, err, lastClass)
+		}
+		unchanged := &kubermaticv1.Cluster{}
+		if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(cluster), unchanged); err != nil {
+			t.Fatalf("get Cluster: %v", err)
+		}
+		if unchanged.ResourceVersion != clusterResourceVersion {
+			t.Fatalf("Cluster changed during Project-only propagation: resourceVersion %s -> %s", clusterResourceVersion, unchanged.ResourceVersion)
+		}
+	}
+	waitForClass("eg-initial")
+	project.Spec.DefaultTenantSpec = &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-updated"}}`)}
+	if err := client.Update(ctx, project); err != nil {
+		t.Fatalf("update Project defaults: %v", err)
+	}
+	waitForClass("eg-updated")
+	project.Spec.DefaultTenantSpec = nil
+	if err := client.Update(ctx, project); err != nil {
+		t.Fatalf("remove Project defaults: %v", err)
+	}
+	waitForClass("")
+}
+
+// These resources are used only for watching and reading through the cache;
+// preserve their typed payloads without installing unrelated KKP validation.
+func projectWatchIntegrationCRD(kind, plural string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: plural + "." + kubermaticv1.SchemeGroupVersion.Group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: kubermaticv1.SchemeGroupVersion.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: kind, ListKind: kind + "List", Plural: plural},
+			Scope: apiextensionsv1.ClusterScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name: kubermaticv1.SchemeGroupVersion.Version, Served: true, Storage: true,
+				Subresources: &apiextensionsv1.CustomResourceSubresources{Status: &apiextensionsv1.CustomResourceSubresourceStatus{}},
+				Schema: &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"spec":   {Type: "object", XPreserveUnknownFields: ptr.To(true)},
+						"status": {Type: "object", XPreserveUnknownFields: ptr.To(true)},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+// These cases need an API server: the fake client's deduced schema does not
+// reproduce CRD defaulting or the list-map ownership of GatewayClass mappings.
+func TestTenantProjectDefaultsIntegration(t *testing.T) {
+	fixture := newTenantIntegrationFixture(t)
+	t.Run("update and remove project fields while preserving administrator settings", fixture.updateAndRemoveDefaults)
+	t.Run("administrator override conflicts without partially applying defaults", fixture.administratorConflict)
+	t.Run("legacy KKP fields migrate and removed defaults are deleted", fixture.legacyMigration)
+	t.Run("legacy administrator edit survives ownership migration", fixture.legacyAdministratorEdit)
+	t.Run("migration cannot overwrite concurrent field ownership changes", fixture.concurrentMigration)
+	t.Run("unknown previous owner is not migrated", fixture.unknownOwner)
+	t.Run("invalid defaults leave existing Tenant unchanged", fixture.invalidDefaults)
+	t.Run("Tenant pending deletion is not updated", fixture.deletingTenant)
+}
+
+type tenantIntegrationFixture struct {
+	ctx        context.Context
+	client     ctrlruntimeclient.Client
+	reconciler *reconciler
+	sequence   int
+}
+
+func newTenantIntegrationFixture(t *testing.T) *tenantIntegrationFixture {
+	t.Helper()
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{"testdata/tenant-crd.yaml"},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("start API server: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := env.Stop(); err != nil {
+			t.Errorf("stop API server: %v", err)
+		}
+	})
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	return &tenantIntegrationFixture{ctx: context.Background(), client: client, reconciler: &reconciler{}}
+}
+
+func (f *tenantIntegrationFixture) newCluster() *kubermaticv1.Cluster {
+	f.sequence++
+	cluster := &kubermaticv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Name:   fmt.Sprintf("tenant-defaults-%d", f.sequence),
+		Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: "test-project"},
+	}}
+	cluster.Status.Address.ExternalName = "test.example.com"
+	return cluster
+}
+
+func (f *tenantIntegrationFixture) get(t *testing.T, cluster *kubermaticv1.Cluster) *unstructured.Unstructured {
+	t.Helper()
+	tenant := integrationTenant(cluster.Name, nil)
+	if err := f.client.Get(f.ctx, ctrlruntimeclient.ObjectKeyFromObject(tenant), tenant); err != nil {
+		t.Fatalf("get Tenant: %v", err)
+	}
+	return tenant
+}
+
+func (f *tenantIntegrationFixture) reconcile(t *testing.T, cluster *kubermaticv1.Cluster, raw string) {
+	t.Helper()
+	if err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(raw)}); err != nil {
+		t.Fatalf("reconcile Tenant: %v", err)
+	}
+}
+
+func (f *tenantIntegrationFixture) applyAdmin(t *testing.T, cluster *kubermaticv1.Cluster, raw string, force bool) {
+	t.Helper()
+	tenant := integrationTenant(cluster.Name, integrationTenantSpec(t, raw))
+	opts := []ctrlruntimeclient.ApplyOption{ctrlruntimeclient.FieldOwner("tenant-admin")}
+	if force {
+		opts = append(opts, ctrlruntimeclient.ForceOwnership)
+	}
+	if err := f.client.Apply(f.ctx, ctrlruntimeclient.ApplyConfigurationFromUnstructured(tenant), opts...); err != nil {
+		t.Fatalf("apply administrator settings: %v", err)
+	}
+}
+
+func (f *tenantIntegrationFixture) setManagerMetadata(t *testing.T, cluster *kubermaticv1.Cluster) {
+	t.Helper()
+	tenant := f.get(t, cluster)
+	base := tenant.DeepCopy()
+	tenant.SetFinalizers([]string{"kubelb.k8c.io/cleanup"})
+	tenant.SetAnnotations(map[string]string{"test.kubelb.k8c.io/keep": "true"})
+	if err := f.client.Patch(f.ctx, tenant, ctrlruntimeclient.MergeFrom(base), ctrlruntimeclient.FieldOwner("kubelb-manager")); err != nil {
+		t.Fatalf("set manager metadata: %v", err)
+	}
+	tenant.Object["status"] = map[string]interface{}{"phase": "Ready"}
+	if err := f.client.Status().Update(f.ctx, tenant, ctrlruntimeclient.FieldOwner("kubelb-manager")); err != nil {
+		t.Fatalf("set manager status: %v", err)
+	}
+}
+
+func assertIntegrationManagerMetadata(t *testing.T, tenant *unstructured.Unstructured) {
+	t.Helper()
+	if !reflect.DeepEqual(tenant.GetFinalizers(), []string{"kubelb.k8c.io/cleanup"}) || tenant.GetAnnotations()["test.kubelb.k8c.io/keep"] != "true" {
+		t.Errorf("manager metadata changed: finalizers=%v annotations=%v", tenant.GetFinalizers(), tenant.GetAnnotations())
+	}
+	if !reflect.DeepEqual(tenant.Object["status"], map[string]interface{}{"phase": "Ready"}) {
+		t.Errorf("manager status changed: %v", tenant.Object["status"])
+	}
+}
+
+func (f *tenantIntegrationFixture) updateAndRemoveDefaults(t *testing.T) {
+	cluster := f.newCluster()
+	f.reconcile(t, cluster, `{
+		"allowedDomains":["*.example.com"],
+		"gatewayAPI":{"classMappings":[{"source":"internal","target":"eg-internal"},{"source":"public","target":"eg-public"}]},
+		"timeouts":{"connect":"5s","request":"30s"},
+		"defaultAnnotations":{"service":{"project":"old","remove":"old"}}
+	}`)
+	initial := f.get(t, cluster)
+	if initial.GetLabels()["kubermatic.k8c.io/cluster-project-id"] != "test-project" || initial.GetLabels()["kubermatic.k8c.io/cluster-name"] != cluster.Name || initial.GetLabels()["kubermatic.k8c.io/cluster-external-name"] != "test.example.com" {
+		t.Fatalf("missing cluster identity labels: %v", initial.GetLabels())
+	}
+	f.applyAdmin(t, cluster, `{
+		"gatewayAPI":{"class":"eg-admin","classMappings":[{"source":"admin","target":"eg-admin"}]},
+		"timeouts":{"idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"admin":"keep"}}
+	}`, false)
+	f.setManagerMetadata(t, cluster)
+	cluster.Status.Address.ExternalName = "updated.example.com"
+	f.reconcile(t, cluster, `{
+		"gatewayAPI":{"classMappings":[{"source":"internal","target":"eg-internal-v2"}]},
+		"timeouts":{"connect":"10s"},
+		"defaultAnnotations":{"service":{"project":"new"}}
+	}`)
+	tenant := f.get(t, cluster)
+	assertIntegrationTenantSpec(t, tenant, `{
+		"allowedDomains":["**"],
+		"gatewayAPI":{"class":"eg-admin","classMappings":[{"source":"internal","target":"eg-internal-v2"},{"source":"admin","target":"eg-admin"}]},
+		"timeouts":{"connect":"10s","idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"project":"new","admin":"keep"}}
+	}`)
+	if tenant.GetUID() != initial.GetUID() || tenant.GetLabels()["kubermatic.k8c.io/cluster-external-name"] != "updated.example.com" {
+		t.Errorf("Tenant identity or external-name label incorrect: uid=%s labels=%v", tenant.GetUID(), tenant.GetLabels())
+	}
+	assertIntegrationManagerMetadata(t, tenant)
+
+	for _, defaults := range []*runtime.RawExtension{nil, {}, {Raw: []byte(`{}`)}, {Raw: []byte(`null`)}} {
+		if err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, defaults); err != nil {
+			t.Fatalf("clear project defaults: %v", err)
+		}
+		tenant = f.get(t, cluster)
+		assertIntegrationTenantSpec(t, tenant, `{
+			"allowedDomains":["**"],
+			"gatewayAPI":{"class":"eg-admin","classMappings":[{"source":"admin","target":"eg-admin"}]},
+			"timeouts":{"idleConnection":"1h"},
+			"defaultAnnotations":{"service":{"admin":"keep"}}
+		}`)
+		assertIntegrationManagerMetadata(t, tenant)
+	}
+}
+
+func (f *tenantIntegrationFixture) administratorConflict(t *testing.T) {
+	cluster := f.newCluster()
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-project"},"loadBalancer":{"limit":5}}`)
+	f.applyAdmin(t, cluster, `{"gatewayAPI":{"class":"eg-admin"}}`, true)
+	before := f.get(t, cluster)
+	err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-new"},"loadBalancer":{"limit":10}}`)})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected field ownership conflict, got %v", err)
+	}
+	after := f.get(t, cluster)
+	if !reflect.DeepEqual(before.Object, after.Object) {
+		t.Error("conflicting apply changed the existing Tenant")
+	}
+}
+
+func (f *tenantIntegrationFixture) legacyMigration(t *testing.T) {
+	cluster := f.newCluster()
+	tenant := integrationTenant(cluster.Name, integrationTenantSpec(t, `{
+		"gatewayAPI":{"class":"eg-old"},
+		"timeouts":{"connect":"5s","request":"30s"},
+		"defaultAnnotations":{"service":{"project":"old","remove":"old"}}
+	}`))
+	tenant.SetLabels(map[string]string{
+		"kubermatic.k8c.io/cluster-name":          cluster.Name,
+		"kubermatic.k8c.io/cluster-external-name": "old.example.com",
+		"kubermatic.k8c.io/cluster-project-id":    "test-project",
+	})
+	if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("seed-controller-manager")); err != nil {
+		t.Fatalf("create legacy Tenant: %v", err)
+	}
+	f.applyAdmin(t, cluster, `{"timeouts":{"idleConnection":"1h"},"defaultAnnotations":{"service":{"admin":"keep"}}}`, false)
+	f.setManagerMetadata(t, cluster)
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-new"},"timeouts":{"connect":"10s"}}`)
+	tenant = f.get(t, cluster)
+	assertIntegrationTenantSpec(t, tenant, `{
+		"allowedDomains":["**"],
+		"gatewayAPI":{"class":"eg-new"},
+		"timeouts":{"connect":"10s","idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"admin":"keep"}}
+	}`)
+	assertIntegrationManagerMetadata(t, tenant)
+	if tenant.GetLabels()["kubermatic.k8c.io/cluster-external-name"] != "test.example.com" {
+		t.Error("legacy cluster label was not updated")
+	}
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-later"}}`)
+	assertIntegrationTenantSpec(t, f.get(t, cluster), `{
+		"allowedDomains":["**"],
+		"gatewayAPI":{"class":"eg-later"},
+		"timeouts":{"idleConnection":"1h"},
+		"defaultAnnotations":{"service":{"admin":"keep"}}
+	}`)
+}
+
+func (f *tenantIntegrationFixture) legacyAdministratorEdit(t *testing.T) {
+	cluster := f.newCluster()
+	tenant := integrationTenant(cluster.Name, integrationTenantSpec(t, `{"gatewayAPI":{"class":"eg-old"},"loadBalancer":{"limit":5}}`))
+	if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("seed-controller-manager")); err != nil {
+		t.Fatalf("create legacy Tenant: %v", err)
+	}
+	if err := f.client.Patch(f.ctx, tenant, ctrlruntimeclient.RawPatch(types.MergePatchType, []byte(`{"spec":{"gatewayAPI":{"class":"eg-admin"}}}`)), ctrlruntimeclient.FieldOwner("tenant-admin")); err != nil {
+		t.Fatalf("edit legacy Tenant: %v", err)
+	}
+	err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-project"},"loadBalancer":{"limit":10}}`)})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected conflict with the administrator's legacy edit, got %v", err)
+	}
+	assertIntegrationTenantSpec(t, f.get(t, cluster), `{"allowedDomains":["**"],"gatewayAPI":{"class":"eg-admin"},"loadBalancer":{"limit":5}}`)
+}
+
+func (f *tenantIntegrationFixture) concurrentMigration(t *testing.T) {
+	cluster := f.newCluster()
+	tenant := integrationTenant(cluster.Name, integrationTenantSpec(t, `{"gatewayAPI":{"class":"eg-old"}}`))
+	if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("seed-controller-manager")); err != nil {
+		t.Fatalf("create legacy Tenant: %v", err)
+	}
+	migration, err := kubelbclusterresources.TenantManagedFieldsMigrationPatch(tenant, ControllerName)
+	if err != nil || migration == nil {
+		t.Fatalf("prepare ownership migration: patch=%s error=%v", migration, err)
+	}
+	if err := f.client.Patch(f.ctx, tenant, ctrlruntimeclient.RawPatch(types.MergePatchType, []byte(`{"spec":{"gatewayAPI":{"class":"eg-admin"}}}`)), ctrlruntimeclient.FieldOwner("tenant-admin")); err != nil {
+		t.Fatalf("concurrent administrator edit: %v", err)
+	}
+	before := f.get(t, cluster)
+	if err := f.client.Patch(f.ctx, tenant, ctrlruntimeclient.RawPatch(types.JSONPatchType, migration)); !apierrors.IsConflict(err) {
+		t.Fatalf("expected stale ownership migration to conflict, got %v", err)
+	}
+	if !reflect.DeepEqual(before.Object, f.get(t, cluster).Object) {
+		t.Error("stale migration changed the Tenant or its field ownership")
+	}
+}
+
+func (f *tenantIntegrationFixture) unknownOwner(t *testing.T) {
+	cluster := f.newCluster()
+	tenant := integrationTenant(cluster.Name, integrationTenantSpec(t, `{"gatewayAPI":{"class":"eg-existing"}}`))
+	if err := f.client.Create(f.ctx, tenant, ctrlruntimeclient.FieldOwner("external-installer")); err != nil {
+		t.Fatalf("create externally managed Tenant: %v", err)
+	}
+	before := f.get(t, cluster)
+	err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-project"}}`)})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected existing owner conflict, got %v", err)
+	}
+	if !reflect.DeepEqual(before.Object, f.get(t, cluster).Object) {
+		t.Error("reconciliation changed an externally managed Tenant after a conflict")
+	}
+}
+
+func (f *tenantIntegrationFixture) invalidDefaults(t *testing.T) {
+	cluster := f.newCluster()
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-stable"}}`)
+	for _, raw := range []string{`{`, `[]`, `"text"`, `true`, `42`, `{"unknownSetting":true}`, `{"loadBalancer":{"limit":"invalid"}}`} {
+		t.Run(raw, func(t *testing.T) {
+			before := f.get(t, cluster)
+			err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(raw)})
+			if err == nil {
+				t.Fatal("expected invalid defaults to be rejected")
+			}
+			if !reflect.DeepEqual(before.Object, f.get(t, cluster).Object) {
+				t.Error("invalid defaults changed the existing Tenant")
+			}
+		})
+	}
+}
+
+func (f *tenantIntegrationFixture) deletingTenant(t *testing.T) {
+	cluster := f.newCluster()
+	f.reconcile(t, cluster, `{"gatewayAPI":{"class":"eg-original"}}`)
+	f.setManagerMetadata(t, cluster)
+	tenant := f.get(t, cluster)
+	if err := f.client.Delete(f.ctx, tenant); err != nil {
+		t.Fatalf("delete Tenant: %v", err)
+	}
+	before := f.get(t, cluster)
+	if before.GetDeletionTimestamp().IsZero() {
+		t.Fatal("Tenant should be pending finalization")
+	}
+	if err := f.reconciler.createOrUpdateKubeLBManagementClusterResources(f.ctx, f.client, cluster, &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-new"}}`)}); err == nil {
+		t.Fatal("expected reconciliation of a deleting Tenant to fail")
+	}
+	if !reflect.DeepEqual(before.Object, f.get(t, cluster).Object) {
+		t.Error("reconciliation changed a Tenant pending deletion")
+	}
+}
+
+func integrationTenant(name string, spec map[string]interface{}) *unstructured.Unstructured {
+	tenant := &unstructured.Unstructured{}
+	tenant.SetGroupVersionKind(kubelbclusterresources.KubelbTenantGVK)
+	tenant.SetName(name)
+	if spec != nil {
+		tenant.Object["spec"] = spec
+	}
+	return tenant
+}
+
+func integrationTenantSpec(t *testing.T, raw string) map[string]interface{} {
+	t.Helper()
+	var spec map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &spec); err != nil {
+		t.Fatalf("decode test Tenant spec: %v", err)
+	}
+	return spec
+}
+
+func assertIntegrationTenantSpec(t *testing.T, tenant *unstructured.Unstructured, raw string) {
+	t.Helper()
+	expected := integrationTenantSpec(t, raw)
+	actual, _, err := unstructured.NestedMap(tenant.Object, "spec")
+	if err != nil {
+		t.Fatalf("read Tenant spec: %v", err)
+	}
+	// The API server may reorder a map list when merging independently owned
+	// entries. Compare mappings by source, since ordering has no significance.
+	for _, spec := range []map[string]interface{}{expected, actual} {
+		mappings, found, err := unstructured.NestedSlice(spec, "gatewayAPI", "classMappings")
+		if err != nil {
+			t.Fatalf("read GatewayClass mappings: %v", err)
+		}
+		if found {
+			bySource := map[string]interface{}{}
+			for _, entry := range mappings {
+				mapping := entry.(map[string]interface{})
+				bySource[mapping["source"].(string)] = mapping["target"]
+			}
+			if err := unstructured.SetNestedMap(spec, bySource, "gatewayAPI", "classMappings"); err != nil {
+				t.Fatalf("normalize GatewayClass mappings: %v", err)
+			}
+		}
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Tenant spec mismatch:\nexpected: %#v\nactual:   %#v", expected, actual)
+	}
+}

--- a/pkg/ee/kubelb/controller_test.go
+++ b/pkg/ee/kubelb/controller_test.go
@@ -27,15 +27,35 @@ package kubelbcontroller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
+	"time"
+
+	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
+	"k8c.io/kubermatic/v2/pkg/controller/util"
+	kubelbclusterresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/kubelb-cluster"
+	kubelbuserclusterresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/user-cluster"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/workqueue"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -242,4 +262,298 @@ func projectWatchCluster(name string) *kubermaticv1.Cluster {
 		Spec:       kubermaticv1.ClusterSpec{KubeLB: &kubermaticv1.KubeLB{Enabled: true}},
 		Status:     kubermaticv1.ClusterStatus{NamespaceName: "cluster-" + name},
 	}
+}
+
+func TestReconcileKubeLBResourcesMaintainsCCMOnTenantError(t *testing.T) {
+	conflict := apierrors.NewConflict(schema.GroupResource{Group: "kubelb.k8c.io", Resource: "tenants"}, "active", errors.New("administrator owns requested field"))
+	invalid := apierrors.NewBadRequest("strict decoding error: unknown field spec.unknownSetting")
+	for _, test := range []struct {
+		name       string
+		defaults   string
+		applyErr   error
+		migrateErr error
+		wantError  string
+	}{
+		{name: "apply ownership conflict", defaults: `{}`, applyErr: conflict, wantError: conflict.Error()},
+		{name: "unknown Tenant field", defaults: `{"unknownSetting":true}`, applyErr: invalid, wantError: invalid.Error()},
+		{name: "invalid defaults object", defaults: `[]`, wantError: "failed to decode project default tenant spec"},
+		{name: "migration resource version conflict", defaults: `{}`, migrateErr: conflict, wantError: conflict.Error()},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tenant := resourceTestTenant()
+			if test.migrateErr != nil {
+				tenant.SetLabels(map[string]string{kubelbclusterresources.TenantClusterNameLabelKey: tenant.GetName()})
+				tenant.SetManagedFields([]metav1.ManagedFieldsEntry{{
+					Manager: "seed-controller-manager", Operation: metav1.ManagedFieldsOperationUpdate,
+					APIVersion: kubelbclusterresources.KubelbTenantGVK.GroupVersion().String(), FieldsType: "FieldsV1",
+					FieldsV1: metav1.NewFieldsV1(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{}}}}`),
+				}})
+			}
+			f := newKubeLBResourceFixture(t, tenant, true, interceptor.Funcs{
+				Apply: func(context.Context, ctrlruntimeclient.WithWatch, runtime.ApplyConfiguration, ...ctrlruntimeclient.ApplyOption) error {
+					if test.applyErr == nil {
+						return fmt.Errorf("unexpected Tenant apply")
+					}
+					return test.applyErr
+				},
+				Patch: func(context.Context, ctrlruntimeclient.WithWatch, ctrlruntimeclient.Object, ctrlruntimeclient.Patch, ...ctrlruntimeclient.PatchOption) error {
+					if test.migrateErr == nil {
+						return fmt.Errorf("unexpected Tenant migration")
+					}
+					return test.migrateErr
+				},
+			})
+			_, err := f.reconcile(t, test.defaults)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("reconciliation error = %v, want %q", err, test.wantError)
+			}
+			if test.applyErr != nil && !errors.Is(err, test.applyErr) {
+				t.Error("Tenant apply error was not retained")
+			}
+			f.assertCCMImage(t, "quay.io/kubermatic/kubelb-ccm-ee:v1.5.0")
+			f.assertUserResources(t)
+			f.assertFailedCondition(t)
+			unchanged := resourceTestTenant()
+			if err := f.management.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(unchanged), unchanged); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(unchanged.Object["spec"], tenant.Object["spec"]) {
+				t.Fatal("Tenant spec changed despite the failed defaults update")
+			}
+		})
+	}
+}
+
+func TestReconcileKubeLBResourcesBlocksUnusableTenant(t *testing.T) {
+	readErr := errors.New("management API unavailable")
+	createErr := errors.New("Tenant creation rejected")
+	for _, test := range []struct {
+		name       string
+		absent     bool
+		terminates bool
+		getErr     error
+		wantError  string
+	}{
+		{name: "failed creation", absent: true, wantError: createErr.Error()},
+		{name: "failed existence read", getErr: readErr, wantError: readErr.Error()},
+		{name: "terminating Tenant", terminates: true, wantError: "still terminating"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tenant := resourceTestTenant()
+			if test.absent {
+				tenant = nil
+			}
+			if test.terminates {
+				now := metav1.Now()
+				tenant.SetDeletionTimestamp(&now)
+				tenant.SetFinalizers([]string{"kubelb.k8c.io/cleanup"})
+			}
+			f := newKubeLBResourceFixture(t, tenant, true, interceptor.Funcs{
+				Get: func(ctx context.Context, c ctrlruntimeclient.WithWatch, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+					if test.getErr != nil {
+						return test.getErr
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+				Apply: func(context.Context, ctrlruntimeclient.WithWatch, runtime.ApplyConfiguration, ...ctrlruntimeclient.ApplyOption) error {
+					return createErr
+				},
+			})
+			_, err := f.reconcile(t, `{}`)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("reconciliation error = %v, want %q", err, test.wantError)
+			}
+			f.assertCCMImage(t, "quay.io/kubermatic/kubelb-ccm-ee:v1.4.3")
+			roles := &rbacv1.RoleList{}
+			if err := f.user.List(context.Background(), roles); err != nil {
+				t.Fatal(err)
+			}
+			if len(roles.Items) != 0 {
+				t.Fatal("user resources were reconciled for an unusable Tenant")
+			}
+			f.assertFailedCondition(t)
+		})
+	}
+}
+
+func TestReconcileKubeLBResourcesWaitsForNewTenantCredentials(t *testing.T) {
+	f := newKubeLBResourceFixture(t, nil, false, interceptor.Funcs{
+		Apply: func(ctx context.Context, c ctrlruntimeclient.WithWatch, _ runtime.ApplyConfiguration, _ ...ctrlruntimeclient.ApplyOption) error {
+			return c.Create(ctx, resourceTestTenant())
+		},
+	})
+	result, err := f.reconcile(t, `{}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || result.RequeueAfter != 15*time.Second {
+		t.Fatalf("result = %v, want a retry while manager creates credentials", result)
+	}
+	if err := f.management.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: f.cluster.Name}, resourceTestTenant()); err != nil {
+		t.Fatalf("Tenant must be created before waiting for credentials: %v", err)
+	}
+	f.assertUserResources(t)
+	f.assertCCMImage(t, "quay.io/kubermatic/kubelb-ccm-ee:v1.4.3")
+}
+
+func TestReconcileKubeLBResourcesPreservesDownstreamErrors(t *testing.T) {
+	tenantErr := errors.New("Tenant defaults rejected")
+	downstreamErr := errors.New("resource write failed")
+	for _, stage := range []string{"user", "seed"} {
+		t.Run(stage, func(t *testing.T) {
+			f := newKubeLBResourceFixture(t, resourceTestTenant(), true, interceptor.Funcs{
+				Apply: func(context.Context, ctrlruntimeclient.WithWatch, runtime.ApplyConfiguration, ...ctrlruntimeclient.ApplyOption) error {
+					return tenantErr
+				},
+			})
+			if stage == "user" {
+				f.r.userClusterConnectionProvider = resourceTestUserClients{interceptor.NewClient(f.user, interceptor.Funcs{
+					Create: func(context.Context, ctrlruntimeclient.WithWatch, ctrlruntimeclient.Object, ...ctrlruntimeclient.CreateOption) error {
+						return downstreamErr
+					},
+				})}
+			} else {
+				f.r.Client = interceptor.NewClient(f.seed, interceptor.Funcs{
+					Update: func(ctx context.Context, c ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.UpdateOption) error {
+						if _, ok := obj.(*appsv1.Deployment); ok {
+							return downstreamErr
+						}
+						return c.Update(ctx, obj, opts...)
+					},
+				})
+			}
+			_, err := f.reconcile(t, `{}`)
+			if !errors.Is(err, tenantErr) || !errors.Is(err, downstreamErr) {
+				t.Fatalf("reconciliation error = %v, want both Tenant and %s errors", err, stage)
+			}
+			f.assertCCMImage(t, "quay.io/kubermatic/kubelb-ccm-ee:v1.4.3")
+			f.assertFailedCondition(t)
+		})
+	}
+}
+
+type kubeLBResourceFixture struct {
+	r          *reconciler
+	cluster    *kubermaticv1.Cluster
+	seed       ctrlruntimeclient.WithWatch
+	user       ctrlruntimeclient.WithWatch
+	management ctrlruntimeclient.WithWatch
+	kubeconfig []byte
+}
+
+func newKubeLBResourceFixture(t *testing.T, tenant *unstructured.Unstructured, credentialsReady bool, managementInterceptors interceptor.Funcs) *kubeLBResourceFixture {
+	t.Helper()
+	cluster := projectWatchCluster("active")
+	cluster.UID = "cluster-uid"
+	cluster.Status.Address.InternalName = "apiserver.example.test"
+	seed := fake.NewClientBuilder().WithObjects(cluster,
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: resources.KubeLBDeploymentName, Namespace: cluster.Status.NamespaceName},
+			Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: resources.KubeLBDeploymentName, Image: "quay.io/kubermatic/kubelb-ccm-ee:v1.4.3"}},
+			}}},
+		},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: resources.KubeLBCCMKubeconfigSecretName, Namespace: cluster.Status.NamespaceName}},
+	).Build()
+	scheme := fake.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	user := fake.NewClientBuilder().WithScheme(scheme).Build()
+	kubeconfig, err := clientcmd.Write(clientcmdapi.Config{Clusters: map[string]*clientcmdapi.Cluster{
+		"management": {Server: "https://kubelb.example.test"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var managementObjects []ctrlruntimeclient.Object
+	if tenant != nil {
+		managementObjects = append(managementObjects, tenant)
+	}
+	if credentialsReady {
+		managementObjects = append(managementObjects, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: kubeLBCCMKubeconfigSecretName, Namespace: "tenant-" + cluster.Name},
+			Data:       map[string][]byte{kubeconfigSecretKey: kubeconfig},
+		})
+	}
+	management := fake.NewClientBuilder().WithObjects(managementObjects...).WithReturnManagedFields().WithInterceptorFuncs(managementInterceptors).Build()
+	r := &reconciler{
+		Client: seed, log: zap.NewNop().Sugar(),
+		userClusterConnectionProvider: resourceTestUserClients{user},
+		configGetter: func(context.Context) (*kubermaticv1.KubermaticConfiguration, error) {
+			return &kubermaticv1.KubermaticConfiguration{Spec: kubermaticv1.KubermaticConfigurationSpec{
+				UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{KubeLB: kubermaticv1.KubeLBConfiguration{ImageTag: "v1.5.0"}},
+			}}, nil
+		},
+	}
+	return &kubeLBResourceFixture{r: r, cluster: cluster, seed: seed, user: user, management: management, kubeconfig: kubeconfig}
+}
+
+func (f *kubeLBResourceFixture) reconcile(t *testing.T, defaults string) (*reconcile.Result, error) {
+	t.Helper()
+	return util.ClusterReconcileWrapper(context.Background(), f.r.Client, "", f.cluster, kubermatic.Versions{GitVersion: "test"},
+		kubermaticv1.ClusterConditionKubeLBControllerReconcilingSuccess, func() (*reconcile.Result, error) {
+			return f.r.reconcileKubeLBResources(context.Background(), f.management, f.kubeconfig, f.cluster, kubermaticv1.Datacenter{}, &runtime.RawExtension{Raw: []byte(defaults)})
+		})
+}
+
+func (f *kubeLBResourceFixture) assertCCMImage(t *testing.T, image string) {
+	t.Helper()
+	deployment := &appsv1.Deployment{}
+	if err := f.seed.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: resources.KubeLBDeploymentName, Namespace: f.cluster.Status.NamespaceName}, deployment); err != nil {
+		t.Fatal(err)
+	}
+	if len(deployment.Spec.Template.Spec.Containers) != 1 || deployment.Spec.Template.Spec.Containers[0].Image != image {
+		t.Errorf("CCM containers = %v, want image %s", deployment.Spec.Template.Spec.Containers, image)
+	}
+}
+
+func (f *kubeLBResourceFixture) assertUserResources(t *testing.T) {
+	t.Helper()
+	role := &rbacv1.ClusterRole{}
+	if err := f.user.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: "system:kubermatic-kubelb-ccm"}, role); err != nil {
+		t.Fatal(err)
+	}
+	foundWAF := false
+	for _, rule := range role.Rules {
+		if slices.Contains(rule.Resources, "tenantwafpolicies") && slices.Contains(rule.Verbs, "watch") {
+			foundWAF = true
+		}
+	}
+	if !foundWAF {
+		t.Error("user RBAC lacks current CCM TenantWAFPolicy permissions")
+	}
+	for _, name := range []string{kubelbuserclusterresources.SyncSecretCRDName, kubelbuserclusterresources.TenantWAFPolicyCRDName} {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := f.user.Get(context.Background(), ctrlruntimeclient.ObjectKey{Name: name}, crd); err != nil {
+			t.Fatal(err)
+		}
+		if crd.Spec.Group != "kubelb.k8c.io" || len(crd.Spec.Versions) == 0 {
+			t.Errorf("CRD %s has no KubeLB schema", name)
+		}
+	}
+}
+
+func (f *kubeLBResourceFixture) assertFailedCondition(t *testing.T) {
+	t.Helper()
+	cluster := &kubermaticv1.Cluster{}
+	if err := f.seed.Get(context.Background(), ctrlruntimeclient.ObjectKeyFromObject(f.cluster), cluster); err != nil {
+		t.Fatal(err)
+	}
+	if !cluster.Status.HasConditionValue(kubermaticv1.ClusterConditionKubeLBControllerReconcilingSuccess, corev1.ConditionFalse) {
+		t.Error("failed Tenant reconciliation must retain a failed controller condition")
+	}
+}
+
+func resourceTestTenant() *unstructured.Unstructured {
+	tenant := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"allowedDomains": []any{"example.test"}}}}
+	tenant.SetGroupVersionKind(kubelbclusterresources.KubelbTenantGVK)
+	tenant.SetName("active")
+	return tenant
+}
+
+type resourceTestUserClients struct{ client ctrlruntimeclient.Client }
+
+func (p resourceTestUserClients) GetClient(context.Context, *kubermaticv1.Cluster, ...clusterclient.ConfigOption) (ctrlruntimeclient.Client, error) {
+	return p.client, nil
 }

--- a/pkg/ee/kubelb/controller_test.go
+++ b/pkg/ee/kubelb/controller_test.go
@@ -1,0 +1,245 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2026 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package kubelbcontroller
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/test/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestEnqueueClustersForProjectFiltersClusters(t *testing.T) {
+	project := &kubermaticv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project"}}
+	objects := []ctrlruntimeclient.Object{project, projectWatchCluster("active")}
+	for _, fixture := range []struct {
+		name   string
+		modify func(*kubermaticv1.Cluster)
+	}{
+		{name: "other-project", modify: func(c *kubermaticv1.Cluster) { c.Labels[kubermaticv1.ProjectIDLabelKey] = "other" }},
+		{name: "no-project", modify: func(c *kubermaticv1.Cluster) { delete(c.Labels, kubermaticv1.ProjectIDLabelKey) }},
+		{name: "paused", modify: func(c *kubermaticv1.Cluster) { c.Spec.Pause = true }},
+		{name: "disabled", modify: func(c *kubermaticv1.Cluster) { c.Spec.KubeLB.Enabled = false }},
+		{name: "unconfigured", modify: func(c *kubermaticv1.Cluster) { c.Spec.KubeLB = nil }},
+		{name: "unprovisioned", modify: func(c *kubermaticv1.Cluster) { c.Status.NamespaceName = "" }},
+		{name: "deleting", modify: func(c *kubermaticv1.Cluster) {
+			now := metav1.Now()
+			c.DeletionTimestamp = &now
+			c.Finalizers = []string{CleanupFinalizer}
+		}},
+		{name: "canary-worker", modify: func(c *kubermaticv1.Cluster) { c.Labels[kubermaticv1.WorkerNameLabelKey] = "canary" }},
+		{name: "other-worker", modify: func(c *kubermaticv1.Cluster) { c.Labels[kubermaticv1.WorkerNameLabelKey] = "other" }},
+		{name: "empty-worker", modify: func(c *kubermaticv1.Cluster) { c.Labels[kubermaticv1.WorkerNameLabelKey] = "" }},
+	} {
+		cluster := projectWatchCluster(fixture.name)
+		fixture.modify(cluster)
+		objects = append(objects, cluster)
+	}
+
+	for _, test := range []struct {
+		name       string
+		workerName string
+		want       []string
+	}{
+		{name: "default worker", want: []string{"active", "empty-worker"}},
+		{name: "named worker", workerName: "canary", want: []string{"canary-worker"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			t.Cleanup(queue.ShutDown)
+			r := &reconciler{
+				Client:     fake.NewClientBuilder().WithObjects(objects...).Build(),
+				workerName: test.workerName,
+			}
+			handler := r.enqueueClustersForProject()
+			handler.Create(context.Background(), event.CreateEvent{Object: project}, queue)
+			handler.Update(context.Background(), event.UpdateEvent{ObjectOld: project, ObjectNew: project.DeepCopy()}, queue)
+
+			var got []string
+			for queue.Len() > 0 {
+				request, _ := queue.Get()
+				got = append(got, request.Name)
+				queue.Done(request)
+			}
+			slices.Sort(got)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("enqueued clusters = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEnqueueClustersForProjectListFailure(t *testing.T) {
+	listCalled := false
+	client := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		List: func(_ context.Context, _ ctrlruntimeclient.WithWatch, list ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+			listCalled = true
+			list.(*kubermaticv1.ClusterList).Items = []kubermaticv1.Cluster{*projectWatchCluster("partial-result")}
+			return errors.New("temporary list failure")
+		},
+	}).Build()
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	t.Cleanup(queue.ShutDown)
+	r := &reconciler{Client: client}
+	r.enqueueClustersForProject().Create(context.Background(), event.CreateEvent{
+		Object: &kubermaticv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project"}},
+	}, queue)
+	if !listCalled {
+		t.Fatal("Project event did not list clusters")
+	}
+	if queue.Len() != 0 {
+		t.Fatal("failed list must not enqueue partial results")
+	}
+}
+
+func TestEnqueueClustersForProjectSkipsInvalidProject(t *testing.T) {
+	now := metav1.Now()
+	for _, test := range []struct {
+		name   string
+		object ctrlruntimeclient.Object
+	}{
+		{name: "nil"},
+		{name: "wrong resource", object: projectWatchCluster("active")},
+		{name: "terminating", object: &kubermaticv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", DeletionTimestamp: &now}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			t.Cleanup(queue.ShutDown)
+			r := &reconciler{}
+			r.enqueueClustersForProject().Create(context.Background(), event.CreateEvent{Object: test.object}, queue)
+			if queue.Len() != 0 {
+				t.Fatal("invalid or terminating project must not enqueue clusters")
+			}
+		})
+	}
+}
+
+func TestProjectDefaultsChangedPredicate(t *testing.T) {
+	base := &kubermaticv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project"}}
+	configured := base.DeepCopy()
+	configured.Spec.DefaultTenantSpec = &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg"}}`)}
+	changed := configured.DeepCopy()
+	changed.Spec.DefaultTenantSpec = &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"internal"}}`)}
+	metadataOnly := configured.DeepCopy()
+	metadataOnly.Labels = map[string]string{"label": "changed"}
+	metadataOnly.ResourceVersion = "2"
+	statusOnly := configured.DeepCopy()
+	statusOnly.Status.Phase = kubermaticv1.ProjectActive
+	otherSpec := configured.DeepCopy()
+	otherSpec.Spec.Name = "renamed"
+	formatted := configured.DeepCopy()
+	formatted.Spec.DefaultTenantSpec = &runtime.RawExtension{Raw: []byte("{\n  \"gatewayAPI\": { \"class\": \"eg\" }\n}")}
+	terminating := configured.DeepCopy()
+	now := metav1.Now()
+	terminating.DeletionTimestamp = &now
+	p := projectDefaultsChangedPredicate()
+
+	for _, test := range []struct {
+		name     string
+		old, new *kubermaticv1.Project
+		want     bool
+	}{
+		{name: "defaults added", old: base, new: configured, want: true},
+		{name: "defaults changed", old: configured, new: changed, want: true},
+		{name: "defaults removed", old: configured, new: base, want: true},
+		{name: "unchanged", old: configured, new: configured.DeepCopy()},
+		{name: "metadata only", old: configured, new: metadataOnly},
+		{name: "status only", old: configured, new: statusOnly},
+		{name: "other spec field", old: configured, new: otherSpec},
+		{name: "formatting only", old: configured, new: formatted},
+		{name: "project terminating", old: base, new: terminating},
+		{name: "nil old", new: configured},
+		{name: "nil new", old: configured},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := p.Update(event.UpdateEvent{ObjectOld: test.old, ObjectNew: test.new}); got != test.want {
+				t.Errorf("predicate = %v, want %v", got, test.want)
+			}
+		})
+	}
+
+	if !p.Create(event.CreateEvent{Object: base}) {
+		t.Error("initial event with empty defaults must reconcile changes made while the controller was stopped")
+	}
+	if !p.Create(event.CreateEvent{Object: configured}) {
+		t.Error("initial event with defaults must reconcile existing tenants")
+	}
+	if p.Create(event.CreateEvent{Object: terminating}) || p.Create(event.CreateEvent{}) {
+		t.Error("nil or terminating projects must not enqueue clusters")
+	}
+	if p.Delete(event.DeleteEvent{Object: configured}) || p.Generic(event.GenericEvent{Object: configured}) {
+		t.Error("delete and generic events must not enqueue clusters")
+	}
+}
+
+func TestProjectDefaultTenantSpecsEqual(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		old, new string
+		want     bool
+	}{
+		{
+			name: "object key order",
+			old:  `{"gatewayAPI":{"class":"eg"},"loadBalancer":{"limit":15}}`,
+			new:  `{"loadBalancer":{"limit":15}, "gatewayAPI": {"class":"eg"}}`,
+			want: true,
+		},
+		{
+			name: "distinct large integers",
+			old:  `{"limit":9007199254740992}`,
+			new:  `{"limit":9007199254740993}`,
+		},
+		{name: "invalid old value", old: `{`, new: `{}`},
+		{name: "invalid new value", old: `{}`, new: `{`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			oldSpec := &runtime.RawExtension{Raw: []byte(test.old)}
+			newSpec := &runtime.RawExtension{Raw: []byte(test.new)}
+			if got := projectDefaultTenantSpecsEqual(oldSpec, newSpec); got != test.want {
+				t.Errorf("equal = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func projectWatchCluster(name string) *kubermaticv1.Cluster {
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: "project"}},
+		Spec:       kubermaticv1.ClusterSpec{KubeLB: &kubermaticv1.KubeLB{Enabled: true}},
+		Status:     kubermaticv1.ClusterStatus{NamespaceName: "cluster-" + name},
+	}
+}

--- a/pkg/ee/kubelb/resources/kubelb-cluster/resources.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/resources.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Kubermatic GmbH
+                     Copyright © 2026 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent
@@ -24,14 +24,19 @@
 
 package resources
 
-import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// KKP identity labels on management-cluster Tenants.
+const (
+	TenantClusterNameLabelKey         = "kubermatic.k8c.io/cluster-name"
+	TenantClusterExternalNameLabelKey = "kubermatic.k8c.io/cluster-external-name"
+	TenantProjectIDLabelKey           = "kubermatic.k8c.io/cluster-project-id"
 )
 
-func ResourcesForDeletion(name string) []ctrlruntimeclient.Object {
-	tenant := &unstructured.Unstructured{}
-	tenant.SetGroupVersionKind(KubelbTenantGVK)
-	tenant.SetName(name)
-	return []ctrlruntimeclient.Object{tenant}
+// KubelbTenantGVK identifies the kubelb Tenant CR. We use the unstructured
+// client to avoid a compile-time dep on k8c.io/kubelb.
+var KubelbTenantGVK = schema.GroupVersionKind{
+	Group:   "kubelb.k8c.io",
+	Version: "v1alpha1",
+	Kind:    "Tenant",
 }

--- a/pkg/ee/kubelb/resources/kubelb-cluster/tenant.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/tenant.go
@@ -3,7 +3,7 @@
 /*
                   Kubermatic Enterprise Read-Only License
                          Version 1.0 ("KERO-1.0”)
-                     Copyright © 2021 Kubermatic GmbH
+                     Copyright © 2026 Kubermatic GmbH
 
    1.	You may only view, read and display for studying purposes the source
       code of the software licensed under this license, and, to the extent
@@ -25,13 +25,39 @@
 package resources
 
 import (
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
-func ResourcesForDeletion(name string) []ctrlruntimeclient.Object {
+// Tenant builds only the fields KKP applies to a management-cluster Tenant.
+func Tenant(cluster *kubermaticv1.Cluster, defaultTenantSpec *runtime.RawExtension) (*unstructured.Unstructured, error) {
 	tenant := &unstructured.Unstructured{}
 	tenant.SetGroupVersionKind(KubelbTenantGVK)
-	tenant.SetName(name)
-	return []ctrlruntimeclient.Object{tenant}
+	tenant.SetName(cluster.Name)
+	tenant.SetLabels(map[string]string{
+		TenantClusterNameLabelKey:         cluster.Name,
+		TenantClusterExternalNameLabelKey: cluster.Status.Address.ExternalName,
+		TenantProjectIDLabelKey:           cluster.Labels[kubermaticv1.ProjectIDLabelKey],
+	})
+
+	if defaultTenantSpec != nil {
+		raw, err := json.Marshal(defaultTenantSpec)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode project default tenant spec: %w", err)
+		}
+		var spec map[string]any
+		if err := json.Unmarshal(raw, &spec); err != nil {
+			return nil, fmt.Errorf("failed to decode project default tenant spec: %w", err)
+		}
+		if len(spec) > 0 {
+			tenant.Object["spec"] = spec
+		}
+	}
+
+	return tenant, nil
 }

--- a/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields.go
@@ -31,15 +31,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+	"sigs.k8s.io/structured-merge-diff/v6/value"
 )
 
 const legacyTenantFieldManager = "seed-controller-manager"
 
-// TenantManagedFieldsMigrationPatch transfers the fields still owned by KKP's
-// create-only reconciler to its apply manager. Applying without this transfer
-// would leave the old update manager as a co-owner, blocking later changes and
-// removals. Fields already changed by another manager are not transferred.
-func TenantManagedFieldsMigrationPatch(existing *unstructured.Unstructured, fieldManager string) ([]byte, error) {
+// TenantManagedFieldsMigrationPatch transfers legacy KKP ownership only for
+// fields explicitly included in the desired Tenant. Create ownership also
+// includes API defaults, so omitted legacy fields must remain with their old
+// owner: their original source cannot be recovered from managedFields.
+// Fields already owned by another manager are not transferred.
+func TenantManagedFieldsMigrationPatch(existing, desired *unstructured.Unstructured, fieldManager string) ([]byte, error) {
 	apiVersion := KubelbTenantGVK.GroupVersion().String()
 	entries := existing.GetManagedFields()
 	migrated := make([]metav1.ManagedFieldsEntry, 0, len(entries)+1)
@@ -58,7 +60,7 @@ func TenantManagedFieldsMigrationPatch(existing *unstructured.Unstructured, fiel
 		remaining := fieldpath.NewSet()
 		owned := fieldpath.NewSet()
 		fields.Iterate(func(path fieldpath.Path) {
-			if isKKPTenantField(path) {
+			if isKKPTenantField(path) && tenantFieldIsSpecified(desired.Object, path) {
 				owned.Insert(path)
 			} else {
 				remaining.Insert(path)
@@ -156,4 +158,48 @@ func isKKPTenantField(path fieldpath.Path) bool {
 	default:
 		return false
 	}
+}
+
+// tenantFieldIsSpecified follows the API server's recorded ownership path in
+// the desired object. Associative list entries are matched by their keys, not
+// position, so adopting one GatewayClass mapping preserves omitted mappings.
+func tenantFieldIsSpecified(object any, path fieldpath.Path) bool {
+	if len(path) == 0 {
+		return true
+	}
+	element := path[0]
+	switch {
+	case element.FieldName != nil:
+		fields, ok := object.(map[string]any)
+		if !ok {
+			return false
+		}
+		child, found := fields[*element.FieldName]
+		return found && tenantFieldIsSpecified(child, path[1:])
+	case element.Key != nil:
+		items, ok := object.([]any)
+		if !ok {
+			return false
+		}
+		for _, item := range items {
+			fields, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			matches := true
+			for _, key := range *element.Key {
+				field, found := fields[key.Name]
+				if !found || !value.Equals(value.NewValueInterface(field), key.Value) {
+					matches = false
+					break
+				}
+			}
+			if matches && tenantFieldIsSpecified(item, path[1:]) {
+				return true
+			}
+		}
+	}
+	// Tenant list fields are atomic or keyed maps. Preserve any ownership
+	// using other selectors instead of guessing how to adopt it.
+	return false
 }

--- a/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields.go
@@ -1,0 +1,159 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2026 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+)
+
+const legacyTenantFieldManager = "seed-controller-manager"
+
+// TenantManagedFieldsMigrationPatch transfers the fields still owned by KKP's
+// create-only reconciler to its apply manager. Applying without this transfer
+// would leave the old update manager as a co-owner, blocking later changes and
+// removals. Fields already changed by another manager are not transferred.
+func TenantManagedFieldsMigrationPatch(existing *unstructured.Unstructured, fieldManager string) ([]byte, error) {
+	apiVersion := KubelbTenantGVK.GroupVersion().String()
+	entries := existing.GetManagedFields()
+	migrated := make([]metav1.ManagedFieldsEntry, 0, len(entries)+1)
+	transferred := fieldpath.NewSet()
+	var transferTime *metav1.Time
+	for _, entry := range entries {
+		if entry.Manager != legacyTenantFieldManager || entry.Operation != metav1.ManagedFieldsOperationUpdate || entry.APIVersion != apiVersion || entry.Subresource != "" || entry.FieldsType != "FieldsV1" {
+			migrated = append(migrated, entry)
+			continue
+		}
+
+		fields, err := tenantManagedFieldSet(entry)
+		if err != nil {
+			return nil, err
+		}
+		remaining := fieldpath.NewSet()
+		owned := fieldpath.NewSet()
+		fields.Iterate(func(path fieldpath.Path) {
+			if isKKPTenantField(path) {
+				owned.Insert(path)
+			} else {
+				remaining.Insert(path)
+			}
+		})
+		if owned.Empty() {
+			migrated = append(migrated, entry)
+			continue
+		}
+		transferred = transferred.Union(owned)
+		if transferTime == nil {
+			transferTime = entry.Time
+		}
+		if !remaining.Empty() {
+			raw, err := remaining.ToJSON()
+			if err != nil {
+				return nil, fmt.Errorf("failed to encode remaining legacy tenant fields: %w", err)
+			}
+			entry.FieldsV1 = metav1.NewFieldsV1(string(raw))
+			migrated = append(migrated, entry)
+		}
+	}
+	if transferred.Empty() {
+		return nil, nil
+	}
+	if existing.GetResourceVersion() == "" {
+		return nil, fmt.Errorf("cannot migrate tenant field ownership without a resource version")
+	}
+
+	applyIndex := -1
+	for i, entry := range migrated {
+		if entry.Manager != fieldManager || entry.Operation != metav1.ManagedFieldsOperationApply || entry.Subresource != "" {
+			continue
+		}
+		// An apply manager's identity excludes APIVersion. Adding another
+		// entry here would overwrite ownership that requires API conversion.
+		if entry.APIVersion != apiVersion {
+			return nil, fmt.Errorf("cannot migrate tenant apply ownership from API version %q", entry.APIVersion)
+		}
+		if applyIndex != -1 {
+			return nil, fmt.Errorf("found multiple tenant apply field managers for %q", fieldManager)
+		}
+		fields, err := tenantManagedFieldSet(entry)
+		if err != nil {
+			return nil, err
+		}
+		transferred = transferred.Union(fields)
+		applyIndex = i
+	}
+	if applyIndex == -1 {
+		applyIndex = len(migrated)
+		migrated = append(migrated, metav1.ManagedFieldsEntry{
+			Manager:    fieldManager,
+			Operation:  metav1.ManagedFieldsOperationApply,
+			APIVersion: apiVersion,
+			Time:       transferTime,
+			FieldsType: "FieldsV1",
+		})
+	}
+	raw, err := transferred.ToJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode migrated tenant fields: %w", err)
+	}
+	migrated[applyIndex].FieldsV1 = metav1.NewFieldsV1(string(raw))
+
+	// As in client-go's csaupgrade helper, replacing resourceVersion makes
+	// concurrent writes return an API conflict instead of overwriting ownership.
+	return json.Marshal([]map[string]any{
+		{"op": "replace", "path": "/metadata/managedFields", "value": migrated},
+		{"op": "replace", "path": "/metadata/resourceVersion", "value": existing.GetResourceVersion()},
+	})
+}
+
+func tenantManagedFieldSet(entry metav1.ManagedFieldsEntry) (*fieldpath.Set, error) {
+	if entry.FieldsType != "FieldsV1" || entry.FieldsV1 == nil {
+		return nil, fmt.Errorf("unsupported tenant field ownership for manager %q", entry.Manager)
+	}
+	fields := fieldpath.NewSet()
+	if err := fields.FromJSON(entry.FieldsV1.GetRawReader()); err != nil {
+		return nil, fmt.Errorf("failed to decode tenant fields for manager %q: %w", entry.Manager, err)
+	}
+	return fields, nil
+}
+
+func isKKPTenantField(path fieldpath.Path) bool {
+	if len(path) > 0 && path[0].FieldName != nil && *path[0].FieldName == "spec" {
+		return true
+	}
+	if len(path) != 3 || path[0].FieldName == nil || *path[0].FieldName != "metadata" || path[1].FieldName == nil || *path[1].FieldName != "labels" || path[2].FieldName == nil {
+		return false
+	}
+	switch *path[2].FieldName {
+	case TenantClusterNameLabelKey, TenantClusterExternalNameLabelKey, TenantProjectIDLabelKey:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields_test.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields_test.go
@@ -65,20 +65,23 @@ func TestTenantManagedFieldsMigrationPatch(t *testing.T) {
 	manager := entry("kubelb", metav1.ManagedFieldsOperationUpdate, `{"f:metadata":{"f:finalizers":{}},"f:spec":{"f:allowedDomains":{}}}`)
 
 	tests := []struct {
-		name    string
-		entries []metav1.ManagedFieldsEntry
-		want    []metav1.ManagedFieldsEntry
+		name        string
+		desiredSpec string
+		entries     []metav1.ManagedFieldsEntry
+		want        []metav1.ManagedFieldsEntry
 	}{
 		{name: "no ownership"},
 		{name: "unknown and unrelated ownership", entries: []metav1.ManagedFieldsEntry{admin, manager, otherVersion, status, legacyApply, unknownFieldsType, otherApplyVersion}},
 		{name: "legacy metadata outside KKP labels", entries: []metav1.ManagedFieldsEntry{legacy(`{"f:metadata":{"f:annotations":{"f:example.com/note":{}},"f:labels":{".":{},"f:example.com/label":{}},"f:finalizers":{}}}`)}},
 		{
-			name:    "create apply owner from legacy spec and all KKP labels",
-			entries: []metav1.ManagedFieldsEntry{legacy(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{},"f:kubermatic.k8c.io/cluster-external-name":{},"f:kubermatic.k8c.io/cluster-project-id":{}}},"f:spec":{".":{},"f:gatewayAPI":{"f:class":{}},"f:waf":{"f:enableTenantPolicies":{}}}}`)},
-			want:    []metav1.ManagedFieldsEntry{applied(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{},"f:kubermatic.k8c.io/cluster-external-name":{},"f:kubermatic.k8c.io/cluster-project-id":{}}},"f:spec":{".":{},"f:gatewayAPI":{"f:class":{}},"f:waf":{"f:enableTenantPolicies":{}}}}`)},
+			name:        "create apply owner from explicit defaults and all KKP labels",
+			desiredSpec: `{"gatewayAPI":{"class":"eg-project"},"waf":{"enableTenantPolicies":false}}`,
+			entries:     []metav1.ManagedFieldsEntry{legacy(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{},"f:kubermatic.k8c.io/cluster-external-name":{},"f:kubermatic.k8c.io/cluster-project-id":{}}},"f:spec":{".":{},"f:gatewayAPI":{"f:class":{}},"f:waf":{"f:enableTenantPolicies":{}}}}`)},
+			want:        []metav1.ManagedFieldsEntry{applied(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{},"f:kubermatic.k8c.io/cluster-external-name":{},"f:kubermatic.k8c.io/cluster-project-id":{}}},"f:spec":{".":{},"f:gatewayAPI":{"f:class":{}},"f:waf":{"f:enableTenantPolicies":{}}}}`)},
 		},
 		{
-			name: "preserve unrelated legacy fields and all other owners",
+			name:        "preserve unrelated legacy fields and all other owners",
+			desiredSpec: `{"loadBalancer":{"limit":0}}`,
 			entries: []metav1.ManagedFieldsEntry{
 				legacy(`{"f:metadata":{"f:annotations":{"f:example.com/note":{}},"f:labels":{".":{},"f:example.com/label":{},"f:kubermatic.k8c.io/cluster-name":{}},"f:finalizers":{}},"f:spec":{"f:loadBalancer":{"f:limit":{}}},"f:status":{"f:phase":{}}}`),
 				admin, manager, otherVersion, status, legacyApply, unknownFieldsType, appliedStatus,
@@ -90,7 +93,8 @@ func TestTenantManagedFieldsMigrationPatch(t *testing.T) {
 			},
 		},
 		{
-			name: "union mapping entries with existing apply owner",
+			name:        "union mapping entries with existing apply owner",
+			desiredSpec: `{"gatewayAPI":{"classMappings":[{"source":"public","target":"eg-public"}]}}`,
 			entries: []metav1.ManagedFieldsEntry{
 				legacy(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"public\"}":{".":{},"f:source":{},"f:target":{}}}}}}`),
 				applied(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"internal\"}":{".":{},"f:source":{},"f:target":{}}}},"f:waf":{"f:enableTenantPolicies":{}}}}`),
@@ -100,9 +104,53 @@ func TestTenantManagedFieldsMigrationPatch(t *testing.T) {
 			},
 		},
 		{
-			name:    "legacy and apply co-ownership becomes sole KKP workflow",
-			entries: []metav1.ManagedFieldsEntry{legacy(`{"f:spec":{"f:ingress":{"f:class":{}}}}`), applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
-			want:    []metav1.ManagedFieldsEntry{applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
+			name:        "legacy and apply co-ownership becomes sole KKP workflow",
+			desiredSpec: `{"ingress":{"class":""}}`,
+			entries:     []metav1.ManagedFieldsEntry{legacy(`{"f:spec":{"f:ingress":{"f:class":{}}}}`), applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
+			want:        []metav1.ManagedFieldsEntry{applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
+		},
+		{
+			name:        "retain ambiguous legacy defaults and omitted sibling fields",
+			desiredSpec: `{"timeouts":{"connect":"10s"}}`,
+			entries:     []metav1.ManagedFieldsEntry{legacy(`{"f:spec":{".":{},"f:allowedDomains":{},"f:timeouts":{".":{},"f:connect":{},"f:request":{}}}}`)},
+			want: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:spec":{"f:allowedDomains":{},"f:timeouts":{"f:request":{}}}}`),
+				applied(`{"f:spec":{".":{},"f:timeouts":{".":{},"f:connect":{}}}}`),
+			},
+		},
+		{
+			name:    "no project defaults preserves all legacy spec ownership",
+			entries: []metav1.ManagedFieldsEntry{legacy(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{}}},"f:spec":{".":{},"f:allowedDomains":{},"f:ingress":{"f:class":{}}}}`)},
+			want: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:spec":{".":{},"f:allowedDomains":{},"f:ingress":{"f:class":{}}}}`),
+				applied(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{}}}}`),
+			},
+		},
+		{
+			name:        "explicit empty atomic list adopts its legacy ownership",
+			desiredSpec: `{"allowedDomains":[]}`,
+			entries:     []metav1.ManagedFieldsEntry{legacy(`{"f:spec":{"f:allowedDomains":{}}}`)},
+			want:        []metav1.ManagedFieldsEntry{applied(`{"f:spec":{"f:allowedDomains":{}}}`)},
+		},
+		{
+			name:        "explicit null adopts its legacy field without adopting siblings",
+			desiredSpec: `{"timeouts":{"connect":null}}`,
+			entries:     []metav1.ManagedFieldsEntry{legacy(`{"f:spec":{"f:timeouts":{"f:connect":{},"f:request":{}}}}`)},
+			want: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:spec":{"f:timeouts":{"f:request":{}}}}`),
+				applied(`{"f:spec":{"f:timeouts":{"f:connect":{}}}}`),
+			},
+		},
+		{
+			name:        "match mapping by source while preserving omitted entry and child",
+			desiredSpec: `{"gatewayAPI":{"classMappings":[{"source":"new","target":"eg-new"},{"source":"public","target":"eg-public"}]}}`,
+			entries: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"internal\"}":{".":{},"f:source":{},"f:target":{}},"k:{\"source\":\"public\"}":{".":{},"f:source":{},"f:target":{},"f:extra":{}}}}}}`),
+			},
+			want: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"internal\"}":{".":{},"f:source":{},"f:target":{}},"k:{\"source\":\"public\"}":{"f:extra":{}}}}}}`),
+				applied(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"public\"}":{".":{},"f:source":{},"f:target":{}}}}}}`),
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -113,12 +161,17 @@ func TestTenantManagedFieldsMigrationPatch(t *testing.T) {
 			existing.SetResourceVersion("42")
 			existing.SetManagedFields(tc.entries)
 			before := existing.DeepCopy()
-			patch, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+			desired := tenantMigrationDesired(t, tc.desiredSpec)
+			desiredBefore := desired.DeepCopy()
+			patch, err := TenantManagedFieldsMigrationPatch(existing, desired, testTenantFieldManager)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(existing, before) {
 				t.Fatal("migration mutated its input")
+			}
+			if !reflect.DeepEqual(desired, desiredBefore) {
+				t.Fatal("migration mutated the desired Tenant")
 			}
 			if tc.want == nil {
 				if patch != nil {
@@ -163,7 +216,7 @@ func TestTenantManagedFieldsMigrationPatch(t *testing.T) {
 				t.Fatalf("ownership mismatch:\ngot  %s\nwant %s", gotJSON, wantJSON)
 			}
 			existing.SetManagedFields(got)
-			second, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+			second, err := TenantManagedFieldsMigrationPatch(existing, desired, testTenantFieldManager)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -192,7 +245,7 @@ func TestTenantManagedFieldsMigrationPatchErrors(t *testing.T) {
 				Manager: legacyTenantFieldManager, Operation: metav1.ManagedFieldsOperationUpdate,
 				APIVersion: existing.GetAPIVersion(), FieldsType: "FieldsV1", FieldsV1: metav1.NewFieldsV1(tc.fields),
 			}})
-			patch, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+			patch, err := TenantManagedFieldsMigrationPatch(existing, tenantMigrationDesired(t, `{"ingress":{"class":"eg-project"}}`), testTenantFieldManager)
 			if err == nil || patch != nil {
 				t.Fatalf("expected error without patch, got %s, %v", patch, err)
 			}
@@ -215,11 +268,31 @@ func TestTenantManagedFieldsMigrationPatchRejectsUnknownApplyVersion(t *testing.
 			FieldsV1: metav1.NewFieldsV1(`{"f:spec":{"f:loadBalancer":{"f:limit":{}}}}`)},
 	})
 	before := existing.DeepCopy()
-	patch, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+	patch, err := TenantManagedFieldsMigrationPatch(existing, tenantMigrationDesired(t, `{"ingress":{"class":"eg-project"}}`), testTenantFieldManager)
 	if err == nil || patch != nil {
 		t.Fatalf("expected error without patch, got %s, %v", patch, err)
 	}
 	if !reflect.DeepEqual(existing, before) {
 		t.Fatal("migration mutated its input")
 	}
+}
+
+func tenantMigrationDesired(t *testing.T, spec string) *unstructured.Unstructured {
+	t.Helper()
+	desired := &unstructured.Unstructured{}
+	desired.SetGroupVersionKind(KubelbTenantGVK)
+	desired.SetName("test-cluster")
+	desired.SetLabels(map[string]string{
+		TenantClusterNameLabelKey:         "test-cluster",
+		TenantClusterExternalNameLabelKey: "test.example.com",
+		TenantProjectIDLabelKey:           "test-project",
+	})
+	if spec != "" {
+		var fields map[string]any
+		if err := json.Unmarshal([]byte(spec), &fields); err != nil {
+			t.Fatal(err)
+		}
+		desired.Object["spec"] = fields
+	}
+	return desired
 }

--- a/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields_test.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/tenant_managed_fields_test.go
@@ -1,0 +1,225 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2026 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package resources
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const testTenantFieldManager = "kkp-kubelb-controller"
+
+func TestTenantManagedFieldsMigrationPatch(t *testing.T) {
+	apiVersion := KubelbTenantGVK.GroupVersion().String()
+	entry := func(manager string, operation metav1.ManagedFieldsOperationType, fields string) metav1.ManagedFieldsEntry {
+		return metav1.ManagedFieldsEntry{
+			Manager: manager, Operation: operation, APIVersion: apiVersion,
+			FieldsType: "FieldsV1", FieldsV1: metav1.NewFieldsV1(fields),
+		}
+	}
+	legacy := func(fields string) metav1.ManagedFieldsEntry {
+		return entry(legacyTenantFieldManager, metav1.ManagedFieldsOperationUpdate, fields)
+	}
+	applied := func(fields string) metav1.ManagedFieldsEntry {
+		return entry(testTenantFieldManager, metav1.ManagedFieldsOperationApply, fields)
+	}
+	otherVersion := legacy(`{"f:spec":{"f:loadBalancer":{"f:limit":{}}}}`)
+	otherVersion.APIVersion = "kubelb.k8c.io/v1beta1"
+	status := legacy(`{"f:status":{"f:phase":{}}}`)
+	status.Subresource = "status"
+	legacyApply := legacy(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)
+	legacyApply.Operation = metav1.ManagedFieldsOperationApply
+	unknownFieldsType := legacy(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)
+	unknownFieldsType.FieldsType = "FutureFields"
+	otherApplyVersion := applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)
+	otherApplyVersion.APIVersion = "kubelb.k8c.io/v1beta1"
+	appliedStatus := applied(`{"f:status":{"f:phase":{}}}`)
+	appliedStatus.Subresource = "status"
+	admin := entry("kubectl-edit", metav1.ManagedFieldsOperationUpdate, `{"f:spec":{"f:loadBalancer":{"f:limit":{}}}}`)
+	manager := entry("kubelb", metav1.ManagedFieldsOperationUpdate, `{"f:metadata":{"f:finalizers":{}},"f:spec":{"f:allowedDomains":{}}}`)
+
+	tests := []struct {
+		name    string
+		entries []metav1.ManagedFieldsEntry
+		want    []metav1.ManagedFieldsEntry
+	}{
+		{name: "no ownership"},
+		{name: "unknown and unrelated ownership", entries: []metav1.ManagedFieldsEntry{admin, manager, otherVersion, status, legacyApply, unknownFieldsType, otherApplyVersion}},
+		{name: "legacy metadata outside KKP labels", entries: []metav1.ManagedFieldsEntry{legacy(`{"f:metadata":{"f:annotations":{"f:example.com/note":{}},"f:labels":{".":{},"f:example.com/label":{}},"f:finalizers":{}}}`)}},
+		{
+			name:    "create apply owner from legacy spec and all KKP labels",
+			entries: []metav1.ManagedFieldsEntry{legacy(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{},"f:kubermatic.k8c.io/cluster-external-name":{},"f:kubermatic.k8c.io/cluster-project-id":{}}},"f:spec":{".":{},"f:gatewayAPI":{"f:class":{}},"f:waf":{"f:enableTenantPolicies":{}}}}`)},
+			want:    []metav1.ManagedFieldsEntry{applied(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{},"f:kubermatic.k8c.io/cluster-external-name":{},"f:kubermatic.k8c.io/cluster-project-id":{}}},"f:spec":{".":{},"f:gatewayAPI":{"f:class":{}},"f:waf":{"f:enableTenantPolicies":{}}}}`)},
+		},
+		{
+			name: "preserve unrelated legacy fields and all other owners",
+			entries: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:metadata":{"f:annotations":{"f:example.com/note":{}},"f:labels":{".":{},"f:example.com/label":{},"f:kubermatic.k8c.io/cluster-name":{}},"f:finalizers":{}},"f:spec":{"f:loadBalancer":{"f:limit":{}}},"f:status":{"f:phase":{}}}`),
+				admin, manager, otherVersion, status, legacyApply, unknownFieldsType, appliedStatus,
+			},
+			want: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:metadata":{"f:annotations":{"f:example.com/note":{}},"f:labels":{".":{},"f:example.com/label":{}},"f:finalizers":{}},"f:status":{"f:phase":{}}}`),
+				admin, manager, otherVersion, status, legacyApply, unknownFieldsType, appliedStatus,
+				applied(`{"f:metadata":{"f:labels":{"f:kubermatic.k8c.io/cluster-name":{}}},"f:spec":{"f:loadBalancer":{"f:limit":{}}}}`),
+			},
+		},
+		{
+			name: "union mapping entries with existing apply owner",
+			entries: []metav1.ManagedFieldsEntry{
+				legacy(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"public\"}":{".":{},"f:source":{},"f:target":{}}}}}}`),
+				applied(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"internal\"}":{".":{},"f:source":{},"f:target":{}}}},"f:waf":{"f:enableTenantPolicies":{}}}}`),
+			},
+			want: []metav1.ManagedFieldsEntry{
+				applied(`{"f:spec":{"f:gatewayAPI":{"f:classMappings":{"k:{\"source\":\"internal\"}":{".":{},"f:source":{},"f:target":{}},"k:{\"source\":\"public\"}":{".":{},"f:source":{},"f:target":{}}}},"f:waf":{"f:enableTenantPolicies":{}}}}`),
+			},
+		},
+		{
+			name:    "legacy and apply co-ownership becomes sole KKP workflow",
+			entries: []metav1.ManagedFieldsEntry{legacy(`{"f:spec":{"f:ingress":{"f:class":{}}}}`), applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
+			want:    []metav1.ManagedFieldsEntry{applied(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := &unstructured.Unstructured{}
+			existing.SetGroupVersionKind(KubelbTenantGVK)
+			existing.SetName("test-cluster")
+			existing.SetResourceVersion("42")
+			existing.SetManagedFields(tc.entries)
+			before := existing.DeepCopy()
+			patch, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(existing, before) {
+				t.Fatal("migration mutated its input")
+			}
+			if tc.want == nil {
+				if patch != nil {
+					t.Fatalf("unexpected patch: %s", patch)
+				}
+				return
+			}
+			if patch == nil {
+				t.Fatal("expected ownership migration patch")
+			}
+			var operations []struct {
+				Op    string
+				Path  string
+				Value json.RawMessage
+			}
+			if err := json.Unmarshal(patch, &operations); err != nil {
+				t.Fatal(err)
+			}
+			if len(operations) != 2 || operations[0].Op != "replace" || operations[0].Path != "/metadata/managedFields" || operations[1].Op != "replace" || operations[1].Path != "/metadata/resourceVersion" || string(operations[1].Value) != `"42"` {
+				t.Fatalf("patch must change only ownership and guard observed resource version: %s", patch)
+			}
+			var got []metav1.ManagedFieldsEntry
+			if err := json.Unmarshal(operations[0].Value, &got); err != nil {
+				t.Fatal(err)
+			}
+			gotJSON, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantJSON, err := json.Marshal(tc.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var gotValue, wantValue any
+			if err := json.Unmarshal(gotJSON, &gotValue); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(wantJSON, &wantValue); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(gotValue, wantValue) {
+				t.Fatalf("ownership mismatch:\ngot  %s\nwant %s", gotJSON, wantJSON)
+			}
+			existing.SetManagedFields(got)
+			second, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if second != nil {
+				t.Fatalf("migration is not idempotent: %s", second)
+			}
+		})
+	}
+}
+
+func TestTenantManagedFieldsMigrationPatchErrors(t *testing.T) {
+	tests := []struct {
+		name            string
+		fields          string
+		resourceVersion string
+	}{
+		{name: "malformed field set", fields: `{"f:spec":1}`, resourceVersion: "42"},
+		{name: "missing resource version", fields: `{"f:spec":{"f:ingress":{"f:class":{}}}}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := &unstructured.Unstructured{}
+			existing.SetGroupVersionKind(KubelbTenantGVK)
+			existing.SetResourceVersion(tc.resourceVersion)
+			existing.SetManagedFields([]metav1.ManagedFieldsEntry{{
+				Manager: legacyTenantFieldManager, Operation: metav1.ManagedFieldsOperationUpdate,
+				APIVersion: existing.GetAPIVersion(), FieldsType: "FieldsV1", FieldsV1: metav1.NewFieldsV1(tc.fields),
+			}})
+			patch, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+			if err == nil || patch != nil {
+				t.Fatalf("expected error without patch, got %s, %v", patch, err)
+			}
+		})
+	}
+}
+
+// API versions do not form part of an apply manager's identity. Ownership from
+// another version must not be overwritten by adding a second apply entry.
+func TestTenantManagedFieldsMigrationPatchRejectsUnknownApplyVersion(t *testing.T) {
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(KubelbTenantGVK)
+	existing.SetResourceVersion("42")
+	existing.SetManagedFields([]metav1.ManagedFieldsEntry{
+		{Manager: legacyTenantFieldManager, Operation: metav1.ManagedFieldsOperationUpdate,
+			APIVersion: existing.GetAPIVersion(), FieldsType: "FieldsV1",
+			FieldsV1: metav1.NewFieldsV1(`{"f:spec":{"f:ingress":{"f:class":{}}}}`)},
+		{Manager: testTenantFieldManager, Operation: metav1.ManagedFieldsOperationApply,
+			APIVersion: "kubelb.k8c.io/v1beta1", FieldsType: "FieldsV1",
+			FieldsV1: metav1.NewFieldsV1(`{"f:spec":{"f:loadBalancer":{"f:limit":{}}}}`)},
+	})
+	before := existing.DeepCopy()
+	patch, err := TenantManagedFieldsMigrationPatch(existing, testTenantFieldManager)
+	if err == nil || patch != nil {
+		t.Fatalf("expected error without patch, got %s, %v", patch, err)
+	}
+	if !reflect.DeepEqual(existing, before) {
+		t.Fatal("migration mutated its input")
+	}
+}

--- a/pkg/ee/kubelb/resources/kubelb-cluster/tenant_test.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/tenant_test.go
@@ -1,0 +1,60 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2026 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package resources
+
+import (
+	"reflect"
+	"testing"
+
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestTenantDefaultSpecRepresentations(t *testing.T) {
+	cluster := &kubermaticv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"}}
+	decoded := &runtime.RawExtension{Object: &unstructured.Unstructured{
+		Object: map[string]any{"gatewayAPI": map[string]any{"class": "eg-object"}},
+	}}
+	tenant, err := Tenant(cluster, decoded)
+	if err != nil {
+		t.Fatalf("build Tenant from decoded defaults: %v", err)
+	}
+	class, found, err := unstructured.NestedString(tenant.Object, "spec", "gatewayAPI", "class")
+	if err != nil || !found || class != "eg-object" {
+		t.Fatalf("decoded GatewayClass = %q, found=%t, error=%v", class, found, err)
+	}
+
+	raw := &runtime.RawExtension{Raw: []byte(`{"gatewayAPI":{"class":"eg-object"}}`)}
+	fromRaw, err := Tenant(cluster, raw)
+	if err != nil {
+		t.Fatalf("build Tenant from raw defaults: %v", err)
+	}
+	if !reflect.DeepEqual(tenant.Object, fromRaw.Object) {
+		t.Errorf("raw and decoded defaults produce different Tenants:\ndecoded: %#v\nraw: %#v", tenant.Object, fromRaw.Object)
+	}
+}

--- a/pkg/ee/kubelb/testdata/tenant-crd.yaml
+++ b/pkg/ee/kubelb/testdata/tenant-crd.yaml
@@ -1,3 +1,23 @@
+#                Kubermatic Enterprise Read-Only License
+#                       Version 1.0 ("KERO-1.0”)
+#                   Copyright © 2026 Kubermatic GmbH
+#
+# 1.	You may only view, read and display for studying purposes the source
+#    code of the software licensed under this license, and, to the extent
+#    explicitly provided under this license, the binary code.
+# 2.	Any use of the software which exceeds the foregoing right, including,
+#    without limitation, its execution, compilation, copying, modification
+#    and distribution, is expressly prohibited.
+# 3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+#    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+#    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+#    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+#    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+#    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# END OF TERMS AND CONDITIONS
+
 # Structural subset of the KubeLB v1.5 Tenant schema, including its defaulting
 # and field ownership semantics. Only the fields exercised by these tests are included.
 apiVersion: apiextensions.k8s.io/v1

--- a/pkg/ee/kubelb/testdata/tenant-crd.yaml
+++ b/pkg/ee/kubelb/testdata/tenant-crd.yaml
@@ -1,0 +1,85 @@
+# Structural subset of the KubeLB v1.5 Tenant schema, including its defaulting
+# and field ownership semantics. Only the fields exercised by these tests are included.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: tenants.kubelb.k8c.io
+spec:
+  group: kubelb.k8c.io
+  names:
+    kind: Tenant
+    listKind: TenantList
+    plural: tenants
+    singular: tenant
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              properties:
+                allowedDomains:
+                  type: array
+                  default: ["**"]
+                  items:
+                    type: string
+                defaultAnnotations:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    additionalProperties:
+                      type: string
+                gatewayAPI:
+                  type: object
+                  properties:
+                    class:
+                      type: string
+                    classMappings:
+                      type: array
+                      maxItems: 32
+                      x-kubernetes-list-type: map
+                      x-kubernetes-list-map-keys: [source]
+                      items:
+                        type: object
+                        required: [source, target]
+                        properties:
+                          source:
+                            type: string
+                            minLength: 1
+                            maxLength: 253
+                          target:
+                            type: string
+                            minLength: 1
+                            maxLength: 253
+                loadBalancer:
+                  type: object
+                  properties:
+                    limit:
+                      type: integer
+                timeouts:
+                  type: object
+                  properties:
+                    connect:
+                      type: string
+                    request:
+                      type: string
+                    idleConnection:
+                      type: string
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reconciles existing KubeLB Tenants when Project defaults change. We use Server Side Apply to update and remove KKP managed defaults while preserving other managers settings, with safe adoption of legacy ownership.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/16186

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Project level KubeLB defaults now propagate to existing Tenants while preserving settings managed by other field managers.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
