### PR TITLE
Add cosign signing to the release by using GCP service account

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -51,6 +51,8 @@ export DASHBOARD_GIT_TAG="${DASHBOARD_GIT_TAG:-$GIT_TAG}"
 # point to GIT_TAG
 export RELEASE_NAME="${RELEASE_NAME:-$GIT_TAG}"
 
+export CHECKSUMS_FILE="_dist/checksums.txt"
+
 # utility function setting some curl default values for calling the github API
 # first argument is the URL, the rest of the arguments is used as curl
 # arguments.
@@ -95,6 +97,8 @@ function upload_asset {
     contentType="application/zip"
   elif [[ "$file" == *.json ]]; then
     contentType="application/json"
+  elif [[ "$file" == *.txt ]]; then
+    contentType="text/plain"
   fi
   res=$(github_cli \
     "https://uploads.github.com/repos/$GIT_REPO/releases/$releaseID/assets?name=$(basename "$file")" \
@@ -156,6 +160,41 @@ function generate_sbom() {
   syft "$target" -o "spdx-json=$outFile"
 }
 
+# keyless-signs a release artifact, producing a Sigstore bundle
+# (signature + certificate + Rekor proof) next to it
+function sign_blob() {
+  local file="$1"
+
+  ensure_sigstore_token
+
+  echodate "Signing $(basename "$file")..."
+  cosign sign-blob --yes --bundle "$file.sigstore.json" "$file"
+}
+
+function record_checksum() {
+  local file="$1"
+  local checksums
+  checksums="$(realpath "$CHECKSUMS_FILE")"
+
+  (
+    cd "$(dirname "$file")"
+    sha256sum "$(basename "$file")" >> "$checksums"
+  )
+}
+
+# signs, checksums and uploads a release artifact, removing it afterwards
+function ship_asset() {
+  local file="$1"
+
+  sign_blob "$file"
+  record_checksum "$file"
+
+  echodate "Uploading $(basename "$file")..."
+  upload_asset "$file"
+  upload_asset "$file.sigstore.json"
+  rm -- "$file" "$file.sigstore.json"
+}
+
 function ship_archive() {
   local archive="$1"
   local buildTarget="$2"
@@ -168,14 +207,11 @@ function ship_archive() {
   fi
 
   if ! $DRY_RUN; then
-    echodate "Uploading $buildTarget archive..."
-    upload_asset "$archive"
-    rm -- "$archive"
+    echodate "Shipping $buildTarget archive..."
+    ship_asset "$archive"
 
     for sbom in "${sboms[@]}"; do
-      echodate "Uploading $(basename "$sbom")..."
-      upload_asset "$sbom"
-      rm -- "$sbom"
+      ship_asset "$sbom"
     done
   fi
 }
@@ -208,6 +244,8 @@ echodate "Pre-Release  : $prerelease"
 
 if $DRY_RUN; then
   echodate "This is a dry-run, no actual communication with GitHub happens."
+else
+  ensure_sigstore_token
 fi
 
 export KUBERMATICDOCKERTAG="$GIT_TAG"
@@ -239,14 +277,14 @@ fi
 set_helm_charts_version "$CHART_TAG" "$GIT_TAG"
 
 mkdir -p _dist
+rm -f "$CHECKSUMS_FILE"
 
 helmChartSbom="_dist/kubermatic-helmchart-$RELEASE_NAME.sbom.spdx.json"
 ./hack/generate-helmchart-sbom.sh "$RELEASE_NAME" _dist
 
 if ! $DRY_RUN; then
-  echodate "Uploading helm charts SBOM..."
-  upload_asset "$helmChartSbom"
-  rm -- "$helmChartSbom"
+  echodate "Shipping helm charts SBOM..."
+  ship_asset "$helmChartSbom"
 fi
 
 # CRDs since KKP 2.21 are not directly put into the charts/ directory
@@ -361,5 +399,14 @@ for buildTarget in $RELEASE_PLATFORMS; do
 
   ship_archive "$archive" "$buildTarget" "$binarySbom"
 done
+
+if ! $DRY_RUN; then
+  sign_blob "$CHECKSUMS_FILE"
+
+  echodate "Uploading checksums..."
+  upload_asset "$CHECKSUMS_FILE"
+  upload_asset "$CHECKSUMS_FILE.sigstore.json"
+  rm -- "$CHECKSUMS_FILE" "$CHECKSUMS_FILE.sigstore.json"
+fi
 
 echodate "Done."

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -118,6 +118,56 @@ is_containerized() {
   [ -n "${KUBERNETES_SERVICE_HOST:-}" ] || [ -n "${CONTAINERIZED:-}" ]
 }
 
+# Mints an OIDC identity token for Sigstore keyless signing using a Google service account. The JSON key is expected at $GOOGLE_APPLICATION_CREDENTIALS
+# or is otherwise fetched from Vault (requires the preset-vault label on the job). Fails if no token can be obtained, as signing is a mandatory part of
+# the release process. Tokens expire after 1 hour, so calling this again after 45 minutes re-mints; call it before every signing operation in long-running jobs.
+ensure_sigstore_token() {
+  local now
+  now="$(date +%s)"
+
+  if [ -n "${SIGSTORE_ID_TOKEN:-}" ]; then
+    # a token we did not mint ourselves is assumed to be managed externally
+    if [ "${SIGSTORE_TOKEN_MINTED_AT:-0}" -eq 0 ] || [ $((now - SIGSTORE_TOKEN_MINTED_AT)) -lt 2700 ]; then
+      return 0
+    fi
+  fi
+
+  if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] || [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    echodate "Fetching Sigstore signing service account from Vault..."
+    retry 5 vault_ci_login
+
+    # gcloud requires the key as a file, so it cannot be kept in an env var only
+    GOOGLE_APPLICATION_CREDENTIALS="$(mktemp)"
+    # the key is stored base64-encoded in Vault
+    vault kv get -field=serviceAccount dev/kubermatic-cosign-credentials | base64 -d > "$GOOGLE_APPLICATION_CREDENTIALS"
+    export GOOGLE_APPLICATION_CREDENTIALS
+  fi
+
+  if [ ! -s "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    echodate "Error: no Google service account key available for Sigstore signing."
+    return 1
+  fi
+
+  if [ -z "${SIGSTORE_SA_ACTIVATED:-}" ]; then
+    echodate "Activating Google service account for Sigstore signing..."
+    gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+    SIGSTORE_SA_ACTIVATED=true
+  fi
+
+  echodate "Minting Sigstore identity token..."
+  local token
+  # the audience must be exactly "sigstore", Fulcio rejects anything else
+  token="$(gcloud auth print-identity-token --audiences=sigstore)"
+
+  if [ -z "$token" ]; then
+    echodate "Error: could not obtain a Sigstore identity token via gcloud."
+    return 1
+  fi
+
+  export SIGSTORE_ID_TOKEN="$token"
+  SIGSTORE_TOKEN_MINTED_AT="$now"
+}
+
 containerize() {
   local cmd="$1"
   local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.10.0}"

--- a/hack/release-images.sh
+++ b/hack/release-images.sh
@@ -67,16 +67,24 @@ generate_image_sbom() {
   syft "docker:$imageRef" -o "spdx-json=$outFile"
 }
 
+resolve_digest_ref() {
+  local imageRef="$1"
+
+  local repo="${imageRef%:*}"
+  local digest
+  digest="$(oras manifest fetch --descriptor "$imageRef" | jq -er '.digest')"
+
+  echo "$repo@$digest"
+}
+
 declare -A ATTACHED_REFS
 
 attach_image_sbom() {
   local imageRef="$1"
   local sbomFile="$2"
 
-  local repo="${imageRef%:*}"
-  local digest
-  digest="$(oras manifest fetch --descriptor "$imageRef" | jq -er '.digest')"
-  local ref="$repo@$digest"
+  local ref
+  ref="$(resolve_digest_ref "$imageRef")"
   local key="$ref:$(basename "$sbomFile")"
 
   if [[ -n "${ATTACHED_REFS[$key]:-}" ]]; then
@@ -89,6 +97,39 @@ attach_image_sbom() {
     "$ref" "$sbomFile:application/spdx+json"
 
   ATTACHED_REFS[$key]=1
+}
+
+declare -A SIGNED_REFS
+
+# Keyless-signs the image (by digest) and attests its SBOM via cosign.
+# Signatures for a digest are created only once, even if multiple tags
+# point to it.
+sign_image() {
+  local imageRef="$1"
+  local sbomFile="${2:-}"
+
+  local ref
+  ref="$(resolve_digest_ref "$imageRef")"
+
+  if [[ -n "${SIGNED_REFS[$ref]:-}" ]]; then
+    echodate "Image $ref already signed, skipping duplicate for $imageRef..."
+    return
+  fi
+
+  ensure_sigstore_token
+
+  echodate "Signing $ref..."
+  cosign sign --yes "$ref"
+
+  if [ -n "$sbomFile" ]; then
+    echodate "Attesting SBOM $(basename "$sbomFile") for $ref..."
+    cosign attest --yes \
+      --type spdxjson \
+      --predicate "$sbomFile" \
+      "$ref"
+  fi
+
+  SIGNED_REFS[$ref]=1
 }
 
 # build Docker images
@@ -190,6 +231,12 @@ for arch in $ARCHITECTURES; do
   generate_image_sbom "$DOCKER_REPO/network-interface-manager:$PRIMARY_TAG-$arch" "_dist/images/network-interface-manager-$arch.sbom.spdx.json"
 done
 
+# mint the signing token only now, right before pushing/signing,
+# as identity tokens expire after one hour
+if [ -z "${NO_PUSH:-}" ]; then
+  ensure_sigstore_token
+fi
+
 # for each given tag, tag and push the image
 for TAG in $ALL_TAGS; do
   if [ -z "$TAG" ]; then
@@ -208,18 +255,23 @@ for TAG in $ALL_TAGS; do
 
     docker push "$DOCKER_REPO/kubermatic$REPOSUFFIX:$TAG"
     attach_image_sbom "$DOCKER_REPO/kubermatic$REPOSUFFIX:$TAG" "_dist/images/kubermatic$REPOSUFFIX.sbom.spdx.json"
+    sign_image "$DOCKER_REPO/kubermatic$REPOSUFFIX:$TAG" "_dist/images/kubermatic$REPOSUFFIX.sbom.spdx.json"
 
     docker push "$DOCKER_REPO/nodeport-proxy:$TAG"
     attach_image_sbom "$DOCKER_REPO/nodeport-proxy:$TAG" "_dist/images/nodeport-proxy.sbom.spdx.json"
+    sign_image "$DOCKER_REPO/nodeport-proxy:$TAG" "_dist/images/nodeport-proxy.sbom.spdx.json"
 
     docker push "$DOCKER_REPO/addons:$TAG"
     attach_image_sbom "$DOCKER_REPO/addons:$TAG" "_dist/images/addons.sbom.spdx.json"
+    sign_image "$DOCKER_REPO/addons:$TAG" "_dist/images/addons.sbom.spdx.json"
 
     docker push "$DOCKER_REPO/etcd-launcher:$TAG"
     attach_image_sbom "$DOCKER_REPO/etcd-launcher:$TAG" "_dist/images/etcd-launcher.sbom.spdx.json"
+    sign_image "$DOCKER_REPO/etcd-launcher:$TAG" "_dist/images/etcd-launcher.sbom.spdx.json"
 
     docker push "$DOCKER_REPO/conformance-tests:$TAG"
     attach_image_sbom "$DOCKER_REPO/conformance-tests:$TAG" "_dist/images/conformance-tests.sbom.spdx.json"
+    sign_image "$DOCKER_REPO/conformance-tests:$TAG" "_dist/images/conformance-tests.sbom.spdx.json"
 
     create_manifest "$DOCKER_REPO/user-ssh-keys-agent" "$PRIMARY_TAG" "$TAG"
     create_manifest "$DOCKER_REPO/kubeletdnat-controller" "$PRIMARY_TAG" "$TAG"
@@ -228,17 +280,23 @@ for TAG in $ALL_TAGS; do
     docker manifest push --purge "$DOCKER_REPO/user-ssh-keys-agent:$TAG"
     for arch in $ARCHITECTURES; do
       attach_image_sbom "$DOCKER_REPO/user-ssh-keys-agent:$TAG-$arch" "_dist/images/user-ssh-keys-agent-$arch.sbom.spdx.json"
+      sign_image "$DOCKER_REPO/user-ssh-keys-agent:$TAG-$arch" "_dist/images/user-ssh-keys-agent-$arch.sbom.spdx.json"
     done
+    sign_image "$DOCKER_REPO/user-ssh-keys-agent:$TAG"
 
     docker manifest push --purge "$DOCKER_REPO/kubeletdnat-controller:$TAG"
     for arch in $ARCHITECTURES; do
       attach_image_sbom "$DOCKER_REPO/kubeletdnat-controller:$TAG-$arch" "_dist/images/kubeletdnat-controller-$arch.sbom.spdx.json"
+      sign_image "$DOCKER_REPO/kubeletdnat-controller:$TAG-$arch" "_dist/images/kubeletdnat-controller-$arch.sbom.spdx.json"
     done
+    sign_image "$DOCKER_REPO/kubeletdnat-controller:$TAG"
 
     docker manifest push --purge "$DOCKER_REPO/network-interface-manager:$TAG"
     for arch in $ARCHITECTURES; do
       attach_image_sbom "$DOCKER_REPO/network-interface-manager:$TAG-$arch" "_dist/images/network-interface-manager-$arch.sbom.spdx.json"
+      sign_image "$DOCKER_REPO/network-interface-manager:$TAG-$arch" "_dist/images/network-interface-manager-$arch.sbom.spdx.json"
     done
+    sign_image "$DOCKER_REPO/network-interface-manager:$TAG"
   fi
 done
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds cosign keyless signing to the release artifacts using a GCP service account.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:
2 other tasks:
- I will create a separate PR on the infra repo to add `preset-vault: "true"` to the postsubmit jobs.
- Add the actual service account to the vault.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TDB 
(a new doc can be added later about how to verify the signed artifacts)
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
